### PR TITLE
Add incremental fetch: reference file discovery and --file flag

### DIFF
--- a/cli/src/commands/get.js
+++ b/cli/src/commands/get.js
@@ -47,13 +47,32 @@ async function fetchEntries(ids, opts, globalOpts) {
       error(`"${id}" ${entryFile.error}`, globalOpts);
     }
 
+    // Determine which reference files exist (beyond DOC.md/SKILL.md)
+    const entryFileName = type === 'skill' ? 'SKILL.md' : 'DOC.md';
+    const refFiles = resolved.files.filter((f) => f !== entryFileName);
+
     try {
-      if (opts.full && resolved.files.length > 0) {
+      if (opts.file) {
+        // --file mode: fetch specific file(s) by path
+        const requested = opts.file.split(',').map((f) => f.trim());
+        const invalid = requested.filter((f) => !resolved.files.includes(f));
+        if (invalid.length > 0) {
+          const available = refFiles.length > 0 ? refFiles.join(', ') : '(none)';
+          error(`File "${invalid[0]}" not found in ${id}. Available: ${available}`, globalOpts);
+        }
+        if (requested.length === 1) {
+          const content = await fetchDoc(resolved.source, join(resolved.path, requested[0]));
+          results.push({ id: entry.id, type, content, path: join(resolved.path, requested[0]) });
+        } else {
+          const allFiles = await fetchDocFull(resolved.source, resolved.path, requested);
+          results.push({ id: entry.id, type, files: allFiles, path: resolved.path });
+        }
+      } else if (opts.full && resolved.files.length > 0) {
         const allFiles = await fetchDocFull(resolved.source, resolved.path, resolved.files);
         results.push({ id: entry.id, type, files: allFiles, path: resolved.path });
       } else {
         const content = await fetchDoc(resolved.source, entryFile.filePath);
-        results.push({ id: entry.id, type, content, path: entryFile.filePath });
+        results.push({ id: entry.id, type, content, path: entryFile.filePath, additionalFiles: refFiles });
       }
     } catch (err) {
       error(err.message, globalOpts);
@@ -112,9 +131,20 @@ async function fetchEntries(ids, opts, globalOpts) {
     }
   } else {
     if (results.length === 1 && !results[0].files) {
+      const r = results[0];
+      const extraFiles = r.additionalFiles || [];
+      const jsonData = { id: r.id, type: r.type, content: r.content, path: r.path };
+      if (extraFiles.length > 0) jsonData.additionalFiles = extraFiles;
       output(
-        { id: results[0].id, type: results[0].type, content: results[0].content, path: results[0].path },
-        (data) => process.stdout.write(data.content),
+        jsonData,
+        (data) => {
+          process.stdout.write(data.content);
+          if (extraFiles.length > 0) {
+            const fileList = extraFiles.map((f) => `  ${f}`).join('\n');
+            const example = `chub get ${r.id} --file ${extraFiles[0]}`;
+            process.stdout.write(`\n\n---\nAdditional files available (use --file to fetch):\n${fileList}\nExample: ${example}\n`);
+          }
+        },
         globalOpts
       );
     } else {
@@ -142,6 +172,7 @@ export function registerGetCommand(program) {
     .option('--version <version>', 'Specific version (for docs)')
     .option('-o, --output <path>', 'Write to file or directory')
     .option('--full', 'Fetch all files (not just entry point)')
+    .option('--file <paths>', 'Fetch specific file(s) by path (comma-separated)')
     .action(async (ids, opts) => {
       const globalOpts = program.optsWithGlobals();
       await fetchEntries(ids, opts, globalOpts);

--- a/cli/test/e2e.test.js
+++ b/cli/test/e2e.test.js
@@ -165,6 +165,40 @@ describe('chub CLI e2e', () => {
       expect(out).toContain('# Deploy Skill');
       expect(out).toContain('Automate deployments');
     });
+
+    it('shows footer with additional files when they exist', () => {
+      const out = chub(['get', 'acme/widgets']);
+      expect(out).toContain('Additional files available');
+      expect(out).toContain('references/advanced.md');
+      expect(out).toContain('--file');
+    });
+
+    it('no footer when entry has only one file', () => {
+      const out = chub(['get', 'multilang/client', '--lang', 'js']);
+      expect(out).not.toContain('Additional files available');
+    });
+
+    it('fetches specific file with --file', () => {
+      const out = chub(['get', 'acme/widgets', '--file', 'references/advanced.md']);
+      expect(out).toContain('Batch Operations');
+      expect(out).not.toContain('# Acme Widgets API');
+    });
+
+    it('errors on nonexistent --file with available list', () => {
+      const out = chub(['get', 'acme/widgets', '--file', 'nonexistent.md'], { expectError: true });
+      expect(out).toContain('not found in acme/widgets');
+      expect(out).toContain('references/advanced.md');
+    });
+
+    it('--json includes additionalFiles array', () => {
+      const data = chubJSON(['get', 'acme/widgets']);
+      expect(data.additionalFiles).toContain('references/advanced.md');
+    });
+
+    it('--json omits additionalFiles when none exist', () => {
+      const data = chubJSON(['get', 'multilang/client', '--lang', 'js']);
+      expect(data.additionalFiles).toBeUndefined();
+    });
   });
 
   describe('json output', () => {


### PR DESCRIPTION
## Summary

- When `chub get <id>` returns a doc with additional reference files, a footer is now appended showing what's available and how to fetch them
- New `--file <paths>` flag lets agents selectively fetch specific reference files (comma-separated) instead of pulling everything with `--full`
- `--json` mode includes an `additionalFiles` array when reference files exist

### Example output

```
# Acme Widgets API
...doc content...

---
Additional files available (use --file to fetch):
  references/function-calling.md
  references/streaming.md
Example: chub get openai/chat-api --file references/function-calling.md
```

### Agent workflow

1. `chub get openai/chat-api` → reads doc, sees footer listing reference files
2. `chub get openai/chat-api --file references/function-calling.md` → fetches only what it needs

No footer is shown when an entry has only DOC.md/SKILL.md.

## Test plan

- [x] `cd cli && npm test` — 89 tests pass (6 new)
- [x] Footer appears for entries with reference files (acme/widgets)
- [x] No footer for single-file entries (multilang/client)
- [x] `--file` fetches individual reference files
- [x] `--file nonexistent.md` errors with available file list
- [x] `--json` includes `additionalFiles` array
- [x] `--json` omits `additionalFiles` when none exist