### PR TITLE
Add Step 0 with chub installation instructions

### DIFF
--- a/cli/skills/get-api-docs/SKILL.md
+++ b/cli/skills/get-api-docs/SKILL.md
@@ -13,6 +13,20 @@ description: >
 When you need documentation for a library or API, fetch it with the `chub` CLI
 rather than guessing from training data. This gives you the current, correct API.
 
+## Step 0 — Install chub
+
+Before using chub, make sure it is installed. Run:
+
+```bash
+chub --version
+```
+
+If the command is not found, install it globally:
+
+```bash
+npm install -g @aisuite/chub
+```
+
 ## Step 1 — Find the right doc ID
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds a **Step 0 — Install chub** section to the `get-api-docs` skill (`cli/skills/get-api-docs/SKILL.md`)
- Guides agents to check for `chub` availability and install it via `npm install -g @aisuite/chub` if not found
- Ensures agents don't fail at Step 1 when `chub` isn't installed

## Test plan
- [ ] Verify Step 0 appears before Step 1 in SKILL.md
- [ ] Confirm the install command matches the one in README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)