### PR TITLE
Document get-api-docs skill installation for Claude Code and Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,12 @@ chub get openai/chat --lang py     # fetch current docs (Python version)
 
 ## How It Works
 
-Chub is designed for your coding agent to use (not for you to use!). You can prompt your agent to use it (e.g., "Use the CLI command chub to get the latest API documentation for calling OpenAI. Run 'chub help' to understand how it works.") Or by creating an agent skill to use Chub using [SKILL.md](cli/skills/get-api-docs/SKILL.md), and ideally prompting your agent to remember to use this skill. (If you are using Claude Code, create the directory ~/.claude/skills/get-api-docs and put SKILL.md there.) 
+Chub is designed for your coding agent to use (not for you to use!). You can prompt your agent to use it (e.g., "Use the CLI command chub to get the latest API documentation for calling OpenAI. Run 'chub help' to understand how it works.") or install the canonical [get-api-docs skill](cli/skills/get-api-docs/SKILL.md) into your agent's skill directory so it remembers to fetch docs with `chub` before answering.
+
+Common install targets:
+
+- Claude Code: `~/.claude/skills/get-api-docs/SKILL.md`
+- Codex: `$CODEX_HOME/skills/get-api-docs/SKILL.md` (typically `~/.codex/skills/get-api-docs/SKILL.md`)
 
 **Most of the time, it's simple — search, fetch, use:**
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -14,18 +14,20 @@ The CLI ships with a skill that teaches agents to fetch docs automatically inste
 
 ### Claude Code
 
-Copy the skill into your project:
+Copy the skill into Claude Code's global skill directory:
 
 ```bash
-mkdir -p .claude/skills
-cp $(npm root -g)/@aisuite/chub/skills/get-api-docs/SKILL.md .claude/skills/get-api-docs.md
+mkdir -p ~/.claude/skills/get-api-docs
+cp "$(npm root -g)/@aisuite/chub/skills/get-api-docs/SKILL.md" ~/.claude/skills/get-api-docs/SKILL.md
 ```
 
-Or install it globally (applies to all projects):
+### Codex
+
+Copy the same skill into Codex's skill directory:
 
 ```bash
-mkdir -p ~/.claude/skills
-cp $(npm root -g)/@aisuite/chub/skills/get-api-docs/SKILL.md ~/.claude/skills/get-api-docs.md
+mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills/get-api-docs"
+cp "$(npm root -g)/@aisuite/chub/skills/get-api-docs/SKILL.md" "${CODEX_HOME:-$HOME/.codex}/skills/get-api-docs/SKILL.md"
 ```
 
 ### Cursor
@@ -34,7 +36,7 @@ Copy the skill into your project's rules directory:
 
 ```bash
 mkdir -p .cursor/rules
-cp $(npm root -g)/@aisuite/chub/skills/get-api-docs/SKILL.md .cursor/rules/get-api-docs.md
+cp "$(npm root -g)/@aisuite/chub/skills/get-api-docs/SKILL.md" .cursor/rules/get-api-docs.md
 ```
 
 ### Other Agent Tools

--- a/docs/design.md
+++ b/docs/design.md
@@ -337,6 +337,9 @@ chub get openai/chat-api stripe/payments -o .context/
 # Install a skill into Claude Code's skill directory
 chub get pw-community/login-flows -o .claude/skills/login-flows/SKILL.md
 
+# Install a skill into Codex's skill directory
+chub get pw-community/login-flows -o "${CODEX_HOME:-$HOME/.codex}/skills/login-flows/SKILL.md"
+
 # Install a skill with all companion files
 chub get pw-community/login-flows --full -o .claude/skills/login-flows/
 


### PR DESCRIPTION
## Summary

This PR keeps the existing `get-api-docs` skill as the single canonical skill and makes its installation path explicit for both Claude Code and Codex.

## Changes

- clarify in the top-level README that the existing `get-api-docs` skill is the canonical agent skill
- document the standard install target for Claude Code
- document the standard install target for Codex
- add a Codex install example to the design docs
- keep the integration model unchanged: `chub` remains the retrieval engine and the skill remains a thin instruction layer

## Why

This is intended as a small adoption improvement, not a new abstraction:
- no duplicate Claude/Codex skill definitions
- no agent-specific behavior changes
- less setup ambiguity for users trying to install the same skill in different agent runtimes

## Validation

- Ran `CHUB_DIR=/tmp/context-hub-mcp-test CHUB_TELEMETRY=0 npx vitest run tests/mcp/tools.test.js`
- Ran `CHUB_TELEMETRY=0 npx vitest run test/e2e.test.js`

Both passed locally. A plain `npm test` run in this sandbox was affected by environment-sensitive filesystem/telemetry behavior unrelated to this docs-only change.
