### PR TITLE
Add multi-version support and versioning guide

### DIFF
--- a/cli/src/commands/get.js
+++ b/cli/src/commands/get.js
@@ -36,6 +36,13 @@ async function fetchEntries(ids, opts, globalOpts) {
       error(`Could not resolve path for "${id}" ${opts.lang || ''} ${opts.version || ''}`.trim(), globalOpts);
     }
 
+    if (resolved.versionNotFound) {
+      error(
+        `Version "${resolved.requested}" not found for "${id}". Available versions: ${resolved.available.join(', ')}`,
+        globalOpts
+      );
+    }
+
     if (resolved.needsLanguage) {
       error(
         `Multiple languages available for "${id}": ${resolved.available.join(', ')}. Specify --lang.`,

--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -78,7 +78,7 @@ const program = new Command();
 program
   .name('chub')
   .description('Context Hub - search and retrieve LLM-optimized docs and skills')
-  .version(pkg.version)
+  .version(pkg.version, '-V, --cli-version')
   .option('--json', 'Output as JSON (machine-readable)')
   .action(() => {
     printUsage();

--- a/cli/src/lib/registry.js
+++ b/cli/src/lib/registry.js
@@ -331,6 +331,13 @@ export function resolveDocPath(entry, language, version) {
   let verObj = null;
   if (version) {
     verObj = langObj.versions?.find((v) => v.version === version);
+    if (!verObj) {
+      return {
+        versionNotFound: true,
+        requested: version,
+        available: langObj.versions?.map((v) => v.version) || [],
+      };
+    }
   } else {
     const rec = langObj.recommendedVersion;
     verObj = langObj.versions?.find((v) => v.version === rec) || langObj.versions?.[0];
@@ -348,7 +355,7 @@ export function resolveDocPath(entry, language, version) {
  * Given a resolved path and a type ("doc" or "skill"), return the entry file path.
  */
 export function resolveEntryFile(resolved, type) {
-  if (!resolved || resolved.needsLanguage) return { error: 'unresolved' };
+  if (!resolved || resolved.needsLanguage || resolved.versionNotFound) return { error: 'unresolved' };
 
   const fileName = type === 'skill' ? 'SKILL.md' : 'DOC.md';
 

--- a/cli/test/e2e.test.js
+++ b/cli/test/e2e.test.js
@@ -56,7 +56,7 @@ describe('chub CLI e2e', () => {
 
     it('registry has correct counts', () => {
       const reg = JSON.parse(readFileSync(join(BUILD_OUTPUT, 'registry.json'), 'utf8'));
-      expect(reg.docs.length).toBe(2); // acme/widgets + multilang/client
+      expect(reg.docs.length).toBe(3); // acme/widgets + acme/versioned-api + multilang/client
       expect(reg.skills.length).toBe(1); // testskills/deploy
     });
 
@@ -67,7 +67,7 @@ describe('chub CLI e2e', () => {
 
     it('validates with --validate-only', () => {
       const out = chub(['build', FIXTURES, '--validate-only']);
-      expect(out).toContain('2 docs');
+      expect(out).toContain('3 docs');
       expect(out).toContain('1 skills');
     });
 
@@ -80,7 +80,7 @@ describe('chub CLI e2e', () => {
   describe('search', () => {
     it('lists all entries', () => {
       const data = chubJSON(['search']);
-      expect(data.total).toBe(3); // 2 docs + 1 skill
+      expect(data.total).toBe(4); // 3 docs + 1 skill
     });
 
     it('fuzzy search finds by name', () => {
@@ -198,6 +198,37 @@ describe('chub CLI e2e', () => {
     it('--json omits additionalFiles when none exist', () => {
       const data = chubJSON(['get', 'multilang/client', '--lang', 'js']);
       expect(data.additionalFiles).toBeUndefined();
+    });
+
+    // Multi-version tests
+    it('build groups multi-version docs correctly', () => {
+      const reg = JSON.parse(readFileSync(join(BUILD_OUTPUT, 'registry.json'), 'utf8'));
+      const doc = reg.docs.find((d) => d.id === 'acme/versioned-api');
+      expect(doc).toBeDefined();
+      const jsLang = doc.languages.find((l) => l.language === 'javascript');
+      expect(jsLang.versions.length).toBe(2);
+      expect(jsLang.versions.map((v) => v.version)).toContain('2.0.0');
+      expect(jsLang.versions.map((v) => v.version)).toContain('1.0.0');
+      expect(jsLang.recommendedVersion).toBe('2.0.0');
+    });
+
+    it('fetches recommended (latest) version by default', () => {
+      const out = chub(['get', 'acme/versioned-api']);
+      expect(out).toContain('Versioned API v2');
+      expect(out).toContain('version 2.0.0');
+    });
+
+    it('fetches specific version with --version', () => {
+      const out = chub(['get', 'acme/versioned-api', '--version', '1.0.0']);
+      expect(out).toContain('Versioned API v1');
+      expect(out).toContain('version 1.0.0');
+    });
+
+    it('errors on nonexistent version with available list', () => {
+      const out = chub(['get', 'acme/versioned-api', '--version', '99.0.0'], { expectError: true });
+      expect(out).toContain('Version "99.0.0" not found');
+      expect(out).toContain('2.0.0');
+      expect(out).toContain('1.0.0');
     });
   });
 

--- a/cli/test/fixtures/acme/docs/versioned-api/v1/DOC.md
+++ b/cli/test/fixtures/acme/docs/versioned-api/v1/DOC.md
@@ -1,0 +1,20 @@
+---
+name: versioned-api
+description: "A test API with multiple versions"
+metadata:
+  languages: "javascript"
+  versions: "1.0.0"
+  revision: 1
+  updated-on: "2025-01-01"
+  source: community
+  tags: "test,versioned"
+---
+# Versioned API v1
+
+This is version 1.0.0 of the API documentation.
+
+## Usage
+
+```javascript
+const client = new AcmeClient({ version: 'v1' });
+```

--- a/cli/test/fixtures/acme/docs/versioned-api/v2/DOC.md
+++ b/cli/test/fixtures/acme/docs/versioned-api/v2/DOC.md
@@ -1,0 +1,20 @@
+---
+name: versioned-api
+description: "A test API with multiple versions"
+metadata:
+  languages: "javascript"
+  versions: "2.0.0"
+  revision: 1
+  updated-on: "2025-06-01"
+  source: community
+  tags: "test,versioned"
+---
+# Versioned API v2
+
+This is version 2.0.0 of the API documentation.
+
+## Usage
+
+```javascript
+const client = new AcmeClient({ version: 'v2' });
+```

--- a/cli/tests/commands/build.test.js
+++ b/cli/tests/commands/build.test.js
@@ -29,8 +29,8 @@ describe('chub build', () => {
     );
 
     const parsed = JSON.parse(result.trim());
-    // test/fixtures has 2 docs (acme/widgets, multilang/client) and 1 skill (testskills/deploy)
-    expect(parsed.docs).toBe(2);
+    // test/fixtures has 3 docs (acme/widgets, acme/versioned-api, multilang/client) and 1 skill (testskills/deploy)
+    expect(parsed.docs).toBe(3);
     expect(parsed.skills).toBe(1);
   });
 

--- a/content/stripe/docs/api/DOC.md
+++ b/content/stripe/docs/api/DOC.md
@@ -4,6 +4,7 @@ description: "Payment processing platform with comprehensive payment and billing
 metadata:
   languages: "javascript"
   versions: "19.1.0"
+  revision: 1
   updated-on: "2025-10-28"
   source: maintainer
   tags: "stripe,api,payments,billing"

--- a/docs/content-guide.md
+++ b/docs/content-guide.md
@@ -19,6 +19,11 @@ my-content/
           DOC.md                  # multi-language: JS variant
         python/
           DOC.md                  # multi-language: Python variant
+      api/
+        v1/
+          DOC.md                  # multi-version: v1
+        v2/
+          DOC.md                  # multi-version: v2
     skills/
       deploy/
         SKILL.md                  # a skill
@@ -40,6 +45,45 @@ Create a subdirectory per language:
 author/docs/entry-name/javascript/DOC.md
 author/docs/entry-name/python/DOC.md
 ```
+
+### Multi-version docs
+
+When an API has breaking changes across major versions, create a subdirectory per version:
+
+```
+author/docs/entry-name/
+  v1/
+    DOC.md                  # versions: "1.0.0"
+  v2/
+    DOC.md                  # versions: "2.0.0"
+```
+
+Both DOC.md files must share the same `name` in frontmatter. The build groups them into a single registry entry with multiple versions. The highest version becomes the `recommendedVersion` — what agents get by default.
+
+You can combine multi-version with multi-language:
+
+```
+author/docs/entry-name/
+  v1/
+    javascript/
+      DOC.md
+    python/
+      DOC.md
+  v2/
+    javascript/
+      DOC.md
+    python/
+      DOC.md
+```
+
+Agents request a specific version with `--version`:
+
+```bash
+chub get author/entry-name                    # latest version (recommended)
+chub get author/entry-name --version 1.0.0    # specific version
+```
+
+If a requested version doesn't exist, the CLI lists available versions.
 
 ### Skills
 
@@ -76,6 +120,7 @@ description: "Acme widget API for creating and managing widgets"
 metadata:
   languages: "javascript"
   versions: "2.0.0"
+  revision: 1
   updated-on: "2026-01-01"
   source: maintainer
   tags: "acme,widgets,api"
@@ -87,8 +132,9 @@ metadata:
 | `name` | Yes | Entry name (used in the ID: `author/name`) |
 | `description` | Yes | Short description for search results |
 | `metadata.languages` | Yes | Language of this doc variant |
-| `metadata.versions` | Yes | Version(s) covered |
-| `metadata.updated-on` | Yes | Last update date |
+| `metadata.versions` | Yes | Package/SDK version this doc covers (the version on npm or pypi) |
+| `metadata.revision` | Yes | Content revision number (monotonically increasing, starts at 1) |
+| `metadata.updated-on` | Yes | Date this content was last revised |
 | `metadata.source` | Yes | Trust level: `official`, `maintainer`, or `community` |
 | `metadata.tags` | No | Comma-separated tags for filtering |
 
@@ -99,6 +145,7 @@ metadata:
 name: deploy
 description: "Deployment automation skill for CI/CD pipelines"
 metadata:
+  revision: 1
   updated-on: "2026-01-01"
   source: community
   tags: "deploy,ci,automation"
@@ -106,6 +153,35 @@ metadata:
 ```
 
 Skills have the same fields as docs except `languages` and `versions` are not required (skills are language-agnostic).
+
+## Versioning Guide
+
+### Package version vs API version
+
+The `versions` field always refers to the **package/SDK version** — the version number on npm or pypi. This is what agents can detect from `package.json` or `requirements.txt`.
+
+If a library has a separate API versioning scheme (like Stripe's dated API versions `2024-12-18.acacia`), document that within the content body. The frontmatter `versions` stays as the package version.
+
+### API-level versioning
+
+When an API has fundamentally different versions (different endpoints, different auth, different request/response shapes), use the entry **name** to distinguish them:
+
+```
+stripe/docs/payments-api-v1/DOC.md    # name: payments-api-v1
+stripe/docs/payments-api-v2/DOC.md    # name: payments-api-v2
+```
+
+These become separate entries in the registry (`stripe/payments-api-v1` and `stripe/payments-api-v2`), each with their own package version tracking.
+
+### Updating content
+
+When you improve content for the same package version (fix examples, add details, clarify wording):
+
+1. Bump `revision` (e.g., 1 → 2)
+2. Update `updated-on` to today's date
+3. Keep `versions` the same
+
+Together, `revision` and `updated-on` give agents a clear signal of content freshness.
 
 ## Writing Content
 


### PR DESCRIPTION
## Summary
- Version error handling: `chub get stripe/api --version 99.0.0` now shows available versions instead of generic error
- Multi-version test fixtures and 4 new e2e tests (build grouping, default version, specific version, version-not-found)
- Content guide: versioning guide section (package version semantics, API versioning by name, revision field, content update workflow)
- Added `revision: 1` to stripe/api DOC.md to trigger content deploy workflow
- Fixed `--version` flag conflict between Commander program-level and get subcommand

## Test plan
- [ ] All 120 tests pass (`npx vitest run` from `cli/`)
- [ ] `chub get acme/versioned-api` returns v2 (latest)
- [ ] `chub get acme/versioned-api --version 1.0.0` returns v1
- [ ] `chub get acme/versioned-api --version 99.0.0` lists available versions
- [ ] Content deploy workflow triggers on merge (content/ changed)