### PR TITLE
Add Blackmagic DeckLink SDK community docs

### DIFF
--- a/content/CrinkleCutz/docs/decklink-sdk/DOC.md
+++ b/content/CrinkleCutz/docs/decklink-sdk/DOC.md
@@ -1,0 +1,490 @@
+---
+name: decklink-sdk
+description: >
+  Blackmagic DeckLink SDK integration guide for macOS video capture.
+  Covers device discovery, frame callbacks, UYVY buffer access, COM lifecycle,
+  signal detection, and Objective-C++ bridging patterns. Derived from 5 versions
+  of production capture software (V4-V8, 3 code reviews, ~200K LOC).
+metadata:
+  languages: "cpp"
+  versions: "15.3.0"
+  updated-on: "2026-03-06"
+  source: "community"
+  tags: "blackmagic,decklink,video,capture,sdi,hdmi,broadcast,uyvy"
+---
+
+# Blackmagic DeckLink SDK — macOS Video Capture Guide
+
+## 1. What This Covers
+
+This guide covers the **DeckLink SDK 15.3** on **macOS** using **C++17** (with
+Objective-C++ where macOS APIs require it). The focus is the **video capture
+path** — discovering devices, enabling input, receiving frames via callback, and
+accessing pixel data.
+
+The SDK ships as a macOS framework (`DeckLinkAPI.framework`) plus C++ headers.
+On macOS, the SDK uses a COM-like reference counting model (AddRef/Release) but
+does NOT use Microsoft COM — there is no CoInitialize, no registry, no
+apartments. The iterator and interface pattern is COM-inspired but runs as plain
+C++ with `QueryInterface` for interface discovery.
+
+**SDK location**: After installing Desktop Video, the framework lives at
+`/Library/Frameworks/DeckLinkAPI.framework`. The SDK download provides headers
+and the critical `DeckLinkAPIDispatch.cpp` file separately.
+
+## 2. Device Discovery
+
+Every DeckLink session starts with `CreateDeckLinkIteratorInstance()`. This is
+the only global factory function — everything else comes from `QueryInterface`.
+
+```cpp
+#include "DeckLinkAPI.h"
+
+IDeckLinkIterator* iterator = CreateDeckLinkIteratorInstance();
+if (!iterator) {
+    // DeckLink drivers not installed or framework not linked
+    fprintf(stderr, "DeckLink drivers not installed\n");
+    return false;
+}
+
+IDeckLink* device = nullptr;
+int index = 0;
+while (iterator->Next(&device) == S_OK) {
+    // Get device name (macOS returns CFStringRef)
+    CFStringRef name_cf = nullptr;
+    if (device->GetDisplayName(&name_cf) == S_OK && name_cf) {
+        char name_buf[256];
+        CFStringGetCString(name_cf, name_buf, sizeof(name_buf),
+                           kCFStringEncodingUTF8);
+        printf("Device %d: %s\n", index, name_buf);
+        CFRelease(name_cf);
+    }
+
+    device->Release();
+    index++;
+}
+iterator->Release();
+```
+
+- Returns `nullptr` if Desktop Video drivers are not installed
+- Each `IDeckLink` = one sub-device (a physical card may expose multiple)
+- On macOS, `GetDisplayName` returns `CFStringRef` — must `CFRelease`
+- Always `Release()` every COM object when done
+
+### Filtering Output-Only Sub-Devices
+
+Many cards expose output-only sub-devices. Filter with `BMDDeckLinkVideoIOSupport`:
+
+```cpp
+IDeckLinkProfileAttributes* attributes = nullptr;
+if (device->QueryInterface(IID_IDeckLinkProfileAttributes,
+                           (void**)&attributes) == S_OK && attributes) {
+    int64_t io_support = 0;
+    if (attributes->GetInt(BMDDeckLinkVideoIOSupport, &io_support) == S_OK) {
+        bool supports_capture = (io_support & bmdDeviceSupportsCapture) != 0;
+        if (!supports_capture) {
+            printf("Skipping output-only device: %s\n", name_buf);
+            attributes->Release();
+            device->Release();
+            continue;
+        }
+    }
+
+    // Also useful: query bus type
+    int64_t bus_type = 0;
+    if (attributes->GetInt(BMDDeckLinkDeviceInterface, &bus_type) == S_OK) {
+        // bmdDeviceInterfaceThunderbolt, bmdDeviceInterfaceUSB,
+        // bmdDeviceInterfacePCI
+    }
+
+    attributes->Release();
+}
+```
+
+## 3. Enabling Video Input
+
+Get `IDeckLinkInput` via QueryInterface, then enable a specific video mode:
+
+```cpp
+IDeckLinkInput* input = nullptr;
+device->QueryInterface(IID_IDeckLinkInput, (void**)&input);
+
+input->EnableVideoInput(bmdModeHD1080p30, bmdFormat8BitYUV,
+                        bmdVideoInputFlagDefault);
+```
+
+### Auto-Detection Pattern
+
+There is no "give me whatever signal is present" call. `EnableVideoInput`
+succeeds only when the hardware can lock to the specified mode AND a compatible
+signal is present. Cycle through common modes until one succeeds:
+
+```cpp
+BMDDisplayMode modes_to_try[] = {
+    bmdModeHD1080p30, bmdModeHD1080p2997, bmdModeHD1080p25,
+    bmdModeHD1080p24, bmdModeHD1080p2398, bmdModeHD1080i5994,
+    bmdModeHD1080i50, bmdModeHD720p5994, bmdModeHD720p50,
+    bmdModeNTSC, bmdModePAL
+};
+
+for (auto mode : modes_to_try) {
+    if (input->EnableVideoInput(mode, bmdFormat8BitYUV,
+                                bmdVideoInputFlagDefault) == S_OK) {
+        printf("Detected: %s\n", modeToString(mode));
+        return true;
+    }
+}
+// No signal detected on any mode
+```
+
+**Warning**: Do NOT use `bmdVideoInputEnableFormatDetection` for initial mode
+discovery — it requires streams to already be running and changes the mode
+asynchronously via `VideoInputFormatChanged`. The cycling approach above is
+synchronous and reliable for startup.
+
+## 4. Frame Callback
+
+Implement `IDeckLinkInputCallback` to receive frames. You must implement three
+interfaces: `QueryInterface` (return `E_NOINTERFACE`), `AddRef`/`Release`
+(atomic ref counting), `VideoInputFormatChanged` (can return `S_OK`), and
+`VideoInputFrameArrived` (your frame processing logic). See the complete
+example in section 11 for the full class.
+
+### Buffer Access (SDK 15.3+)
+
+SDK 15.3 changed frame pixel data access. The correct pattern uses
+`IDeckLinkVideoBuffer` (not direct `GetBytes()` on the frame):
+
+```cpp
+HRESULT VideoInputFrameArrived(
+    IDeckLinkVideoInputFrame* videoFrame,
+    IDeckLinkAudioInputPacket* /*audioPacket*/) {
+
+    if (!videoFrame) return S_OK;
+
+    // Query for IDeckLinkVideoBuffer (SDK 15.3+ pattern)
+    void* bytes = nullptr;
+    IDeckLinkVideoBuffer* videoBuffer = nullptr;
+    HRESULT hr = videoFrame->QueryInterface(IID_IDeckLinkVideoBuffer,
+                                            (void**)&videoBuffer);
+    if (hr != S_OK || !videoBuffer) {
+        fprintf(stderr, "QueryInterface for IDeckLinkVideoBuffer failed\n");
+        return S_OK;
+    }
+
+    // Must call StartAccess before GetBytes
+    hr = videoBuffer->StartAccess(bmdBufferAccessRead);
+    if (hr != S_OK) {
+        videoBuffer->Release();
+        return S_OK;
+    }
+
+    hr = videoBuffer->GetBytes(&bytes);
+    if (hr != S_OK || !bytes) {
+        videoBuffer->EndAccess(bmdBufferAccessRead);
+        videoBuffer->Release();
+        return S_OK;
+    }
+
+    // Now safe to read pixel data
+    int width = videoFrame->GetWidth();
+    int height = videoFrame->GetHeight();
+    int rowBytes = videoFrame->GetRowBytes();
+    const uint8_t* pixels = static_cast<const uint8_t*>(bytes);
+
+    // Process the frame...
+    processFrame(pixels, width, height, rowBytes);
+
+    // MUST end access and release in this order
+    videoBuffer->EndAccess(bmdBufferAccessRead);
+    videoBuffer->Release();
+    return S_OK;
+}
+```
+
+**Critical**: Always call `EndAccess` before `Release`. Always check every
+HRESULT. The buffer pointer is only valid between `StartAccess` and `EndAccess`.
+
+## 5. COM Reference Counting
+
+Every SDK object starts with ref count 1. `QueryInterface` increments it.
+`Release` decrements — at 0, the object deletes itself. Use `std::atomic<int32_t>`
+for your own callback ref counts (see section 11 example).
+
+### Cleanup Order — Critical
+
+Release in this exact order or you get crashes/hangs:
+
+1. `StopStreams()` — stop capture pipeline
+2. `DisableVideoInput()` — release hardware mode lock
+3. **`SetCallback(nullptr)`** — disconnect callback BEFORE releasing
+4. `input->Release()` — release IDeckLinkInput
+5. `device->Release()` — release IDeckLink
+
+Skipping step 3 causes use-after-free — the SDK may fire callbacks during
+`Release()`.
+
+## 6. Starting and Stopping Streams
+
+```cpp
+input->SetCallback(callback);
+input->StartStreams();    // Frames now arrive via callback
+// ...
+input->StopStreams();     // Teardown per section 5
+input->DisableVideoInput();
+input->SetCallback(nullptr);
+```
+
+**Pause/Resume**: Call `StopStreams()`/`StartStreams()` without re-enabling video
+input — the mode lock persists.
+
+## 7. Display Mode Enumeration
+
+Discover supported modes for UI dropdowns or capability reporting:
+
+```cpp
+IDeckLinkDisplayModeIterator* mode_iter = nullptr;
+if (input->GetDisplayModeIterator(&mode_iter) == S_OK && mode_iter) {
+    IDeckLinkDisplayMode* mode = nullptr;
+    while (mode_iter->Next(&mode) == S_OK) {
+        long w = mode->GetWidth();
+        long h = mode->GetHeight();
+        bool progressive = (mode->GetFieldDominance() == bmdProgressiveFrame);
+
+        BMDTimeValue duration = 0;
+        BMDTimeScale scale = 0;
+        mode->GetFrameRate(&duration, &scale);
+        double fps = (duration > 0)
+            ? static_cast<double>(scale) / duration : 0.0;
+
+        printf("%ldx%ld%s%.1f\n", w, h, progressive ? "p" : "i", fps);
+        mode->Release();
+    }
+    mode_iter->Release();
+}
+```
+
+## 8. UYVY Pixel Format Basics
+
+The standard DeckLink capture format is `bmdFormat8BitYUV` (UYVY 4:2:2). Memory
+layout for each pixel pair (4 bytes):
+
+```
+Byte 0: U  (Cb, shared by pixel 0 and pixel 1)
+Byte 1: Y0 (luma of pixel 0)
+Byte 2: V  (Cr, shared by pixel 0 and pixel 1)
+Byte 3: Y1 (luma of pixel 1)
+```
+
+- **2 bytes per pixel** (but pixels are always processed in pairs)
+- **Row stride** (`GetRowBytes()`) may include padding — always use it, never
+  assume `width * 2`
+- **Luma range**: Y is 16–235 (limited range) for broadcast; 0–255 if full range
+- **Chroma range**: U/V centered at 128
+
+To extract the luma (brightness) of a single pixel at position `(x, y)`:
+
+```cpp
+const uint8_t* row = buffer + y * rowBytes;
+int byte_idx = x * 2;  // 2 bytes per pixel in UYVY
+uint8_t luma = row[byte_idx + 1];  // Y is at odd byte positions
+// For even x: Y0 is at byte_idx+1
+// For odd x:  Y1 is at byte_idx+1 (which is byte_idx-1+3 of the pair)
+```
+
+For color math (UYVY to RGB conversion, ROI luma extraction), see the
+[UYVY Color Math](references/uyvy-color-math.md) reference.
+
+## 9. Common Pitfalls
+
+- **SetCallback(nullptr) before Release** — The SDK may fire callbacks during
+  `Release()`. Always `SetCallback(nullptr)` first (see section 5).
+
+- **NSRunLoop pumping vs sleep()** — `std::this_thread::sleep_for()` blocks the
+  run loop, preventing SDK callbacks from firing. Use NSRunLoop pumping:
+  ```cpp
+  // Wrong: std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  // Correct:
+  @autoreleasepool {
+      [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
+          beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.2]];
+  }
+  ```
+
+- **Output-only sub-devices** — `QueryInterface` for `IDeckLinkInput` succeeds
+  on output-only devices, but `EnableVideoInput` fails. Filter first (section 2).
+
+- **Missing DeckLinkAPIDispatch.cpp** — Headers alone aren't enough. Compile and
+  link this file or you get undefined symbols. See
+  [Build Configuration](references/build-configuration.md).
+
+- **GetDisplayName returns CFStringRef on macOS** — Not `const char*`. Convert
+  with `CFStringGetCString`, then `CFRelease`. Forgetting `CFRelease` leaks.
+
+## 10. Build Setup
+
+Minimum Makefile for a DeckLink capture project:
+
+```makefile
+CXX = clang++
+CXXFLAGS = -std=c++17 -O2 -Wall -Wextra
+OBJCFLAGS = -fobjc-arc
+
+# Set via: make DECKLINK_INC=/path/to/DeckLinkSDK/Mac/include
+DECKLINK_INC ?=
+
+FRAMEWORKS = -framework Foundation -framework CoreFoundation \
+             -F/Library/Frameworks -framework DeckLinkAPI
+
+SOURCES = main.mm
+DISPATCH_OBJ = build/DeckLinkAPIDispatch.o
+
+all: check-sdk build/capture
+
+check-sdk:
+ifeq ($(DECKLINK_INC),)
+	$(error Set DECKLINK_INC to DeckLink SDK include directory)
+endif
+
+build/DeckLinkAPIDispatch.o:
+	@mkdir -p build
+	$(CXX) $(CXXFLAGS) -I"$(DECKLINK_INC)" \
+	    -c "$(DECKLINK_INC)/DeckLinkAPIDispatch.cpp" -o $@
+
+build/capture: $(SOURCES) $(DISPATCH_OBJ)
+	$(CXX) $(CXXFLAGS) $(OBJCFLAGS) -I"$(DECKLINK_INC)" \
+	    -o $@ $^ $(FRAMEWORKS)
+
+clean:
+	rm -rf build
+```
+
+For multi-file builds, test targets, and conditional DeckLink inclusion, see
+[Build Configuration](references/build-configuration.md).
+
+## 11. Minimal Complete Example
+
+Working program — discovers device, captures 100 frames, prints average luma:
+
+```cpp
+// capture_example.mm — Build with Makefile from section 10
+#include "DeckLinkAPI.h"
+#import <Foundation/Foundation.h>
+#include <atomic>
+#include <cstdio>
+#include <cstdint>
+
+class FrameCounter : public IDeckLinkInputCallback {
+    std::atomic<int32_t> ref_count_{1};
+    std::atomic<int> frames_{0};
+    int target_;
+public:
+    FrameCounter(int n) : target_(n) {}
+    int count() const { return frames_.load(); }
+    bool done() const { return frames_.load() >= target_; }
+
+    HRESULT QueryInterface(REFIID, void**) override { return E_NOINTERFACE; }
+    ULONG AddRef() override { return ++ref_count_; }
+    ULONG Release() override {
+        auto c = --ref_count_; if (c == 0) delete this; return c;
+    }
+    HRESULT VideoInputFormatChanged(BMDVideoInputFormatChangedEvents,
+        IDeckLinkDisplayMode*, BMDDetectedVideoInputFormatFlags) override {
+        return S_OK;
+    }
+    HRESULT VideoInputFrameArrived(
+        IDeckLinkVideoInputFrame* vf, IDeckLinkAudioInputPacket*) override {
+        if (!vf) return S_OK;
+
+        IDeckLinkVideoBuffer* buf = nullptr;
+        if (vf->QueryInterface(IID_IDeckLinkVideoBuffer,
+                               (void**)&buf) != S_OK) return S_OK;
+        buf->StartAccess(bmdBufferAccessRead);
+        void* bytes = nullptr;
+        buf->GetBytes(&bytes);
+        if (bytes) {
+            auto* px = static_cast<const uint8_t*>(bytes);
+            int w = vf->GetWidth(), h = vf->GetHeight(), rb = vf->GetRowBytes();
+            uint64_t sum = 0;
+            for (int y = 0; y < h; y++) {
+                const uint8_t* row = px + y * rb;
+                for (int x = 0; x < w; x++) sum += row[x * 2 + 1]; // Y byte
+            }
+            printf("Frame %d: %dx%d luma=%.1f\n", frames_.load(), w, h,
+                   (double)sum / (w * h));
+        }
+        buf->EndAccess(bmdBufferAccessRead);
+        buf->Release();
+        frames_++;
+        return S_OK;
+    }
+};
+
+int main() {
+    @autoreleasepool {
+        // 1. Find first capture-capable device (sections 2-3)
+        IDeckLinkIterator* iter = CreateDeckLinkIteratorInstance();
+        if (!iter) { fprintf(stderr, "No DeckLink drivers\n"); return 1; }
+
+        IDeckLink* dev = nullptr;
+        IDeckLinkInput* input = nullptr;
+        while (iter->Next(&dev) == S_OK) {
+            IDeckLinkProfileAttributes* a = nullptr;
+            if (dev->QueryInterface(IID_IDeckLinkProfileAttributes,
+                                    (void**)&a) == S_OK) {
+                int64_t io = 0; a->GetInt(BMDDeckLinkVideoIOSupport, &io);
+                a->Release();
+                if (io & bmdDeviceSupportsCapture) {
+                    dev->QueryInterface(IID_IDeckLinkInput, (void**)&input);
+                    break;
+                }
+            }
+            dev->Release(); dev = nullptr;
+        }
+        iter->Release();
+        if (!input) { fprintf(stderr, "No capture device\n"); return 1; }
+
+        // 2. Auto-detect signal (section 3)
+        BMDDisplayMode modes[] = { bmdModeHD1080p30, bmdModeHD1080p2997,
+            bmdModeHD1080p25, bmdModeHD1080i5994, bmdModeHD720p5994 };
+        bool ok = false;
+        for (auto m : modes)
+            if (input->EnableVideoInput(m, bmdFormat8BitYUV,
+                                        bmdVideoInputFlagDefault) == S_OK)
+                { ok = true; break; }
+        if (!ok) { fprintf(stderr, "No signal\n"); return 1; }
+
+        // 3. Capture (section 6) — pump NSRunLoop (section 9)
+        auto* cb = new FrameCounter(100);
+        input->SetCallback(cb);
+        input->StartStreams();
+        while (!cb->done()) {
+            @autoreleasepool {
+                [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
+                    beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
+            }
+        }
+
+        // 4. Clean teardown (section 5)
+        input->StopStreams();
+        input->DisableVideoInput();
+        input->SetCallback(nullptr);
+        input->Release(); dev->Release(); cb->Release();
+        printf("Done: %d frames\n", cb->count());
+    }
+    return 0;
+}
+```
+
+## 12. References
+
+- [Objective-C++ Bridging Patterns](references/objcpp-bridging.md) — CGFloat
+  vs double, dispatch_async copy semantics, alive_ lifecycle pattern
+- [UYVY Color Math](references/uyvy-color-math.md) — Byte-level UYVY layout,
+  ROI luma extraction, BT.709 RGB conversion
+- [Signal Detection](references/signal-detection.md) — Mode cycling probe,
+  NSRunLoop pumping, VideoInputFormatChanged
+- [Thread Safety](references/thread-safety.md) — Callback thread contract,
+  mutex lock ordering, snapshot pattern, lifecycle guards
+- [Build Configuration](references/build-configuration.md) — Complete Makefile,
+  SDK paths, framework linking, conditional compilation

--- a/content/CrinkleCutz/docs/decklink-sdk/references/build-configuration.md
+++ b/content/CrinkleCutz/docs/decklink-sdk/references/build-configuration.md
@@ -1,0 +1,163 @@
+# Build Configuration
+
+## SDK Components
+
+The DeckLink SDK requires three things at build time:
+
+1. **Headers** (`DeckLinkAPI.h` and friends) — provided in the SDK download
+2. **DeckLinkAPIDispatch.cpp** — provided alongside the headers, must be
+   compiled and linked
+3. **DeckLinkAPI.framework** — installed at `/Library/Frameworks/` by the
+   Desktop Video installer
+
+`DeckLinkAPIDispatch.cpp` contains the implementation of
+`CreateDeckLinkIteratorInstance()` and other factory functions. Without it, you
+get undefined symbols at link time. This is the most common build mistake.
+
+## Complete Makefile Template
+
+```makefile
+PROJECT = my_capture_app
+CXX = clang++
+CXXFLAGS = -std=c++17 -O2 -Wall -Wextra
+OBJCFLAGS = -fobjc-arc
+
+# DeckLink SDK include path — set via command line:
+#   make DECKLINK_INC=/path/to/DeckLinkSDK/Mac/include
+# The directory must contain DeckLinkAPI.h and DeckLinkAPIDispatch.cpp
+DECKLINK_INC ?=
+
+# DeckLink framework (installed by Desktop Video)
+DECKLINK_FLAGS = -F/Library/Frameworks -framework DeckLinkAPI
+
+# macOS frameworks needed for capture apps
+FRAMEWORKS = -framework Foundation -framework CoreFoundation \
+             -framework AppKit -framework AVFoundation \
+             -framework CoreMedia -framework CoreVideo
+
+# Source files
+CPP_SOURCES = src/luma_math.cpp src/config.cpp
+MM_SOURCES = src/main.mm src/capture_callback.mm src/decklink_capture.mm
+
+# Object files
+BUILD_DIR = build
+CPP_OBJECTS = $(CPP_SOURCES:src/%.cpp=$(BUILD_DIR)/%.o)
+MM_OBJECTS = $(MM_SOURCES:src/%.mm=$(BUILD_DIR)/%.o)
+DISPATCH_OBJ = $(BUILD_DIR)/DeckLinkAPIDispatch.o
+ALL_OBJECTS = $(CPP_OBJECTS) $(MM_OBJECTS) $(DISPATCH_OBJ)
+
+all: check-sdk dirs bin/$(PROJECT)
+
+# Validate SDK path is set
+check-sdk:
+ifeq ($(DECKLINK_INC),)
+	$(error DECKLINK_INC not set. Example: make DECKLINK_INC=/path/to/SDK/include)
+endif
+
+dirs:
+	@mkdir -p $(BUILD_DIR) bin
+
+# Link
+bin/$(PROJECT): $(ALL_OBJECTS)
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(DECKLINK_FLAGS) $(FRAMEWORKS)
+
+# Compile DeckLinkAPIDispatch.cpp from SDK
+$(DISPATCH_OBJ):
+	$(CXX) $(CXXFLAGS) -I"$(DECKLINK_INC)" \
+	    -c "$(DECKLINK_INC)/DeckLinkAPIDispatch.cpp" -o $@
+
+# Compile C++ sources (pure C++, no ObjC)
+$(BUILD_DIR)/%.o: src/%.cpp
+	$(CXX) $(CXXFLAGS) -I"$(DECKLINK_INC)" -c $< -o $@
+
+# Compile Objective-C++ sources
+$(BUILD_DIR)/%.o: src/%.mm
+	$(CXX) $(CXXFLAGS) $(OBJCFLAGS) -I"$(DECKLINK_INC)" -c $< -o $@
+
+clean:
+	rm -rf $(BUILD_DIR) bin
+
+# Test target — pure C++ tests, no DeckLink SDK needed
+TEST_SOURCES = tests/test_math.cpp src/luma_math.cpp
+test: dirs bin/test_math
+	./bin/test_math
+
+bin/test_math: $(TEST_SOURCES)
+	$(CXX) $(CXXFLAGS) -Isrc -Itests -o $@ $^
+
+.PHONY: all clean test dirs check-sdk
+```
+
+Build with:
+```bash
+make DECKLINK_INC=/Users/you/Developer/Blackmagic/DeckLinkSDK-15.3/Mac/include
+```
+
+## Conditional DeckLink Inclusion
+
+If your app supports both DeckLink hardware and other capture sources (e.g.,
+USB webcams via AVFoundation), use `__has_include` to make DeckLink optional:
+
+```cpp
+#if __has_include("DeckLinkAPI.h")
+#include "DeckLinkAPI.h"
+#define HAS_DECKLINK 1
+#else
+#define HAS_DECKLINK 0
+#endif
+
+std::vector<DeviceInfo> scanDevices() {
+    std::vector<DeviceInfo> devices;
+
+#if HAS_DECKLINK
+    IDeckLinkIterator* iter = CreateDeckLinkIteratorInstance();
+    if (iter) {
+        // Enumerate DeckLink devices...
+        iter->Release();
+    }
+#endif
+
+    // Enumerate webcam devices (always available)...
+    return devices;
+}
+```
+
+This lets test binaries compile without the DeckLink SDK path. Pure C++ math
+and config tests don't need the SDK at all.
+
+## Framework Linking
+
+The DeckLink framework installs to `/Library/Frameworks/`. Link with:
+
+```
+-F/Library/Frameworks -framework DeckLinkAPI
+```
+
+If the framework is not installed (user hasn't installed Desktop Video),
+`CreateDeckLinkIteratorInstance()` returns `nullptr` at runtime — it doesn't
+crash. This is the designed graceful degradation path.
+
+## SDK Header Warnings
+
+The DeckLink SDK headers generate warnings under strict compiler settings
+(`-Wall -Wextra`). These are in Blackmagic's code, not yours. Common warnings:
+
+- Unused parameters in interface default implementations
+- Implicit conversions in COM GUID definitions
+- Missing override specifiers
+
+These are expected and harmless. Do not suppress them project-wide — instead,
+let them pass. They only appear in SDK headers, not your code.
+
+## Incremental Build Pitfall
+
+After significant changes to `.mm` files (especially header changes that affect
+class layout), always do a clean build:
+
+```bash
+make clean && make DECKLINK_INC=/path/to/SDK/include
+```
+
+Incremental builds can produce stale object files that link successfully but
+crash at runtime with SIGTRAP (assertion failure). This manifests as crashes
+that disappear under the debugger (because lldb changes memory layout/timing).

--- a/content/CrinkleCutz/docs/decklink-sdk/references/objcpp-bridging.md
+++ b/content/CrinkleCutz/docs/decklink-sdk/references/objcpp-bridging.md
@@ -1,0 +1,186 @@
+# Objective-C++ Bridging Patterns for DeckLink
+
+When integrating the DeckLink SDK into a macOS application, you inevitably cross
+the C++/Objective-C boundary. These patterns prevent the most common crashes and
+type corruption bugs.
+
+## CGFloat vs double
+
+`CGFloat` is `double` on 64-bit macOS, but `std::min`/`std::max` fail with it
+due to template type deduction. The compiler sees `CGFloat` and `double` as
+different types, causing implicit conversion that can corrupt values:
+
+```cpp
+// WRONG — template deduction failure, potential memory corruption
+CGFloat width = std::min(screenWidth, 1000.0);
+CGFloat height = std::max(screenHeight, 600.0);
+
+// CORRECT — explicit ternary, no template ambiguity
+CGFloat width = (screenWidth < 1000.0) ? screenWidth : 1000.0;
+CGFloat height = (screenHeight > 600.0) ? screenHeight : 600.0;
+```
+
+**Rule**: Use `CGFloat` only inside `#ifdef __OBJC__` blocks. Use `double` in
+pure C++ headers. When passing values across the boundary, assign to a `double`
+local first.
+
+## Header Classification
+
+Classify every header at the top to prevent accidental ObjC imports in pure C++
+compilation units:
+
+```cpp
+// Pure C++ — no ObjC dependency
+// (luma_math.h, capture_callback.h, capture_source.h)
+#pragma once
+#include <cstdint>
+#include <vector>
+
+// Mixed — C++ class with ObjC members behind guards
+// (monitor_dashboard.h, preview_window.h)
+#ifndef DASHBOARD_H
+#define DASHBOARD_H
+#include <string>
+
+class Dashboard {
+    std::string title_;
+#ifdef __OBJC__
+    NSWindow* window_;      // Only visible in .mm compilation
+    NSTextField* label_;
+#endif
+public:
+    void show();
+    void hide();
+};
+#endif
+
+// Pure ObjC (guarded) — entire content inside guard
+// (dashboard_views.h, timeline_graph_view.h)
+#ifdef __OBJC__
+#import <AppKit/AppKit.h>
+@interface LogoGlowView : NSView
+@end
+#endif
+```
+
+## dispatch_async Copy Semantics
+
+Objective-C blocks capture C++ variables by copy. But `const&` parameters are
+captured by reference to the original — which may be dead by the time the block
+executes:
+
+```cpp
+// WRONG — stats is a dangling reference when block runs
+void updateUI(const FrameStats& stats) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        label.stringValue = [NSString stringWithFormat:@"%d", stats.frame_count];
+        // stats reference is now dangling!
+    });
+}
+
+// CORRECT — copy before async, block owns the copy
+void updateUI(const FrameStats& stats) {
+    FrameStats stats_copy = stats;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        label.stringValue = [NSString stringWithFormat:@"%d",
+                             stats_copy.frame_count];
+    });
+}
+```
+
+This applies to `std::string`, any struct, and any C++ object passed by
+reference. The block's implicit copy happens at the point of block creation, but
+references are copied as references, not as values.
+
+## Lifecycle-Safe dispatch_async — The alive_ Pattern
+
+When a C++ object dispatches work to the main queue, the object may be destroyed
+before the block runs. Use `shared_ptr<atomic<bool>>` to guard:
+
+```cpp
+class PreviewWindow {
+    std::shared_ptr<std::atomic<bool>> alive_ =
+        std::make_shared<std::atomic<bool>>(true);
+
+    void scheduleUpdate() {
+        auto alive = alive_;  // Copy shared_ptr into block
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (!*alive) return;  // Object was destroyed
+            // Safe to use 'this' here
+            this->redraw();
+        });
+    }
+
+    ~PreviewWindow() {
+        *alive_ = false;
+        // Synchronous cleanup on main thread
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            // Tear down UI...
+        });
+    }
+};
+```
+
+**Key points**:
+- `alive_` is a `shared_ptr` so the atomic bool outlives the object
+- The block captures the `shared_ptr` by value (extending its lifetime)
+- The destructor sets `*alive_ = false` THEN does synchronous cleanup
+- Use `dispatch_sync` (never `dispatch_async`) in destructors
+
+## Destructor Cleanup Order
+
+When a C++ object owns ObjC views that hold back-references (delegates,
+targets), clean up in this exact order:
+
+```cpp
+~MyWindow() {
+    void (^cleanup)(void) = ^{
+        // 1. Clear back-references FIRST
+        if (delegate_) delegate_.owner = nil;
+        if (view_) view_.owner = nil;
+
+        // 2. Clear delegate
+        if (window_) [window_ setDelegate:nil];
+
+        // 3. Now safe to close
+        if (window_) {
+            [window_ orderOut:nil];
+            [window_ close];
+            window_ = nil;
+        }
+    };
+
+    if ([NSThread isMainThread]) cleanup();
+    else dispatch_sync(dispatch_get_main_queue(), cleanup);
+}
+```
+
+## C++ Lambdas and ARC
+
+C++ lambdas cannot capture addresses of ARC-managed Objective-C member
+variables. This fails:
+
+```cpp
+// WRONG — cannot take address of autoreleasing parameter
+auto setup = [&](NSTextField* label, NSString* text) {
+    label.stringValue = text;  // Compiler error under ARC
+};
+```
+
+Use inline code instead. When creating multiple similar UI elements, the
+repetition is preferable to the compilation failure.
+
+## NSWindow Lifecycle with ARC
+
+Set `releasedWhenClosed = NO` for any `NSWindow` whose pointer is held as a
+strong reference. Otherwise, closing the window triggers a double-free (ARC
+releases + NSWindow releases itself):
+
+```cpp
+window_ = [[NSWindow alloc] initWithContentRect:frame ...];
+window_.releasedWhenClosed = NO;  // Critical for ARC
+
+// Every closable window needs a delegate that handles close
+window_.delegate = delegate_;
+// In delegate: windowWillClose: sets the window pointer to nil
+```

--- a/content/CrinkleCutz/docs/decklink-sdk/references/signal-detection.md
+++ b/content/CrinkleCutz/docs/decklink-sdk/references/signal-detection.md
@@ -1,0 +1,161 @@
+# Signal Detection
+
+Detecting the active input signal on a DeckLink device is one of the
+least-documented aspects of the SDK. There is no "tell me what signal is
+connected" API call. You must probe by trying modes.
+
+## The Problem
+
+`EnableVideoInput` succeeds when the hardware can configure itself for the
+requested mode, but frames only arrive when the physical signal matches. There
+is no "detect" mode that auto-selects — you must cycle through candidate modes
+and check for frame arrival.
+
+`IDeckLinkStatus` (via `GetInt(bmdDeckLinkStatusDetectedVideoInputMode)`) only
+reports the detected mode AFTER streams have been started and frames have
+arrived. You cannot query it cold.
+
+## Mode Cycling Probe
+
+The proven pattern: for each candidate mode, enable it, start streams briefly,
+check if frames arrived, then stop and try the next mode:
+
+```cpp
+class SignalProbeCallback : public IDeckLinkInputCallback {
+    std::atomic<int32_t> ref_count_{1};
+public:
+    std::atomic<bool> frames_arrived{false};
+
+    HRESULT QueryInterface(REFIID, void**) override { return E_NOINTERFACE; }
+    ULONG AddRef() override { return ++ref_count_; }
+    ULONG Release() override {
+        int32_t c = --ref_count_;
+        if (c == 0) delete this;
+        return c;
+    }
+    HRESULT VideoInputFormatChanged(BMDVideoInputFormatChangedEvents,
+        IDeckLinkDisplayMode*, BMDDetectedVideoInputFormatFlags) override {
+        return S_OK;
+    }
+    HRESULT VideoInputFrameArrived(IDeckLinkVideoInputFrame* frame,
+                                    IDeckLinkAudioInputPacket*) override {
+        if (frame) frames_arrived.store(true);
+        return S_OK;
+    }
+};
+
+BMDDisplayMode detectSignal(IDeckLinkInput* input) {
+    auto* probe = new SignalProbeCallback();
+    input->SetCallback(probe);
+
+    BMDDisplayMode probe_modes[] = {
+        bmdModeHD1080p30, bmdModeHD1080p2997, bmdModeHD1080p25,
+        bmdModeHD1080p24, bmdModeHD1080p2398,
+        bmdModeHD1080p50, bmdModeHD1080p5994, bmdModeHD1080p6000,
+        bmdModeHD1080i5994, bmdModeHD1080i50, bmdModeHD1080i6000,
+        bmdModeHD720p50, bmdModeHD720p5994, bmdModeHD720p60,
+        bmdModeNTSC, bmdModePAL
+    };
+
+    BMDDisplayMode detected = 0;
+
+    for (auto mode : probe_modes) {
+        if (input->EnableVideoInput(mode, bmdFormat8BitYUV,
+                                    bmdVideoInputFlagDefault) != S_OK) {
+            continue;  // Hardware doesn't support this mode
+        }
+
+        probe->frames_arrived.store(false);
+
+        if (input->StartStreams() != S_OK) {
+            input->DisableVideoInput();
+            continue;
+        }
+
+        // Poll for up to 200ms — MUST pump NSRunLoop
+        bool got_frames = false;
+        for (int poll = 0; poll < 4; poll++) {
+            @autoreleasepool {
+                NSDate* until = [NSDate dateWithTimeIntervalSinceNow:0.05];
+                [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
+                                         beforeDate:until];
+            }
+            if (probe->frames_arrived.load()) {
+                got_frames = true;
+                break;
+            }
+        }
+
+        input->StopStreams();
+        input->DisableVideoInput();
+
+        if (got_frames) {
+            detected = mode;
+            break;
+        }
+    }
+
+    input->SetCallback(nullptr);
+    probe->Release();
+    return detected;
+}
+```
+
+## NSRunLoop Pumping — Why It Matters
+
+The DeckLink SDK on macOS dispatches frame callbacks through the main run loop.
+If you use `std::this_thread::sleep_for` instead of `NSRunLoop runMode:`, the
+callbacks never fire because the run loop is blocked:
+
+```cpp
+// WRONG — callbacks never arrive
+input->StartStreams();
+std::this_thread::sleep_for(std::chrono::milliseconds(200));
+// probe->frames_arrived is still false!
+
+// CORRECT — pumps the run loop, callbacks fire
+input->StartStreams();
+for (int i = 0; i < 4; i++) {
+    @autoreleasepool {
+        [[NSRunLoop currentRunLoop]
+            runMode:NSDefaultRunLoopMode
+            beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
+    }
+    if (probe->frames_arrived.load()) break;
+}
+```
+
+Each 50ms pump gives the SDK time to deliver a frame. At 30fps, frames arrive
+every ~33ms, so 200ms (4 x 50ms) provides ample time for at least one frame.
+
+## VideoInputFormatChanged
+
+If you enable format detection (`bmdVideoInputEnableFormatDetection` flag), the
+SDK calls `VideoInputFormatChanged` when it detects a different input format
+than what was enabled. The callback provides the actual `IDeckLinkDisplayMode`:
+
+```cpp
+HRESULT VideoInputFormatChanged(
+    BMDVideoInputFormatChangedEvents events,
+    IDeckLinkDisplayMode* newMode,
+    BMDDetectedVideoInputFormatFlags flags) override {
+    if (newMode) {
+        BMDDisplayMode mode = newMode->GetDisplayMode();
+        // Can re-enable with the detected mode
+    }
+    return S_OK;
+}
+```
+
+**Caveat**: Format detection requires streams to already be running. It cannot
+be used for cold-start detection. The mode cycling probe above is the reliable
+approach for initial discovery.
+
+## Timing Considerations
+
+- **200ms per mode** is a reliable timeout — allows 6+ frame intervals at 30fps
+- **16 modes** means a full scan takes ~3.2 seconds worst case (no signal)
+- **Order modes by likelihood** — 1080p30/29.97 first, then 1080p25/24, then
+  interlaced, then SD. Most modern setups are progressive HD.
+- Use `bmdVideoInputFlagDefault` (not format detection) for the probe — format
+  detection changes the mode asynchronously which complicates the probe logic

--- a/content/CrinkleCutz/docs/decklink-sdk/references/thread-safety.md
+++ b/content/CrinkleCutz/docs/decklink-sdk/references/thread-safety.md
@@ -1,0 +1,213 @@
+# Thread Safety
+
+The DeckLink SDK delivers frame callbacks on a background thread owned by the
+SDK. Your callback code runs concurrently with your UI thread and any other
+threads in your application. Getting thread safety wrong here causes data races,
+crashes, and subtle corruption.
+
+## Callback Thread Contract
+
+`VideoInputFrameArrived` is called on a DeckLink-owned background thread. Key
+rules:
+
+- The callback thread is **not the main thread** — you cannot call AppKit/UIKit
+  directly
+- The callback is **serialized** — the SDK will not call VideoInputFrameArrived
+  concurrently with itself (one frame at a time)
+- The callback must return promptly — blocking the callback thread stalls the
+  capture pipeline and may drop frames
+- The frame buffer pointer is only valid for the duration of the callback (or
+  between StartAccess/EndAccess for SDK 15.3)
+
+If you extract the frame processing into a shared function (e.g., for multiple
+capture backends), document the thread contract:
+
+```cpp
+// Thread contract: must be called from a single producer thread.
+// Not reentrant. Callers must not call concurrently.
+void processFrame(const uint8_t* bytes, int width, int height, int rowBytes);
+```
+
+## Mutex Lock Ordering
+
+When multiple mutexes protect different data that must be accessed together,
+define and document a strict lock ordering. Violating the order causes deadlocks:
+
+```cpp
+class CaptureCallback {
+    // Lock ordering: config_mutex -> stats_mutex
+    // Both VideoInputFrameArrived and updateConfig follow this order.
+    mutable std::mutex config_mutex;
+    mutable std::mutex stats_mutex;
+
+    MonitorConfig config;
+    FrameStats stats;
+
+public:
+    void processFrame(const uint8_t* bytes, int w, int h, int rb) {
+        // Lock config first, then stats (matches declared order)
+        std::lock_guard<std::mutex> cfg_lock(config_mutex);
+        MonitorConfig config_snapshot = config;
+
+        std::lock_guard<std::mutex> stats_lock(stats_mutex);
+        stats.frame_count++;
+
+        // Process ROIs using config_snapshot and update stats...
+    }
+
+    void updateConfig(const MonitorConfig& new_config) {
+        // Same order: config first, then stats
+        std::lock_guard<std::mutex> cfg_lock(config_mutex);
+        bool roi_count_changed = (new_config.rois.size() != config.rois.size());
+        config = new_config;
+
+        if (roi_count_changed) {
+            std::lock_guard<std::mutex> stats_lock(stats_mutex);
+            stats.initForROICount(config.rois.size());
+        }
+    }
+};
+```
+
+**Why this matters**: `processFrame` (callback thread) reads config and writes
+stats. `updateConfig` (UI thread) writes config and may resize stats. Without
+consistent lock ordering, thread A locks config then waits for stats, while
+thread B locks stats then waits for config — deadlock.
+
+## Snapshot Pattern
+
+Return copies of shared data rather than references. This allows the caller to
+read without holding a lock:
+
+```cpp
+// Thread-safe: returns copy under lock
+FrameStats getStats() const {
+    std::lock_guard<std::mutex> lock(stats_mutex);
+    return stats;  // Copy
+}
+
+MonitorConfig getConfig() const {
+    std::lock_guard<std::mutex> lock(config_mutex);
+    return config;  // Copy
+}
+```
+
+The caller gets a consistent snapshot. The lock is held only for the duration of
+the copy, not while the caller processes the data.
+
+## shared_ptr<atomic<bool>> Lifecycle Guard
+
+When dispatching work from a callback thread to the main thread, the owning
+object may be destroyed before the dispatched block runs. The `alive_` pattern
+prevents use-after-free:
+
+```cpp
+class CaptureSystem {
+    std::shared_ptr<std::atomic<bool>> alive_ =
+        std::make_shared<std::atomic<bool>>(true);
+
+    void onFrameReceived(const FrameData& data) {
+        // Copy data AND alive_ into block
+        FrameData data_copy = data;
+        auto alive = alive_;
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (!*alive) return;  // Owner destroyed, bail out
+            updateUI(data_copy);
+        });
+    }
+
+    ~CaptureSystem() {
+        *alive_ = false;
+        // Synchronous drain — ensures no pending blocks access 'this'
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            teardownUI();
+        });
+    }
+};
+```
+
+**Why shared_ptr**: The atomic bool must outlive the object. `shared_ptr` ensures
+the bool stays alive as long as any block holds a reference to it. Using a raw
+member `atomic<bool>` would be a use-after-free because the bool is destroyed
+with the object.
+
+## condition_variable for Alert Queuing
+
+Instead of polling (sleep + check), use `condition_variable` for zero-CPU idle
+wait:
+
+```cpp
+class AlertSystem {
+    std::queue<Alert> alert_queue;
+    std::mutex queue_mutex;
+    std::condition_variable alert_cv;
+    std::atomic<bool> running{true};
+    std::thread alert_thread;
+
+    void alertWorkerThread() {
+        while (running) {
+            Alert alert;
+            bool has_alert = false;
+
+            {
+                std::unique_lock<std::mutex> lock(queue_mutex);
+                alert_cv.wait(lock, [this] {
+                    return !alert_queue.empty() || !running;
+                });
+                if (!running && alert_queue.empty()) break;
+                if (!alert_queue.empty()) {
+                    alert = alert_queue.front();
+                    alert_queue.pop();
+                    has_alert = true;
+                }
+            }
+
+            if (has_alert) {
+                dispatchAlert(alert);
+            }
+        }
+    }
+
+    void enqueueAlert(const Alert& alert) {
+        {
+            std::lock_guard<std::mutex> lock(queue_mutex);
+            alert_queue.push(alert);
+        }
+        alert_cv.notify_one();  // Wake worker
+    }
+
+    void stop() {
+        running = false;
+        alert_cv.notify_one();  // Unblock worker
+        if (alert_thread.joinable()) alert_thread.join();
+    }
+};
+```
+
+**Why not sleep-poll**: A 50ms sleep loop wastes CPU cycles and adds up to 50ms
+latency. `condition_variable::wait` uses zero CPU when idle and wakes instantly
+on `notify_one`.
+
+## Alert Callback Thread Safety
+
+If external code registers callbacks that fire on alerts, protect the callback
+list with its own mutex (separate from the queue mutex to avoid lock ordering
+issues):
+
+```cpp
+std::vector<AlertCallback> alert_callbacks;
+std::mutex alert_cb_mutex;
+
+void addAlertCallback(AlertCallback cb) {
+    std::lock_guard<std::mutex> lock(alert_cb_mutex);
+    alert_callbacks.push_back(std::move(cb));
+}
+
+void dispatchAlert(const Alert& alert) {
+    std::lock_guard<std::mutex> lock(alert_cb_mutex);
+    for (const auto& cb : alert_callbacks) {
+        cb(alert);
+    }
+}
+```

--- a/content/CrinkleCutz/docs/decklink-sdk/references/uyvy-color-math.md
+++ b/content/CrinkleCutz/docs/decklink-sdk/references/uyvy-color-math.md
@@ -1,0 +1,150 @@
+# UYVY Color Math
+
+## Byte-Level Memory Layout
+
+DeckLink's `bmdFormat8BitYUV` delivers frames in UYVY 4:2:2 format. Each pair
+of pixels occupies 4 bytes:
+
+```
+Offset:  0    1    2    3    4    5    6    7   ...
+         U0   Y0   V0   Y1   U2   Y2   V2   Y3  ...
+         |----pair 0----|    |----pair 1----|
+```
+
+- **U** (Cb): Blue-difference chroma, shared between two pixels
+- **Y**: Luma (brightness) — one per pixel
+- **V** (Cr): Red-difference chroma, shared between two pixels
+- **2 bytes per pixel**, but always accessed in pairs of 4 bytes
+- Pixels at even x-coordinates have Y at byte offset 1; odd x at byte offset 3
+
+Row stride (`GetRowBytes()`) may include padding beyond `width * 2`. Always use
+the actual row bytes value for row addressing.
+
+## ROI Luma Extraction
+
+To compute the average brightness of a rectangular region of interest (ROI)
+within a UYVY frame:
+
+```cpp
+double computeROILumaFromUYVY(const uint8_t* buffer, int width, int height,
+                               int rowBytes, int roiX, int roiY,
+                               int roiW, int roiH) {
+    // Clamp ROI to frame boundaries
+    int rx0 = std::clamp(roiX, 0, width - 1);
+    int ry0 = std::clamp(roiY, 0, height - 1);
+    int rx1 = std::clamp(roiX + roiW, rx0 + 1, width);
+    int ry1 = std::clamp(roiY + roiH, ry0 + 1, height);
+
+    uint64_t sum_y = 0;
+    uint64_t count = 0;
+
+    for (int y = ry0; y < ry1; y++) {
+        const uint8_t* row = buffer + y * rowBytes;
+
+        // Align to even pixel boundary for UYVY pairs
+        int x_start = (rx0 & ~1);
+
+        for (int x = x_start; x < rx1; x += 2) {
+            int byte_idx = x * 2;
+
+            // Extract Y0 (even pixel)
+            if (x >= rx0 && x < rx1) {
+                sum_y += row[byte_idx + 1];
+                count++;
+            }
+            // Extract Y1 (odd pixel)
+            if ((x + 1) >= rx0 && (x + 1) < rx1) {
+                sum_y += row[byte_idx + 3];
+                count++;
+            }
+        }
+    }
+
+    return (count > 0) ? static_cast<double>(sum_y) / count : 0.0;
+}
+```
+
+**Key details**:
+- ROI x-start must align to even boundary (`& ~1`) since UYVY pairs start at
+  even pixels
+- Use `uint64_t` for the accumulator — a 1920x1080 ROI sums ~2M values of
+  0-255, which fits in 32 bits, but larger ROIs or multi-frame accumulation need
+  64 bits
+- `std::clamp` (C++17) prevents out-of-bounds reads
+
+## BT.709 UYVY to RGB Conversion
+
+For HD content (720p and above), use the BT.709 color matrix. Integer-only math
+avoids floating-point overhead in per-pixel loops:
+
+```cpp
+std::vector<uint8_t> convertUYVYtoRGB(const uint8_t* uyvy_data,
+                                       int width, int height, int row_bytes) {
+    std::vector<uint8_t> rgb(width * height * 3);
+
+    for (int y = 0; y < height; y++) {
+        const uint8_t* row = uyvy_data + y * row_bytes;
+        for (int x = 0; x < width; x += 2) {
+            int idx = x * 2;
+
+            int u  = row[idx + 0] - 128;
+            int y0 = row[idx + 1] - 16;
+            int v  = row[idx + 2] - 128;
+            int y1 = row[idx + 3] - 16;
+
+            // BT.709 coefficients scaled to integer math (>>8 = /256)
+            // R = 1.164(Y-16) + 1.793(V-128)
+            // G = 1.164(Y-16) - 0.213(U-128) - 0.533(V-128)
+            // B = 1.164(Y-16) + 2.112(U-128)
+            int r0 = std::clamp((298 * y0 + 459 * v + 128) >> 8, 0, 255);
+            int g0 = std::clamp((298 * y0 - 55 * u - 136 * v + 128) >> 8,
+                                0, 255);
+            int b0 = std::clamp((298 * y0 + 541 * u + 128) >> 8, 0, 255);
+
+            int r1 = std::clamp((298 * y1 + 459 * v + 128) >> 8, 0, 255);
+            int g1 = std::clamp((298 * y1 - 55 * u - 136 * v + 128) >> 8,
+                                0, 255);
+            int b1 = std::clamp((298 * y1 + 541 * u + 128) >> 8, 0, 255);
+
+            int rgb_idx = (y * width + x) * 3;
+            rgb[rgb_idx]     = r0;
+            rgb[rgb_idx + 1] = g0;
+            rgb[rgb_idx + 2] = b0;
+
+            if (x + 1 < width) {
+                rgb[rgb_idx + 3] = r1;
+                rgb[rgb_idx + 4] = g1;
+                rgb[rgb_idx + 5] = b1;
+            }
+        }
+    }
+    return rgb;
+}
+```
+
+**Notes on the integer coefficients**:
+- `298 = 1.164 * 256`, `459 = 1.793 * 256`, `55 = 0.213 * 256`,
+  `136 = 0.533 * 256`, `541 = 2.112 * 256`
+- The `+ 128` before `>> 8` provides rounding (equivalent to `+ 0.5` before
+  truncation)
+- `std::clamp` handles out-of-range values from super-white or super-black
+  signals
+- BT.601 (SD content) uses different coefficients — only use BT.709 for HD
+
+## EMA Baseline Smoothing
+
+For change detection (monitoring luma drift over time), use an exponential
+moving average to establish a stable baseline:
+
+```cpp
+double updateEMABaseline(double current_baseline, double new_value,
+                         double alpha) {
+    return current_baseline * (1.0 - alpha) + new_value * alpha;
+}
+```
+
+- **alpha = 0.02** works well at ~30fps (slow adaptation, stable baseline)
+- Lower frame rates (webcams at 15fps) may need higher alpha for equivalent
+  responsiveness
+- Initialize baseline to the first observed value, then apply EMA from frame 2
+  onward


### PR DESCRIPTION
## Summary

- Adds community documentation for the **Blackmagic DeckLink SDK 15.3** on macOS
- Covers the video capture path: device discovery, frame callbacks, buffer access, COM lifecycle, signal detection, UYVY pixel format, thread safety, and Obj-C++ bridging
- Derived from 5 versions of production capture software (Luma Detect V4–V8, 3 code reviews, ~200K LOC)

## Content

| File | Lines | Content |
|------|-------|---------|
| `DOC.md` | 490 | Main guide — 12 sections including minimal complete example |
| `references/objcpp-bridging.md` | 186 | CGFloat vs double, dispatch_async copy semantics, alive_ lifecycle |
| `references/thread-safety.md` | 213 | Callback thread contract, mutex ordering, snapshot pattern |
| `references/build-configuration.md` | 163 | Complete Makefile, SDK paths, conditional compilation |
| `references/signal-detection.md` | 161 | Mode cycling probe, NSRunLoop pumping |
| `references/uyvy-color-math.md` | 150 | UYVY layout, ROI luma extraction, BT.709 RGB conversion |

## Why This Matters

The DeckLink SDK has notoriously sparse official documentation. Key patterns like:
- SDK 15.3's `IDeckLinkVideoBuffer` access pattern (breaking change from older SDKs)
- NSRunLoop pumping requirement (callbacks silently fail with `sleep()`)
- Signal detection via mode cycling (no "detect" API exists)
- COM cleanup ordering (`SetCallback(nullptr)` before `Release()`)

...are not documented anywhere and must be discovered through trial and error.

## Validation

```
$ chub build content/ --validate-only
Valid: 70 docs, 2 skills, 0 warnings
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)