### PR TITLE
Fix frontmatter names to short identifiers

### DIFF
--- a/content/landingai-ade/docs/api/DOC.md
+++ b/content/landingai-ade/docs/api/DOC.md
@@ -1,5 +1,5 @@
 ---
-name: landingai-ade-api
+name: api
 description: "REST API specification for LandingAI's Agentic Document Extraction (ADE). Covers all endpoints (Parse, Extract, Split, Parse Jobs), request parameters, response structures, data types, error codes, model versions, and curl examples."
 metadata:
   languages: "http"

--- a/content/landingai-ade/docs/sdk/python/DOC.md
+++ b/content/landingai-ade/docs/sdk/python/DOC.md
@@ -1,5 +1,5 @@
 ---
-name: landingai-ade-sdk
+name: sdk
 description: "Python SDK reference for LandingAI's Agentic Document Extraction (ADE). Includes Pydantic schema extraction, async processing, error handling, save_to, visual grounding, table cell lookup, and complete API context."
 metadata:
   languages: "python"

--- a/content/landingai-ade/docs/sdk/typescript/DOC.md
+++ b/content/landingai-ade/docs/sdk/typescript/DOC.md
@@ -1,5 +1,5 @@
 ---
-name: landingai-ade-sdk
+name: sdk
 description: "TypeScript/JavaScript SDK reference for LandingAI's Agentic Document Extraction (ADE). Includes type definitions, Zod schema validation, async processing, error handling, type guards, and complete API context."
 metadata:
   languages: "typescript"

--- a/content/landingai-ade/skills/SKILL.md
+++ b/content/landingai-ade/skills/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: landing-ade
+name: skill
 description: Use when the user mentions document parsing, PDF extraction, OCR, markdown extraction, structured data extraction from documents, document classification/splitting, LandingAI, ADE API, or wants to pull data out of a PDF/image/spreadsheet
 metadata:
   updated-on: "2026-03-04"


### PR DESCRIPTION
## Summary
- Renamed frontmatter `name` fields to short identifiers (`sdk`, `api`, `skill`) to match context-hub conventions

## Files changed
- `content/landingai-ade/docs/sdk/python/DOC.md`
- `content/landingai-ade/docs/sdk/typescript/DOC.md`
- `content/landingai-ade/docs/api/DOC.md`
- `content/landingai-ade/skills/SKILL.md`