### PR TITLE
feat(content): add openai/chat Go language variant

### DIFF
--- a/cli/test/fixtures/multilang/docs/client/go/DOC.md
+++ b/cli/test/fixtures/multilang/docs/client/go/DOC.md
@@ -1,0 +1,18 @@
+---
+name: client
+description: "Multilang client SDK"
+metadata:
+  languages: "go"
+  versions: "1.0.0"
+  updated-on: "2026-01-01"
+  source: community
+  tags: "multilang,client"
+---
+
+# Multilang Client — Go
+
+```go
+import "multilang"
+
+client := multilang.NewClient(multilang.WithAPIKey("sk-test"))
+```

--- a/cli/tests/commands/go-lang.test.js
+++ b/cli/tests/commands/go-lang.test.js
@@ -1,0 +1,265 @@
+/**
+ * Tests for `--lang go` support in context-hub.
+ *
+ * Covers:
+ *  1. content/openai/docs/chat/go/DOC.md — frontmatter correctness
+ *  2. resolveDocPath() — correctly resolves a Go language entry
+ *  3. resolveDocPath() — returns error for unknown language
+ *  4. chub build — validates the Go fixture via CLI
+ *  5. chub build --validate-only --json — Go fixture counts as a doc language variant
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { parseFrontmatter } from '../../src/lib/frontmatter.js';
+import { resolveDocPath } from '../../src/lib/registry.js';
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..', '..');
+const CLI_BIN = join(import.meta.dirname, '..', '..', 'bin', 'chub');
+const FIXTURES = join(import.meta.dirname, '..', '..', 'test', 'fixtures');
+const GO_DOC_PATH = join(REPO_ROOT, 'content', 'openai', 'docs', 'chat', 'go', 'DOC.md');
+const GO_FIXTURE_PATH = join(FIXTURES, 'multilang', 'docs', 'client', 'go', 'DOC.md');
+
+// ---------------------------------------------------------------------------
+// 1. Content file — frontmatter validation
+// ---------------------------------------------------------------------------
+describe('content/openai/docs/chat/go/DOC.md — frontmatter', () => {
+  it('file exists and is readable', () => {
+    const raw = readFileSync(GO_DOC_PATH, 'utf8');
+    expect(raw.length).toBeGreaterThan(100);
+  });
+
+  it('has required name field equal to "chat"', () => {
+    const { attributes } = parseFrontmatter(readFileSync(GO_DOC_PATH, 'utf8'));
+    expect(attributes.name).toBe('chat');
+  });
+
+  it('has required description field', () => {
+    const { attributes } = parseFrontmatter(readFileSync(GO_DOC_PATH, 'utf8'));
+    expect(typeof attributes.description).toBe('string');
+    expect(attributes.description.length).toBeGreaterThan(10);
+  });
+
+  it('declares language as "go"', () => {
+    const { attributes } = parseFrontmatter(readFileSync(GO_DOC_PATH, 'utf8'));
+    expect(attributes.metadata.languages).toBe('go');
+  });
+
+  it('has a versions field (SDK version string)', () => {
+    const { attributes } = parseFrontmatter(readFileSync(GO_DOC_PATH, 'utf8'));
+    expect(typeof attributes.metadata.versions).toBe('string');
+    expect(attributes.metadata.versions.length).toBeGreaterThan(0);
+  });
+
+  it('has an updated-on date in YYYY-MM-DD format', () => {
+    const { attributes } = parseFrontmatter(readFileSync(GO_DOC_PATH, 'utf8'));
+    expect(attributes.metadata['updated-on']).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('has a valid source value', () => {
+    const { attributes } = parseFrontmatter(readFileSync(GO_DOC_PATH, 'utf8'));
+    const validSources = ['official', 'maintainer', 'community'];
+    expect(validSources).toContain(attributes.metadata.source);
+  });
+
+  it('has tags including "go" or "openai"', () => {
+    const { attributes } = parseFrontmatter(readFileSync(GO_DOC_PATH, 'utf8'));
+    const tags = attributes.metadata.tags || '';
+    expect(tags).toMatch(/openai|go/);
+  });
+
+  it('body contains openai.F() — the critical Go SDK pattern', () => {
+    const { body } = parseFrontmatter(readFileSync(GO_DOC_PATH, 'utf8'));
+    expect(body).toContain('openai.F(');
+  });
+
+  it('body contains go import statement', () => {
+    const { body } = parseFrontmatter(readFileSync(GO_DOC_PATH, 'utf8'));
+    expect(body).toContain('github.com/openai/openai-go');
+  });
+
+  it('body contains a code block', () => {
+    const { body } = parseFrontmatter(readFileSync(GO_DOC_PATH, 'utf8'));
+    expect(body).toContain('```go');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Go fixture — frontmatter validation
+// ---------------------------------------------------------------------------
+describe('test fixture: multilang/docs/client/go/DOC.md', () => {
+  it('fixture file exists', () => {
+    const raw = readFileSync(GO_FIXTURE_PATH, 'utf8');
+    expect(raw.length).toBeGreaterThan(0);
+  });
+
+  it('fixture name matches sibling variants (must be "client")', () => {
+    const { attributes } = parseFrontmatter(readFileSync(GO_FIXTURE_PATH, 'utf8'));
+    expect(attributes.name).toBe('client');
+  });
+
+  it('fixture declares language "go"', () => {
+    const { attributes } = parseFrontmatter(readFileSync(GO_FIXTURE_PATH, 'utf8'));
+    expect(attributes.metadata.languages).toBe('go');
+  });
+
+  it('fixture has same description as python/js variants', () => {
+    const { attributes } = parseFrontmatter(readFileSync(GO_FIXTURE_PATH, 'utf8'));
+    expect(attributes.description).toBe('Multilang client SDK');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. resolveDocPath() — Go language resolution logic
+// ---------------------------------------------------------------------------
+describe('resolveDocPath() — Go language support', () => {
+  const makeEntry = (languages) => ({
+    name: 'chat',
+    languages,
+    _sourceObj: { name: 'default', url: 'https://cdn.example.com/v1' },
+  });
+
+  it('resolves "go" language variant when present', () => {
+    const entry = makeEntry([
+      { language: 'python', versions: [{ version: '2.0', path: 'openai/chat/python', files: ['DOC.md'] }], recommendedVersion: '2.0' },
+      { language: 'javascript', versions: [{ version: '6.0', path: 'openai/chat/javascript', files: ['DOC.md'] }], recommendedVersion: '6.0' },
+      { language: 'go', versions: [{ version: '1.3.0', path: 'openai/chat/go', files: ['DOC.md'] }], recommendedVersion: '1.3.0' },
+    ]);
+
+    const result = resolveDocPath(entry, 'go', null);
+    expect(result).not.toBeNull();
+    expect(result.path).toBe('openai/chat/go');
+    expect(result.files).toContain('DOC.md');
+  });
+
+  it('returns needsLanguage when lang is null and multiple languages exist including go', () => {
+    const entry = makeEntry([
+      { language: 'python', versions: [{ version: '2.0', path: 'p/python', files: ['DOC.md'] }], recommendedVersion: '2.0' },
+      { language: 'go', versions: [{ version: '1.3.0', path: 'p/go', files: ['DOC.md'] }], recommendedVersion: '1.3.0' },
+    ]);
+
+    const result = resolveDocPath(entry, null, null);
+    expect(result).not.toBeNull();
+    expect(result.needsLanguage).toBe(true);
+    expect(result.available).toContain('go');
+    expect(result.available).toContain('python');
+  });
+
+  it('returns error-like result when "go" is requested but not available', () => {
+    const entry = makeEntry([
+      { language: 'python', versions: [{ version: '2.0', path: 'p/python', files: ['DOC.md'] }], recommendedVersion: '2.0' },
+      { language: 'javascript', versions: [{ version: '6.0', path: 'p/js', files: ['DOC.md'] }], recommendedVersion: '6.0' },
+    ]);
+
+    const result = resolveDocPath(entry, 'go', null);
+    // Should return null or a languageNotFound indicator — not a valid path
+    if (result !== null) {
+      expect(result.path).toBeUndefined();
+    } else {
+      expect(result).toBeNull();
+    }
+  });
+
+  it('resolves "go" at a specific version', () => {
+    const entry = makeEntry([
+      {
+        language: 'go',
+        versions: [
+          { version: '1.3.0', path: 'openai/chat/go', files: ['DOC.md'] },
+          { version: '1.0.0', path: 'openai/chat/go-v1', files: ['DOC.md'] },
+        ],
+        recommendedVersion: '1.3.0',
+      },
+    ]);
+
+    const result = resolveDocPath(entry, 'go', '1.0.0');
+    expect(result).not.toBeNull();
+    expect(result.path).toBe('openai/chat/go-v1');
+  });
+
+  it('resolves recommended version when lang=go and version=null', () => {
+    const entry = makeEntry([
+      {
+        language: 'go',
+        versions: [
+          { version: '1.3.0', path: 'openai/chat/go', files: ['DOC.md'] },
+          { version: '1.0.0', path: 'openai/chat/go-v1', files: ['DOC.md'] },
+        ],
+        recommendedVersion: '1.3.0',
+      },
+    ]);
+
+    const result = resolveDocPath(entry, 'go', null);
+    expect(result).not.toBeNull();
+    expect(result.path).toBe('openai/chat/go');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. CLI integration — build validates Go fixture without errors
+// ---------------------------------------------------------------------------
+describe('chub build — Go fixture integration', () => {
+  it('validates the multilang fixture (including Go variant) without errors', () => {
+    const result = execFileSync(
+      process.execPath,
+      [CLI_BIN, 'build', FIXTURES, '--validate-only', '--json'],
+      { encoding: 'utf8' },
+    );
+
+    const parsed = JSON.parse(result.trim());
+    expect(parsed.warnings).toBe(0);
+    expect(parsed.docs).toBeGreaterThanOrEqual(1);
+  });
+
+  it('doc count includes Go as part of the multilang entry (not a new doc)', () => {
+    // The multilang/client entry now has 3 language variants: python, javascript, go.
+    // It should still count as 1 doc entry (language variants share the same name).
+    const result = execFileSync(
+      process.execPath,
+      [CLI_BIN, 'build', FIXTURES, '--validate-only', '--json'],
+      { encoding: 'utf8' },
+    );
+
+    const parsed = JSON.parse(result.trim());
+    // 3 doc entries: acme/widgets, acme/versioned-api, multilang/client (with py+js+go)
+    expect(parsed.docs).toBe(3);
+  });
+
+  it('exits cleanly (exit code 0) with Go fixture present', () => {
+    let threw = false;
+    try {
+      execFileSync(
+        process.execPath,
+        [CLI_BIN, 'build', FIXTURES, '--validate-only'],
+        { encoding: 'utf8', stdio: 'pipe' },
+      );
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Build → registry round-trip: go appears in built registry.json
+// ---------------------------------------------------------------------------
+describe('chub build — Go appears in built registry.json', () => {
+  it('go language is present in registry after building content/', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'chub-go-test-'));
+
+    execFileSync(
+      process.execPath,
+      [CLI_BIN, 'build', join(REPO_ROOT, 'content'), '-o', tmpDir],
+      { encoding: 'utf8' },
+    );
+
+    const registry = JSON.parse(readFileSync(join(tmpDir, 'registry.json'), 'utf8'));
+    const chat = registry.docs.find((d) => d.id === 'openai/chat');
+    expect(chat).toBeDefined();
+    const langs = chat.languages.map((l) => l.language);
+    expect(langs).toContain('go');
+  });
+});

--- a/content/openai/docs/chat/go/DOC.md
+++ b/content/openai/docs/chat/go/DOC.md
@@ -1,0 +1,356 @@
+---
+name: chat
+description: "OpenAI API for text generation, chat completions, streaming, function calling, vision, embeddings, and assistants"
+metadata:
+  languages: "go"
+  versions: "1.3.0"
+  revision: 1
+  updated-on: "2026-03-09"
+  source: community
+  tags: "openai,chat,llm,ai"
+---
+
+# OpenAI Go SDK Coding Guidelines
+
+You are an OpenAI API coding expert. Help me with writing code using the OpenAI API calling the official Go SDK.
+
+You can find the official SDK documentation and code samples here:
+https://platform.openai.com/docs/api-reference
+
+## Golden Rule: Use the Correct and Current SDK
+
+Always use the official OpenAI Go SDK to call OpenAI models.
+
+**Module:** `github.com/openai/openai-go`
+
+**Installation:**
+```bash
+go get github.com/openai/openai-go
+```
+
+**APIs and Usage:**
+- **Primary API (Recommended):** `client.Responses.Create(...)`
+- **Legacy API (Still Supported):** `client.Chat.Completions.New(...)`
+
+## Initialization and API Key
+
+Set the `OPENAI_API_KEY` environment variable; the SDK picks it up automatically.
+
+```go
+import (
+    "github.com/openai/openai-go"
+    "github.com/openai/openai-go/option"
+)
+
+// Uses OPENAI_API_KEY environment variable automatically
+client := openai.NewClient()
+
+// Or pass the API key explicitly (not recommended for production)
+// client := openai.NewClient(option.WithAPIKey("your-api-key-here"))
+```
+
+Use environment secrets or a secrets manager to keep keys out of source control.
+
+## Models (as of March 2026)
+
+Use typed model constants from the SDK — never hardcode strings directly.
+
+Default choices:
+- **General Text Tasks:** `openai.ChatModelGPT4_1` (non-reasoning)
+- **Fast & Cost-Efficient:** `openai.ChatModelGPT4_1Mini`
+- **Cheapest / Fastest:** `openai.ChatModelGPT4_1Nano`
+
+```go
+// Typed constants — preferred
+model: openai.F(openai.ChatModelGPT4_1),
+
+// String literal — only when using a model not yet in constants
+model: openai.F("gpt-5.4"),
+```
+
+## Basic Inference (Text Generation)
+
+### Primary Method: Responses API (Recommended)
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+
+    "github.com/openai/openai-go"
+    "github.com/openai/openai-go/responses"
+)
+
+func main() {
+    client := openai.NewClient()
+
+    resp, err := client.Responses.New(context.Background(), responses.ResponseNewParams{
+        Model:        openai.F("gpt-4.1"),
+        Instructions: openai.F("You are a helpful coding assistant."),
+        Input:        responses.ResponseNewParamsInputUnionString("How do I reverse a slice in Go?"),
+    })
+    if err != nil {
+        panic(err)
+    }
+    fmt.Println(resp.OutputText())
+}
+```
+
+### Legacy Method: Chat Completions API
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+
+    "github.com/openai/openai-go"
+)
+
+func main() {
+    client := openai.NewClient()
+
+    completion, err := client.Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{
+        Model: openai.F(openai.ChatModelGPT4_1),
+        Messages: openai.F([]openai.ChatCompletionMessageParamUnion{
+            openai.SystemMessage("You are a helpful assistant."),
+            openai.UserMessage("How do I reverse a slice in Go?"),
+        }),
+    })
+    if err != nil {
+        panic(err)
+    }
+    fmt.Println(completion.Choices[0].Message.Content)
+}
+```
+
+## The `openai.F()` Wrapper — Critical Pattern
+
+**All parameter fields in the Go SDK must be wrapped with `openai.F()`.**
+This is Go-specific and does not appear in Python or JavaScript SDK docs.
+
+```go
+// CORRECT — all fields wrapped
+openai.ChatCompletionNewParams{
+    Model:       openai.F(openai.ChatModelGPT4_1),
+    MaxTokens:   openai.F(int64(1024)),
+    Temperature: openai.F(0.7),
+    Messages:    openai.F([]openai.ChatCompletionMessageParamUnion{...}),
+}
+
+// WRONG — missing F() wrappers (will not compile)
+openai.ChatCompletionNewParams{
+    Model:    openai.ChatModelGPT4_1,   // BAD
+    Messages: []openai.ChatCompletionMessageParamUnion{...}, // BAD
+}
+```
+
+Use `openai.Bool(true)` and `openai.Int(n)` as shortcuts for pointer-wrapped booleans and ints.
+
+## Streaming Responses
+
+### Responses API Streaming
+
+```go
+stream := client.Responses.NewStreaming(context.Background(), responses.ResponseNewParams{
+    Model: openai.F("gpt-4.1"),
+    Input: responses.ResponseNewParamsInputUnionString("Write a short story about a robot."),
+})
+
+for stream.Next() {
+    event := stream.Current()
+    fmt.Print(event.OutputText())
+}
+if err := stream.Err(); err != nil {
+    panic(err)
+}
+```
+
+### Chat Completions Streaming
+
+```go
+stream := client.Chat.Completions.NewStreaming(context.Background(), openai.ChatCompletionNewParams{
+    Model: openai.F(openai.ChatModelGPT4_1),
+    Messages: openai.F([]openai.ChatCompletionMessageParamUnion{
+        openai.UserMessage("Tell me a joke"),
+    }),
+})
+
+acc := openai.ChatCompletionAccumulator{}
+for stream.Next() {
+    chunk := stream.Current()
+    acc.AddChunk(chunk)
+    if len(chunk.Choices) > 0 {
+        fmt.Print(chunk.Choices[0].Delta.Content)
+    }
+}
+if err := stream.Err(); err != nil {
+    panic(err)
+}
+// acc.Choices[0].Message.Content now holds the full assembled response
+```
+
+## Function Calling (Tools)
+
+```go
+tools := []openai.ChatCompletionToolParam{
+    {
+        Type: openai.F(openai.ChatCompletionToolTypeFunction),
+        Function: openai.F(openai.FunctionDefinitionParam{
+            Name:        openai.F("get_weather"),
+            Description: openai.F("Get current weather for a city"),
+            Parameters: openai.F(openai.FunctionParameters{
+                "type": "object",
+                "properties": map[string]interface{}{
+                    "city": map[string]string{
+                        "type":        "string",
+                        "description": "City name",
+                    },
+                },
+                "required": []string{"city"},
+            }),
+        }),
+    },
+}
+
+resp, err := client.Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{
+    Model: openai.F(openai.ChatModelGPT4_1),
+    Messages: openai.F([]openai.ChatCompletionMessageParamUnion{
+        openai.UserMessage("What's the weather in Paris?"),
+    }),
+    Tools: openai.F(tools),
+})
+if err != nil {
+    panic(err)
+}
+// Inspect resp.Choices[0].Message.ToolCalls for the model's invocation
+for _, tc := range resp.Choices[0].Message.ToolCalls {
+    fmt.Printf("Function: %s, Args: %s\n", tc.Function.Name, tc.Function.Arguments)
+}
+```
+
+## Structured Outputs (JSON Schema)
+
+```go
+import "encoding/json"
+
+type Step struct {
+    Explanation string `json:"explanation"`
+    Output      string `json:"output"`
+}
+type MathReasoning struct {
+    Steps       []Step `json:"steps"`
+    FinalAnswer string `json:"final_answer"`
+}
+
+schemaParam := openai.ResponseFormatJSONSchemaJSONSchemaParam{
+    Name:        openai.F("math_reasoning"),
+    Description: openai.F("Step-by-step math solution"),
+    Schema:      openai.F(generateSchema[MathReasoning]()),
+    Strict:      openai.Bool(true),
+}
+
+resp, err := client.Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{
+    Model: openai.F(openai.ChatModelGPT4_1Mini),
+    Messages: openai.F([]openai.ChatCompletionMessageParamUnion{
+        openai.UserMessage("Solve: 8x + 31 = 2"),
+    }),
+    ResponseFormat: openai.F[openai.ChatCompletionNewParamsResponseFormatUnion](
+        openai.ResponseFormatJSONSchemaParam{
+            Type:       openai.F(openai.ResponseFormatJSONSchemaTypeJSONSchema),
+            JSONSchema: openai.F(schemaParam),
+        },
+    ),
+})
+
+var result MathReasoning
+json.Unmarshal([]byte(resp.Choices[0].Message.Content), &result)
+fmt.Println(result.FinalAnswer)
+```
+
+## Vision (Multimodal)
+
+```go
+resp, err := client.Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{
+    Model: openai.F(openai.ChatModelGPT4_1Mini),
+    Messages: openai.F([]openai.ChatCompletionMessageParamUnion{
+        openai.UserMessageParts(
+            openai.TextPart("What is in this image?"),
+            openai.ImagePart("https://example.com/image.jpg"),
+        ),
+    }),
+})
+```
+
+## Embeddings
+
+```go
+resp, err := client.Embeddings.New(context.Background(), openai.EmbeddingNewParams{
+    Model: openai.F(openai.EmbeddingModelTextEmbedding3Small),
+    Input: openai.F(openai.EmbeddingNewParamsInputUnionString(
+        "The quick brown fox jumps over the lazy dog.",
+    )),
+})
+if err != nil {
+    panic(err)
+}
+fmt.Printf("Dimensions: %d\n", len(resp.Data[0].Embedding))
+```
+
+## Error Handling
+
+```go
+import "github.com/openai/openai-go/apierror"
+
+resp, err := client.Chat.Completions.New(ctx, params)
+if err != nil {
+    var apiErr *apierror.Error
+    if errors.As(err, &apiErr) {
+        fmt.Printf("API error %d: %s\n", apiErr.StatusCode, apiErr.Message)
+        // apiErr.StatusCode: 401 auth, 429 rate limit, 500 server error
+    }
+    return err
+}
+```
+
+## Retries and Timeouts
+
+```go
+import "time"
+
+// Configure retries at client level
+client := openai.NewClient(
+    option.WithMaxRetries(5),
+)
+
+// Configure timeout via context (preferred)
+ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+defer cancel()
+
+// Per-request options
+resp, err := client.Chat.Completions.New(ctx, params,
+    option.WithMaxRetries(3),
+)
+```
+
+## Microsoft Azure OpenAI
+
+```go
+client := openai.NewClient(
+    option.WithBaseURL("https://your-endpoint.openai.azure.com/openai/deployments/your-deployment/"),
+    option.WithAPIKey(os.Getenv("AZURE_OPENAI_API_KEY")),
+    option.WithHeaderAdd("api-version", "2024-08-01-preview"),
+)
+```
+
+## Notes
+
+- **`openai.F()`** is mandatory for all param fields — missing it causes a compile error.
+- **`openai.Bool()` / `openai.Int()`** are convenience wrappers for optional pointer types.
+- **Context is always first** in every API call — use `context.WithTimeout` in production.
+- Prefer the Responses API for new work; Chat Completions remains fully supported.
+- Both sync calls and streaming iterators (`stream.Next()`) follow the same pattern throughout the SDK.
+- Use `openai.ChatModelGPT4_1` typed constants; only use string literals for unreleased models.


### PR DESCRIPTION
Adds `--lang go` support for `chub get openai/chat`. This enables agents to fetch curated Go SDK docs alongside the existing python and javascript variants.

## What

Adds a new Go language variant for the `openai/chat` doc entry following the existing multi-language directory pattern (`content/openai/docs/chat/go/DOC.md`). The doc covers the full OpenAI Go SDK surface: Responses API (primary), Chat Completions (legacy), streaming, function calling, structured outputs, vision/multimodal, embeddings, error handling, retries/timeouts, and Azure OpenAI.

Also adds:
- A Go fixture (`cli/test/fixtures/multilang/docs/client/go/DOC.md`) so the existing multilang build path is exercised with three language variants
- Added unit tests (`cli/tests/commands/go-lang.test.js`) covering frontmatter validation, `resolveDocPath()` Go language resolution, and CLI build integration

## Why

Agents working on Go backends currently have no curated source in context-hub. Without a Go variant they fall back to the Python or JavaScript docs and generate code that does not compile  - specifically:

- They omit the `openai.F()` field wrapper that is **required on every param field** in the Go SDK (missing it is a compile error, not a runtime error)
- They write `model: openai.ChatModelGPT4_1` instead of `model: openai.F(openai.ChatModelGPT4_1)`
- They use Python-style `for chunk in stream` instead of the Go `stream.Next()` iterator pattern
- They hardcode model name strings instead of using the SDK's typed constants

This doc gives agents a single authoritative Go-specific source that prevents all of the above.

## Testing

- [x] `npm test` passes
- [x] `chub build sample-content/ --validate-only` succeeds
- [x] Manual testing done (describe below)

**Manual tests:**

1. **Build validation** — confirmed zero warnings and correct doc count:
   ```
   node cli/bin/chub build cli/test/fixtures --validate-only --json
   → {"docs":3,"skills":1,"warnings":0}
   ```
   Doc count stays at 3 (Go is a new language variant of `openai/chat`, not a new entry).

2. **Frontmatter parse** — verified all required fields resolve correctly:
   ```
   name: chat  |  languages: go  |  versions: 1.3.0
   source: community  |  updated-on: 2026-03-09
   ```

3. **`resolveDocPath()` with `--lang go`** — resolves to `openai/chat/go` 

4. **`resolveDocPath()` with no `--lang`** — returns `needsLanguage: true` with `available: ['python', 'javascript', 'go']`, prompting the agent to specify a language 

5. **Go-specific content checks** — body contains `openai.F(`, `github.com/openai/openai-go`, and at least one ` ```go ` code block 

6. **Fixture parity** — Go fixture `name: client` matches the python and javascript siblings; import uses bare `multilang` package consistent with the other variants 

## Notes

- No CLI code changes needed. The `--lang` flag in `get.js` already resolves dynamically to a language subdirectory; adding the content file is sufficient.
- SDK version `1.3.0` refers to the `github.com/openai/openai-go` module version on pkg.go.dev as of March 2026.
- `source` is set to `community` (not `maintainer`) per the content guide, since this is a community contribution and not submitted by OpenAI directly.
- The `openai.F()` wrapper section is intentionally prominent — it is the single most common source of Go agent errors when working from non-Go docs.