### PR TITLE
docs: add DataHub Python SDK API reference

### DIFF
--- a/content/datahub/docs/sdk/python/DOC.md
+++ b/content/datahub/docs/sdk/python/DOC.md
@@ -93,8 +93,6 @@ results = client.search.get_urns(filter=F.platform("snowflake"))
 ### Combine query and filters
 
 ```python
-from datahub.sdk import FilterDsl as F
-
 results = client.search.get_urns(
     query="forecast",
     filter=F.and_(F.platform("snowflake"), F.entity_type("dataset"))
@@ -200,131 +198,65 @@ client.entities.delete(
 
 ## Enriching Metadata
 
-### Descriptions
+Pattern: fetch the entity, call setters, then update. All setters work across supported entity types.
 
 ```python
 dataset = client.entities.get(dataset_urn)
+
 dataset.set_description("Updated description for this table")
-client.entities.update(dataset)
-```
-
-### Tags
-
-```python
-dataset = client.entities.get(dataset_urn)
-
-# On the dataset
 dataset.set_tags(["critical", "pii"])
+dataset.set_terms(["urn:li:glossaryTerm:PII", "urn:li:glossaryTerm:CustomerData"])
+dataset.set_domain("urn:li:domain:analytics")
+dataset.set_owners(["urn:li:corpuser:alice", "urn:li:corpGroup:data-engineering"])
+dataset.set_custom_properties({"team": "data-eng", "refresh_cadence": "hourly"})
+dataset.set_structured_properties({
+    "urn:li:structuredProperty:data_tier": ["tier1"],
+    "urn:li:structuredProperty:retention_days": [90],
+})
 
-# On individual columns
+# Column-level: tags, terms, and descriptions on individual schema fields
 for field in dataset.schema:
     if field.field_path == "email":
         field.add_tag("pii")
+        field.add_term("urn:li:glossaryTerm:EmailAddress")
         field.set_description("User email address, PII-classified")
 
 client.entities.update(dataset)
 ```
 
-### Glossary terms
+### Available setters
 
-```python
-dataset = client.entities.get(dataset_urn)
-dataset.set_terms(["urn:li:glossaryTerm:PII", "urn:li:glossaryTerm:CustomerData"])
+| Method | Example value |
+|--------|---------------|
+| `set_description(str)` | `"Core users table"` |
+| `set_tags(list)` | `["critical", "pii"]` |
+| `set_terms(list)` | `["urn:li:glossaryTerm:PII"]` |
+| `set_domain(str)` | `"urn:li:domain:analytics"` |
+| `set_owners(list)` | `["urn:li:corpuser:alice"]` |
+| `set_custom_properties(dict)` | `{"team": "data-eng"}` |
+| `set_structured_properties(dict)` | `{"urn:li:structuredProperty:tier": ["tier1"]}` |
 
-for field in dataset.schema:
-    if field.field_path == "email":
-        field.add_term("urn:li:glossaryTerm:EmailAddress")
-
-client.entities.update(dataset)
-```
-
-### Domains
-
-```python
-dataset = client.entities.get(dataset_urn)
-dataset.set_domain("urn:li:domain:analytics")
-client.entities.update(dataset)
-```
-
-### Owners
-
-```python
-dataset = client.entities.get(dataset_urn)
-dataset.set_owners([
-    "urn:li:corpuser:alice",
-    "urn:li:corpGroup:data-engineering",
-])
-client.entities.update(dataset)
-```
-
-### Structured properties
-
-```python
-dataset = client.entities.get(dataset_urn)
-dataset.set_structured_properties({
-    "urn:li:structuredProperty:data_tier": ["tier1"],
-    "urn:li:structuredProperty:retention_days": [90],
-})
-client.entities.update(dataset)
-```
-
-### Custom properties
-
-```python
-dataset = client.entities.get(dataset_urn)
-dataset.set_custom_properties({
-    "team": "data-engineering",
-    "slack_channel": "#data-eng",
-    "refresh_cadence": "hourly",
-})
-client.entities.update(dataset)
-```
+Column-level methods on `SchemaField`: `add_tag(str)`, `add_term(str)`, `set_description(str)`.
 
 ## Containers
 
-Organize datasets logically with containers (databases, schemas, folders).
+Containers organize datasets into hierarchies (databases, schemas, folders). Use `DatabaseKey` and `SchemaKey` to create them with proper parent-child relationships.
 
 ```python
 from datahub.sdk import Container
-from datahub.emitter.mcp_builder import DatabaseKey, SchemaKey
+from datahub.emitter.mcp_builder import DatabaseKey
 
-database_key = DatabaseKey(
-    platform="snowflake",
-    instance="production",
-    database="analytics_db",
-)
-
-database_container = Container(
-    database_key,
+container = Container(
+    DatabaseKey(platform="snowflake", instance="production", database="analytics_db"),
     display_name="Analytics Database",
-    description="Main analytics database",
     subtype="Database",
 )
-client.entities.upsert(database_container)
-
-schema_key = SchemaKey(
-    platform="snowflake",
-    instance="production",
-    database="analytics_db",
-    schema="reporting",
-)
-
-schema_container = Container(
-    schema_key,
-    display_name="Reporting Schema",
-    description="Schema for reporting tables and views",
-    subtype="Schema",
-    parent_container=database_key,
-    domain="urn:li:domain:analytics",
-)
-client.entities.upsert(schema_container)
+client.entities.upsert(container)
 ```
 
 ## Documents
 
-Documents store knowledge content — tutorials, runbooks, FAQs, or references to external docs in systems like Notion or Confluence.
-
-### Native document (stored in DataHub)
+Documents store knowledge content — tutorials, runbooks, FAQs, or external doc references (Notion, Confluence).
 
 ```python
 from datahub.sdk import Document
@@ -339,44 +271,7 @@ doc = Document.create_document(
 client.entities.upsert(doc)
 ```
 
-### External document (Notion, Confluence, etc.)
-
-```python
-doc = Document.create_external_document(
-    id="notion-team-handbook",
-    title="Engineering Handbook",
-    platform="notion",
-    external_url="https://notion.so/team/engineering-handbook",
-    external_id="notion-page-abc123",
-    text="Summary of the handbook for search indexing...",
-)
-client.entities.upsert(doc)
-```
-
-### AI-only context document
-
-Documents hidden from global search/sidebar, accessible only through related assets:
-
-```python
-doc = Document.create_document(
-    id="orders-dataset-context",
-    title="Orders Dataset Context",
-    text="This dataset contains daily order summaries...",
-    show_in_global_context=False,
-    related_assets=["urn:li:dataset:(urn:li:dataPlatform:snowflake,orders,PROD)"],
-)
-client.entities.upsert(doc)
-```
-
-### Document properties
-
-- `doc.set_title("New Title")` / `doc.title`
-- `doc.set_text("New content")` / `doc.text`
-- `doc.publish()` / `doc.unpublish()` / `doc.status`
-- `doc.set_parent_document("urn:li:document:parent-doc")` — hierarchical organization
-- `doc.add_related_asset("urn:li:dataset:...")` / `doc.set_related_assets([...])`
-- `doc.add_related_document("urn:li:document:...")` / `doc.set_related_documents([...])`
-- `doc.hide_from_global_context()` / `doc.show_in_global_search()`
+See `references/entities.md` for nested container hierarchies, external documents, AI-only context documents, and document properties.
 
 ## Lineage
 
@@ -527,7 +422,6 @@ DataHub identifies every entity with a URN (Uniform Resource Name) — a globall
 | Tag | `urn:li:tag:{name}` | Lightweight labels for classification (e.g. critical, deprecated) |
 | Document | `urn:li:document:{id}` | Knowledge content: tutorials, runbooks, FAQs, or external doc references |
 | Assertion | `urn:li:assertion:{id}` | A data quality check bound to a dataset |
-| Incident | `urn:li:incident:{id}` | A data incident or issue raised against an asset |
 | User | `urn:li:corpuser:{id}` | An individual user identity |
 | Group | `urn:li:corpGroup:{id}` | A team or group of users |
 

--- a/content/datahub/docs/sdk/python/references/assertions.md
+++ b/content/datahub/docs/sdk/python/references/assertions.md
@@ -7,8 +7,7 @@ The actor making API calls needs `Edit Assertions` and `Edit Monitors` privilege
 ## Setup
 
 ```python
-from datahub.sdk import DataHubClient
-from datahub.sdk.search_filters import FilterDsl as F
+from datahub.sdk import DataHubClient, FilterDsl as F
 from datahub.metadata.urns import DatasetUrn
 
 client = DataHubClient(server="<your_server>", token="<your_token>")
@@ -124,13 +123,13 @@ def create_sql_assertions(datasets, client):
 def get_dataset_columns(client, dataset_urn):
     try:
         dataset = client.entities.get(dataset_urn)
-        if dataset and hasattr(dataset, "schema") and dataset.schema:
+        if dataset and dataset.schema:
             return [
                 {
                     "name": field.field_path,
-                    "type": field.native_data_type,
+                    "type": field.native_type,
                 }
-                for field in dataset.schema.fields
+                for field in dataset.schema
             ]
         return []
     except Exception as e:
@@ -231,24 +230,6 @@ def batch_create_assertions(datasets, client, batch_size=10, delay_seconds=1.0):
             time.sleep(delay_seconds)
 
     return results
-```
-
-## Store and Load Assertion URNs
-
-```python
-import json
-from datetime import datetime
-
-def save_registry(registry, filename=None):
-    if filename is None:
-        filename = f"assertion_registry_{datetime.now():%Y%m%d_%H%M%S}.json"
-    with open(filename, "w") as f:
-        json.dump({"created_at": datetime.now().isoformat(), "assertions": registry}, f, indent=2)
-    return filename
-
-def load_registry(filename):
-    with open(filename) as f:
-        return json.load(f)["assertions"]
 ```
 
 ## Important Considerations

--- a/content/datahub/docs/sdk/python/references/entities.md
+++ b/content/datahub/docs/sdk/python/references/entities.md
@@ -1,0 +1,101 @@
+# Entity Reference
+
+Advanced information & guidelines for specific entity types.
+
+## Containers
+
+Datasets are organized physically using the container entity (e.g. databases, schemas, folders).
+
+```python
+from datahub.sdk import Container
+from datahub.emitter.mcp_builder import DatabaseKey, SchemaKey
+
+database_key = DatabaseKey(
+    platform="snowflake",
+    instance="production",
+    database="analytics_db",
+)
+
+database_container = Container(
+    database_key,
+    display_name="Analytics Database",
+    description="Main analytics database",
+    subtype="Database",
+)
+client.entities.upsert(database_container)
+
+schema_key = SchemaKey(
+    platform="snowflake",
+    instance="production",
+    database="analytics_db",
+    schema="reporting",
+)
+
+schema_container = Container(
+    schema_key,
+    display_name="Reporting Schema",
+    description="Schema for reporting tables and views",
+    subtype="Schema",
+    parent_container=database_key,
+    domain="urn:li:domain:analytics",
+)
+client.entities.upsert(schema_container)
+```
+
+## Documents
+
+Documents store knowledge content — tutorials, runbooks, FAQs, or references to external docs in systems like Notion or Confluence.
+
+### Native document (stored in DataHub)
+
+```python
+from datahub.sdk import Document
+
+doc = Document.create_document(
+    id="getting-started-guide",
+    title="Getting Started with DataHub",
+    text="# Welcome\n\nThis guide will help you get started...",
+    tags=["onboarding"],
+    domain="urn:li:domain:data-governance",
+)
+client.entities.upsert(doc)
+```
+
+### External document (Notion, Confluence, etc.)
+
+```python
+doc = Document.create_external_document(
+    id="notion-team-handbook",
+    title="Engineering Handbook",
+    platform="notion",
+    external_url="https://notion.so/team/engineering-handbook",
+    external_id="notion-page-abc123",
+    text="Summary of the handbook for search indexing...",
+)
+client.entities.upsert(doc)
+```
+
+### AI-only context document
+
+Documents hidden from global search/sidebar, accessible only through related assets:
+
+```python
+doc = Document.create_document(
+    id="orders-dataset-context",
+    title="Orders Dataset Context",
+    text="This dataset contains daily order summaries...",
+    show_in_global_context=False,
+    related_assets=["urn:li:dataset:(urn:li:dataPlatform:snowflake,orders,PROD)"],
+)
+client.entities.upsert(doc)
+```
+
+### Document properties
+
+- `doc.set_title("New Title")` / `doc.title`
+- `doc.set_text("New content")` / `doc.text`
+- `doc.publish()` / `doc.unpublish()` / `doc.status`
+- `doc.set_parent_document("urn:li:document:parent-doc")` — hierarchical organization
+- `doc.add_related_asset("urn:li:dataset:...")` / `doc.set_related_assets([...])`
+- `doc.add_related_document("urn:li:document:...")` / `doc.set_related_documents([...])`
+- `doc.hide_from_global_context()` / `doc.show_in_global_search()`

--- a/content/datahub/docs/sdk/python/references/lineage.md
+++ b/content/datahub/docs/sdk/python/references/lineage.md
@@ -22,28 +22,6 @@ client.lineage.add_lineage(
 )
 ```
 
-## Dataset Transform Lineage
-
-Declare a transformation with explicit column-level mapping and the SQL that produced it:
-
-```python
-client.lineage.add_lineage(
-    upstream="urn:li:dataset:(urn:li:dataPlatform:snowflake,raw.orders,PROD)",
-    downstream="urn:li:dataset:(urn:li:dataPlatform:snowflake,analytics.daily_revenue,PROD)",
-    column_lineage={
-        "order_date": ["created_at"],
-        "total_revenue": ["amount"],
-        "order_count": ["order_id"],
-    },
-    transformation_text=(
-        "SELECT DATE(created_at) AS order_date, "
-        "SUM(amount) AS total_revenue, "
-        "COUNT(order_id) AS order_count "
-        "FROM raw.orders GROUP BY DATE(created_at)"
-    ),
-)
-```
-
 ## Column Lineage Options
 
 The `column_lineage` parameter on `add_lineage()` accepts several forms:
@@ -131,50 +109,9 @@ Parameters:
 | `default_schema` | Default schema for unqualified table names |
 | `override_dialect` | Override SQL dialect for parsing |
 
-## Get Lineage (Impact Analysis)
+## Filtered Lineage
 
-### Upstream lineage (data origins)
-
-```python
-results = client.lineage.get_lineage(
-    source_urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,analytics.sessions,PROD)",
-    direction="upstream",
-    max_hops=3,
-    count=500,
-)
-
-for result in results:
-    print(f"  {result.urn}")
-    print(f"  Type: {result.type}, Platform: {result.platform}")
-    print(f"  Hops: {result.hops}, Name: {result.name}")
-    if result.paths:
-        for path in result.paths:
-            print(f"    Path: {path.urn} -> {path.entity_name}")
-```
-
-### Downstream lineage (impact analysis)
-
-```python
-results = client.lineage.get_lineage(
-    source_urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,raw.events,PROD)",
-    direction="downstream",
-    max_hops=5,
-)
-```
-
-### Column-level lineage
-
-```python
-results = client.lineage.get_lineage(
-    source_urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,analytics.revenue,PROD)",
-    source_column="total_revenue",
-    direction="upstream",
-)
-```
-
-### Filtered lineage
-
-Combine lineage queries with search filters:
+Combine `get_lineage()` with search filters to narrow results:
 
 ```python
 from datahub.sdk import FilterDsl as F

--- a/content/datahub/docs/sdk/python/references/search.md
+++ b/content/datahub/docs/sdk/python/references/search.md
@@ -13,16 +13,6 @@ client = DataHubClient.from_env()
 results = client.search.get_urns(query="...", filter=F.platform("..."))
 ```
 
-## Query-Based Search
-
-Free-text search across common fields: name, description, column names, and other indexed metadata.
-
-```python
-results = client.search.get_urns(query="customer revenue")
-```
-
-Best for exploration when you don't know the exact asset name or location.
-
 ## Filter-Based Search
 
 Structured filters scope results by platform, entity type, domain, and other metadata fields.
@@ -194,74 +184,7 @@ Fields annotated with `@Searchable` in DataHub's PDL models can be used with `cu
 
 The exact searchable fields vary by entity type. Refer to the PDL model files in the [DataHub repo](https://github.com/datahub-project/datahub/tree/master/metadata-models/src/main/pegasus) for the full list.
 
-## Logical Operators
-
-Combine filters with `and_`, `or_`, and `not_`.
-
-### AND — all conditions must match
-
-```python
-results = client.search.get_urns(
-    filter=F.and_(
-        F.platform("snowflake"),
-        F.entity_type("dataset"),
-        F.domain("urn:li:domain:analytics"),
-    )
-)
-```
-
-### OR — at least one condition must match
-
-```python
-results = client.search.get_urns(
-    filter=F.or_(
-        F.entity_type("chart"),
-        F.and_(F.platform("snowflake"), F.entity_type("dataset")),
-    )
-)
-```
-
-### NOT — exclude matching entities
-
-```python
-results = client.search.get_urns(
-    filter=F.and_(
-        F.entity_type("dataset"),
-        F.not_(F.tag("urn:li:tag:deprecated")),
-    )
-)
-```
-
-### Combining query and filters
-
-Query narrows by keyword, filters scope by metadata. Use both for precise results.
-
-```python
-results = client.search.get_urns(
-    query="revenue",
-    filter=F.and_(
-        F.platform("snowflake"),
-        F.entity_type("dataset"),
-        F.domain("urn:li:domain:finance"),
-    )
-)
-```
-
 ## Common Patterns
-
-### Find all assets in a domain
-
-```python
-results = client.search.get_urns(filter=F.domain("urn:li:domain:marketing"))
-```
-
-### Find all dashboards on a BI platform
-
-```python
-results = client.search.get_urns(
-    filter=F.and_(F.entity_type("dashboard"), F.platform("looker"))
-)
-```
 
 ### Find datasets tagged as critical but missing an owner
 
@@ -271,26 +194,6 @@ for urn in critical:
     entity = client.entities.get(urn)
     if not entity.owners:
         print(f"Missing owner: {urn}")
-```
-
-### Find all documents in a domain
-
-```python
-results = client.search.get_urns(
-    filter=F.and_(
-        F.entity_type("document"),
-        F.domain("urn:li:domain:engineering"),
-    )
-)
-```
-
-### Search documents by keyword
-
-```python
-results = client.search.get_urns(
-    query="data quality",
-    filter=F.entity_type("document"),
-)
 ```
 
 ## Caching


### PR DESCRIPTION
## What

Adds curated API reference for the [DataHub](https://datahub.com/) Python SDK (`acryl-datahub` v1.4.0.5 + `acryl-datahub-cloud`) under `content/datahub/docs/sdk/python/`.

## Why

DataHub is a widely-used data catalog and metadata platform, but agents frequently hallucinate SDK method names, use deprecated patterns (e.g. the old `add_dataset_transform_lineage` instead of the unified `add_lineage`), and get schema field formats wrong (tuples, not dicts). This doc gives agents verified, working patterns for the most common flows — validated against the actual SDK source code.

## API Coverage

**Main doc (`DOC.md`, 447 lines):**
- Client initialization (`DataHubClient`, `from_env()`, `test_connection()`)
- Search API with `FilterDsl` — query-based, filter-based, and combined search
- Entity CRUD — create, get, update, upsert, delete datasets
- Metadata enrichment — descriptions, tags, glossary terms, domains, owners, structured/custom properties (asset + column level)
- Containers and Documents — brief examples with pointers to reference file
- Lineage — table-level, column-level, copy lineage, SQL inference, impact analysis
- Data quality assertions (DataHub Cloud) — freshness, volume, column metric, SQL assertions
- URN reference table covering 14 entity types
- Best practices

**Reference files:**
- `references/search.md` — detailed filter types with use-case guidance, `custom_filter` conditions, searchable fields
- `references/lineage.md` — cross-entity lineage, column lineage options, DataJob lineage, SQL inference parameters, filtered lineage, `LineageResult` object, view lineage
- `references/assertions.md` — bulk assertion creation, table discovery, column-level assertions, batch processing, updating existing assertions
- `references/entities.md` — nested container hierarchies, external documents (Notion/Confluence), AI-only context documents, document properties