### PR TITLE
docs: add applitools-playwright-sdk

### DIFF
--- a/content/applitools/docs/eyes-playwright/javascript/DOC.md
+++ b/content/applitools/docs/eyes-playwright/javascript/DOC.md
@@ -65,7 +65,6 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   reporter: [
-    ['html'],
     ['@applitools/eyes-playwright/reporter']
   ],
   use: {
@@ -167,8 +166,8 @@ export const test = mergeTests(base, eyesTest);
 
 | Option | Default | Notes |
 | :--- | :--- | :--- |
-| `apiKey` | `APPLITOOLS_API_KEY` env var | Never hardcode. |
-| `appName` | `'My App'` | Set to your app name for dashboard grouping. |
+| `apiKey` | `APPLITOOLS_API_KEY` env var | Never hardcode (unless it's an untracked file). |
+| `appName` | `'My App'` | Set to your app name for dashboard grouping (default - package.json `name` field). |
 | `matchLevel` | `'Strict'` | See Match Levels above. |
 | `failTestsOnDiff` | `'afterAll'` in CI, `'afterEach'` locally | See CI/CD strategy above. |
 | `ignoreDisplacements` | `false` | Set `true` to suppress vertical shift noise. |


### PR DESCRIPTION
## What

Added technical context for the **Applitools Eyes Playwright SDK**. 
This contribution includes:
* Comprehensive architectural overview of the asynchronous capture mechanism.
* Strategic implementation guide for the `failTestsOnDiff` configuration.
* Performance optimization guidelines using the Ultrafast Grid (UFG).
* Best practices for merging Applitools fixtures into existing Playwright suites.

## Why

Currently, AI agents lack specific context regarding visual testing lifecycle management. This contribution solves several problems:
1. **Efficiency**: Prevents agents from recommending $O(N)$ linear scaling for cross-browser testing by providing the UFG $O(1)$ alternative.
2. **Stability**: Guides agents to use the proper CI/CD strategy (`failTestsOnDiff: false`) to avoid wasteful retries in SCM-integrated pipelines.
3. **Correctness**: Ensures agents follow the fixture-based lifecycle rather than manually (and incorrectly) calling `eyes.open()`.

## Testing

- [x] `npm test` passes (in `cli/` directory).
- [x] `node cli/bin/chub build content/applitools --validate-only` succeeds.
- [x] Manual testing: Verified the Markdown renders correctly and the frontmatter is detectable by the `chub` CLI.

## Notes

The content is written specifically for LLM consumption, adhering to the project's guidelines for direct, code-first documentation.