### PR TITLE
Rewrite README and add llms.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Context Hub
 
-Always-current docs and skills for AI agents. One CLI to search, fetch, and use up-to-date documentation — so your agent stops hallucinating deprecated APIs.
+Context Hub gives AI agents the right documentation — and agents that use it get smarter with every task.
 
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![npm](https://img.shields.io/npm/v/@aisuite/chub)](https://www.npmjs.com/package/@aisuite/chub)
@@ -8,41 +8,66 @@ Always-current docs and skills for AI agents. One CLI to search, fetch, and use 
 
 ## The Problem
 
-Your AI coding agent was trained months ago. The API you're using shipped a breaking change last week. The agent doesn't know — it writes code against the old API, you debug for 20 minutes, then paste the docs into chat yourself.
+Your AI agent was trained months ago. The API you're using shipped a breaking change last week. The agent doesn't know — it hallucinate parameters, uses deprecated patterns, and writes code that doesn't compile. You debug for 20 minutes, then paste the docs into chat yourself.
 
-## The Solution
+Pasting docs into chat doesn't scale. The agent forgets everything next session. It makes the same mistakes again.
+
+## Quick Start
 
 ```bash
 npm install -g @aisuite/chub
+chub update                          # download the registry
+chub search "stripe"                 # find what's available
+chub get stripe/api --lang js        # fetch current docs
 ```
 
+## Two Content Types
+
+**Docs** — API and SDK references. Versioned, language-specific. "What to know."
 ```bash
-chub update                                    # download the registry
-chub search "stripe"                           # find what's available
-chub get stripe/api --lang js                  # fetch current docs
+chub get openai/chat-api --lang py   # Python variant
+chub get stripe/api --lang js        # JavaScript variant
 ```
 
-That's it. Search, fetch, use. No hallucinated parameters, no outdated patterns.
+**Skills** — Task recipes, automation patterns, coding playbooks. Standalone. "How to do it."
+```bash
+chub get pw-community/login-flows    # fetch a skill
+```
 
-## How Agents Use It
+Both are markdown with YAML frontmatter, following the [Agent Skills](https://agentskills.io) open standard — compatible with Claude Code, Cursor, Codex, and other AI tools.
+
+## The Agent Workflow
+
+Context Hub is designed for a loop where agents get better over time:
+
+```
+Search  →  Fetch  →  Use  →  Annotate  →  (next time) Fetch with notes
+```
+
+Here's what that looks like in practice:
 
 ```bash
-# Agent searches for current docs:
+# 1. Agent searches for relevant docs
 ID=$(chub search "stripe payments" --json | jq -r '.results[0].id')
 
-# Agent fetches and reads them:
-chub get "$ID" --lang python -o .context/stripe.md
+# 2. Agent fetches the doc
+chub get "$ID" --lang js -o .context/stripe.md
 
-# Now it writes correct code against the latest API.
+# 3. Agent reads the doc, writes code, discovers that webhook
+#    signature verification requires raw body (not parsed JSON)
+
+# 4. Agent annotates for next time
+chub annotate "$ID" "Webhook signature verification requires raw request body — do not parse JSON before verifying"
+
+# 5. Next session — the annotation appears automatically when fetching
+chub get "$ID" --lang js
+# Output includes:
+# ---
+# [Agent note — 2025-01-15T10:30:00Z]
+# Webhook signature verification requires raw request body — do not parse JSON before verifying
 ```
 
-For reusable patterns — login flows, deployment scripts, auth integrations — agents fetch skills:
-
-```bash
-chub get playwright-community/login-flows -o .claude/skills/login-flows/SKILL.md
-```
-
-The skill is installed. The agent discovers it automatically in every future session.
+The annotation persists across sessions. Every future fetch of that doc includes the note. The agent doesn't repeat the same mistake.
 
 ## Commands
 
@@ -50,29 +75,115 @@ The skill is installed. The agent discovers it automatically in every future ses
 |---------|---------|
 | `chub search [query]` | Search docs and skills (no query = list all) |
 | `chub get <ids...>` | Fetch docs or skills by ID |
-| `chub feedback <id> <up\|down>` | Rate a doc or skill |
+| `chub annotate <id> <note>` | Attach a note to a doc or skill |
+| `chub annotate <id> --clear` | Remove an annotation |
+| `chub annotate --list` | List all annotations |
+| `chub feedback <id> <up\|down>` | Rate a doc or skill (sent to maintainers) |
 | `chub update` | Refresh the cached registry |
 | `chub cache status\|clear` | Manage the local cache |
-| `chub build <content-dir>` | Build registry from content directory |
+| `chub build <content-dir>` | Build registry from a content directory |
 
-Every command supports `--json` for machine-readable output, making it easy to pipe into agents.
+Every command supports `--json` for machine-readable output.
 
 ### Key Flags
 
-```bash
---json                 # Structured JSON output
---tags <csv>           # Filter by tags
---lang <language>      # Language variant (js, py, ts)
---full                 # Fetch all files, not just the entry point
--o, --output <path>    # Write content to file or directory
+| Flag | Purpose |
+|------|---------|
+| `--json` | Structured JSON output (for agents and piping) |
+| `--tags <csv>` | Filter search results by tags |
+| `--lang <language>` | Language variant (js, py, ts, etc.) |
+| `--full` | Fetch all files, not just the entry point |
+| `--file <paths>` | Fetch specific reference file(s), comma-separated |
+| `-o, --output <path>` | Write content to file or directory |
+
+## Key Features
+
+### Incremental Fetch
+
+When a doc has reference files beyond the main entry point, the CLI tells you:
+
+```
+# Acme Widgets API
+...
+
+---
+Additional files available (use --file to fetch):
+  references/advanced.md
+  references/errors.md
+Example: chub get acme/widgets --file references/advanced.md
 ```
 
-## Two Content Types
+Fetch only what you need. No wasted tokens on files you won't use.
 
-- **Docs** ("what to know") — API/SDK reference documentation. Large, detailed, versioned per language. Fetched on-demand for a specific task.
-- **Skills** ("how to do it") — Behavioral instructions, coding patterns, automation playbooks. Smaller, actionable, installable into agent skill directories.
+```bash
+chub get acme/widgets --file references/advanced.md     # one file
+chub get acme/widgets --file advanced.md,errors.md       # multiple
+chub get acme/widgets --full                             # everything
+```
 
-Both follow the [Agent Skills](https://agentskills.io) open standard — compatible with Claude Code, Cursor, Codex, and 30+ other tools.
+### Agent Annotations
+
+Agents attach notes to docs that persist across sessions:
+
+```bash
+chub annotate stripe/api "Use idempotency keys for all POST requests to avoid duplicate charges"
+```
+
+The note appears automatically on every future `chub get stripe/api`. Annotations are local — they live in `~/.chub/annotations/` and are specific to your machine.
+
+To view, replace, or clear:
+```bash
+chub annotate stripe/api                  # view current note
+chub annotate stripe/api "new note"       # replaces previous
+chub annotate stripe/api --clear          # removes it
+chub annotate --list                      # list all annotations
+```
+
+### Feedback
+
+Rate docs to help maintainers improve them:
+
+```bash
+chub feedback stripe/api up "Clear examples, well structured"
+chub feedback openai/chat down --label outdated --label wrong-examples
+```
+
+Feedback is sent to the registry. Annotations are local. Both matter.
+
+### Multi-Source
+
+Combine the public registry with your own private docs:
+
+```yaml
+# ~/.chub/config.yaml
+sources:
+  - name: community
+    url: https://cdn.aichub.org/v1
+  - name: internal
+    path: /path/to/local/docs
+```
+
+Build your own content with `chub build`:
+
+```bash
+chub build my-content/ -o dist/
+```
+
+### JSON Output
+
+Every command supports `--json` for agent piping:
+
+```bash
+# Search and fetch in one pipeline
+ID=$(chub search "stripe" --json | jq -r '.results[0].id')
+chub get "$ID" --lang js -o .context/stripe.md
+
+# Check for additional files
+chub get acme/widgets --json | jq '.additionalFiles'
+
+# List all annotations as JSON
+chub annotate --list --json
+```
 
 ## Configuration
 
@@ -81,58 +192,20 @@ Config lives at `~/.chub/config.yaml`:
 ```yaml
 sources:
   - name: community
-    url: https://cdn.aichub.org/v1           # Public registry
+    url: https://cdn.aichub.org/v1
   - name: internal
-    path: /path/to/local/docs                # Your private docs
+    path: /path/to/local/docs
 
-source: "official,maintainer,community"       # Trust policy
-refresh_interval: 86400                       # Cache TTL (24h)
-telemetry: true                               # Anonymous usage analytics (opt-out)
+source: "official,maintainer,community"   # trust policy
+refresh_interval: 86400                   # cache TTL in seconds (24h)
+telemetry: true                           # anonymous usage analytics
 ```
 
-## Bring Your Own Docs
-
-Build and serve your team's internal documentation alongside the public registry:
-
-```bash
-# Create content with DOC.md / SKILL.md frontmatter
-chub build my-content/ -o .chub-local/
-
-# Add as a local source
-# In ~/.chub/config.yaml:
-#   sources:
-#     - name: internal
-#       path: /path/to/.chub-local
-```
-
-Now `chub search` covers both public and private content. See [docs/byod-guide.md](docs/byod-guide.md) for the full guide.
-
-## Why Context Hub
-
-**Curated, not auto-scraped.** Every doc is written by humans who understand the library — structured, complete, and optimized for how LLMs read. Not disconnected code snippets from a scraping pipeline.
-
-**Local-first, offline-capable.** Everything is cached locally. Works offline, in CI/CD, in air-gapped environments. No hosted service dependency.
-
-**Open and transparent.** The registry is open. Every doc is a markdown file you can read, fork, and modify. No opaque scoring systems or proprietary enrichment pipelines.
-
-## Telemetry
-
-Context Hub collects anonymous usage analytics to improve the registry. No personally identifiable information is collected — only a hashed machine identifier.
-
-Opt out anytime:
+Opt out of telemetry:
 ```yaml
-# ~/.chub/config.yaml
 telemetry: false
 ```
-
 Or via environment variable: `CHUB_TELEMETRY=0`
-
-## Contributing
-
-We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for:
-- Development setup
-- Code contribution guidelines
-- How to contribute docs and skills
 
 ## License
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,169 @@
+# Context Hub (chub)
+
+> CLI tool for searching and fetching LLM-optimized documentation and skills. Install: npm install -g @aisuite/chub
+
+## Content Types
+
+- doc: API/SDK reference documentation. Versioned, language-specific. Entry file: DOC.md
+- skill: Task recipes, automation patterns, coding playbooks. Standalone. Entry file: SKILL.md
+
+## Commands
+
+### chub search [query]
+Search docs and skills. No query lists all entries.
+
+Flags:
+  --tags <csv>        Filter by tags (comma-separated)
+  --json              JSON output with { total, results[] }
+
+Examples:
+  chub search                         # list everything
+  chub search "stripe"                # fuzzy search by name/description
+  chub search stripe/payments         # exact id returns full detail
+  chub search --tags automation       # filter by tag
+
+### chub get <ids...>
+Fetch one or more docs or skills by ID. Auto-detects type (doc vs skill). Auto-infers language when only one is available.
+
+Flags:
+  --lang <language>   Language variant (js, py, ts, etc.)
+  --version <version> Specific doc version
+  --full              Fetch all files, not just the entry point
+  --file <paths>      Fetch specific file(s) by path (comma-separated)
+  -o, --output <path> Write to file or directory
+  --json              JSON output with { id, type, content, path, additionalFiles?, annotation? }
+
+Examples:
+  chub get stripe/api                           # single doc (auto-infers lang if only one)
+  chub get openai/chat-api --lang py            # specific language
+  chub get pw-community/login-flows             # fetch a skill
+  chub get stripe/api openai/chat-api           # multiple entries
+  chub get acme/widgets --file references/advanced.md   # specific reference file
+  chub get acme/widgets --full                  # all files
+  chub get stripe/api -o .context/stripe.md     # save to file
+
+Behavior:
+  - When additional reference files exist beyond the entry point, output includes a footer listing them
+  - Use --file to fetch specific reference files without fetching everything
+  - If an annotation exists for the entry, it is appended after the content
+
+### chub annotate [id] [note]
+Attach persistent notes to a doc or skill. Notes appear on future `chub get` calls.
+
+Flags:
+  --clear             Remove annotation for this entry
+  --list              List all annotations
+  --json              JSON output
+
+Examples:
+  chub annotate stripe/api "Use idempotency keys for POST requests"   # set note
+  chub annotate stripe/api                     # view current note
+  chub annotate stripe/api "Updated note"      # replaces previous note
+  chub annotate stripe/api --clear             # remove note
+  chub annotate --list                         # list all annotations
+
+Storage: ~/.chub/annotations/ (local, per-machine)
+
+### chub feedback [id] [rating] [comment]
+Rate a doc or skill (up/down). Sent to the registry for maintainers.
+
+Flags:
+  --label <label>     Feedback label (repeatable). Valid: accurate, well-structured, helpful, good-examples, outdated, inaccurate, incomplete, wrong-examples, wrong-version, poorly-structured
+  --lang <language>   Language variant
+  --file <file>       Specific file within the entry
+  --agent <name>      AI tool name
+  --model <model>     LLM model name
+  --status            Show telemetry status
+  --json              JSON output
+
+Examples:
+  chub feedback stripe/api up "Clear examples"
+  chub feedback openai/chat down --label outdated --label wrong-examples
+
+### chub update
+Download or refresh the cached registry.
+
+### chub cache status|clear
+Manage the local cache. `status` shows cache info, `clear` removes cached content.
+
+### chub build <content-dir>
+Build a registry from a local content directory.
+
+Flags:
+  -o, --output <path>     Output directory (default: <content-dir>/dist)
+  --base-url <url>        Base URL for remote serving
+  --validate-only         Validate without building
+  --json                  JSON output
+
+## Agent Workflow
+
+Recommended pattern for AI agents using Context Hub:
+
+1. SEARCH: Find relevant documentation
+   chub search "stripe payments" --json | jq -r '.results[0].id'
+
+2. FETCH: Get the documentation
+   chub get stripe/api --lang js
+
+3. USE: Read the content, write code based on it
+
+4. ANNOTATE: Record what you learned for future sessions
+   chub annotate stripe/api "Webhook verification requires raw body, not parsed JSON"
+
+5. NEXT SESSION: Fetch again — your annotation appears automatically
+   chub get stripe/api --lang js
+   # Content is followed by your previous annotation
+
+This loop means agents improve over time. Annotations persist across sessions.
+
+## Annotation Best Practices
+
+After using a doc to complete a task, annotate what you learned that wasn't obvious from the doc itself:
+- Environment-specific gotchas ("requires raw body for webhook verification")
+- Version-specific notes ("v3 API requires different auth header format")
+- Project-specific context ("we use the batch endpoint, not individual calls")
+- Error resolutions ("rate limit errors need exponential backoff with jitter")
+
+Do NOT annotate information that's already clearly stated in the doc.
+
+## Piping Patterns
+
+# Search, pick first result, fetch
+ID=$(chub search "stripe" --json | jq -r '.results[0].id')
+chub get "$ID" --lang js -o .context/stripe.md
+
+# Fetch multiple docs at once
+chub get openai/chat stripe/api -o .context/
+
+# Check what additional files are available
+chub get acme/widgets --json | jq '.additionalFiles'
+
+# Fetch a specific reference file
+chub get acme/widgets --file references/advanced.md
+
+# List all your annotations
+chub annotate --list --json
+
+## Key Behaviors
+
+- Auto-detect type: `chub get` works for both docs and skills. No need to specify type.
+- Auto-infer language: If a doc has only one language variant, --lang is not required.
+- Multi-language prompt: If a doc has multiple languages and --lang is not specified, the CLI lists available languages.
+- Incremental fetch: Default fetch returns only the entry file. A footer lists additional reference files. Use --file for selective fetch, --full for everything.
+- Annotations on fetch: If an annotation exists for an entry, it appears at the end of `chub get` output in both human and JSON modes.
+- Multi-source: Config supports multiple sources (URLs and local paths). On ID collision, prefix with source name: `chub get internal:openai/chat`.
+- JSON everywhere: All commands support --json for structured output.
+
+## Configuration
+
+File: ~/.chub/config.yaml
+
+sources:
+  - name: community
+    url: https://cdn.aichub.org/v1
+  - name: internal
+    path: /path/to/local/docs
+
+source: "official,maintainer,community"   # trust policy
+refresh_interval: 86400                   # cache TTL in seconds
+telemetry: true                           # anonymous analytics (opt out: false or CHUB_TELEMETRY=0)


### PR DESCRIPTION
## Summary
- Rewrote README to lead with the self-learning loop — agents that use Context Hub get smarter over time via annotations
- Covers all current features: incremental fetch, agent annotations, feedback, multi-source config, JSON piping
- Added `llms.txt` — a machine-readable reference for AI agents with commands, flags, workflow, and best practices

## Test plan
- [ ] Review README for accuracy against current CLI behavior
- [ ] Review llms.txt for completeness (all commands, flags, behaviors)
- [ ] Verify links (Agent Skills, badges, LICENSE)