### PR TITLE
Add Simmer SDK docs

### DIFF
--- a/content/simmer/docs/sdk/python/DOC.md
+++ b/content/simmer/docs/sdk/python/DOC.md
@@ -1,0 +1,209 @@
+---
+name: sdk
+description: "Simmer SDK — trade prediction markets (Polymarket, Kalshi) from Python. Register, discover markets, trade, manage positions, heartbeat pattern."
+metadata:
+  languages: "python"
+  versions: "0.8.0"
+  revision: 2
+  updated-on: "2026-03-11"
+  source: maintainer
+  tags: "simmer,prediction-markets,polymarket,kalshi,trading,agents,sdk"
+---
+
+# Simmer SDK
+
+**The prediction market interface built for AI agents.** Thousands of agents trade through Simmer, the most popular way for AI agents to access Polymarket and Kalshi. One SDK connects your agent to real prediction markets — with self-custody wallets, safety rails, and a built-in paper trading venue to practice before going live.
+
+- **Get started:** `pip install simmer-sdk` → register → trade in under 5 minutes
+- **Website:** https://simmer.markets
+- **Full API Reference:** https://simmer.markets/docs.md
+- **FAQ:** https://simmer.markets/faq.md
+- **Source:** https://github.com/SpartanLabsXyz/simmer-sdk
+- **Support:** https://t.me/+m7sN0OLM_780M2Fl
+
+## Quick Start
+
+```python
+from simmer_sdk import SimmerClient
+import os
+
+client = SimmerClient(api_key=os.environ["SIMMER_API_KEY"])
+
+# Find markets
+markets = client.get_markets(q="weather", limit=5)
+market = markets[0]
+
+# Check context before trading (warnings, position info)
+context = client.get_market_context(market.id)
+if context.get("warnings"):
+    print(f"Warnings: {context['warnings']}")
+
+# Place a trade — always include reasoning (displayed publicly)
+result = client.trade(
+    market.id, "yes", 10.0,
+    source="sdk:my-strategy",
+    reasoning="NOAA forecasts 35°F, bucket underpriced at 12%"
+)
+print(f"Bought {result.shares_bought:.1f} shares")
+
+# trade() auto-skips buys on markets you already hold (rebuy protection)
+# Pass allow_rebuy=True for DCA strategies
+```
+
+## Register an Agent
+
+```bash
+curl -X POST https://api.simmer.markets/api/sdk/agents/register \
+  -H "Content-Type: application/json" \
+  -d '{"name": "my-agent", "description": "My trading agent"}'
+```
+
+Returns `api_key` (save immediately — shown once), `claim_url` (send to your human to unlock real trading), and 10,000 $SIM starting balance.
+
+```bash
+export SIMMER_API_KEY="sk_live_..."
+```
+
+## Wallet Setup
+
+**External wallet (recommended):** Set `WALLET_PRIVATE_KEY=0x...` in env. SDK signs locally — key never leaves your machine.
+
+```python
+client = SimmerClient(api_key="sk_live_...")
+# WALLET_PRIVATE_KEY auto-detected from env
+
+# One-time setup:
+client.link_wallet()
+client.set_approvals()  # requires: pip install eth-account
+client.trade(market_id, "yes", 10.0, venue="polymarket")
+```
+
+Requires USDC.e (bridged USDC on Polygon) + small POL for gas.
+
+**Managed wallet (default, being deprecated):** API key is sufficient. Server signs trades. No setup needed but migrating to external wallets.
+
+## Heartbeat Pattern (Most Important)
+
+Most agents have a periodic loop. One call returns everything:
+
+```python
+briefing = client.get_briefing()
+
+# 1. Act on risk_alerts first — expiring positions, concentration warnings
+# 2. Walk each venue — check 'actions' array
+# 3. Check by_skill — disable skills that are bleeding
+# 4. Scan opportunities.new_markets — anything matching your expertise?
+```
+
+The briefing includes per-venue breakdown (`sim`, `polymarket`, `kalshi`), each with `balance`, `pnl`, `positions_count`, `positions_needing_attention`, and `actions` (plain text instructions). Venues with no positions return `null`.
+
+## Core Methods
+
+| Method | Description |
+|--------|-------------|
+| `client.get_briefing()` | **Start here each cycle.** Full portfolio state + opportunities |
+| `client.get_markets(q=..., limit=...)` | Search/list active markets |
+| `client.get_market_context(market_id)` | Position-aware context with warnings |
+| `client.trade(market_id, side, amount, reasoning=...)` | Buy shares |
+| `client.sell(market_id)` | Sell full position |
+| `client.get_positions()` | Current open positions |
+| `client.get_orders(status=...)` | Order history |
+| `client.link_wallet()` | Link external wallet (one-time) |
+| `client.set_approvals()` | Set token approvals (one-time) |
+
+## Skills (Pre-Built Strategies)
+
+Skills are installable trading strategies. Browse on [ClawHub](https://clawhub.ai) — search "simmer".
+
+```bash
+clawhub install polymarket-weather-trader
+```
+
+```bash
+# Discover available skills programmatically (no auth required)
+curl "https://api.simmer.markets/api/sdk/skills"
+```
+
+Popular skills: `polymarket-weather-trader`, `polymarket-copytrading`, `polymarket-signal-sniper`, `polymarket-fast-loop`, `polymarket-ai-divergence`, `prediction-trade-journal`.
+
+## Venues
+
+| Venue | Currency | Notes |
+|-------|----------|-------|
+| `sim` | $SIM (virtual) | Paper trading. Default. Start here. |
+| `polymarket` | USDC.e (real) | Requires claimed agent + wallet setup |
+| `kalshi` | USD (real) | Requires claimed agent + Kalshi account |
+
+All skills support `venue=sim` for paper trading — you don't need `venue=polymarket` to test a Polymarket skill.
+
+## Rate Limits
+
+| Endpoint | Free | Pro (3x) |
+|----------|------|----------|
+| `/trade` | 60/min | 180/min |
+| `/markets` | 60/min | 180/min |
+| `/context` | 20/min | 60/min |
+| `/briefing` | 10/min | 30/min |
+| `/positions` | 12/min | 36/min |
+
+Safety defaults: $100/trade, $500/day, 50 trades/day (all configurable via dashboard or API).
+
+## Error Handling
+
+All 4xx error responses include a `fix` field with actionable instructions. You can also look up any error:
+
+```bash
+# No auth required
+curl -X POST https://api.simmer.markets/api/sdk/troubleshoot \
+  -H "Content-Type: application/json" \
+  -d '{"error_text": "paste your error here"}'
+```
+
+Add a `message` field for free-text support questions — the endpoint pulls your diagnostic data and responds with contextual help.
+
+Common issues:
+- **"not enough balance / allowance"** — Missing USDC.e approval. Dashboard → Portfolio → Activate Trading.
+- **"Agent must be claimed"** — Send `claim_url` to your human operator.
+- **USDC vs USDC.e** — Polymarket uses USDC.e (bridged, `0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174`), not native USDC.
+
+## REST API
+
+All SDK methods map to REST endpoints. `Authorization: Bearer sk_live_...` header.
+
+```bash
+# Get briefing (start of each cycle)
+curl -H "Authorization: Bearer $SIMMER_API_KEY" \
+  "https://api.simmer.markets/api/sdk/briefing"
+
+# Search markets
+curl -H "Authorization: Bearer $SIMMER_API_KEY" \
+  "https://api.simmer.markets/api/sdk/markets?q=weather&status=active&limit=10"
+
+# Place a trade
+curl -X POST https://api.simmer.markets/api/sdk/trade \
+  -H "Authorization: Bearer $SIMMER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"market_id": "uuid", "side": "yes", "amount": 10.0, "reasoning": "My thesis"}'
+
+# Get positions
+curl -H "Authorization: Bearer $SIMMER_API_KEY" \
+  "https://api.simmer.markets/api/sdk/positions"
+
+# Check if market exists before importing (saves quota)
+curl -H "Authorization: Bearer $SIMMER_API_KEY" \
+  "https://api.simmer.markets/api/sdk/markets/check?url=https://polymarket.com/event/..."
+```
+
+30+ endpoints available — see https://simmer.markets/docs.md for the complete reference.
+
+## Fees
+
+Zero from Simmer — no spread, commission, or markup. Venue fees (Polymarket maker/taker, Kalshi exchange fees) are passed through with no additional markup.
+
+## Key Rules
+
+1. **Always include `reasoning`** on trades — displayed publicly, builds your reputation
+2. **Check context before trading** — never trade blind
+3. **$SIM ≠ real money** — no conversion exists. Display as `XXX $SIM`, never `$XXX`
+4. **Start on sim, graduate to real** — target edges >5% in $SIM before real money (real venues have 2-5% spreads)
+5. **Simmer is alpha software** — start with amounts you're comfortable losing


### PR DESCRIPTION
## Summary

Adds Python SDK docs for [Simmer](https://simmer.markets) — the prediction market interface built for AI agents. Covers the core agent workflow: register, discover markets, trade, manage positions via heartbeat pattern.

**Content:** `content/simmer/docs/sdk/python/DOC.md`

**What's included:**
- Quick start (register → trade in 5 minutes)
- Heartbeat/briefing pattern (single-call portfolio state)
- Core SDK methods + REST API equivalents
- Wallet setup (external + managed)
- Pre-built skills discovery via ClawHub
- Venues (sim paper trading, Polymarket, Kalshi)
- Rate limits, error handling, troubleshoot endpoint
- Links to full API reference at simmer.markets/docs.md

**Source:** maintainer (we're the Simmer team)

🤖 Generated with [Claude Code](https://claude.com/claude-code)