### PR TITLE
Add chub annotate: local agent notes on docs

### DIFF
--- a/cli/src/commands/annotate.js
+++ b/cli/src/commands/annotate.js
@@ -1,0 +1,83 @@
+import chalk from 'chalk';
+import { readAnnotation, writeAnnotation, clearAnnotation, listAnnotations } from '../lib/annotations.js';
+import { output, error, info } from '../lib/output.js';
+
+export function registerAnnotateCommand(program) {
+  program
+    .command('annotate [id] [note]')
+    .description('Attach agent notes to a doc or skill')
+    .option('--clear', 'Remove annotation for this entry')
+    .option('--list', 'List all annotations')
+    .action((id, note, opts) => {
+      const globalOpts = program.optsWithGlobals();
+
+      if (opts.list) {
+        const annotations = listAnnotations();
+        output(
+          annotations,
+          (data) => {
+            if (data.length === 0) {
+              console.log('No annotations.');
+              return;
+            }
+            for (const a of data) {
+              console.log(`${chalk.bold(a.id)} ${chalk.dim(`(${a.updatedAt})`)}`);
+              console.log(`  ${a.note}`);
+              console.log();
+            }
+          },
+          globalOpts
+        );
+        return;
+      }
+
+      if (!id) {
+        error('Usage: chub annotate <id> <note> | chub annotate <id> --clear | chub annotate --list', globalOpts);
+      }
+
+      if (opts.clear) {
+        const removed = clearAnnotation(id);
+        output(
+          { id, cleared: removed },
+          (data) => {
+            if (data.cleared) {
+              console.log(`Annotation cleared for ${chalk.bold(id)}.`);
+            } else {
+              console.log(`No annotation found for ${chalk.bold(id)}.`);
+            }
+          },
+          globalOpts
+        );
+        return;
+      }
+
+      if (!note) {
+        // Show existing annotation
+        const existing = readAnnotation(id);
+        if (existing) {
+          output(
+            existing,
+            (data) => {
+              console.log(`${chalk.bold(data.id)} ${chalk.dim(`(${data.updatedAt})`)}`);
+              console.log(data.note);
+            },
+            globalOpts
+          );
+        } else {
+          output(
+            { id, note: null },
+            () => console.log(`No annotation for ${chalk.bold(id)}.`),
+            globalOpts
+          );
+        }
+        return;
+      }
+
+      const data = writeAnnotation(id, note);
+      output(
+        data,
+        (d) => console.log(`Annotation saved for ${chalk.bold(d.id)}.`),
+        globalOpts
+      );
+    });
+}

--- a/cli/src/commands/get.js
+++ b/cli/src/commands/get.js
@@ -5,6 +5,7 @@ import { getEntry, resolveDocPath, resolveEntryFile } from '../lib/registry.js';
 import { fetchDoc, fetchDocFull } from '../lib/cache.js';
 import { output, error, info } from '../lib/output.js';
 import { trackEvent } from '../lib/analytics.js';
+import { readAnnotation } from '../lib/annotations.js';
 
 /**
  * Fetch one or more entries by ID. Auto-detects doc vs skill per entry.
@@ -133,12 +134,17 @@ async function fetchEntries(ids, opts, globalOpts) {
     if (results.length === 1 && !results[0].files) {
       const r = results[0];
       const extraFiles = r.additionalFiles || [];
+      const annotation = readAnnotation(r.id);
       const jsonData = { id: r.id, type: r.type, content: r.content, path: r.path };
       if (extraFiles.length > 0) jsonData.additionalFiles = extraFiles;
+      if (annotation) jsonData.annotation = annotation;
       output(
         jsonData,
         (data) => {
           process.stdout.write(data.content);
+          if (annotation) {
+            process.stdout.write(`\n\n---\n[Agent note — ${annotation.updatedAt}]\n${annotation.note}\n`);
+          }
           if (extraFiles.length > 0) {
             const fileList = extraFiles.map((f) => `  ${f}`).join('\n');
             const example = `chub get ${r.id} --file ${extraFiles[0]}`;

--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -10,6 +10,7 @@ import { registerSearchCommand } from './commands/search.js';
 import { registerGetCommand } from './commands/get.js';
 import { registerBuildCommand } from './commands/build.js';
 import { registerFeedbackCommand } from './commands/feedback.js';
+import { registerAnnotateCommand } from './commands/annotate.js';
 import { trackEvent, shutdownAnalytics } from './lib/analytics.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -84,7 +85,7 @@ program
   });
 
 // Commands that don't need registry
-const SKIP_REGISTRY = ['update', 'cache', 'build', 'feedback', 'help'];
+const SKIP_REGISTRY = ['update', 'cache', 'build', 'feedback', 'annotate', 'help'];
 
 program.hook('preAction', async (thisCommand) => {
   const cmdName = thisCommand.args?.[0] || thisCommand.name();
@@ -111,6 +112,7 @@ registerSearchCommand(program);
 registerGetCommand(program);
 registerBuildCommand(program);
 registerFeedbackCommand(program);
+registerAnnotateCommand(program);
 
 program.parse();
 

--- a/cli/src/lib/annotations.js
+++ b/cli/src/lib/annotations.js
@@ -1,0 +1,57 @@
+import { readFileSync, writeFileSync, mkdirSync, unlinkSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { getChubDir } from './config.js';
+
+function getAnnotationsDir() {
+  return join(getChubDir(), 'annotations');
+}
+
+function annotationPath(entryId) {
+  const safe = entryId.replace(/\//g, '--');
+  return join(getAnnotationsDir(), `${safe}.json`);
+}
+
+export function readAnnotation(entryId) {
+  try {
+    return JSON.parse(readFileSync(annotationPath(entryId), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+export function writeAnnotation(entryId, note) {
+  const dir = getAnnotationsDir();
+  mkdirSync(dir, { recursive: true });
+  const data = {
+    id: entryId,
+    note,
+    updatedAt: new Date().toISOString(),
+  };
+  writeFileSync(annotationPath(entryId), JSON.stringify(data, null, 2));
+  return data;
+}
+
+export function clearAnnotation(entryId) {
+  try {
+    unlinkSync(annotationPath(entryId));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function listAnnotations() {
+  const dir = getAnnotationsDir();
+  try {
+    const files = readdirSync(dir).filter((f) => f.endsWith('.json'));
+    return files.map((f) => {
+      try {
+        return JSON.parse(readFileSync(join(dir, f), 'utf8'));
+      } catch {
+        return null;
+      }
+    }).filter(Boolean);
+  } catch {
+    return [];
+  }
+}

--- a/cli/test/e2e.test.js
+++ b/cli/test/e2e.test.js
@@ -201,6 +201,66 @@ describe('chub CLI e2e', () => {
     });
   });
 
+  describe('annotate', () => {
+    it('saves and displays annotation on get', () => {
+      chub(['annotate', 'acme/widgets', 'Use batch mode for large datasets']);
+      const out = chub(['get', 'acme/widgets']);
+      expect(out).toContain('Agent note');
+      expect(out).toContain('Use batch mode for large datasets');
+    });
+
+    it('replaces annotation on re-annotate', () => {
+      chub(['annotate', 'acme/widgets', 'Updated: use streaming instead']);
+      const out = chub(['get', 'acme/widgets']);
+      expect(out).toContain('use streaming instead');
+      expect(out).not.toContain('batch mode');
+    });
+
+    it('shows annotation with chub annotate <id> (no note)', () => {
+      const out = chub(['annotate', 'acme/widgets']);
+      expect(out).toContain('use streaming instead');
+    });
+
+    it('clears annotation', () => {
+      chub(['annotate', 'acme/widgets', '--clear']);
+      const out = chub(['get', 'acme/widgets']);
+      expect(out).not.toContain('Agent note');
+    });
+
+    it('no annotation section when none set', () => {
+      const out = chub(['get', 'multilang/client', '--lang', 'js']);
+      expect(out).not.toContain('Agent note');
+    });
+
+    it('--list shows all annotations', () => {
+      chub(['annotate', 'acme/widgets', 'Note A']);
+      chub(['annotate', 'multilang/client', 'Note B']);
+      const data = chubJSON(['annotate', '--list']);
+      expect(data.length).toBe(2);
+      const ids = data.map((a) => a.id);
+      expect(ids).toContain('acme/widgets');
+      expect(ids).toContain('multilang/client');
+      // Clean up
+      chub(['annotate', 'acme/widgets', '--clear']);
+      chub(['annotate', 'multilang/client', '--clear']);
+    });
+
+    it('--json includes annotation in get output', () => {
+      chub(['annotate', 'acme/widgets', 'JSON test note']);
+      const data = chubJSON(['get', 'acme/widgets']);
+      expect(data.annotation).toBeDefined();
+      expect(data.annotation.note).toBe('JSON test note');
+      expect(data.annotation.id).toBe('acme/widgets');
+      // Clean up
+      chub(['annotate', 'acme/widgets', '--clear']);
+    });
+
+    it('--json omits annotation when none set', () => {
+      const data = chubJSON(['get', 'acme/widgets']);
+      expect(data.annotation).toBeUndefined();
+    });
+  });
+
   describe('json output', () => {
     it('search --json returns valid JSON with total', () => {
       const data = chubJSON(['search']);


### PR DESCRIPTION
## Summary

- New `chub annotate` command lets agents attach persistent notes to docs
- Notes are stored locally in `~/.chub/annotations/` as JSON files
- Notes appear automatically after doc content on `chub get` calls
- Creates a learning loop — agents get smarter about each doc over time

### Commands

```bash
chub annotate openai/chat-api "Function calling requires gpt-4o or later"  # set note
chub annotate openai/chat-api                                               # view note
chub annotate openai/chat-api --clear                                       # remove note
chub annotate --list                                                        # list all
chub annotate --list --json                                                 # JSON output
```

### How it appears in `chub get`

```
# OpenAI Chat API
...doc content...

---
[Agent note — 2026-03-03T00:12:00.000Z]
Function calling requires gpt-4o or later. Set httpx timeout to 600s for batch.

---
Additional files available (use --file to fetch):
  references/function-calling.md
```

### Design decisions

- **Single replace** — each annotate overwrites the previous note (simple for agents)
- **Per entry** — not scoped to language (agent can mention language in note text)
- **After doc content** — annotations appear after doc, before reference files footer
- **Local only** — no backend calls, works offline. Sharing can come later.

## Test plan

- [x] `cd cli && npm test` — 97 tests pass (8 new)
- [x] Annotation saved and appears on `chub get`
- [x] Re-annotate replaces previous note
- [x] `--clear` removes annotation
- [x] No annotation section when none set
- [x] `--list` returns all annotations
- [x] `--json` includes annotation in get response
- [x] `--json` omits annotation when none set
- [x] Works with incremental fetch (annotation + reference files footer)