### PR TITLE
Distribution via atk

### DIFF
--- a/.atk/README.md
+++ b/.atk/README.md
@@ -1,0 +1,47 @@
+# context-hub
+
+Curated, versioned API docs and agent skills for 80+ services — fetched on-demand by coding agents via the `chub` CLI and MCP server.
+
+## Overview
+
+Context Hub gives coding agents accurate, up-to-date API documentation instead of relying on training data that goes stale. Agents search, fetch, annotate, and rate docs in a continuous feedback loop that makes them smarter over time.
+
+Content covers services like OpenAI, Anthropic, Stripe, AWS, GitHub, and many more — all open markdown, inspectable and community-contributed.
+
+## Installation
+
+Requires: Node.js ≥ 18
+
+```bash
+atk add github.com/andrewyng/context-hub
+```
+
+No environment variables required — Context Hub is a free, public service.
+
+After install, register the MCP server with your coding agent:
+
+```bash
+atk mcp show context-hub          # inspect the generated MCP config
+atk mcp add context-hub --claude --codex --gemini    # pick your agents
+```
+
+## Usage
+
+The plugin exposes the `chub` MCP server to your agent. Once connected, the agent can call:
+
+| Tool | Purpose |
+|------|---------|
+| `chub_search` | Search for docs or skills by keyword, tag, or language |
+| `chub_get` | Fetch a doc or skill by ID (e.g. `openai/chat`) |
+| `chub_list` | List all available entries |
+| `chub_annotate` | Read, write, or clear local agent annotations |
+| `chub_feedback` | Send quality ratings back to doc authors |
+
+Your agent is automatically instructed how to use these tools via the bundled `SKILL.md`.
+
+## Links
+
+- [Repository](https://github.com/andrewyng/context-hub)
+- [CLI Reference](https://github.com/andrewyng/context-hub/blob/main/docs/cli-reference.md)
+- [Content Guide](https://github.com/andrewyng/context-hub/blob/main/docs/content-guide.md)
+

--- a/.atk/SKILL.md
+++ b/.atk/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: get-api-docs
+description: >
+  Use this skill when you need documentation for a third-party library, SDK, or API
+  before writing code that uses it — for example, "use the OpenAI API", "call the
+  Stripe API", "use the Anthropic SDK", "query Pinecone", or any time the user asks
+  you to write code against an external service and you need current API reference.
+  Fetch the docs with chub_get before answering, rather than relying on training knowledge.
+---
+
+# Get API Docs via chub
+
+When you need documentation for a library or API, fetch it with the `chub_get` MCP tool
+rather than guessing from training data. This gives you the current, correct API.
+
+## Step 1 — Find the right doc ID
+
+Call `chub_search` with the library name as the `query` parameter (e.g. `"stripe"`, `"openai"`).
+
+Pick the best-matching `id` from the results (e.g. `openai/chat`, `anthropic/sdk`,
+`stripe/api`). If nothing matches, try a broader term.
+
+## Step 2 — Fetch the docs
+
+Call `chub_get` with the `id` and a `lang` parameter (`"python"`, `"js"`, `"ts"`).
+
+Omit `lang` if the doc has only one language variant — it will be auto-selected.
+
+## Step 3 — Use the docs
+
+Read the fetched content and use it to write accurate code or answer the question.
+Do not rely on memorized API shapes — use what the docs say.
+
+## Step 4 — Annotate what you learned
+
+After completing the task, if you discovered something not in the doc — a gotcha,
+workaround, version quirk, or project-specific detail — save it so future sessions
+start smarter:
+
+Call `chub_annotate` with the `id` and a `note` (e.g. `"Webhook verification requires raw body — do not parse before verifying"`).
+
+Annotations are local, persist across sessions, and appear automatically on future
+`chub_get` calls. Keep notes concise and actionable. Don't repeat what's already in
+the doc.
+
+## Step 5 — Give feedback
+
+Rate the doc so authors can improve it. Ask the user before sending.
+
+Call `chub_feedback` with the `id`, a `rating` (`"up"` or `"down"`), and optional `labels`.
+
+Available labels: `outdated`, `inaccurate`, `incomplete`, `wrong-examples`,
+`wrong-version`, `poorly-structured`, `accurate`, `well-structured`, `helpful`,
+`good-examples`.
+
+## Quick reference
+
+| Goal | Tool | Key parameters |
+|------|------|----------------|
+| List everything | `chub_search` | _(no query)_ |
+| Find a doc | `chub_search` | `query="stripe"` |
+| Exact ID detail | `chub_search` | `query="stripe/api"` |
+| Fetch Python docs | `chub_get` | `id="stripe/api"`, `lang="python"` |
+| Fetch JS docs | `chub_get` | `id="openai/chat"`, `lang="js"` |
+| Fetch multiple | `chub_get` | call once per ID |
+| Save a note | `chub_annotate` | `id="stripe/api"`, `note="needs raw body"` |
+| List notes | `chub_annotate` | `list=true` |
+| Rate a doc | `chub_feedback` | `id="stripe/api"`, `rating="up"` |
+
+## Notes
+
+- `chub_search` with no `query` lists everything available
+- IDs are `<author>/<name>` — confirm the ID from search before fetching
+- If `chub_get` returns "multiple languages available", add the `lang` parameter
+

--- a/.atk/plugin.yaml
+++ b/.atk/plugin.yaml
@@ -1,0 +1,22 @@
+schema_version: "2026-01-23"
+name: context-hub
+description: >
+  Curated, versioned API docs and agent skills for 80+ services — fetched on-demand
+  by coding agents so they write correct code instead of hallucinating APIs.
+
+maturity: community
+
+vendor:
+  name: Andrew Ng / AI Suite
+  url: https://github.com/andrewyng/context-hub
+  docs: https://github.com/andrewyng/context-hub#readme
+
+lifecycle:
+  install: npm install -g @aisuite/chub
+  uninstall: npm uninstall -g @aisuite/chub
+
+mcp:
+  transport: stdio
+  command: npx
+  args: ["-y", "--package", "@aisuite/chub", "chub-mcp"]
+

--- a/README.md
+++ b/README.md
@@ -8,11 +8,29 @@ Coding agents hallucinate APIs and forget what they learn in a session. Context 
 
 ## Quick Start
 
+The recommended way to use Context Hub is through its MCP server, which gives your coding agent native tool calls (`chub_search`, `chub_get`, `chub_annotate`, `chub_feedback`) — no shell access required, no manual wiring.
+
+[ATK](https://github.com/Svtoo/atk) installs the MCP server, registers it with your agent, and injects the usage skill — all in three commands:
+
+```bash
+uv tool install atk-cli && atk init         # install ATK once
+atk add github.com/andrewyng/context-hub
+atk mcp add context-hub --claude --codex --gemini --opencode # pick your agents
+```
+
+After this, your agent can call `chub_get`, `chub_search`, and the rest directly as tools, and already knows when and how to use them.
+
+## Alternative: CLI Only
+
+If you prefer to use the `chub` CLI directly and configure your agent manually:
+
 ```bash
 npm install -g @aisuite/chub
 chub search openai                 # find what's available
-chub get openai/chat --lang py     # fetch current docs (Python version) 
+chub get openai/chat --lang py     # fetch current docs (Python version)
 ```
+
+To teach your agent to use the CLI, copy [SKILL.md](cli/skills/get-api-docs/SKILL.md) into your agent's context (e.g. `~/.claude/CLAUDE.md` for Claude Code) and prompt it to use `chub` before writing code against external APIs.
 
 ## How It Works
 


### PR DESCRIPTION
## What

Adds a `.atk/` directory to the repo root, making Context Hub installable via [ATK](https://github.com/Svtoo/atk) — an open-source tool manager for AI development tools.

Three files added (`.atk/plugin.yaml`, `.atk/README.md`, `.atk/SKILL.md`), one file updated (`README.md`). No existing code touched.

**User experience:**

```bash
uv tool install atk-cli                                 # install ATK once
atk add github.com/andrewyng/context-hub                # install chub CLI + MCP server
atk mcp add context-hub --claude --codex --gemini       # wire to coding agents
```

The agent now has `chub_search`, `chub_get`, `chub_annotate`, and `chub_feedback` as native MCP tool calls, and already knows when and how to use them.

## Why

Context Hub already ships an MCP server (`chub-mcp`), but the current setup path doesn't surface it: users install the CLI, manually copy SKILL.md, and configure their agent by hand. That gives the agent CLI access via shell subprocess — which doesn't work in agents without terminal access, and requires a subprocess for every doc lookup.

ATK makes the MCP server the default path and automates all the wiring:

| | CLI only | Via ATK |
|---|---|---|
| How the agent fetches docs | Shell subprocess | Native MCP tool call |
| Works without shell access | ✗ | ✓ |
| Agent skill auto-injected | Manual | Automatic |
| Agents supported | One at a time, manually | Claude, Codex, Gemini, Auggie, OpenCode |
| CLI also installed | Manual | Automatically during `atk add` |

ATK handles install, uninstall, upgrade, MCP registration, and skill injection across an ever-growing list of coding agents, all from the same three commands.

**Demo:**

![context-hub-demo](https://github.com/user-attachments/assets/a73b2f86-5ad4-4326-8574-f044a16b2c63)

Before/after agent MCP lists, then Claude answering a question about the OpenAI batch API by calling `chub_get` directly — without being prompted to.

## Testing

- [x] `npm test` passes
- [x] `chub build sample-content/ --validate-only` succeeds
- [x] Manual testing done (describe below)

Manually tested the full ATK lifecycle:
- `atk add github.com/andrewyng/context-hub` — installs `chub` CLI and copies plugin files
- `atk mcp add context-hub --claude --codex` — registers MCP server and injects SKILL.md with both agents
- `claude mcp list` / `codex mcp list` — confirm `context-hub` appears
- `atk remove context-hub --force` — clean uninstall, MCP entries removed

## Notes

**Files changed:**

- `.atk/plugin.yaml` — plugin definition: npm lifecycle for the CLI (`npm install/uninstall -g @aisuite/chub`), MCP config pointing at `chub-mcp` via npx. Install is idempotent, so `atk upgrade` works out of the box.
- `.atk/SKILL.md` — MCP translation of the existing `cli/skills/get-api-docs/SKILL.md`. Same 5-step structure and wording, CLI commands replaced with MCP tool call descriptions.
- `.atk/README.md` — help file surfaced by `atk help context-hub`.
- `README.md` — Quick Start now leads with the ATK/MCP path; npm install moved to an "Alternative: CLI Only" section.

The `.atk/` directory is invisible to the existing build, test, and publish pipeline.

