### PR TITLE
Add BM25 search with pre-built index

### DIFF
--- a/cli/src/commands/build.js
+++ b/cli/src/commands/build.js
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 import { parseFrontmatter } from '../lib/frontmatter.js';
 import { info } from '../lib/output.js';
 import { trackEvent } from '../lib/analytics.js';
+import { buildIndex } from '../lib/bm25.js';
 
 /**
  * Recursively find all DOC.md and SKILL.md files under a directory.
@@ -300,6 +301,14 @@ export function registerBuildCommand(program) {
       // Write output
       mkdirSync(outputDir, { recursive: true });
       writeFileSync(join(outputDir, 'registry.json'), JSON.stringify(registry, null, 2));
+
+      // Build and write BM25 search index
+      const allEntries = [
+        ...allDocs.map((d) => ({ ...d, _type: 'doc' })),
+        ...allSkills.map((s) => ({ ...s, _type: 'skill' })),
+      ];
+      const searchIndex = buildIndex(allEntries);
+      writeFileSync(join(outputDir, 'search-index.json'), JSON.stringify(searchIndex));
 
       // Copy content tree
       for (const authorEntry of topLevel) {

--- a/cli/src/lib/bm25.js
+++ b/cli/src/lib/bm25.js
@@ -1,0 +1,170 @@
+/**
+ * BM25 search implementation for Context Hub.
+ * Index is built at `chub build` time, scoring happens at search time.
+ * Tokenizer is shared between build and search to ensure consistency.
+ */
+
+const STOP_WORDS = new Set([
+  'a', 'an', 'and', 'are', 'as', 'at', 'be', 'by', 'for', 'from',
+  'has', 'have', 'in', 'is', 'it', 'its', 'of', 'on', 'or', 'that',
+  'the', 'to', 'was', 'were', 'will', 'with', 'this', 'but', 'not',
+  'you', 'your', 'can', 'do', 'does', 'how', 'if', 'may', 'no',
+  'so', 'than', 'too', 'very', 'just', 'about', 'into', 'over',
+  'such', 'then', 'them', 'these', 'those', 'through', 'under',
+  'use', 'using', 'used',
+]);
+
+// BM25 default parameters
+const DEFAULT_K1 = 1.5;
+const DEFAULT_B = 0.75;
+
+// Field weights for multi-field scoring
+const FIELD_WEIGHTS = {
+  name: 3.0,
+  tags: 2.0,
+  description: 1.0,
+};
+
+/**
+ * Tokenize text into lowercase terms with stop word removal.
+ * Must be used identically at build time and search time.
+ */
+export function tokenize(text) {
+  if (!text) return [];
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, ' ')
+    .split(/[\s-]+/)
+    .filter((t) => t.length > 1 && !STOP_WORDS.has(t));
+}
+
+/**
+ * Build a BM25 search index from registry entries.
+ * Called during `chub build`.
+ *
+ * @param {Array} entries - Combined docs and skills from registry
+ * @returns {Object} The search index
+ */
+export function buildIndex(entries) {
+  const documents = [];
+  const dfMap = {}; // document frequency per term (across all fields)
+  const fieldLengths = { name: [], description: [], tags: [] };
+
+  for (const entry of entries) {
+    const nameTokens = tokenize(entry.name);
+    const descTokens = tokenize(entry.description || '');
+    const tagTokens = (entry.tags || []).flatMap((t) => tokenize(t));
+
+    documents.push({
+      id: entry.id,
+      tokens: {
+        name: nameTokens,
+        description: descTokens,
+        tags: tagTokens,
+      },
+    });
+
+    fieldLengths.name.push(nameTokens.length);
+    fieldLengths.description.push(descTokens.length);
+    fieldLengths.tags.push(tagTokens.length);
+
+    // Count document frequency — a term counts once per document (union of all fields)
+    const allTerms = new Set([...nameTokens, ...descTokens, ...tagTokens]);
+    for (const term of allTerms) {
+      dfMap[term] = (dfMap[term] || 0) + 1;
+    }
+  }
+
+  const N = documents.length;
+
+  // Compute IDF for each term
+  const idf = {};
+  for (const [term, df] of Object.entries(dfMap)) {
+    idf[term] = Math.log((N - df + 0.5) / (df + 0.5) + 1);
+  }
+
+  // Compute average field lengths
+  const avg = (arr) => arr.length === 0 ? 0 : arr.reduce((a, b) => a + b, 0) / arr.length;
+  const avgFieldLengths = {
+    name: avg(fieldLengths.name),
+    description: avg(fieldLengths.description),
+    tags: avg(fieldLengths.tags),
+  };
+
+  return {
+    version: '1.0.0',
+    algorithm: 'bm25',
+    params: { k1: DEFAULT_K1, b: DEFAULT_B },
+    totalDocs: N,
+    avgFieldLengths,
+    idf,
+    documents,
+  };
+}
+
+/**
+ * Compute BM25 score for a single field.
+ */
+function scoreField(queryTerms, fieldTokens, idf, avgFieldLen, k1, b) {
+  if (fieldTokens.length === 0) return 0;
+
+  // Build term frequency map for this field
+  const tf = {};
+  for (const t of fieldTokens) {
+    tf[t] = (tf[t] || 0) + 1;
+  }
+
+  let score = 0;
+  const dl = fieldTokens.length;
+
+  for (const term of queryTerms) {
+    const termFreq = tf[term] || 0;
+    if (termFreq === 0) continue;
+
+    const termIdf = idf[term] || 0;
+    const numerator = termFreq * (k1 + 1);
+    const denominator = termFreq + k1 * (1 - b + b * (dl / (avgFieldLen || 1)));
+    score += termIdf * (numerator / denominator);
+  }
+
+  return score;
+}
+
+/**
+ * Search the BM25 index with a query string.
+ *
+ * @param {string} query - The search query
+ * @param {Object} index - The pre-built BM25 index
+ * @param {Object} opts - Options: { limit }
+ * @returns {Array} Sorted results: [{ id, score }]
+ */
+export function search(query, index, opts = {}) {
+  const queryTerms = tokenize(query);
+  if (queryTerms.length === 0) return [];
+
+  const { k1, b } = index.params;
+  const results = [];
+
+  for (const doc of index.documents) {
+    let totalScore = 0;
+
+    for (const [field, weight] of Object.entries(FIELD_WEIGHTS)) {
+      const fieldTokens = doc.tokens[field] || [];
+      const avgLen = index.avgFieldLengths[field] || 1;
+      const fieldScore = scoreField(queryTerms, fieldTokens, index.idf, avgLen, k1, b);
+      totalScore += fieldScore * weight;
+    }
+
+    if (totalScore > 0) {
+      results.push({ id: doc.id, score: totalScore });
+    }
+  }
+
+  results.sort((a, b) => b.score - a.score);
+
+  if (opts.limit) {
+    return results.slice(0, opts.limit);
+  }
+
+  return results;
+}

--- a/cli/src/lib/cache.js
+++ b/cli/src/lib/cache.js
@@ -226,6 +226,20 @@ export function loadSourceRegistry(source) {
 }
 
 /**
+ * Load BM25 search index for a single source (if available).
+ */
+export function loadSearchIndex(source) {
+  const basePath = source.path || getSourceDir(source.name);
+  const indexPath = join(basePath, 'search-index.json');
+  if (!existsSync(indexPath)) return null;
+  try {
+    return JSON.parse(readFileSync(indexPath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Get cache stats.
  */
 export function getCacheStats() {

--- a/cli/src/lib/registry.js
+++ b/cli/src/lib/registry.js
@@ -1,8 +1,10 @@
-import { loadSourceRegistry } from './cache.js';
+import { loadSourceRegistry, loadSearchIndex } from './cache.js';
 import { loadConfig } from './config.js';
 import { normalizeLanguage } from './normalize.js';
+import { search as bm25Search } from './bm25.js';
 
 let _merged = null;
+let _searchIndex = null;
 
 /**
  * Load and merge entries from all configured sources.
@@ -14,10 +16,15 @@ function getMerged() {
   const config = loadConfig();
   const allDocs = [];
   const allSkills = [];
+  const searchIndexes = [];
 
   for (const source of config.sources) {
     const registry = loadSourceRegistry(source);
     if (!registry) continue;
+
+    // Load BM25 search index if available
+    const idx = loadSearchIndex(source);
+    if (idx) searchIndexes.push(idx);
 
     // Support both new format (docs/skills) and old format (entries)
     if (registry.docs) {
@@ -43,6 +50,53 @@ function getMerged() {
           allDocs.push(tagged);
         }
       }
+    }
+  }
+
+  // Merge search indexes (combine documents and recompute IDF)
+  if (searchIndexes.length > 0) {
+    if (searchIndexes.length === 1) {
+      _searchIndex = searchIndexes[0];
+    } else {
+      // Merge multiple indexes: combine documents, recompute global IDF
+      const allDocuments = searchIndexes.flatMap((idx) => idx.documents);
+      const N = allDocuments.length;
+      const dfMap = {};
+      const fieldLengths = { name: [], description: [], tags: [] };
+
+      for (const doc of allDocuments) {
+        const allTerms = new Set([
+          ...(doc.tokens.name || []),
+          ...(doc.tokens.description || []),
+          ...(doc.tokens.tags || []),
+        ]);
+        for (const term of allTerms) {
+          dfMap[term] = (dfMap[term] || 0) + 1;
+        }
+        fieldLengths.name.push((doc.tokens.name || []).length);
+        fieldLengths.description.push((doc.tokens.description || []).length);
+        fieldLengths.tags.push((doc.tokens.tags || []).length);
+      }
+
+      const idf = {};
+      for (const [term, df] of Object.entries(dfMap)) {
+        idf[term] = Math.log((N - df + 0.5) / (df + 0.5) + 1);
+      }
+
+      const avg = (arr) => arr.length === 0 ? 0 : arr.reduce((a, b) => a + b, 0) / arr.length;
+      _searchIndex = {
+        version: '1.0.0',
+        algorithm: 'bm25',
+        params: searchIndexes[0].params,
+        totalDocs: N,
+        avgFieldLengths: {
+          name: avg(fieldLengths.name),
+          description: avg(fieldLengths.description),
+          tags: avg(fieldLengths.tags),
+        },
+        idf,
+        documents: allDocuments,
+      };
     }
   }
 
@@ -121,11 +175,10 @@ export function getDisplayId(entry) {
 
 /**
  * Search entries by query string. Searches both docs and skills.
+ * Uses BM25 when a search index is available, falls back to keyword matching.
  */
 export function searchEntries(query, filters = {}) {
   const entries = applySourceFilter(getAllEntries());
-  const q = query.toLowerCase();
-  const words = q.split(/\s+/);
 
   // Deduplicate: same id+source appearing as both doc and skill → show once
   const seen = new Set();
@@ -138,27 +191,50 @@ export function searchEntries(query, filters = {}) {
     }
   }
 
-  let results = deduped.map((entry) => {
-    let score = 0;
+  // Build entry lookup by id
+  const entryById = new Map();
+  for (const entry of deduped) {
+    entryById.set(entry.id, entry);
+  }
 
-    if (entry.id === q) score += 100;
-    else if (entry.id.includes(q)) score += 50;
+  let results;
 
-    const nameLower = entry.name.toLowerCase();
-    if (nameLower === q) score += 80;
-    else if (nameLower.includes(q)) score += 40;
+  if (_searchIndex) {
+    // BM25 search
+    const bm25Results = bm25Search(query, _searchIndex);
+    results = bm25Results
+      .map((r) => {
+        const entry = entryById.get(r.id);
+        return entry ? { entry, score: r.score } : null;
+      })
+      .filter(Boolean);
+  } else {
+    // Fallback: keyword matching
+    const q = query.toLowerCase();
+    const words = q.split(/\s+/);
 
-    for (const word of words) {
-      if (entry.id.includes(word)) score += 10;
-      if (nameLower.includes(word)) score += 10;
-      if (entry.description?.toLowerCase().includes(word)) score += 5;
-      if (entry.tags?.some((t) => t.toLowerCase().includes(word))) score += 15;
-    }
+    results = deduped.map((entry) => {
+      let score = 0;
 
-    return { entry, score };
-  });
+      if (entry.id === q) score += 100;
+      else if (entry.id.includes(q)) score += 50;
 
-  results = results.filter((r) => r.score > 0);
+      const nameLower = entry.name.toLowerCase();
+      if (nameLower === q) score += 80;
+      else if (nameLower.includes(q)) score += 40;
+
+      for (const word of words) {
+        if (entry.id.includes(word)) score += 10;
+        if (nameLower.includes(word)) score += 10;
+        if (entry.description?.toLowerCase().includes(word)) score += 5;
+        if (entry.tags?.some((t) => t.toLowerCase().includes(word))) score += 15;
+      }
+
+      return { entry, score };
+    });
+
+    results = results.filter((r) => r.score > 0);
+  }
 
   const filtered = applyFilters(results.map((r) => r.entry), filters);
   const filteredSet = new Set(filtered);

--- a/cli/test/lib/bm25.test.js
+++ b/cli/test/lib/bm25.test.js
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest';
+import { tokenize, buildIndex, search } from '../../src/lib/bm25.js';
+
+describe('bm25', () => {
+  describe('tokenize', () => {
+    it('lowercases and splits on whitespace', () => {
+      expect(tokenize('Hello World')).toEqual(['hello', 'world']);
+    });
+
+    it('removes stop words', () => {
+      expect(tokenize('the quick and brown fox')).toEqual(['quick', 'brown', 'fox']);
+    });
+
+    it('removes punctuation', () => {
+      expect(tokenize('hello, world! foo-bar')).toEqual(['hello', 'world', 'foo', 'bar']);
+    });
+
+    it('removes single-character tokens', () => {
+      expect(tokenize('a b cd ef')).toEqual(['cd', 'ef']);
+    });
+
+    it('returns empty array for empty/null input', () => {
+      expect(tokenize('')).toEqual([]);
+      expect(tokenize(null)).toEqual([]);
+      expect(tokenize(undefined)).toEqual([]);
+    });
+  });
+
+  describe('buildIndex', () => {
+    const entries = [
+      { id: 'stripe/api', name: 'api', description: 'Payment processing platform', tags: ['stripe', 'payments'] },
+      { id: 'openai/chat', name: 'chat', description: 'Chat completions API', tags: ['openai', 'ai', 'chat'] },
+      { id: 'redis/cache', name: 'cache', description: 'In-memory data store', tags: ['redis', 'cache', 'database'] },
+    ];
+
+    it('builds index with correct structure', () => {
+      const index = buildIndex(entries);
+      expect(index.version).toBe('1.0.0');
+      expect(index.algorithm).toBe('bm25');
+      expect(index.totalDocs).toBe(3);
+      expect(index.documents).toHaveLength(3);
+      expect(index.params).toEqual({ k1: 1.5, b: 0.75 });
+    });
+
+    it('tokenizes all fields', () => {
+      const index = buildIndex(entries);
+      const stripeDoc = index.documents.find((d) => d.id === 'stripe/api');
+      expect(stripeDoc.tokens.name).toEqual(['api']);
+      expect(stripeDoc.tokens.description).toContain('payment');
+      expect(stripeDoc.tokens.description).toContain('processing');
+      expect(stripeDoc.tokens.tags).toContain('stripe');
+      expect(stripeDoc.tokens.tags).toContain('payments');
+    });
+
+    it('computes IDF values', () => {
+      const index = buildIndex(entries);
+      expect(index.idf).toBeDefined();
+      // 'payment' appears in 1 of 3 docs — should have higher IDF than 'api' if it appeared in more
+      expect(index.idf['payment']).toBeGreaterThan(0);
+    });
+
+    it('computes average field lengths', () => {
+      const index = buildIndex(entries);
+      expect(index.avgFieldLengths.name).toBeGreaterThan(0);
+      expect(index.avgFieldLengths.description).toBeGreaterThan(0);
+      expect(index.avgFieldLengths.tags).toBeGreaterThan(0);
+    });
+
+    it('handles empty entries array', () => {
+      const index = buildIndex([]);
+      expect(index.totalDocs).toBe(0);
+      expect(index.documents).toHaveLength(0);
+    });
+  });
+
+  describe('search', () => {
+    const entries = [
+      { id: 'stripe/api', name: 'api', description: 'Payment processing platform with billing', tags: ['stripe', 'payments', 'billing'] },
+      { id: 'openai/chat', name: 'chat', description: 'Chat completions API for language models', tags: ['openai', 'ai', 'chat'] },
+      { id: 'redis/cache', name: 'cache', description: 'In-memory data store for caching', tags: ['redis', 'cache', 'database'] },
+      { id: 'square/payments', name: 'payments', description: 'Payment processing for commerce', tags: ['square', 'payments', 'commerce'] },
+    ];
+
+    const index = buildIndex(entries);
+
+    it('finds entries by keyword match', () => {
+      const results = search('payment', index);
+      expect(results.length).toBeGreaterThan(0);
+      const ids = results.map((r) => r.id);
+      expect(ids).toContain('stripe/api');
+      expect(ids).toContain('square/payments');
+    });
+
+    it('ranks exact name match higher', () => {
+      const results = search('payments', index);
+      // 'square/payments' has 'payments' as its name — should rank high
+      expect(results[0].id).toBe('square/payments');
+    });
+
+    it('finds by tag', () => {
+      const results = search('database', index);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].id).toBe('redis/cache');
+    });
+
+    it('finds by description terms', () => {
+      const results = search('language models', index);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].id).toBe('openai/chat');
+    });
+
+    it('returns empty for no match', () => {
+      const results = search('nonexistent thing', index);
+      expect(results).toHaveLength(0);
+    });
+
+    it('handles multi-word queries', () => {
+      const results = search('payment processing', index);
+      expect(results.length).toBeGreaterThan(0);
+      // Both stripe and square have 'payment processing' in description
+      const ids = results.map((r) => r.id);
+      expect(ids).toContain('stripe/api');
+      expect(ids).toContain('square/payments');
+    });
+
+    it('respects limit option', () => {
+      const results = search('payment', index, { limit: 1 });
+      expect(results).toHaveLength(1);
+    });
+
+    it('returns empty for stop-words-only query', () => {
+      const results = search('the and is', index);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('search quality report', () => {
+    const entries = [
+      { id: 'stripe/api', name: 'api', description: 'Payment processing platform with billing and subscriptions', tags: ['stripe', 'payments', 'billing'] },
+      { id: 'square/payments', name: 'payments', description: 'Payment processing for commerce and point of sale', tags: ['square', 'payments', 'commerce'] },
+      { id: 'openai/chat', name: 'chat', description: 'Chat completions API for language models and AI assistants', tags: ['openai', 'ai', 'chat', 'llm'] },
+      { id: 'redis/cache', name: 'cache', description: 'In-memory data store for caching and session management', tags: ['redis', 'cache', 'database'] },
+      { id: 'mongodb/driver', name: 'driver', description: 'Document database driver for storing and querying JSON data', tags: ['mongodb', 'database', 'nosql'] },
+      { id: 'auth0/identity', name: 'identity', description: 'Authentication and authorization platform with SSO and MFA', tags: ['auth0', 'auth', 'identity', 'sso'] },
+      { id: 'clerk/auth', name: 'auth', description: 'User authentication with social login and session management', tags: ['clerk', 'auth', 'login'] },
+      { id: 'playwright/testing', name: 'testing', description: 'Browser automation for end-to-end testing of web applications', tags: ['playwright', 'testing', 'browser', 'automation'] },
+      { id: 'sentry/errors', name: 'errors', description: 'Error monitoring and performance tracking for production apps', tags: ['sentry', 'errors', 'monitoring'] },
+      { id: 'twilio/messaging', name: 'messaging', description: 'SMS and messaging API for sending notifications', tags: ['twilio', 'sms', 'messaging'] },
+    ];
+
+    const index = buildIndex(entries);
+
+    const queries = [
+      'payment processing',
+      'database',
+      'authentication login',
+      'browser testing',
+      'error monitoring',
+      'send SMS',
+      'AI language model',
+      'caching',
+      'subscriptions billing',
+      'JSON document store',
+    ];
+
+    it('generates visual search quality report', () => {
+      const lines = ['\n  ┌─────────────────────────────────────────────────────────────────┐'];
+      lines.push('  │                    BM25 SEARCH QUALITY REPORT                  │');
+      lines.push('  └─────────────────────────────────────────────────────────────────┘\n');
+
+      for (const query of queries) {
+        const results = search(query, index);
+        lines.push(`  Query: "${query}"`);
+        if (results.length === 0) {
+          lines.push('    (no results)');
+        } else {
+          for (const r of results.slice(0, 5)) {
+            const bar = '█'.repeat(Math.min(Math.round(r.score * 2), 30));
+            lines.push(`    ${r.score.toFixed(2).padStart(6)}  ${bar}  ${r.id}`);
+          }
+        }
+        lines.push('');
+      }
+
+      // Print to console so it's visible in test output
+      console.log(lines.join('\n'));
+
+      // The test itself just verifies search runs without error
+      expect(true).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces keyword matching search with BM25 ranking for much better search quality
- Search index (`search-index.json`) generated at `chub build` time — no runtime cost
- Falls back to keyword matching when no index is available (backward compatible)
- Multi-source index merging supported
- No new dependencies — BM25 is ~150 lines of pure JS

## Search quality examples
```
"payment processing"   → stripe/api, square/payments
"browser testing"      → playwright/testing
"authentication login" → clerk/auth, auth0/identity
"AI language model"    → openai/chat
"JSON document store"  → mongodb/driver
```

## Test plan
- [x] 19 unit tests for tokenizer, index builder, scorer
- [x] Visual quality report in test output
- [x] All 115 existing tests still pass
- [x] E2E verified: `chub build` → `chub search` with BM25 index