### PR TITLE
feat(content): add Telegram Bot API and Next.js App Router docs

### DIFF
--- a/content/nextjs/docs/app-router/javascript/DOC.md
+++ b/content/nextjs/docs/app-router/javascript/DOC.md
@@ -1,0 +1,648 @@
+---
+name: app-router
+description: "Next.js App Router for building full-stack React applications with server components, routing, data fetching, and API routes"
+metadata:
+  languages: "javascript"
+  versions: "15.3.0"
+  revision: 1
+  updated-on: "2026-03-10"
+  source: community
+  tags: "nextjs,react,app-router,server-components,ssr,vercel"
+---
+
+# Next.js App Router — JavaScript/TypeScript Coding Guidelines
+
+You are a Next.js App Router expert. Help me write code using Next.js 15 with the App Router.
+
+Official documentation:
+https://nextjs.org/docs
+
+## Golden Rule: Use the App Router
+
+Next.js 15 uses the **App Router** (`app/` directory) by default. Do not use the legacy Pages Router (`pages/`) for new projects.
+
+- **Framework:** Next.js 15
+- **NPM Package:** `next`
+- **Current Version:** 15.3.0
+- **React Version:** React 19
+
+**Installation:**
+
+```bash
+npx create-next-app@latest my-app
+```
+
+**Key Conventions:**
+
+- **Correct:** `app/` directory with `page.tsx`, `layout.tsx`, `loading.tsx`
+- **Correct:** Server Components by default (no `"use client"` needed)
+- **Correct:** `"use client"` directive for interactive components
+- **Incorrect:** Using `pages/` directory for new routes
+- **Incorrect:** `getServerSideProps` or `getStaticProps` (App Router uses `fetch` and async components)
+- **Incorrect:** Importing `next/router` (use `next/navigation` in App Router)
+
+## Project Structure
+
+```
+app/
+  layout.tsx          # Root layout (required)
+  page.tsx            # Home page (/)
+  loading.tsx         # Loading UI
+  error.tsx           # Error boundary
+  not-found.tsx       # 404 page
+  globals.css         # Global styles
+  dashboard/
+    page.tsx          # /dashboard
+    layout.tsx        # Dashboard layout (nested)
+    [id]/
+      page.tsx        # /dashboard/:id (dynamic route)
+  api/
+    route.ts          # API route (/api)
+    users/
+      route.ts        # /api/users
+      [id]/
+        route.ts      # /api/users/:id
+```
+
+## Routing
+
+### File Conventions
+
+| File | Purpose |
+|------|---------|
+| `page.tsx` | Route UI (makes route accessible) |
+| `layout.tsx` | Shared layout (persists across navigations) |
+| `loading.tsx` | Loading UI (Suspense boundary) |
+| `error.tsx` | Error boundary |
+| `not-found.tsx` | 404 UI |
+| `route.ts` | API endpoint (no UI) |
+| `template.tsx` | Like layout but re-renders on navigation |
+
+### Dynamic Routes
+
+```
+app/blog/[slug]/page.tsx        → /blog/hello-world
+app/shop/[...slug]/page.tsx     → /shop/a/b/c (catch-all)
+app/shop/[[...slug]]/page.tsx   → /shop or /shop/a/b (optional catch-all)
+```
+
+```typescript
+// app/blog/[slug]/page.tsx
+export default async function BlogPost({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  return <h1>Post: {slug}</h1>;
+}
+```
+
+### Route Groups
+
+Organize routes without affecting the URL:
+
+```
+app/(marketing)/about/page.tsx   → /about
+app/(marketing)/blog/page.tsx    → /blog
+app/(shop)/cart/page.tsx          → /cart
+```
+
+## Server Components (Default)
+
+Components in the `app/` directory are Server Components by default. They run on the server and can directly access databases, APIs, and the filesystem.
+
+```typescript
+// app/users/page.tsx — Server Component (default)
+import { db } from "@/lib/db";
+
+export default async function UsersPage() {
+  const users = await db.user.findMany();
+
+  return (
+    <ul>
+      {users.map((user) => (
+        <li key={user.id}>{user.name}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+**Server Components can:**
+- `await` async operations directly
+- Access backend resources (database, filesystem)
+- Keep secrets on the server
+- Reduce client bundle size
+
+**Server Components cannot:**
+- Use `useState`, `useEffect`, or other hooks
+- Use browser APIs (`window`, `document`)
+- Use event handlers (`onClick`, `onChange`)
+
+## Client Components
+
+Add `"use client"` at the top of files that need interactivity:
+
+```typescript
+"use client";
+
+import { useState } from "react";
+
+export default function Counter() {
+  const [count, setCount] = useState(0);
+  return (
+    <button onClick={() => setCount(count + 1)}>
+      Count: {count}
+    </button>
+  );
+}
+```
+
+**Rule of thumb:** Keep Client Components at the leaves of the component tree. Only add `"use client"` where you actually need interactivity.
+
+## Layouts
+
+```typescript
+// app/layout.tsx — Root Layout (required)
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "My App",
+  description: "Built with Next.js",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}
+```
+
+### Nested Layouts
+
+```typescript
+// app/dashboard/layout.tsx
+export default function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex">
+      <aside>Sidebar</aside>
+      <main>{children}</main>
+    </div>
+  );
+}
+```
+
+## Data Fetching
+
+### In Server Components (Recommended)
+
+```typescript
+// Fetch data directly in async Server Components
+export default async function Page() {
+  const data = await fetch("https://api.example.com/data", {
+    cache: "force-cache",       // default: cache indefinitely
+    // cache: "no-store",       // always fresh
+    // next: { revalidate: 60 }, // revalidate every 60 seconds
+  });
+  const json = await data.json();
+  return <div>{json.title}</div>;
+}
+```
+
+### Caching Behavior
+
+| Option | Behavior |
+|--------|----------|
+| `cache: "force-cache"` | Cache indefinitely (default) |
+| `cache: "no-store"` | No caching, always fresh |
+| `next: { revalidate: N }` | Revalidate every N seconds (ISR) |
+| `next: { tags: ["posts"] }` | Tag-based revalidation |
+
+### Revalidation
+
+```typescript
+// app/actions.ts
+"use server";
+
+import { revalidatePath, revalidateTag } from "next/cache";
+
+export async function refreshPosts() {
+  revalidateTag("posts");   // revalidate by tag
+  revalidatePath("/blog");  // revalidate by path
+}
+```
+
+## Server Actions
+
+Server Actions are async functions that run on the server, called from Client Components.
+
+```typescript
+// app/actions.ts
+"use server";
+
+import { db } from "@/lib/db";
+import { revalidatePath } from "next/cache";
+
+export async function createPost(formData: FormData) {
+  const title = formData.get("title") as string;
+  const content = formData.get("content") as string;
+
+  await db.post.create({ data: { title, content } });
+  revalidatePath("/posts");
+}
+```
+
+```typescript
+// app/posts/new/page.tsx
+import { createPost } from "@/app/actions";
+
+export default function NewPost() {
+  return (
+    <form action={createPost}>
+      <input name="title" placeholder="Title" />
+      <textarea name="content" placeholder="Content" />
+      <button type="submit">Create</button>
+    </form>
+  );
+}
+```
+
+### Server Actions in Client Components
+
+```typescript
+"use client";
+
+import { useTransition } from "react";
+import { createPost } from "@/app/actions";
+
+export default function CreateForm() {
+  const [isPending, startTransition] = useTransition();
+
+  function handleSubmit(formData: FormData) {
+    startTransition(() => createPost(formData));
+  }
+
+  return (
+    <form action={handleSubmit}>
+      <input name="title" />
+      <button disabled={isPending}>
+        {isPending ? "Creating..." : "Create"}
+      </button>
+    </form>
+  );
+}
+```
+
+## API Routes (Route Handlers)
+
+```typescript
+// app/api/users/route.ts
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const query = searchParams.get("q");
+
+  const users = await db.user.findMany({
+    where: query ? { name: { contains: query } } : undefined,
+  });
+
+  return NextResponse.json(users);
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  const user = await db.user.create({ data: body });
+  return NextResponse.json(user, { status: 201 });
+}
+```
+
+### Dynamic API Routes
+
+```typescript
+// app/api/users/[id]/route.ts
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const user = await db.user.findUnique({ where: { id } });
+
+  if (!user) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(user);
+}
+```
+
+## Navigation
+
+### Link Component
+
+```typescript
+import Link from "next/link";
+
+export default function Nav() {
+  return (
+    <nav>
+      <Link href="/">Home</Link>
+      <Link href="/about">About</Link>
+      <Link href={`/blog/${slug}`}>Post</Link>
+    </nav>
+  );
+}
+```
+
+### Programmatic Navigation
+
+```typescript
+"use client";
+
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
+
+export default function Nav() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  return (
+    <button onClick={() => router.push("/dashboard")}>
+      Go to Dashboard
+    </button>
+  );
+}
+```
+
+### Redirects
+
+```typescript
+import { redirect, permanentRedirect } from "next/navigation";
+
+export default async function Page() {
+  const session = await getSession();
+  if (!session) {
+    redirect("/login"); // 307 temporary
+  }
+  // permanentRedirect("/new-path"); // 308 permanent
+}
+```
+
+## Middleware
+
+```typescript
+// middleware.ts (root of project)
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  // Check auth
+  const token = request.cookies.get("token");
+  if (!token && request.nextUrl.pathname.startsWith("/dashboard")) {
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  // Add headers
+  const response = NextResponse.next();
+  response.headers.set("x-custom-header", "value");
+  return response;
+}
+
+export const config = {
+  matcher: ["/dashboard/:path*", "/api/:path*"],
+};
+```
+
+## Metadata and SEO
+
+### Static Metadata
+
+```typescript
+// app/layout.tsx or app/page.tsx
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "My App",
+  description: "Description here",
+  openGraph: {
+    title: "My App",
+    description: "Description here",
+    images: ["/og-image.png"],
+  },
+};
+```
+
+### Dynamic Metadata
+
+```typescript
+// app/blog/[slug]/page.tsx
+import type { Metadata } from "next";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const post = await getPost(slug);
+  return {
+    title: post.title,
+    description: post.excerpt,
+  };
+}
+```
+
+## Static Generation
+
+```typescript
+// Generate static params at build time
+export async function generateStaticParams() {
+  const posts = await getPosts();
+  return posts.map((post) => ({
+    slug: post.slug,
+  }));
+}
+
+// This page will be statically generated for each slug
+export default async function PostPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const post = await getPost(slug);
+  return <article>{post.content}</article>;
+}
+```
+
+## Image Optimization
+
+```typescript
+import Image from "next/image";
+
+// Local image
+import heroImage from "./hero.png";
+
+export default function Page() {
+  return (
+    <>
+      {/* Local image — auto width/height */}
+      <Image src={heroImage} alt="Hero" priority />
+
+      {/* Remote image — must specify width/height */}
+      <Image
+        src="https://example.com/photo.jpg"
+        alt="Photo"
+        width={800}
+        height={600}
+      />
+
+      {/* Fill container */}
+      <div style={{ position: "relative", width: "100%", height: 400 }}>
+        <Image src="/bg.jpg" alt="Background" fill style={{ objectFit: "cover" }} />
+      </div>
+    </>
+  );
+}
+```
+
+Configure remote image domains in `next.config.ts`:
+
+```typescript
+// next.config.ts
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      { protocol: "https", hostname: "example.com" },
+      { protocol: "https", hostname: "**.amazonaws.com" },
+    ],
+  },
+};
+
+export default nextConfig;
+```
+
+## Loading and Error States
+
+```typescript
+// app/dashboard/loading.tsx — automatic Suspense boundary
+export default function Loading() {
+  return <div>Loading dashboard...</div>;
+}
+
+// app/dashboard/error.tsx — automatic error boundary
+"use client";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div>
+      <h2>Something went wrong!</h2>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  );
+}
+```
+
+## Environment Variables
+
+```
+# .env.local (git-ignored)
+DATABASE_URL=postgresql://...
+API_SECRET=secret123
+
+# Public (exposed to browser) — must start with NEXT_PUBLIC_
+NEXT_PUBLIC_API_URL=https://api.example.com
+```
+
+- Server-only: `process.env.DATABASE_URL` (only in Server Components, Route Handlers, Server Actions)
+- Client-accessible: `process.env.NEXT_PUBLIC_API_URL` (available everywhere)
+
+## Parallel and Intercepting Routes
+
+### Parallel Routes (Slots)
+
+```
+app/
+  @modal/
+    page.tsx          # Renders in parallel with main page
+  layout.tsx          # Receives both children and modal
+  page.tsx
+```
+
+```typescript
+// app/layout.tsx
+export default function Layout({
+  children,
+  modal,
+}: {
+  children: React.ReactNode;
+  modal: React.ReactNode;
+}) {
+  return (
+    <>
+      {children}
+      {modal}
+    </>
+  );
+}
+```
+
+### Intercepting Routes
+
+```
+app/
+  feed/
+    page.tsx
+    (..)photo/[id]/
+      page.tsx        # Intercepts /photo/[id] when navigating from /feed
+  photo/[id]/
+    page.tsx          # Full page (direct navigation or refresh)
+```
+
+## Common next.config.ts Options
+
+```typescript
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  reactStrictMode: true,
+  images: {
+    remotePatterns: [
+      { protocol: "https", hostname: "**.example.com" },
+    ],
+  },
+  redirects: async () => [
+    { source: "/old", destination: "/new", permanent: true },
+  ],
+  rewrites: async () => [
+    { source: "/api/:path*", destination: "https://backend.example.com/:path*" },
+  ],
+  headers: async () => [
+    {
+      source: "/api/:path*",
+      headers: [
+        { key: "Access-Control-Allow-Origin", value: "*" },
+      ],
+    },
+  ],
+};
+
+export default nextConfig;
+```

--- a/content/telegram/docs/bot-api/javascript/DOC.md
+++ b/content/telegram/docs/bot-api/javascript/DOC.md
@@ -1,0 +1,339 @@
+---
+name: bot-api
+description: "Telegram Bot API via grammy and node-telegram-bot-api for building Telegram bots in JavaScript/TypeScript"
+metadata:
+  languages: "javascript"
+  versions: "1.35.0"
+  revision: 1
+  updated-on: "2026-03-10"
+  source: community
+  tags: "telegram,bot,messaging,grammy,chat"
+---
+
+# Telegram Bot API — JavaScript/TypeScript SDK Coding Guidelines
+
+You are a Telegram Bot API coding expert. Help me write code using the Telegram Bot API with the official and recommended libraries.
+
+Official Telegram Bot API documentation:
+https://core.telegram.org/bots/api
+
+## Golden Rule: Use the Correct and Current SDK
+
+Use **grammY** (recommended) or **node-telegram-bot-api** for Telegram bot development in JavaScript/TypeScript.
+
+- **Recommended Library:** grammY
+- **NPM Package:** `grammy`
+- **Current Version:** 1.35.0
+- **Alternative:** `node-telegram-bot-api` (callback-based, less TypeScript support)
+
+**Installation:**
+
+```bash
+npm install grammy
+```
+
+**APIs and Usage:**
+
+- **Correct:** `import { Bot, Context, InlineKeyboard } from 'grammy'`
+- **Correct:** `const bot = new Bot("BOT_TOKEN")`
+- **Correct:** `bot.command("start", (ctx) => ctx.reply("Hello!"))`
+- **Correct:** `bot.on("message:text", handler)`
+- **Incorrect:** `new Telegraf()` (different library)
+- **Incorrect:** `bot.sendMessage()` (use `ctx.reply()` or `ctx.api.sendMessage()`)
+
+## Initialization
+
+```typescript
+import { Bot } from "grammy";
+
+const bot = new Bot(process.env.TELEGRAM_BOT_TOKEN!);
+
+// Handle /start command
+bot.command("start", (ctx) => ctx.reply("Welcome! I'm your bot."));
+
+// Handle text messages
+bot.on("message:text", (ctx) => {
+  console.log(`Message from ${ctx.from?.first_name}: ${ctx.message.text}`);
+  return ctx.reply(`You said: ${ctx.message.text}`);
+});
+
+bot.start();
+```
+
+## Sending Messages
+
+### Plain Text
+
+```typescript
+await ctx.reply("Hello!");
+
+// With parse mode
+await ctx.reply("*Bold* and _italic_", { parse_mode: "MarkdownV2" });
+await ctx.reply("<b>Bold</b> and <i>italic</i>", { parse_mode: "HTML" });
+```
+
+### Sending to a Specific Chat
+
+```typescript
+// Use bot.api to send without a context
+await bot.api.sendMessage(chatId, "Hello from bot!");
+
+// Send to a topic/thread in a group
+await bot.api.sendMessage(chatId, "Hello topic!", {
+  message_thread_id: topicId,
+});
+```
+
+### Photos, Documents, and Media
+
+```typescript
+// Send a photo by URL
+await ctx.replyWithPhoto("https://example.com/image.jpg");
+
+// Send a photo with caption
+await ctx.replyWithPhoto("https://example.com/image.jpg", {
+  caption: "Check this out!",
+});
+
+// Send a document
+await ctx.replyWithDocument(new InputFile("/path/to/file.pdf"));
+
+// Send a photo from buffer
+import { InputFile } from "grammy";
+await ctx.replyWithPhoto(new InputFile(buffer, "photo.jpg"));
+
+// Send media group (album)
+await ctx.replyWithMediaGroup([
+  { type: "photo", media: "https://example.com/1.jpg" },
+  { type: "photo", media: "https://example.com/2.jpg" },
+]);
+```
+
+## Inline Keyboards
+
+```typescript
+import { InlineKeyboard } from "grammy";
+
+const keyboard = new InlineKeyboard()
+  .text("Button 1", "btn_1")
+  .text("Button 2", "btn_2")
+  .row()
+  .url("Visit Site", "https://example.com");
+
+await ctx.reply("Choose an option:", { reply_markup: keyboard });
+
+// Handle callback queries
+bot.callbackQuery("btn_1", async (ctx) => {
+  await ctx.answerCallbackQuery("You clicked Button 1!");
+  await ctx.editMessageText("You selected option 1.");
+});
+```
+
+## Custom Keyboards (Reply Keyboards)
+
+```typescript
+import { Keyboard } from "grammy";
+
+const keyboard = new Keyboard()
+  .text("Option A").text("Option B").row()
+  .text("Option C")
+  .resized()      // fit keyboard to buttons
+  .oneTime();     // hide after use
+
+await ctx.reply("Pick one:", { reply_markup: keyboard });
+```
+
+## Commands
+
+```typescript
+// Set bot commands (shows in menu)
+await bot.api.setMyCommands([
+  { command: "start", description: "Start the bot" },
+  { command: "help", description: "Show help" },
+  { command: "settings", description: "Open settings" },
+]);
+
+// Handle commands
+bot.command("start", (ctx) => ctx.reply("Welcome!"));
+bot.command("help", (ctx) => ctx.reply("Here's how to use me..."));
+```
+
+## Conversations and Sessions
+
+### Sessions (Persistent State)
+
+```typescript
+import { Bot, Context, session } from "grammy";
+
+interface SessionData {
+  count: number;
+}
+
+type MyContext = Context & { session: SessionData };
+
+const bot = new Bot<MyContext>(process.env.TELEGRAM_BOT_TOKEN!);
+
+bot.use(session({ initial: (): SessionData => ({ count: 0 }) }));
+
+bot.command("count", (ctx) => {
+  ctx.session.count++;
+  return ctx.reply(`Count: ${ctx.session.count}`);
+});
+```
+
+## Middleware
+
+```typescript
+// Logging middleware
+bot.use(async (ctx, next) => {
+  const start = Date.now();
+  await next();
+  const ms = Date.now() - start;
+  console.log(`Response time: ${ms}ms`);
+});
+
+// Error handling
+bot.catch((err) => {
+  console.error("Bot error:", err);
+});
+```
+
+## Webhooks
+
+```typescript
+import express from "express";
+import { webhookCallback } from "grammy";
+
+const app = express();
+app.use(express.json());
+
+// Set webhook
+await bot.api.setWebhook("https://yourdomain.com/webhook");
+
+// Handle webhook
+app.use("/webhook", webhookCallback(bot, "express"));
+
+app.listen(3000);
+```
+
+## Forum Topics (Supergroups)
+
+```typescript
+// Create a topic
+const topic = await bot.api.createForumTopic(chatId, "New Topic", {
+  icon_color: 0x6FB9F0,
+});
+
+// Send message to a topic
+await bot.api.sendMessage(chatId, "Hello topic!", {
+  message_thread_id: topic.message_thread_id,
+});
+
+// Close/reopen a topic
+await bot.api.closeForumTopic(chatId, topic.message_thread_id);
+await bot.api.reopenForumTopic(chatId, topic.message_thread_id);
+
+// Delete a topic
+await bot.api.deleteForumTopic(chatId, topic.message_thread_id);
+```
+
+## Editing and Deleting Messages
+
+```typescript
+// Edit message text
+await ctx.editMessageText("Updated text");
+
+// Edit with API (when you have chat_id and message_id)
+await bot.api.editMessageText(chatId, messageId, "Updated text");
+
+// Delete a message
+await ctx.deleteMessage();
+await bot.api.deleteMessage(chatId, messageId);
+```
+
+## Error Handling
+
+```typescript
+import { GrammyError, HttpError } from "grammy";
+
+bot.catch((err) => {
+  const ctx = err.ctx;
+  const e = err.error;
+
+  if (e instanceof GrammyError) {
+    console.error("Telegram API error:", e.description);
+    // e.error_code — numeric HTTP status
+    // e.description — human-readable error
+  } else if (e instanceof HttpError) {
+    console.error("Network error:", e);
+  } else {
+    console.error("Unknown error:", e);
+  }
+});
+```
+
+## Rate Limits
+
+Telegram enforces rate limits:
+
+- **1 message/second** to the same chat
+- **30 messages/second** overall
+- **20 messages/minute** to the same group
+
+Use `bot.api.config.use(autoRetry())` from `@grammyjs/auto-retry` to handle rate limits automatically:
+
+```typescript
+import { autoRetry } from "@grammyjs/auto-retry";
+
+bot.api.config.use(autoRetry());
+```
+
+## Plugins (grammY Ecosystem)
+
+| Plugin | Package | Purpose |
+|--------|---------|---------|
+| Auto Retry | `@grammyjs/auto-retry` | Handle rate limits |
+| Conversations | `@grammyjs/conversations` | Multi-step dialogs |
+| Menu | `@grammyjs/menu` | Interactive menus |
+| Router | `@grammyjs/router` | Route updates |
+| Parse Mode | `@grammyjs/parse-mode` | Default parse mode |
+| Hydrate | `@grammyjs/hydrate` | Call methods on API objects |
+| Files | `@grammyjs/files` | Download files easily |
+| Runner | `@grammyjs/runner` | Scale with long polling |
+
+## Common Patterns
+
+### Restricting Access
+
+```typescript
+// Only allow specific users
+const ADMIN_IDS = [123456789, 987654321];
+
+bot.use((ctx, next) => {
+  if (ctx.from && ADMIN_IDS.includes(ctx.from.id)) {
+    return next();
+  }
+  return ctx.reply("Unauthorized.");
+});
+```
+
+### Typing Indicator
+
+```typescript
+await ctx.replyWithChatAction("typing");
+// ... do work ...
+await ctx.reply("Done!");
+```
+
+### Deep Linking
+
+```typescript
+// User opens: t.me/yourbot?start=ref123
+bot.command("start", (ctx) => {
+  const payload = ctx.match; // "ref123"
+  if (payload) {
+    return ctx.reply(`Referred by: ${payload}`);
+  }
+  return ctx.reply("Welcome!");
+});
+```

--- a/content/telegram/docs/bot-api/python/DOC.md
+++ b/content/telegram/docs/bot-api/python/DOC.md
@@ -1,0 +1,399 @@
+---
+name: bot-api
+description: "Telegram Bot API via python-telegram-bot for building Telegram bots in Python"
+metadata:
+  languages: "python"
+  versions: "21.10"
+  revision: 1
+  updated-on: "2026-03-10"
+  source: community
+  tags: "telegram,bot,messaging,python-telegram-bot,chat"
+---
+
+# Telegram Bot API — Python SDK Coding Guidelines
+
+You are a Telegram Bot API coding expert. Help me write code using the Telegram Bot API with the official and recommended Python libraries.
+
+Official Telegram Bot API documentation:
+https://core.telegram.org/bots/api
+
+## Golden Rule: Use the Correct and Current SDK
+
+Use **python-telegram-bot** (recommended) for Telegram bot development in Python.
+
+- **Library Name:** python-telegram-bot
+- **PyPI Package:** `python-telegram-bot`
+- **Current Version:** 21.10
+- **Legacy:** v13.x used synchronous code — v20+ is fully async
+
+**Installation:**
+
+```bash
+pip install python-telegram-bot
+```
+
+**APIs and Usage:**
+
+- **Correct:** `from telegram import Update, Bot`
+- **Correct:** `from telegram.ext import Application, CommandHandler, MessageHandler, filters`
+- **Correct:** `application = Application.builder().token("TOKEN").build()`
+- **Incorrect:** `from telegram.ext import Updater` (removed in v20+)
+- **Incorrect:** `updater.start_polling()` (use `application.run_polling()`)
+- **Incorrect:** `bot.send_message()` synchronously (all methods are async in v20+)
+
+## Initialization
+
+```python
+from telegram import Update
+from telegram.ext import Application, CommandHandler, ContextTypes
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text("Welcome! I'm your bot.")
+
+async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text("Here's how to use me...")
+
+def main() -> None:
+    app = Application.builder().token("YOUR_BOT_TOKEN").build()
+    app.add_handler(CommandHandler("start", start))
+    app.add_handler(CommandHandler("help", help_command))
+    app.run_polling()
+
+if __name__ == "__main__":
+    main()
+```
+
+## Sending Messages
+
+### Plain Text
+
+```python
+await update.message.reply_text("Hello!")
+
+# With parse mode
+await update.message.reply_text("*Bold* and _italic_", parse_mode="MarkdownV2")
+await update.message.reply_text("<b>Bold</b> and <i>italic</i>", parse_mode="HTML")
+```
+
+### Sending to a Specific Chat
+
+```python
+# Use context.bot to send without an update
+await context.bot.send_message(chat_id=chat_id, text="Hello from bot!")
+
+# Send to a topic/thread in a group
+await context.bot.send_message(
+    chat_id=chat_id,
+    text="Hello topic!",
+    message_thread_id=topic_id,
+)
+```
+
+### Photos, Documents, and Media
+
+```python
+# Send a photo by URL
+await update.message.reply_photo("https://example.com/image.jpg")
+
+# Send a photo with caption
+await update.message.reply_photo(
+    "https://example.com/image.jpg",
+    caption="Check this out!",
+)
+
+# Send a document
+await update.message.reply_document(open("/path/to/file.pdf", "rb"))
+
+# Send a photo from bytes
+await context.bot.send_photo(chat_id=chat_id, photo=image_bytes)
+
+# Send media group (album)
+from telegram import InputMediaPhoto
+await update.message.reply_media_group([
+    InputMediaPhoto("https://example.com/1.jpg"),
+    InputMediaPhoto("https://example.com/2.jpg"),
+])
+```
+
+## Inline Keyboards
+
+```python
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+from telegram.ext import CallbackQueryHandler
+
+keyboard = InlineKeyboardMarkup([
+    [
+        InlineKeyboardButton("Button 1", callback_data="btn_1"),
+        InlineKeyboardButton("Button 2", callback_data="btn_2"),
+    ],
+    [InlineKeyboardButton("Visit Site", url="https://example.com")],
+])
+
+await update.message.reply_text("Choose an option:", reply_markup=keyboard)
+
+# Handle callback queries
+async def button_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    await query.answer("You clicked!")
+    await query.edit_message_text(f"You selected: {query.data}")
+
+app.add_handler(CallbackQueryHandler(button_handler))
+```
+
+## Custom Keyboards (Reply Keyboards)
+
+```python
+from telegram import ReplyKeyboardMarkup, KeyboardButton
+
+keyboard = ReplyKeyboardMarkup(
+    [[KeyboardButton("Option A"), KeyboardButton("Option B")],
+     [KeyboardButton("Option C")]],
+    resize_keyboard=True,
+    one_time_keyboard=True,
+)
+
+await update.message.reply_text("Pick one:", reply_markup=keyboard)
+```
+
+## Commands
+
+```python
+# Set bot commands (shows in menu)
+from telegram import BotCommand
+
+await context.bot.set_my_commands([
+    BotCommand("start", "Start the bot"),
+    BotCommand("help", "Show help"),
+    BotCommand("settings", "Open settings"),
+])
+
+# Register handlers
+app.add_handler(CommandHandler("start", start))
+app.add_handler(CommandHandler("help", help_command))
+```
+
+## Conversation Handler (Multi-step Dialogs)
+
+```python
+from telegram.ext import ConversationHandler, MessageHandler, filters
+
+NAME, AGE = range(2)
+
+async def start_conv(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    await update.message.reply_text("What's your name?")
+    return NAME
+
+async def get_name(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    context.user_data["name"] = update.message.text
+    await update.message.reply_text("How old are you?")
+    return AGE
+
+async def get_age(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    name = context.user_data["name"]
+    age = update.message.text
+    await update.message.reply_text(f"Hi {name}, age {age}!")
+    return ConversationHandler.END
+
+async def cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    await update.message.reply_text("Cancelled.")
+    return ConversationHandler.END
+
+conv_handler = ConversationHandler(
+    entry_points=[CommandHandler("register", start_conv)],
+    states={
+        NAME: [MessageHandler(filters.TEXT & ~filters.COMMAND, get_name)],
+        AGE: [MessageHandler(filters.TEXT & ~filters.COMMAND, get_age)],
+    },
+    fallbacks=[CommandHandler("cancel", cancel)],
+)
+
+app.add_handler(conv_handler)
+```
+
+## Message Handlers with Filters
+
+```python
+from telegram.ext import MessageHandler, filters
+
+# Handle text messages
+app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_text))
+
+# Handle photos
+app.add_handler(MessageHandler(filters.PHOTO, handle_photo))
+
+# Handle documents
+app.add_handler(MessageHandler(filters.Document.ALL, handle_document))
+
+# Handle specific text patterns (regex)
+app.add_handler(MessageHandler(filters.Regex(r"^/custom_\w+"), handle_custom))
+
+# Combine filters
+app.add_handler(MessageHandler(
+    filters.TEXT & filters.ChatType.PRIVATE,
+    handle_private_text,
+))
+```
+
+## Webhooks
+
+```python
+async def main() -> None:
+    app = Application.builder().token("YOUR_TOKEN").build()
+    app.add_handler(CommandHandler("start", start))
+
+    await app.bot.set_webhook(url="https://yourdomain.com/webhook")
+    await app.run_webhook(
+        listen="0.0.0.0",
+        port=8443,
+        url_path="webhook",
+        webhook_url="https://yourdomain.com/webhook",
+    )
+```
+
+## Forum Topics (Supergroups)
+
+```python
+# Create a topic
+topic = await context.bot.create_forum_topic(
+    chat_id=chat_id,
+    name="New Topic",
+    icon_color=0x6FB9F0,
+)
+
+# Send message to a topic
+await context.bot.send_message(
+    chat_id=chat_id,
+    text="Hello topic!",
+    message_thread_id=topic.message_thread_id,
+)
+
+# Close/reopen a topic
+await context.bot.close_forum_topic(chat_id, topic.message_thread_id)
+await context.bot.reopen_forum_topic(chat_id, topic.message_thread_id)
+
+# Delete a topic
+await context.bot.delete_forum_topic(chat_id, topic.message_thread_id)
+```
+
+## Editing and Deleting Messages
+
+```python
+# Edit message text
+await update.message.edit_text("Updated text")
+
+# Edit via callback query
+await update.callback_query.edit_message_text("Updated text")
+
+# Edit with bot API (when you have chat_id and message_id)
+await context.bot.edit_message_text(
+    chat_id=chat_id,
+    message_id=message_id,
+    text="Updated text",
+)
+
+# Delete a message
+await update.message.delete()
+await context.bot.delete_message(chat_id=chat_id, message_id=message_id)
+```
+
+## Scheduled Jobs
+
+```python
+from telegram.ext import Application
+
+async def alarm(context: ContextTypes.DEFAULT_TYPE) -> None:
+    await context.bot.send_message(
+        chat_id=context.job.chat_id,
+        text="Reminder!",
+    )
+
+async def set_timer(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    chat_id = update.effective_chat.id
+    context.job_queue.run_once(alarm, when=60, chat_id=chat_id, name=str(chat_id))
+    await update.message.reply_text("Timer set for 60 seconds.")
+
+# Recurring job
+context.job_queue.run_repeating(alarm, interval=3600, chat_id=chat_id)
+```
+
+## Error Handling
+
+```python
+from telegram.error import TelegramError, BadRequest, Forbidden, TimedOut
+
+async def error_handler(update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
+    error = context.error
+    if isinstance(error, BadRequest):
+        print(f"Bad request: {error.message}")
+    elif isinstance(error, Forbidden):
+        print(f"Forbidden: {error.message}")  # bot blocked by user
+    elif isinstance(error, TimedOut):
+        print("Request timed out")
+    else:
+        print(f"Error: {error}")
+
+app.add_error_handler(error_handler)
+```
+
+## Rate Limits
+
+Telegram enforces rate limits:
+
+- **1 message/second** to the same chat
+- **30 messages/second** overall
+- **20 messages/minute** to the same group
+
+Use `python-telegram-bot`'s built-in rate limiter:
+
+```python
+from telegram.ext import AIORateLimiter
+
+app = (
+    Application.builder()
+    .token("YOUR_TOKEN")
+    .rate_limiter(AIORateLimiter())
+    .build()
+)
+```
+
+## Common Patterns
+
+### Restricting Access
+
+```python
+ADMIN_IDS = [123456789, 987654321]
+
+def admin_only(func):
+    async def wrapper(update: Update, context: ContextTypes.DEFAULT_TYPE):
+        if update.effective_user.id not in ADMIN_IDS:
+            await update.message.reply_text("Unauthorized.")
+            return
+        return await func(update, context)
+    return wrapper
+
+@admin_only
+async def secret_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    await update.message.reply_text("Admin-only content.")
+```
+
+### Typing Indicator
+
+```python
+from telegram.constants import ChatAction
+
+await context.bot.send_chat_action(chat_id=chat_id, action=ChatAction.TYPING)
+# ... do work ...
+await context.bot.send_message(chat_id=chat_id, text="Done!")
+```
+
+### Deep Linking
+
+```python
+# User opens: t.me/yourbot?start=ref123
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    args = context.args  # ["ref123"]
+    if args:
+        await update.message.reply_text(f"Referred by: {args[0]}")
+    else:
+        await update.message.reply_text("Welcome!")
+```


### PR DESCRIPTION
## Summary

- **telegram/bot-api** (JS + Python): Covers grammY (JS/TS, v1.35.0) and python-telegram-bot (Python, v21.10) — commands, inline keyboards, sessions, webhooks, forum topics, media, rate limits, error handling, and common patterns
- **nextjs/app-router** (JS/TS): Covers Next.js 15 App Router (v15.3.0) — server/client components, routing, data fetching, server actions, API routes, middleware, metadata/SEO, image optimization, parallel/intercepting routes, and config

## Test plan

- [x] `chub build content/ --validate-only` passes: 71 docs, 2 skills, 0 warnings
- [ ] Content review for accuracy and completeness
- [ ] Verify docs render correctly via `chub get telegram/bot-api --lang js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)