### PR TITLE
Fix multi-source BM25 search collisions

### DIFF
--- a/cli/src/lib/registry.js
+++ b/cli/src/lib/registry.js
@@ -6,6 +6,20 @@ import { search as bm25Search } from './bm25.js';
 let _merged = null;
 let _searchIndex = null;
 
+function getSearchLookupId(sourceName, entryId) {
+  return `${sourceName}:${entryId}`;
+}
+
+function namespaceSearchIndex(index, sourceName) {
+  return {
+    ...index,
+    documents: (index.documents || []).map((doc) => ({
+      ...doc,
+      id: getSearchLookupId(sourceName, doc.id),
+    })),
+  };
+}
+
 /**
  * Load and merge entries from all configured sources.
  * Returns { docs: [...], skills: [...] } with each entry tagged with _source/_sourceObj.
@@ -24,7 +38,7 @@ function getMerged() {
 
     // Load BM25 search index if available
     const idx = loadSearchIndex(source);
-    if (idx) searchIndexes.push(idx);
+    if (idx) searchIndexes.push(namespaceSearchIndex(idx, source.name));
 
     // Support both new format (docs/skills) and old format (entries)
     if (registry.docs) {
@@ -194,7 +208,7 @@ export function searchEntries(query, filters = {}) {
   // Build entry lookup by id
   const entryById = new Map();
   for (const entry of deduped) {
-    entryById.set(entry.id, entry);
+    entryById.set(getSearchLookupId(entry._source, entry.id), entry);
   }
 
   let results;

--- a/cli/tests/lib/registry.multisource.test.js
+++ b/cli/tests/lib/registry.multisource.test.js
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildIndex } from '../../src/lib/bm25.js';
+
+const ORIGINAL_CHUB_DIR = process.env.CHUB_DIR;
+const tempDirs = [];
+
+function writeSource(root, quality, description, tags = []) {
+  mkdirSync(root, { recursive: true });
+  writeFileSync(
+    join(root, 'registry.json'),
+    JSON.stringify({
+      version: '1.0.0',
+      docs: [
+        {
+          id: 'shared/api',
+          name: 'shared api',
+          description,
+          source: quality,
+          tags,
+          languages: [
+            {
+              language: 'javascript',
+              recommendedVersion: '1.0.0',
+              versions: [
+                {
+                  version: '1.0.0',
+                  path: 'shared/api/javascript',
+                  files: ['DOC.md'],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      skills: [],
+    }, null, 2)
+  );
+
+  writeFileSync(
+    join(root, 'search-index.json'),
+    JSON.stringify(
+      buildIndex([
+        {
+          id: 'shared/api',
+          name: 'shared api',
+          description,
+          tags,
+        },
+      ])
+    )
+  );
+}
+
+async function loadRegistryWithSources(sourceRoots) {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'chub-multisource-'));
+  tempDirs.push(tempRoot);
+
+  const chubDir = join(tempRoot, '.chub');
+  mkdirSync(chubDir, { recursive: true });
+
+  const config = [
+    'sources:',
+    ...sourceRoots.map(({ name, root }) => `  - name: ${name}\n    path: ${JSON.stringify(root)}`),
+    'source: official,maintainer,community',
+  ].join('\n');
+
+  writeFileSync(join(chubDir, 'config.yaml'), `${config}\n`);
+  process.env.CHUB_DIR = chubDir;
+
+  vi.resetModules();
+  return import('../../src/lib/registry.js');
+}
+
+afterEach(() => {
+  vi.resetModules();
+  if (ORIGINAL_CHUB_DIR === undefined) delete process.env.CHUB_DIR;
+  else process.env.CHUB_DIR = ORIGINAL_CHUB_DIR;
+
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+describe('searchEntries multi-source collisions', () => {
+  it('returns the entry from the matching source when multiple sources share an id', async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'chub-multisource-data-'));
+    tempDirs.push(tempRoot);
+
+    const alpha = join(tempRoot, 'alpha');
+    const beta = join(tempRoot, 'beta');
+    writeSource(alpha, 'official', 'Alpha payments integration', ['payments']);
+    writeSource(beta, 'official', 'Beta observability traces', ['tracing']);
+
+    const { searchEntries } = await loadRegistryWithSources([
+      { name: 'alpha', root: alpha },
+      { name: 'beta', root: beta },
+    ]);
+
+    const payments = searchEntries('payments');
+    const tracing = searchEntries('tracing');
+
+    expect(payments).toHaveLength(1);
+    expect(payments[0]._source).toBe('alpha');
+    expect(payments[0].description).toContain('payments');
+
+    expect(tracing).toHaveLength(1);
+    expect(tracing[0]._source).toBe('beta');
+    expect(tracing[0].description).toContain('traces');
+  });
+
+  it('keeps both search results when duplicate ids exist across sources', async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'chub-multisource-data-'));
+    tempDirs.push(tempRoot);
+
+    const alpha = join(tempRoot, 'alpha');
+    const beta = join(tempRoot, 'beta');
+    writeSource(alpha, 'official', 'Alpha shared API for payments', ['payments']);
+    writeSource(beta, 'official', 'Beta shared API for tracing', ['tracing']);
+
+    const { searchEntries } = await loadRegistryWithSources([
+      { name: 'alpha', root: alpha },
+      { name: 'beta', root: beta },
+    ]);
+
+    const results = searchEntries('shared');
+
+    expect(results).toHaveLength(2);
+    expect(new Set(results.map((entry) => entry._source))).toEqual(new Set(['alpha', 'beta']));
+  });
+});


### PR DESCRIPTION
## Summary
This fixes a correctness bug in BM25-backed search when multiple configured sources publish the same entry ID.

Before this change, `searchEntries()` built its lookup map by bare `id` while merged search-index documents also kept bare `id`s. In multi-source mode, the later source overwrote earlier ones, so searches could:
- return the wrong source's entry for a matching query
- emit duplicate results for the same source entry when both sources matched

## Changes
- namespace loaded search-index document IDs with `source:id` before merging BM25 indexes
- resolve BM25 results through the same `source:id` lookup key used by registry entries
- add a regression test that reproduces the wrong-source result
- add a regression test that verifies duplicate IDs across sources still produce two distinct results

## Repro
With two local sources that both expose `shared/api`:
- source `alpha` describes payments
- source `beta` describes tracing

Before this patch:
- `searchEntries('payments')` incorrectly returned the `beta` entry
- `searchEntries('shared')` returned the `beta` entry twice

After this patch:
- `searchEntries('payments')` returns `alpha`
- `searchEntries('tracing')` returns `beta`
- `searchEntries('shared')` returns both entries once each

## Validation
- `cd cli && npm test`
- `node cli/bin/chub build content/ --validate-only`
