### PR TITLE
Add Nano Banana and image generation tags to Gemini docs

### DIFF
--- a/content/gemini/docs/genai/javascript/DOC.md
+++ b/content/gemini/docs/genai/javascript/DOC.md
@@ -1,12 +1,12 @@
 ---
 name: genai
-description: "Google Gemini GenAI SDK for multimodal LLM interactions in JavaScript/TypeScript"
+description: "Google Gemini GenAI SDK for multimodal LLM interactions, image generation (Nano Banana), and video generation in JavaScript/TypeScript"
 metadata:
   languages: "javascript"
   versions: "1.43.0"
   updated-on: "2026-03-01"
   source: maintainer
-  tags: "gemini,google,genai,llm,multimodal"
+  tags: "gemini,google,genai,llm,multimodal,nano banana,imagen,image generation,veo,video generation"
 ---
 
 # Gemini API Coding Guidelines (JavaScript/TypeScript)

--- a/content/gemini/docs/genai/python/DOC.md
+++ b/content/gemini/docs/genai/python/DOC.md
@@ -1,12 +1,12 @@
 ---
 name: genai
-description: "Google Gemini GenAI SDK for multimodal LLM interactions in Python"
+description: "Google Gemini GenAI SDK for multimodal LLM interactions, image generation (Nano Banana), and video generation in Python"
 metadata:
   languages: "python"
   versions: "1.56.0"
   updated-on: "2026-03-01"
   source: maintainer
-  tags: "gemini,google,genai,llm,multimodal"
+  tags: "gemini,google,genai,llm,multimodal,nano banana,imagen,image generation,veo,video generation"
 ---
 
 # Gemini API Coding Guidelines (Python)


### PR DESCRIPTION
## Summary

- Searching `chub search "nano banana"` returned zero results, even though the Gemini GenAI doc already covers image generation with Imagen and Gemini image models
- Root cause: the BM25 search index only indexes metadata fields (name, description, tags) — not document body content — so terms like "nano banana" and "imagen" that only appear in the doc body were invisible to search
- This adds "nano banana", "imagen", "image generation", "veo", and "video generation" to the tags and descriptions of both the Python and JavaScript Gemini GenAI docs

## Context

This was reported on [Reddit](https://www.reddit.com/r/learnmachinelearning/comments/1rp7x42/andrew_ngs_recent_post_about_contexthub/) — a user read Andrew Ng's blog post which uses Nano Banana as a motivating example, installed chub, searched for it, and got nothing.

## This is a quick fix

The deeper issue is that the BM25 index only searches metadata, not document content. Longer-term we should consider:
- **Indexing doc body content** (e.g. headings and code identifiers) so new terms are searchable without manually adding tags
- **Build-time keyword extraction** to auto-generate tags from doc content
- **Failed search telemetry** to detect content gaps before users complain

## Test plan

- [x] `chub search "nano banana"` → returns `gemini/genai`
- [x] `chub search "imagen"` → returns `gemini/genai`
- [x] `chub search "veo"` → returns `gemini/genai`
- [x] All 143 existing tests pass
- [x] Fresh agent with no prior context successfully searched, retrieved docs, and wrote correct Nano Banana image generation code