### PR TITLE
Restructure README and add docs pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,23 @@ Context Hub gives AI agents the right documentation — and agents that use it g
 
 ## The Problem
 
-Your AI agent was trained months — or years — ago. The API you're using shipped a breaking change last week. The agent doesn't know. It hallucinates parameters, uses deprecated patterns, and writes code that doesn't compile.
+Your LLM agent was trained months — or years — ago. You need to use an API which was not present in the training set. The agent doesn't know. It hallucinates parameters, uses deprecated patterns, and writes code that doesn't compile. Web search can solve this but is more error prone, and causes token burn.
 
-It gets worse with existing codebases. You're debugging a project pinned to an older SDK version. The agent has no idea what's different between v2 and v3 — it just guesses.
+Debugging existing projects come with their own challenges. They use a particular version of API - and sometimes agents mix up parameters or names across versions. Web search again helps with this, but is still highly error prone based on the agent you are using.
 
 Then there are the things that aren't in any public doc: your team's deployment playbook, your auth patterns, your coding conventions. Every agent on your team should follow them, but none of them know they exist.
 
 You can paste docs into chat, but it doesn't scale. The agent forgets everything next session and makes the same mistakes again. And when the agent does figure something out — a workaround, a missing detail — that knowledge is lost. There's no way to capture it for next time.
 
-## Quick Start
-
-```bash
-npm install -g @aisuite/chub
-chub search "stripe"                 # find what's available
-chub get stripe/api                  # fetch current docs
+```
+  Without Context Hub                          With Context Hub
+  ───────────────────                          ─────────────────
+  Search the web                               Fetch curated docs
+  Noisy results                                Higher chance of code working
+  Code breaks                                  Agent notes any gaps/workarounds
+  Effort in fixing                             ↗ Even smarter next session
+  Knowledge forgotten
+  ↻ Repeat next session
 ```
 
 ## The Agent Workflow
@@ -54,6 +57,14 @@ The annotation persists across sessions. The agent doesn't repeat the same mista
 
 **The content itself improves over time too.** Agents can send feedback (`chub feedback stripe/api up` or `down`) to doc authors, who update the content based on what's working and what isn't. So the docs get better for everyone — not just your local annotations.
 
+## Quick Start
+
+```bash
+npm install -g @aisuite/chub
+chub search "stripe"                 # find what's available
+chub get stripe/api                  # fetch current docs
+```
+
 ## Content Types
 
 **Docs** — API and SDK references. Versioned, language-specific. "What to know."
@@ -62,7 +73,7 @@ chub get openai/chat-api --lang py   # Python variant
 chub get stripe/api --lang js        # JavaScript variant
 ```
 
-**Skills** — Task recipes, automation patterns, coding playbooks. Standalone. "How to do it."
+**Skills** — Task recipes, automation patterns, coding playbooks. Shareable across teams so every agent follows the same proven approach. "How to do it."
 ```bash
 chub get pw-community/login-flows    # fetch a skill
 ```
@@ -79,133 +90,26 @@ Both are markdown with YAML frontmatter, following the [Agent Skills](https://ag
 | `chub annotate <id> --clear` | Remove an annotation |
 | `chub annotate --list` | List all annotations |
 | `chub feedback <id> <up\|down>` | Rate a doc or skill (sent to maintainers) |
-| `chub update` | Refresh the cached registry |
-| `chub cache status\|clear` | Manage the local cache |
-| `chub build <content-dir>` | Build registry from a content directory |
 
-Every command supports `--json` for machine-readable output.
-
-### Key Flags
-
-| Flag | Purpose |
-|------|---------|
-| `--json` | Structured JSON output (for agents and piping) |
-| `--tags <csv>` | Filter search results by tags |
-| `--lang <language>` | Language variant (js, py, ts, etc.) |
-| `--full` | Fetch all files, not just the entry point |
-| `--file <paths>` | Fetch specific reference file(s), comma-separated |
-| `-o, --output <path>` | Write content to file or directory |
+For the full list of commands, flags, and piping patterns, see the [CLI Reference](docs/cli-reference.md).
 
 ## Key Features
 
 ### Incremental Fetch
 
-When a doc has reference files beyond the main entry point, the CLI tells you:
+Docs can have multiple reference files beyond the main entry point. The CLI shows you what's available and lets you fetch only what you need — no wasted tokens. Use `--file` to grab specific references, or `--full` for everything. See the [CLI Reference](docs/cli-reference.md) for details.
 
-```
-# Acme Widgets API
-...
+### Agent Annotations & Feedback
 
----
-Additional files available (use --file to fetch):
-  references/advanced.md
-  references/errors.md
-Example: chub get acme/widgets --file references/advanced.md
-```
+Annotations are local notes that agents attach to docs. They persist across sessions and appear automatically on future fetches — so agents learn from past experience. Feedback (up/down ratings) goes to doc authors to improve the content for everyone. See [Feedback and Annotations](docs/feedback-and-annotations.md).
 
-Fetch only what you need. No wasted tokens on files you won't use.
+### Private Content Repo — *Coming Soon*
 
-```bash
-chub get acme/widgets --file references/advanced.md     # one file
-chub get acme/widgets --file advanced.md,errors.md       # multiple
-chub get acme/widgets --full                             # everything
-```
-
-### Agent Annotations
-
-Agents attach notes to docs that persist across sessions:
-
-```bash
-chub annotate stripe/api "Use idempotency keys for all POST requests to avoid duplicate charges"
-```
-
-The note appears automatically on every future `chub get stripe/api`. Annotations are local — they live in `~/.chub/annotations/` and are specific to your machine.
-
-To view, replace, or clear:
-```bash
-chub annotate stripe/api                  # view current note
-chub annotate stripe/api "new note"       # replaces previous
-chub annotate stripe/api --clear          # removes it
-chub annotate --list                      # list all annotations
-```
-
-### Feedback
-
-Rate docs to help maintainers improve them:
-
-```bash
-chub feedback stripe/api up "Clear examples, well structured"
-chub feedback openai/chat down --label outdated --label wrong-examples
-```
-
-Feedback is sent to the registry. Annotations are local. Both matter.
-
-### Multi-Source
-
-Combine the public registry with your own private docs:
-
-```yaml
-# ~/.chub/config.yaml
-sources:
-  - name: community
-    url: https://cdn.aichub.org/v1
-  - name: internal
-    path: /path/to/local/docs
-```
-
-Build your own content with `chub build`:
-
-```bash
-chub build my-content/ -o dist/
-```
+Teams need their own internal docs alongside the public registry: deployment playbooks, coding conventions, internal API references. Agents should be able to search both seamlessly. We're working on making this easy to set up and distribute across your team. See [Private Content Repo](docs/private-content.md) for more.
 
 ### JSON Output
 
-Every command supports `--json` for agent piping:
-
-```bash
-# Search and fetch in one pipeline
-ID=$(chub search "stripe" --json | jq -r '.results[0].id')
-chub get "$ID" --lang js -o .context/stripe.md
-
-# Check for additional files
-chub get acme/widgets --json | jq '.additionalFiles'
-
-# List all annotations as JSON
-chub annotate --list --json
-```
-
-## Configuration
-
-Config lives at `~/.chub/config.yaml`:
-
-```yaml
-sources:
-  - name: community
-    url: https://cdn.aichub.org/v1
-  - name: internal
-    path: /path/to/local/docs
-
-source: "official,maintainer,community"   # trust policy
-refresh_interval: 86400                   # cache TTL in seconds (24h)
-telemetry: true                           # anonymous usage analytics
-```
-
-Opt out of telemetry:
-```yaml
-telemetry: false
-```
-Or via environment variable: `CHUB_TELEMETRY=0`
+Every command supports `--json` for structured output, making it easy to pipe into agents and automation. See the [CLI Reference](docs/cli-reference.md) for piping patterns.
 
 ## License
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,201 @@
+# CLI Reference
+
+Full command reference for Context Hub (`chub`).
+
+## Global Flags
+
+| Flag | Purpose |
+|------|---------|
+| `--json` | Structured JSON output (for agents and piping) |
+| `--version` | Print CLI version |
+| `--help` | Show help |
+
+## chub search [query]
+
+Search docs and skills. No query lists all entries.
+
+| Flag | Purpose |
+|------|---------|
+| `--tags <csv>` | Filter by comma-separated tags |
+| `--lang <language>` | Filter by language |
+| `--limit <n>` | Max results (default: 20) |
+
+```bash
+chub search                          # list everything
+chub search "stripe"                 # fuzzy search by name/description
+chub search stripe/payments          # exact id — shows full detail
+chub search --tags automation        # filter by tag
+```
+
+**Exact ID match** returns the full entry detail (versions, languages, files). **Fuzzy search** returns a list of matches ranked by relevance.
+
+## chub get \<ids...\>
+
+Fetch one or more docs or skills by ID. Auto-detects type (doc vs skill). Auto-infers language when only one variant exists.
+
+| Flag | Purpose |
+|------|---------|
+| `--lang <language>` | Language variant (js, py, ts, etc.) |
+| `--version <version>` | Specific doc version |
+| `--full` | Fetch all files, not just the entry point |
+| `--file <paths>` | Fetch specific file(s) by path (comma-separated) |
+| `-o, --output <path>` | Write to file or directory |
+
+```bash
+chub get stripe/api                  # single doc (auto-infers lang)
+chub get openai/chat-api --lang py   # specific language
+chub get pw-community/login-flows    # fetch a skill
+chub get stripe/api openai/chat-api  # multiple entries
+chub get stripe/api -o .context/     # save to file
+```
+
+### Incremental Fetch
+
+When a doc has reference files beyond the main entry point, the output includes a footer:
+
+```
+---
+Additional files available (use --file to fetch):
+  references/advanced.md
+  references/errors.md
+Example: chub get acme/widgets --file references/advanced.md
+```
+
+Fetch only what you need:
+
+```bash
+chub get acme/widgets --file references/advanced.md       # one file
+chub get acme/widgets --file advanced.md,errors.md         # multiple
+chub get acme/widgets --full                               # everything
+```
+
+With `--json`, the response includes an `additionalFiles` array listing available reference files.
+
+### Multi-Language Docs
+
+If a doc is available in multiple languages and `--lang` is not specified, the CLI lists available languages and asks you to choose.
+
+If a doc has only one language, `--lang` is not required — it's auto-inferred.
+
+## chub annotate [id] [note]
+
+Attach persistent notes to a doc or skill. See [Feedback and Annotations](feedback-and-annotations.md) for the full guide.
+
+| Flag | Purpose |
+|------|---------|
+| `--clear` | Remove annotation for this entry |
+| `--list` | List all annotations |
+
+```bash
+chub annotate stripe/api "Use idempotency keys for POST requests"
+chub annotate stripe/api                   # view current note
+chub annotate stripe/api "new note"        # replaces previous
+chub annotate stripe/api --clear           # remove
+chub annotate --list                       # list all
+```
+
+## chub feedback [id] [rating] [comment]
+
+Rate a doc or skill. Feedback is sent to the registry for maintainers. See [Feedback and Annotations](feedback-and-annotations.md) for details.
+
+| Flag | Purpose |
+|------|---------|
+| `--label <label>` | Feedback label (repeatable) |
+| `--lang <language>` | Language variant |
+| `--file <file>` | Specific file within the entry |
+| `--agent <name>` | AI tool name |
+| `--model <model>` | LLM model name |
+| `--status` | Show telemetry status |
+
+Valid labels: `accurate`, `well-structured`, `helpful`, `good-examples`, `outdated`, `inaccurate`, `incomplete`, `wrong-examples`, `wrong-version`, `poorly-structured`.
+
+```bash
+chub feedback stripe/api up "Clear examples, well structured"
+chub feedback openai/chat down --label outdated --label wrong-examples
+```
+
+## chub update
+
+Download or refresh the cached registry from remote sources.
+
+| Flag | Purpose |
+|------|---------|
+| `--force` | Re-download even if cache is fresh |
+| `--full` | Download full bundle for offline use |
+
+## chub cache status\|clear
+
+Manage the local cache.
+
+- `cache status` — shows cache info (sources, registries, sizes, last updated)
+- `cache clear` — removes cached content (`--force` to skip confirmation)
+
+## chub build \<content-dir\>
+
+Build a registry from a local content directory. See the [Content Guide](content-guide.md) for how to structure your content.
+
+| Flag | Purpose |
+|------|---------|
+| `-o, --output <path>` | Output directory (default: `<content-dir>/dist`) |
+| `--base-url <url>` | Base URL for remote serving |
+| `--validate-only` | Validate content without building |
+
+```bash
+chub build my-content/                           # build to my-content/dist/
+chub build my-content/ -o dist/                  # custom output dir
+chub build my-content/ --validate-only           # validate only
+```
+
+## Piping Patterns
+
+```bash
+# Search, pick first result, fetch
+ID=$(chub search "stripe" --json | jq -r '.results[0].id')
+chub get "$ID" -o .context/stripe.md
+
+# Fetch multiple docs at once
+chub get openai/chat stripe/api -o .context/
+
+# Check what additional files are available
+chub get acme/widgets --json | jq '.additionalFiles'
+
+# Fetch a specific reference file
+chub get acme/widgets --file references/advanced.md
+
+# List all annotations as JSON
+chub annotate --list --json
+```
+
+## Configuration
+
+Config lives at `~/.chub/config.yaml`:
+
+```yaml
+sources:
+  - name: community
+    url: https://cdn.aichub.org/v1
+  - name: internal
+    path: /path/to/local/docs
+
+source: "official,maintainer,community"   # trust policy
+refresh_interval: 86400                   # cache TTL in seconds (24h)
+telemetry: true                           # anonymous usage analytics
+```
+
+### Telemetry
+
+Anonymous usage analytics help improve the registry. No personally identifiable information is collected.
+
+Opt out:
+```yaml
+telemetry: false
+```
+Or via environment variable: `CHUB_TELEMETRY=0`
+
+### Multi-Source
+
+When multiple sources define the same entry ID, prefix with the source name to disambiguate:
+
+```bash
+chub get internal:openai/chat
+```

--- a/docs/content-guide.md
+++ b/docs/content-guide.md
@@ -1,0 +1,158 @@
+# Content Guide
+
+How to create docs and skills for Context Hub.
+
+## Directory Structure
+
+Content is organized by author (vendor/org), then by type (`docs` or `skills`), then by entry name:
+
+```
+my-content/
+  acme/
+    docs/
+      widgets/
+        DOC.md                    # single-language doc
+        references/
+          advanced.md             # additional reference file
+      client/
+        javascript/
+          DOC.md                  # multi-language: JS variant
+        python/
+          DOC.md                  # multi-language: Python variant
+    skills/
+      deploy/
+        SKILL.md                  # a skill
+```
+
+### Single-language docs
+
+Place `DOC.md` directly in the entry directory:
+
+```
+author/docs/entry-name/DOC.md
+```
+
+### Multi-language docs
+
+Create a subdirectory per language:
+
+```
+author/docs/entry-name/javascript/DOC.md
+author/docs/entry-name/python/DOC.md
+```
+
+### Skills
+
+Place `SKILL.md` in the entry directory:
+
+```
+author/skills/entry-name/SKILL.md
+```
+
+### Reference files
+
+Additional files (examples, advanced topics, error references) go alongside the entry file:
+
+```
+author/docs/widgets/
+  DOC.md
+  references/
+    advanced.md
+    errors.md
+```
+
+These are discoverable via `chub get` (shown in the footer) and fetchable with `--file` or `--full`.
+
+## Frontmatter
+
+Every `DOC.md` and `SKILL.md` starts with YAML frontmatter.
+
+### DOC.md frontmatter
+
+```yaml
+---
+name: widgets
+description: "Acme widget API for creating and managing widgets"
+metadata:
+  languages: "javascript"
+  versions: "2.0.0"
+  updated-on: "2026-01-01"
+  source: maintainer
+  tags: "acme,widgets,api"
+---
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Entry name (used in the ID: `author/name`) |
+| `description` | Yes | Short description for search results |
+| `metadata.languages` | Yes | Language of this doc variant |
+| `metadata.versions` | Yes | Version(s) covered |
+| `metadata.updated-on` | Yes | Last update date |
+| `metadata.source` | Yes | Trust level: `official`, `maintainer`, or `community` |
+| `metadata.tags` | No | Comma-separated tags for filtering |
+
+### SKILL.md frontmatter
+
+```yaml
+---
+name: deploy
+description: "Deployment automation skill for CI/CD pipelines"
+metadata:
+  updated-on: "2026-01-01"
+  source: community
+  tags: "deploy,ci,automation"
+---
+```
+
+Skills have the same fields as docs except `languages` and `versions` are not required (skills are language-agnostic).
+
+## Writing Content
+
+Content is markdown, written for LLM consumption. Keep these in mind:
+
+- **Be direct.** Agents don't need introductions or marketing. Start with what the API does and how to use it.
+- **Show code first.** A working example is worth more than a paragraph of explanation.
+- **Cover the common case.** Don't exhaustively document every option. Cover what agents will actually need 90% of the time.
+- **Use reference files for depth.** Put advanced topics, error handling, and edge cases in separate reference files rather than making the main doc too long.
+
+## Building
+
+Use `chub build` to compile your content directory into a registry:
+
+```bash
+chub build my-content/                           # build to my-content/dist/
+chub build my-content/ -o dist/                  # custom output directory
+chub build my-content/ --validate-only           # validate without building
+```
+
+The build process:
+1. Discovers all `DOC.md` and `SKILL.md` files
+2. Validates frontmatter (checks required fields)
+3. Generates `registry.json` with entry metadata
+4. Copies content files to the output directory
+
+### Validation
+
+Run `--validate-only` to check your content without building:
+
+```bash
+chub build my-content/ --validate-only
+```
+
+This reports the number of docs and skills found, and flags any frontmatter errors.
+
+### Using built content locally
+
+Point your config at the build output to use it alongside the public registry:
+
+```yaml
+# ~/.chub/config.yaml
+sources:
+  - name: community
+    url: https://cdn.aichub.org/v1
+  - name: my-team
+    path: /path/to/my-content/dist
+```
+
+Now `chub search` and `chub get` cover both public and your local content.

--- a/docs/feedback-and-annotations.md
+++ b/docs/feedback-and-annotations.md
@@ -1,0 +1,127 @@
+# Feedback and Annotations
+
+Context Hub has two mechanisms for agents to improve over time: **annotations** (local, for your agent) and **feedback** (sent to authors, for everyone).
+
+## Annotations
+
+Annotations are local notes that agents attach to docs or skills. They persist across sessions and appear automatically on future `chub get` calls.
+
+### Why annotate?
+
+When an agent uses a doc to complete a task, it sometimes discovers things that aren't in the doc itself — environment-specific gotchas, version quirks, project-specific context. Without annotations, that knowledge is lost when the session ends. The agent makes the same discovery again next time.
+
+Annotations close this gap. The agent saves what it learned, and next time it fetches the same doc, the note is right there.
+
+### Usage
+
+```bash
+# Set an annotation
+chub annotate stripe/api "Webhook verification requires raw body — do not parse JSON before verifying"
+
+# View current annotation
+chub annotate stripe/api
+
+# Replace with a new note
+chub annotate stripe/api "Updated: use the v2 webhook endpoint for new integrations"
+
+# Remove an annotation
+chub annotate stripe/api --clear
+
+# List all annotations
+chub annotate --list
+```
+
+### How annotations appear
+
+When an annotation exists, `chub get` appends it after the doc content:
+
+```
+# Stripe API
+...doc content...
+
+---
+[Agent note — 2025-01-15T10:30:00Z]
+Webhook verification requires raw body — do not parse JSON before verifying
+```
+
+With `--json`, the annotation is included in the response:
+
+```json
+{
+  "id": "stripe/api",
+  "type": "doc",
+  "content": "...",
+  "annotation": {
+    "id": "stripe/api",
+    "note": "Webhook verification requires raw body...",
+    "updatedAt": "2025-01-15T10:30:00.000Z"
+  }
+}
+```
+
+### What to annotate
+
+Good annotations capture knowledge that isn't obvious from the doc:
+
+- **Environment-specific gotchas** — "Requires raw body for webhook verification"
+- **Version-specific notes** — "v3 API requires different auth header format"
+- **Project-specific context** — "We use the batch endpoint, not individual calls"
+- **Error resolutions** — "Rate limit errors need exponential backoff with jitter"
+
+Don't annotate information that's already clearly stated in the doc.
+
+### Storage
+
+Annotations are stored locally at `~/.chub/annotations/` as JSON files. They are specific to your machine and are not shared or synced. Each entry gets one annotation — setting a new note replaces the previous one.
+
+## Feedback
+
+Feedback is sent to doc authors via the registry. It helps maintainers understand what's working and what needs improvement.
+
+### Usage
+
+```bash
+# Simple up/down rating
+chub feedback stripe/api up
+chub feedback stripe/api down
+
+# With a comment
+chub feedback stripe/api up "Clear examples, well structured"
+
+# With labels for specific issues
+chub feedback openai/chat down --label outdated --label wrong-examples
+
+# Target a specific file within a doc
+chub feedback acme/widgets down --file references/advanced.md --label incomplete
+
+# Include agent context
+chub feedback stripe/api up --agent "claude-code" --model "claude-sonnet-4"
+```
+
+### Labels
+
+Labels help authors pinpoint specific issues:
+
+**Positive:** `accurate`, `well-structured`, `helpful`, `good-examples`
+
+**Negative:** `outdated`, `inaccurate`, `incomplete`, `wrong-examples`, `wrong-version`, `poorly-structured`
+
+### Telemetry
+
+Feedback is sent via the telemetry system. If telemetry is disabled, feedback is silently skipped. Check status with:
+
+```bash
+chub feedback --status
+```
+
+## Annotations vs Feedback
+
+| | Annotations | Feedback |
+|---|---|---|
+| **For whom** | Your agent, locally | Doc authors, via registry |
+| **Persists** | On your machine | In the registry |
+| **Purpose** | Don't repeat mistakes | Improve the content |
+| **Visible to** | You only | Maintainers |
+| **Effect** | Shows on future fetches | Authors update the doc |
+
+Both matter. Annotations help your agent today. Feedback helps everyone tomorrow.

--- a/docs/private-content.md
+++ b/docs/private-content.md
@@ -1,0 +1,22 @@
+# Private Content Repo
+
+> **Coming Soon**
+
+## The Problem
+
+Teams have internal documentation that agents need: private API references, deployment playbooks, coding conventions, auth patterns. This content doesn't belong in a public registry, but agents should be able to search and fetch it just as easily as public docs.
+
+Today, you can build local content with `chub build` and point your config at it. But distributing that content across a team — keeping it in sync, versioned, and accessible to every developer's agent — is a manual process.
+
+We're working on making private content repos easy to set up, distribute, and keep current across your team.
+
+## What we're solving for
+
+- **Team-wide conventions** — Every agent on your team should follow the same patterns. Write them once, distribute everywhere.
+- **Internal API docs** — Your private APIs need the same quality docs as public ones. Agents shouldn't have to guess.
+- **Seamless search** — `chub search` should cover both public and private content without extra steps.
+- **Easy distribution** — Adding a new team member's agent to the private repo should be simple.
+
+## Enterprise
+
+For enterprise use cases, reach out at info@tbd-domain.com.


### PR DESCRIPTION
## Summary
- **README slimmed down**: adopted cleaner Problem section, added before/after comparison diagram, moved Agent Workflow before Content Types
- **Key Features** trimmed to 2-3 sentences each, linking to dedicated docs pages
- **New docs pages**:
  - `docs/cli-reference.md` — full command reference, all flags, piping patterns, config
  - `docs/feedback-and-annotations.md` — self-learning loop, annotation best practices, feedback labels
  - `docs/content-guide.md` — directory structure, frontmatter spec, `chub build` usage
  - `docs/private-content.md` — coming soon, problem statement for private team docs

## Test plan
- [ ] Review README flow: Problem → Comparison → Workflow → Quick Start → Content Types → Commands → Key Features
- [ ] Verify all links from README to docs/ pages resolve
- [ ] Review each docs page for accuracy