### PR TITLE
Add official Telnyx API docs (35 products, 6 languages)

### DIFF
--- a/content/telnyx/docs/10dlc/curl/DOC.md
+++ b/content/telnyx/docs/10dlc/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,10dlc,a2p,messaging,compliance,brand,campaign"
 ---
 

--- a/content/telnyx/docs/10dlc/go/DOC.md
+++ b/content/telnyx/docs/10dlc/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,10dlc,a2p,messaging,compliance,brand,campaign"
 ---
 

--- a/content/telnyx/docs/10dlc/java/DOC.md
+++ b/content/telnyx/docs/10dlc/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,10dlc,a2p,messaging,compliance,brand,campaign"
 ---
 

--- a/content/telnyx/docs/10dlc/javascript/DOC.md
+++ b/content/telnyx/docs/10dlc/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,10dlc,a2p,messaging,compliance,brand,campaign"
 ---
 

--- a/content/telnyx/docs/10dlc/python/DOC.md
+++ b/content/telnyx/docs/10dlc/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,10dlc,a2p,messaging,compliance,brand,campaign"
 ---
 

--- a/content/telnyx/docs/10dlc/ruby/DOC.md
+++ b/content/telnyx/docs/10dlc/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,10dlc,a2p,messaging,compliance,brand,campaign"
 ---
 

--- a/content/telnyx/docs/account-access/curl/DOC.md
+++ b/content/telnyx/docs/account-access/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,addresses,ip-access,authentication"
 ---
 

--- a/content/telnyx/docs/account-access/go/DOC.md
+++ b/content/telnyx/docs/account-access/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,addresses,ip-access,authentication"
 ---
 

--- a/content/telnyx/docs/account-access/java/DOC.md
+++ b/content/telnyx/docs/account-access/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,addresses,ip-access,authentication"
 ---
 

--- a/content/telnyx/docs/account-access/javascript/DOC.md
+++ b/content/telnyx/docs/account-access/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,addresses,ip-access,authentication"
 ---
 

--- a/content/telnyx/docs/account-access/python/DOC.md
+++ b/content/telnyx/docs/account-access/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,addresses,ip-access,authentication"
 ---
 

--- a/content/telnyx/docs/account-access/ruby/DOC.md
+++ b/content/telnyx/docs/account-access/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,addresses,ip-access,authentication"
 ---
 

--- a/content/telnyx/docs/account-management/curl/DOC.md
+++ b/content/telnyx/docs/account-management/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,sub-accounts,reseller,enterprise"
 ---
 

--- a/content/telnyx/docs/account-management/go/DOC.md
+++ b/content/telnyx/docs/account-management/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,sub-accounts,reseller,enterprise"
 ---
 

--- a/content/telnyx/docs/account-management/java/DOC.md
+++ b/content/telnyx/docs/account-management/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,sub-accounts,reseller,enterprise"
 ---
 

--- a/content/telnyx/docs/account-management/javascript/DOC.md
+++ b/content/telnyx/docs/account-management/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,sub-accounts,reseller,enterprise"
 ---
 

--- a/content/telnyx/docs/account-management/python/DOC.md
+++ b/content/telnyx/docs/account-management/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,sub-accounts,reseller,enterprise"
 ---
 

--- a/content/telnyx/docs/account-management/ruby/DOC.md
+++ b/content/telnyx/docs/account-management/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,sub-accounts,reseller,enterprise"
 ---
 

--- a/content/telnyx/docs/account-notifications/curl/DOC.md
+++ b/content/telnyx/docs/account-notifications/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,notifications,alerts,channels"
 ---
 

--- a/content/telnyx/docs/account-notifications/go/DOC.md
+++ b/content/telnyx/docs/account-notifications/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,notifications,alerts,channels"
 ---
 

--- a/content/telnyx/docs/account-notifications/java/DOC.md
+++ b/content/telnyx/docs/account-notifications/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,notifications,alerts,channels"
 ---
 

--- a/content/telnyx/docs/account-notifications/javascript/DOC.md
+++ b/content/telnyx/docs/account-notifications/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,notifications,alerts,channels"
 ---
 

--- a/content/telnyx/docs/account-notifications/python/DOC.md
+++ b/content/telnyx/docs/account-notifications/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,notifications,alerts,channels"
 ---
 

--- a/content/telnyx/docs/account-notifications/ruby/DOC.md
+++ b/content/telnyx/docs/account-notifications/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,notifications,alerts,channels"
 ---
 

--- a/content/telnyx/docs/account-reports/curl/DOC.md
+++ b/content/telnyx/docs/account-reports/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,reports,usage,analytics,billing"
 ---
 

--- a/content/telnyx/docs/account-reports/go/DOC.md
+++ b/content/telnyx/docs/account-reports/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,reports,usage,analytics,billing"
 ---
 

--- a/content/telnyx/docs/account-reports/java/DOC.md
+++ b/content/telnyx/docs/account-reports/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,reports,usage,analytics,billing"
 ---
 

--- a/content/telnyx/docs/account-reports/javascript/DOC.md
+++ b/content/telnyx/docs/account-reports/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,reports,usage,analytics,billing"
 ---
 

--- a/content/telnyx/docs/account-reports/python/DOC.md
+++ b/content/telnyx/docs/account-reports/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,reports,usage,analytics,billing"
 ---
 

--- a/content/telnyx/docs/account-reports/ruby/DOC.md
+++ b/content/telnyx/docs/account-reports/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,reports,usage,analytics,billing"
 ---
 

--- a/content/telnyx/docs/account/curl/DOC.md
+++ b/content/telnyx/docs/account/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,billing,balance,invoices,webhooks"
 ---
 

--- a/content/telnyx/docs/account/go/DOC.md
+++ b/content/telnyx/docs/account/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,billing,balance,invoices,webhooks"
 ---
 

--- a/content/telnyx/docs/account/java/DOC.md
+++ b/content/telnyx/docs/account/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,billing,balance,invoices,webhooks"
 ---
 

--- a/content/telnyx/docs/account/javascript/DOC.md
+++ b/content/telnyx/docs/account/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,billing,balance,invoices,webhooks"
 ---
 

--- a/content/telnyx/docs/account/python/DOC.md
+++ b/content/telnyx/docs/account/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,billing,balance,invoices,webhooks"
 ---
 

--- a/content/telnyx/docs/account/ruby/DOC.md
+++ b/content/telnyx/docs/account/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,account,billing,balance,invoices,webhooks"
 ---
 

--- a/content/telnyx/docs/ai-assistants/curl/DOC.md
+++ b/content/telnyx/docs/ai-assistants/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,ai,assistants,voice-ai,knowledge-base"
 ---
 

--- a/content/telnyx/docs/ai-assistants/go/DOC.md
+++ b/content/telnyx/docs/ai-assistants/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,ai,assistants,voice-ai,knowledge-base"
 ---
 

--- a/content/telnyx/docs/ai-assistants/java/DOC.md
+++ b/content/telnyx/docs/ai-assistants/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,ai,assistants,voice-ai,knowledge-base"
 ---
 

--- a/content/telnyx/docs/ai-assistants/javascript/DOC.md
+++ b/content/telnyx/docs/ai-assistants/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,ai,assistants,voice-ai,knowledge-base"
 ---
 

--- a/content/telnyx/docs/ai-assistants/python/DOC.md
+++ b/content/telnyx/docs/ai-assistants/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,ai,assistants,voice-ai,knowledge-base"
 ---
 

--- a/content/telnyx/docs/ai-assistants/ruby/DOC.md
+++ b/content/telnyx/docs/ai-assistants/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,ai,assistants,voice-ai,knowledge-base"
 ---
 

--- a/content/telnyx/docs/ai-inference/curl/DOC.md
+++ b/content/telnyx/docs/ai-inference/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,ai,inference,llm,embeddings,analytics"
 ---
 

--- a/content/telnyx/docs/ai-inference/go/DOC.md
+++ b/content/telnyx/docs/ai-inference/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,ai,inference,llm,embeddings,analytics"
 ---
 

--- a/content/telnyx/docs/ai-inference/java/DOC.md
+++ b/content/telnyx/docs/ai-inference/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,ai,inference,llm,embeddings,analytics"
 ---
 

--- a/content/telnyx/docs/ai-inference/javascript/DOC.md
+++ b/content/telnyx/docs/ai-inference/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,ai,inference,llm,embeddings,analytics"
 ---
 

--- a/content/telnyx/docs/ai-inference/python/DOC.md
+++ b/content/telnyx/docs/ai-inference/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,ai,inference,llm,embeddings,analytics"
 ---
 

--- a/content/telnyx/docs/ai-inference/ruby/DOC.md
+++ b/content/telnyx/docs/ai-inference/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,ai,inference,llm,embeddings,analytics"
 ---
 

--- a/content/telnyx/docs/fax/curl/DOC.md
+++ b/content/telnyx/docs/fax/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,fax,send,receive"
 ---
 

--- a/content/telnyx/docs/fax/go/DOC.md
+++ b/content/telnyx/docs/fax/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,fax,send,receive"
 ---
 

--- a/content/telnyx/docs/fax/java/DOC.md
+++ b/content/telnyx/docs/fax/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,fax,send,receive"
 ---
 

--- a/content/telnyx/docs/fax/javascript/DOC.md
+++ b/content/telnyx/docs/fax/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,fax,send,receive"
 ---
 

--- a/content/telnyx/docs/fax/python/DOC.md
+++ b/content/telnyx/docs/fax/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,fax,send,receive"
 ---
 

--- a/content/telnyx/docs/fax/ruby/DOC.md
+++ b/content/telnyx/docs/fax/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,fax,send,receive"
 ---
 

--- a/content/telnyx/docs/iot/curl/DOC.md
+++ b/content/telnyx/docs/iot/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,iot,sim,esim,m2m,wireless"
 ---
 

--- a/content/telnyx/docs/iot/go/DOC.md
+++ b/content/telnyx/docs/iot/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,iot,sim,esim,m2m,wireless"
 ---
 

--- a/content/telnyx/docs/iot/java/DOC.md
+++ b/content/telnyx/docs/iot/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,iot,sim,esim,m2m,wireless"
 ---
 

--- a/content/telnyx/docs/iot/javascript/DOC.md
+++ b/content/telnyx/docs/iot/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,iot,sim,esim,m2m,wireless"
 ---
 

--- a/content/telnyx/docs/iot/python/DOC.md
+++ b/content/telnyx/docs/iot/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,iot,sim,esim,m2m,wireless"
 ---
 

--- a/content/telnyx/docs/iot/ruby/DOC.md
+++ b/content/telnyx/docs/iot/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,iot,sim,esim,m2m,wireless"
 ---
 

--- a/content/telnyx/docs/messaging-hosted/curl/DOC.md
+++ b/content/telnyx/docs/messaging-hosted/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,messaging,hosted-sms,toll-free,rcs"
 ---
 

--- a/content/telnyx/docs/messaging-hosted/go/DOC.md
+++ b/content/telnyx/docs/messaging-hosted/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,messaging,hosted-sms,toll-free,rcs"
 ---
 

--- a/content/telnyx/docs/messaging-hosted/java/DOC.md
+++ b/content/telnyx/docs/messaging-hosted/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,messaging,hosted-sms,toll-free,rcs"
 ---
 

--- a/content/telnyx/docs/messaging-hosted/javascript/DOC.md
+++ b/content/telnyx/docs/messaging-hosted/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,messaging,hosted-sms,toll-free,rcs"
 ---
 

--- a/content/telnyx/docs/messaging-hosted/python/DOC.md
+++ b/content/telnyx/docs/messaging-hosted/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,messaging,hosted-sms,toll-free,rcs"
 ---
 

--- a/content/telnyx/docs/messaging-hosted/ruby/DOC.md
+++ b/content/telnyx/docs/messaging-hosted/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,messaging,hosted-sms,toll-free,rcs"
 ---
 

--- a/content/telnyx/docs/messaging-profiles/curl/DOC.md
+++ b/content/telnyx/docs/messaging-profiles/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,messaging,profiles,number-pool,short-codes"
 ---
 

--- a/content/telnyx/docs/messaging-profiles/go/DOC.md
+++ b/content/telnyx/docs/messaging-profiles/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,messaging,profiles,number-pool,short-codes"
 ---
 

--- a/content/telnyx/docs/messaging-profiles/java/DOC.md
+++ b/content/telnyx/docs/messaging-profiles/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,messaging,profiles,number-pool,short-codes"
 ---
 

--- a/content/telnyx/docs/messaging-profiles/javascript/DOC.md
+++ b/content/telnyx/docs/messaging-profiles/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,messaging,profiles,number-pool,short-codes"
 ---
 

--- a/content/telnyx/docs/messaging-profiles/python/DOC.md
+++ b/content/telnyx/docs/messaging-profiles/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,messaging,profiles,number-pool,short-codes"
 ---
 

--- a/content/telnyx/docs/messaging-profiles/ruby/DOC.md
+++ b/content/telnyx/docs/messaging-profiles/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,messaging,profiles,number-pool,short-codes"
 ---
 

--- a/content/telnyx/docs/messaging/curl/DOC.md
+++ b/content/telnyx/docs/messaging/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,sms,mms,messaging,telecom,whatsapp"
 ---
 

--- a/content/telnyx/docs/messaging/go/DOC.md
+++ b/content/telnyx/docs/messaging/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,sms,mms,messaging,telecom,whatsapp"
 ---
 

--- a/content/telnyx/docs/messaging/java/DOC.md
+++ b/content/telnyx/docs/messaging/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,sms,mms,messaging,telecom,whatsapp"
 ---
 

--- a/content/telnyx/docs/messaging/javascript/DOC.md
+++ b/content/telnyx/docs/messaging/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,sms,mms,messaging,telecom,whatsapp"
 ---
 

--- a/content/telnyx/docs/messaging/python/DOC.md
+++ b/content/telnyx/docs/messaging/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,sms,mms,messaging,telecom,whatsapp"
 ---
 

--- a/content/telnyx/docs/messaging/ruby/DOC.md
+++ b/content/telnyx/docs/messaging/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,sms,mms,messaging,telecom,whatsapp"
 ---
 

--- a/content/telnyx/docs/missions/curl/DOC.md
+++ b/content/telnyx/docs/missions/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,missions,workflows,automation,tasks"
 ---
 

--- a/content/telnyx/docs/missions/go/DOC.md
+++ b/content/telnyx/docs/missions/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,missions,workflows,automation,tasks"
 ---
 

--- a/content/telnyx/docs/missions/java/DOC.md
+++ b/content/telnyx/docs/missions/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,missions,workflows,automation,tasks"
 ---
 

--- a/content/telnyx/docs/missions/javascript/DOC.md
+++ b/content/telnyx/docs/missions/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,missions,workflows,automation,tasks"
 ---
 

--- a/content/telnyx/docs/missions/python/DOC.md
+++ b/content/telnyx/docs/missions/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,missions,workflows,automation,tasks"
 ---
 

--- a/content/telnyx/docs/missions/ruby/DOC.md
+++ b/content/telnyx/docs/missions/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,missions,workflows,automation,tasks"
 ---
 

--- a/content/telnyx/docs/networking/curl/DOC.md
+++ b/content/telnyx/docs/networking/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,networking,vpn,wireguard,private-network"
 ---
 

--- a/content/telnyx/docs/networking/go/DOC.md
+++ b/content/telnyx/docs/networking/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,networking,vpn,wireguard,private-network"
 ---
 

--- a/content/telnyx/docs/networking/java/DOC.md
+++ b/content/telnyx/docs/networking/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,networking,vpn,wireguard,private-network"
 ---
 

--- a/content/telnyx/docs/networking/javascript/DOC.md
+++ b/content/telnyx/docs/networking/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,networking,vpn,wireguard,private-network"
 ---
 

--- a/content/telnyx/docs/networking/python/DOC.md
+++ b/content/telnyx/docs/networking/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,networking,vpn,wireguard,private-network"
 ---
 

--- a/content/telnyx/docs/networking/ruby/DOC.md
+++ b/content/telnyx/docs/networking/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,networking,vpn,wireguard,private-network"
 ---
 

--- a/content/telnyx/docs/numbers-compliance/curl/DOC.md
+++ b/content/telnyx/docs/numbers-compliance/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,phone-numbers,compliance,regulatory,documents"
 ---
 

--- a/content/telnyx/docs/numbers-compliance/go/DOC.md
+++ b/content/telnyx/docs/numbers-compliance/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,phone-numbers,compliance,regulatory,documents"
 ---
 

--- a/content/telnyx/docs/numbers-compliance/java/DOC.md
+++ b/content/telnyx/docs/numbers-compliance/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,phone-numbers,compliance,regulatory,documents"
 ---
 

--- a/content/telnyx/docs/numbers-compliance/javascript/DOC.md
+++ b/content/telnyx/docs/numbers-compliance/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,phone-numbers,compliance,regulatory,documents"
 ---
 

--- a/content/telnyx/docs/numbers-compliance/python/DOC.md
+++ b/content/telnyx/docs/numbers-compliance/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,phone-numbers,compliance,regulatory,documents"
 ---
 

--- a/content/telnyx/docs/numbers-compliance/ruby/DOC.md
+++ b/content/telnyx/docs/numbers-compliance/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,phone-numbers,compliance,regulatory,documents"
 ---
 

--- a/content/telnyx/docs/numbers-config/curl/DOC.md
+++ b/content/telnyx/docs/numbers-config/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,phone-numbers,configuration,caller-id,forwarding"
 ---
 

--- a/content/telnyx/docs/numbers-config/go/DOC.md
+++ b/content/telnyx/docs/numbers-config/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,phone-numbers,configuration,caller-id,forwarding"
 ---
 

--- a/content/telnyx/docs/numbers-config/java/DOC.md
+++ b/content/telnyx/docs/numbers-config/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,phone-numbers,configuration,caller-id,forwarding"
 ---
 

--- a/content/telnyx/docs/numbers-config/javascript/DOC.md
+++ b/content/telnyx/docs/numbers-config/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,phone-numbers,configuration,caller-id,forwarding"
 ---
 

--- a/content/telnyx/docs/numbers-config/python/DOC.md
+++ b/content/telnyx/docs/numbers-config/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,phone-numbers,configuration,caller-id,forwarding"
 ---
 

--- a/content/telnyx/docs/numbers-config/ruby/DOC.md
+++ b/content/telnyx/docs/numbers-config/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,phone-numbers,configuration,caller-id,forwarding"
 ---
 

--- a/content/telnyx/docs/numbers-services/curl/DOC.md
+++ b/content/telnyx/docs/numbers-services/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,phone-numbers,voicemail,e911,emergency"
 ---
 

--- a/content/telnyx/docs/numbers-services/go/DOC.md
+++ b/content/telnyx/docs/numbers-services/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,phone-numbers,voicemail,e911,emergency"
 ---
 

--- a/content/telnyx/docs/numbers-services/java/DOC.md
+++ b/content/telnyx/docs/numbers-services/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,phone-numbers,voicemail,e911,emergency"
 ---
 

--- a/content/telnyx/docs/numbers-services/javascript/DOC.md
+++ b/content/telnyx/docs/numbers-services/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,phone-numbers,voicemail,e911,emergency"
 ---
 

--- a/content/telnyx/docs/numbers-services/python/DOC.md
+++ b/content/telnyx/docs/numbers-services/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,phone-numbers,voicemail,e911,emergency"
 ---
 

--- a/content/telnyx/docs/numbers-services/ruby/DOC.md
+++ b/content/telnyx/docs/numbers-services/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,phone-numbers,voicemail,e911,emergency"
 ---
 

--- a/content/telnyx/docs/numbers/curl/DOC.md
+++ b/content/telnyx/docs/numbers/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,phone-numbers,search,order,coverage"
 ---
 

--- a/content/telnyx/docs/numbers/go/DOC.md
+++ b/content/telnyx/docs/numbers/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,phone-numbers,search,order,coverage"
 ---
 

--- a/content/telnyx/docs/numbers/java/DOC.md
+++ b/content/telnyx/docs/numbers/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,phone-numbers,search,order,coverage"
 ---
 

--- a/content/telnyx/docs/numbers/javascript/DOC.md
+++ b/content/telnyx/docs/numbers/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,phone-numbers,search,order,coverage"
 ---
 

--- a/content/telnyx/docs/numbers/python/DOC.md
+++ b/content/telnyx/docs/numbers/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,phone-numbers,search,order,coverage"
 ---
 

--- a/content/telnyx/docs/numbers/ruby/DOC.md
+++ b/content/telnyx/docs/numbers/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,phone-numbers,search,order,coverage"
 ---
 

--- a/content/telnyx/docs/oauth/curl/DOC.md
+++ b/content/telnyx/docs/oauth/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,oauth,authentication,api-access"
 ---
 

--- a/content/telnyx/docs/oauth/go/DOC.md
+++ b/content/telnyx/docs/oauth/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,oauth,authentication,api-access"
 ---
 

--- a/content/telnyx/docs/oauth/java/DOC.md
+++ b/content/telnyx/docs/oauth/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,oauth,authentication,api-access"
 ---
 

--- a/content/telnyx/docs/oauth/javascript/DOC.md
+++ b/content/telnyx/docs/oauth/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,oauth,authentication,api-access"
 ---
 

--- a/content/telnyx/docs/oauth/python/DOC.md
+++ b/content/telnyx/docs/oauth/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,oauth,authentication,api-access"
 ---
 

--- a/content/telnyx/docs/oauth/ruby/DOC.md
+++ b/content/telnyx/docs/oauth/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,oauth,authentication,api-access"
 ---
 

--- a/content/telnyx/docs/porting-in/curl/DOC.md
+++ b/content/telnyx/docs/porting-in/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,porting,port-in,number-transfer,loa"
 ---
 

--- a/content/telnyx/docs/porting-in/go/DOC.md
+++ b/content/telnyx/docs/porting-in/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,porting,port-in,number-transfer,loa"
 ---
 

--- a/content/telnyx/docs/porting-in/java/DOC.md
+++ b/content/telnyx/docs/porting-in/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,porting,port-in,number-transfer,loa"
 ---
 

--- a/content/telnyx/docs/porting-in/javascript/DOC.md
+++ b/content/telnyx/docs/porting-in/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,porting,port-in,number-transfer,loa"
 ---
 

--- a/content/telnyx/docs/porting-in/python/DOC.md
+++ b/content/telnyx/docs/porting-in/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,porting,port-in,number-transfer,loa"
 ---
 

--- a/content/telnyx/docs/porting-in/ruby/DOC.md
+++ b/content/telnyx/docs/porting-in/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,porting,port-in,number-transfer,loa"
 ---
 

--- a/content/telnyx/docs/porting-out/curl/DOC.md
+++ b/content/telnyx/docs/porting-out/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,porting,port-out,number-transfer"
 ---
 

--- a/content/telnyx/docs/porting-out/go/DOC.md
+++ b/content/telnyx/docs/porting-out/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,porting,port-out,number-transfer"
 ---
 

--- a/content/telnyx/docs/porting-out/java/DOC.md
+++ b/content/telnyx/docs/porting-out/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,porting,port-out,number-transfer"
 ---
 

--- a/content/telnyx/docs/porting-out/javascript/DOC.md
+++ b/content/telnyx/docs/porting-out/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,porting,port-out,number-transfer"
 ---
 

--- a/content/telnyx/docs/porting-out/python/DOC.md
+++ b/content/telnyx/docs/porting-out/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,porting,port-out,number-transfer"
 ---
 

--- a/content/telnyx/docs/porting-out/ruby/DOC.md
+++ b/content/telnyx/docs/porting-out/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,porting,port-out,number-transfer"
 ---
 

--- a/content/telnyx/docs/sip-integrations/curl/DOC.md
+++ b/content/telnyx/docs/sip-integrations/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,sip,recordings,dialogflow,media-storage"
 ---
 

--- a/content/telnyx/docs/sip-integrations/go/DOC.md
+++ b/content/telnyx/docs/sip-integrations/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,sip,recordings,dialogflow,media-storage"
 ---
 

--- a/content/telnyx/docs/sip-integrations/java/DOC.md
+++ b/content/telnyx/docs/sip-integrations/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,sip,recordings,dialogflow,media-storage"
 ---
 

--- a/content/telnyx/docs/sip-integrations/javascript/DOC.md
+++ b/content/telnyx/docs/sip-integrations/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,sip,recordings,dialogflow,media-storage"
 ---
 

--- a/content/telnyx/docs/sip-integrations/python/DOC.md
+++ b/content/telnyx/docs/sip-integrations/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,sip,recordings,dialogflow,media-storage"
 ---
 

--- a/content/telnyx/docs/sip-integrations/ruby/DOC.md
+++ b/content/telnyx/docs/sip-integrations/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,sip,recordings,dialogflow,media-storage"
 ---
 

--- a/content/telnyx/docs/sip/curl/DOC.md
+++ b/content/telnyx/docs/sip/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,sip,trunking,pbx,voice"
 ---
 

--- a/content/telnyx/docs/sip/go/DOC.md
+++ b/content/telnyx/docs/sip/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,sip,trunking,pbx,voice"
 ---
 

--- a/content/telnyx/docs/sip/java/DOC.md
+++ b/content/telnyx/docs/sip/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,sip,trunking,pbx,voice"
 ---
 

--- a/content/telnyx/docs/sip/javascript/DOC.md
+++ b/content/telnyx/docs/sip/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,sip,trunking,pbx,voice"
 ---
 

--- a/content/telnyx/docs/sip/python/DOC.md
+++ b/content/telnyx/docs/sip/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,sip,trunking,pbx,voice"
 ---
 

--- a/content/telnyx/docs/sip/ruby/DOC.md
+++ b/content/telnyx/docs/sip/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,sip,trunking,pbx,voice"
 ---
 

--- a/content/telnyx/docs/storage/curl/DOC.md
+++ b/content/telnyx/docs/storage/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,storage,s3,buckets,objects"
 ---
 

--- a/content/telnyx/docs/storage/go/DOC.md
+++ b/content/telnyx/docs/storage/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,storage,s3,buckets,objects"
 ---
 

--- a/content/telnyx/docs/storage/java/DOC.md
+++ b/content/telnyx/docs/storage/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,storage,s3,buckets,objects"
 ---
 

--- a/content/telnyx/docs/storage/javascript/DOC.md
+++ b/content/telnyx/docs/storage/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,storage,s3,buckets,objects"
 ---
 

--- a/content/telnyx/docs/storage/python/DOC.md
+++ b/content/telnyx/docs/storage/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,storage,s3,buckets,objects"
 ---
 

--- a/content/telnyx/docs/storage/ruby/DOC.md
+++ b/content/telnyx/docs/storage/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,storage,s3,buckets,objects"
 ---
 

--- a/content/telnyx/docs/texml/curl/DOC.md
+++ b/content/telnyx/docs/texml/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,texml,twiml,voice,xml"
 ---
 

--- a/content/telnyx/docs/texml/go/DOC.md
+++ b/content/telnyx/docs/texml/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,texml,twiml,voice,xml"
 ---
 

--- a/content/telnyx/docs/texml/java/DOC.md
+++ b/content/telnyx/docs/texml/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,texml,twiml,voice,xml"
 ---
 

--- a/content/telnyx/docs/texml/javascript/DOC.md
+++ b/content/telnyx/docs/texml/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,texml,twiml,voice,xml"
 ---
 

--- a/content/telnyx/docs/texml/python/DOC.md
+++ b/content/telnyx/docs/texml/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,texml,twiml,voice,xml"
 ---
 

--- a/content/telnyx/docs/texml/ruby/DOC.md
+++ b/content/telnyx/docs/texml/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,texml,twiml,voice,xml"
 ---
 

--- a/content/telnyx/docs/verify/curl/DOC.md
+++ b/content/telnyx/docs/verify/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,verify,otp,2fa,phone-verification,lookup"
 ---
 

--- a/content/telnyx/docs/verify/go/DOC.md
+++ b/content/telnyx/docs/verify/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,verify,otp,2fa,phone-verification,lookup"
 ---
 

--- a/content/telnyx/docs/verify/java/DOC.md
+++ b/content/telnyx/docs/verify/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,verify,otp,2fa,phone-verification,lookup"
 ---
 

--- a/content/telnyx/docs/verify/javascript/DOC.md
+++ b/content/telnyx/docs/verify/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,verify,otp,2fa,phone-verification,lookup"
 ---
 

--- a/content/telnyx/docs/verify/python/DOC.md
+++ b/content/telnyx/docs/verify/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,verify,otp,2fa,phone-verification,lookup"
 ---
 

--- a/content/telnyx/docs/verify/ruby/DOC.md
+++ b/content/telnyx/docs/verify/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,verify,otp,2fa,phone-verification,lookup"
 ---
 

--- a/content/telnyx/docs/video/curl/DOC.md
+++ b/content/telnyx/docs/video/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,video,rooms,conferencing,real-time"
 ---
 

--- a/content/telnyx/docs/video/go/DOC.md
+++ b/content/telnyx/docs/video/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,video,rooms,conferencing,real-time"
 ---
 

--- a/content/telnyx/docs/video/java/DOC.md
+++ b/content/telnyx/docs/video/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,video,rooms,conferencing,real-time"
 ---
 

--- a/content/telnyx/docs/video/javascript/DOC.md
+++ b/content/telnyx/docs/video/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,video,rooms,conferencing,real-time"
 ---
 

--- a/content/telnyx/docs/video/python/DOC.md
+++ b/content/telnyx/docs/video/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,video,rooms,conferencing,real-time"
 ---
 

--- a/content/telnyx/docs/video/ruby/DOC.md
+++ b/content/telnyx/docs/video/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,video,rooms,conferencing,real-time"
 ---
 

--- a/content/telnyx/docs/voice-advanced/curl/DOC.md
+++ b/content/telnyx/docs/voice-advanced/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,dtmf,siprec,noise-suppression"
 ---
 

--- a/content/telnyx/docs/voice-advanced/go/DOC.md
+++ b/content/telnyx/docs/voice-advanced/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,dtmf,siprec,noise-suppression"
 ---
 

--- a/content/telnyx/docs/voice-advanced/java/DOC.md
+++ b/content/telnyx/docs/voice-advanced/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,dtmf,siprec,noise-suppression"
 ---
 

--- a/content/telnyx/docs/voice-advanced/javascript/DOC.md
+++ b/content/telnyx/docs/voice-advanced/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,dtmf,siprec,noise-suppression"
 ---
 

--- a/content/telnyx/docs/voice-advanced/python/DOC.md
+++ b/content/telnyx/docs/voice-advanced/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,dtmf,siprec,noise-suppression"
 ---
 

--- a/content/telnyx/docs/voice-advanced/ruby/DOC.md
+++ b/content/telnyx/docs/voice-advanced/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,dtmf,siprec,noise-suppression"
 ---
 

--- a/content/telnyx/docs/voice-conferencing/curl/DOC.md
+++ b/content/telnyx/docs/voice-conferencing/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,conference,call-center,queue"
 ---
 

--- a/content/telnyx/docs/voice-conferencing/go/DOC.md
+++ b/content/telnyx/docs/voice-conferencing/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,conference,call-center,queue"
 ---
 

--- a/content/telnyx/docs/voice-conferencing/java/DOC.md
+++ b/content/telnyx/docs/voice-conferencing/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,conference,call-center,queue"
 ---
 

--- a/content/telnyx/docs/voice-conferencing/javascript/DOC.md
+++ b/content/telnyx/docs/voice-conferencing/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,conference,call-center,queue"
 ---
 

--- a/content/telnyx/docs/voice-conferencing/python/DOC.md
+++ b/content/telnyx/docs/voice-conferencing/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,conference,call-center,queue"
 ---
 

--- a/content/telnyx/docs/voice-conferencing/ruby/DOC.md
+++ b/content/telnyx/docs/voice-conferencing/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,conference,call-center,queue"
 ---
 

--- a/content/telnyx/docs/voice-gather/curl/DOC.md
+++ b/content/telnyx/docs/voice-gather/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,dtmf,speech,gather,ivr"
 ---
 

--- a/content/telnyx/docs/voice-gather/go/DOC.md
+++ b/content/telnyx/docs/voice-gather/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,dtmf,speech,gather,ivr"
 ---
 

--- a/content/telnyx/docs/voice-gather/java/DOC.md
+++ b/content/telnyx/docs/voice-gather/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,dtmf,speech,gather,ivr"
 ---
 

--- a/content/telnyx/docs/voice-gather/javascript/DOC.md
+++ b/content/telnyx/docs/voice-gather/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,dtmf,speech,gather,ivr"
 ---
 

--- a/content/telnyx/docs/voice-gather/python/DOC.md
+++ b/content/telnyx/docs/voice-gather/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,dtmf,speech,gather,ivr"
 ---
 

--- a/content/telnyx/docs/voice-gather/ruby/DOC.md
+++ b/content/telnyx/docs/voice-gather/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,dtmf,speech,gather,ivr"
 ---
 

--- a/content/telnyx/docs/voice-media/curl/DOC.md
+++ b/content/telnyx/docs/voice-media/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,tts,audio,recording,ivr"
 ---
 

--- a/content/telnyx/docs/voice-media/go/DOC.md
+++ b/content/telnyx/docs/voice-media/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,tts,audio,recording,ivr"
 ---
 

--- a/content/telnyx/docs/voice-media/java/DOC.md
+++ b/content/telnyx/docs/voice-media/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,tts,audio,recording,ivr"
 ---
 

--- a/content/telnyx/docs/voice-media/javascript/DOC.md
+++ b/content/telnyx/docs/voice-media/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,tts,audio,recording,ivr"
 ---
 

--- a/content/telnyx/docs/voice-media/python/DOC.md
+++ b/content/telnyx/docs/voice-media/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,tts,audio,recording,ivr"
 ---
 

--- a/content/telnyx/docs/voice-media/ruby/DOC.md
+++ b/content/telnyx/docs/voice-media/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,tts,audio,recording,ivr"
 ---
 

--- a/content/telnyx/docs/voice-streaming/curl/DOC.md
+++ b/content/telnyx/docs/voice-streaming/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,streaming,transcription,real-time"
 ---
 

--- a/content/telnyx/docs/voice-streaming/go/DOC.md
+++ b/content/telnyx/docs/voice-streaming/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,streaming,transcription,real-time"
 ---
 

--- a/content/telnyx/docs/voice-streaming/java/DOC.md
+++ b/content/telnyx/docs/voice-streaming/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,streaming,transcription,real-time"
 ---
 

--- a/content/telnyx/docs/voice-streaming/javascript/DOC.md
+++ b/content/telnyx/docs/voice-streaming/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,streaming,transcription,real-time"
 ---
 

--- a/content/telnyx/docs/voice-streaming/python/DOC.md
+++ b/content/telnyx/docs/voice-streaming/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,streaming,transcription,real-time"
 ---
 

--- a/content/telnyx/docs/voice-streaming/ruby/DOC.md
+++ b/content/telnyx/docs/voice-streaming/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,streaming,transcription,real-time"
 ---
 

--- a/content/telnyx/docs/voice/curl/DOC.md
+++ b/content/telnyx/docs/voice/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,call-control,telephony,sip,calls"
 ---
 

--- a/content/telnyx/docs/voice/go/DOC.md
+++ b/content/telnyx/docs/voice/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,call-control,telephony,sip,calls"
 ---
 

--- a/content/telnyx/docs/voice/java/DOC.md
+++ b/content/telnyx/docs/voice/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,call-control,telephony,sip,calls"
 ---
 

--- a/content/telnyx/docs/voice/javascript/DOC.md
+++ b/content/telnyx/docs/voice/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,call-control,telephony,sip,calls"
 ---
 

--- a/content/telnyx/docs/voice/python/DOC.md
+++ b/content/telnyx/docs/voice/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,call-control,telephony,sip,calls"
 ---
 

--- a/content/telnyx/docs/voice/ruby/DOC.md
+++ b/content/telnyx/docs/voice/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,voice,call-control,telephony,sip,calls"
 ---
 

--- a/content/telnyx/docs/webrtc/curl/DOC.md
+++ b/content/telnyx/docs/webrtc/curl/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "curl"
   versions: "v2"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,webrtc,browser,softphone,push-notifications"
 ---
 

--- a/content/telnyx/docs/webrtc/go/DOC.md
+++ b/content/telnyx/docs/webrtc/go/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "go"
   versions: "4.43.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,webrtc,browser,softphone,push-notifications"
 ---
 

--- a/content/telnyx/docs/webrtc/java/DOC.md
+++ b/content/telnyx/docs/webrtc/java/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "java"
   versions: "6.26.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,webrtc,browser,softphone,push-notifications"
 ---
 

--- a/content/telnyx/docs/webrtc/javascript/DOC.md
+++ b/content/telnyx/docs/webrtc/javascript/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "javascript"
   versions: "6.4.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,webrtc,browser,softphone,push-notifications"
 ---
 

--- a/content/telnyx/docs/webrtc/python/DOC.md
+++ b/content/telnyx/docs/webrtc/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "4.60.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,webrtc,browser,softphone,push-notifications"
 ---
 

--- a/content/telnyx/docs/webrtc/ruby/DOC.md
+++ b/content/telnyx/docs/webrtc/ruby/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "ruby"
   versions: "5.52.0"
   updated-on: "2026-03-06"
-  source: maintainer
+  source: official
   tags: "telnyx,webrtc,browser,softphone,push-notifications"
 ---
 


### PR DESCRIPTION
## Summary

- Adds official API documentation for [**Telnyx**](https://telnyx.com) — 35 products across 6 language variants
- **210 DOC.md files** total (35 products × 6 languages)
- Languages: Python, JavaScript, Go, Java, Ruby, curl (REST API)
- Code examples from official Telnyx SDKs

## Content

Each doc covers one Telnyx product area for one language:

| Category | Products |
|----------|----------|
| **Messaging** | messaging, messaging-profiles, messaging-hosted, 10dlc |
| **Voice** | voice, voice-conferencing, voice-media, voice-streaming, voice-gather, voice-advanced, texml, sip, sip-integrations, webrtc |
| **Numbers** | numbers, numbers-config, numbers-compliance, numbers-services, porting-in, porting-out, verify |
| **AI** | ai-assistants, ai-inference, missions |
| **IoT & Networking** | iot, networking |
| **Other** | storage, video, fax, oauth |
| **Account** | account, account-access, account-management, account-notifications, account-reports |

Each DOC.md includes:
- SDK install + setup boilerplate
- Every API operation with endpoint, required/optional params, code example, and response fields
- Webhook events and payload schemas (where applicable)

## Why

Telnyx has 950+ API operations across 6 official SDKs but no existing coverage in Context Hub. These docs give coding agents accurate, copy-pasteable SDK code for every endpoint.

Note: Go, Java, Ruby, and curl are new language variants for the repo — existing content covers Python, JavaScript, and TypeScript only.

## Structure

```
content/telnyx/docs/{product}/{language}/DOC.md
```

Examples:
- `content/telnyx/docs/messaging/python/DOC.md`
- `content/telnyx/docs/voice/javascript/DOC.md`
- `content/telnyx/docs/numbers/go/DOC.md`

## Validation

```
$ chub build content/ --validate-only
Valid: 104 docs, 2 skills, 0 warnings
```

## Source

Official documentation maintained by Telnyx ([@aisling404](https://github.com/aisling404)).

SDK versions: Python 4.60.0, JavaScript 6.4.0, Go 4.43.0, Java 6.26.0, Ruby 5.52.0, curl v2.

## Context

We've been working on a similar problem at Telnyx — giving coding agents accurate SDK information — via [telnyx-skills](https://github.com/team-telnyx/telnyx-skills) (agent skills for Claude Code, Cursor, etc.). After figuring out how to generate and auto-update the skills, the hardest part has been knowing where they fall short. The feedback and annotation loop in Context Hub is exactly what's been missing! Having agents surface what's actually wrong or outdated so authors can fix it, rather than guessing. Really glad someone is building this infrastructure. Happy to be an early contributor!