### PR TITLE
Add Simmer SDK docs — prediction market API for AI agents

### DIFF
--- a/content/simmer/docs/sdk/python/DOC.md
+++ b/content/simmer/docs/sdk/python/DOC.md
@@ -16,7 +16,7 @@ The prediction market interface for AI agents. One SDK connects your agent to Po
 
 - **Install:** `pip install simmer-sdk`
 - **Source:** https://github.com/SpartanLabsXyz/simmer-sdk
-- **Full docs:** https://simmer.mintlify.app/llms-full.txt
+- **Full docs:** https://docs.simmer.markets/llms-full.txt
 - **Support:** https://t.me/+DykggGXL67E4MGE9
 
 ## Quick Start
@@ -140,4 +140,4 @@ briefing = client.get_briefing()
 
 ## Full Reference
 
-For the complete API (alerts, webhooks, risk monitors, order management, Kalshi trading, error handling), see https://simmer.mintlify.app/llms-full.txt
+For the complete API (alerts, webhooks, risk monitors, order management, Kalshi trading, error handling), see https://docs.simmer.markets/llms-full.txt


### PR DESCRIPTION
## Summary

- Adds `content/simmer/docs/sdk/python/DOC.md` — Simmer SDK documentation for connecting AI agents to prediction markets (Polymarket, Kalshi)
- Covers: quick start, constructor, core methods (trading, markets, positions, heartbeat), venues, wallet setup, and heartbeat pattern
- All method signatures verified against SDK source (`simmer_sdk/client.py` v0.9.12)

## About Simmer

Simmer is the prediction market interface for AI agents — one SDK connects to Polymarket (USDC), Kalshi (USD), and a built-in paper trading venue ($SIM). 6,000+ registered agents.

- **PyPI:** https://pypi.org/project/simmer-sdk/
- **Docs:** https://docs.simmer.markets
- **Source:** https://github.com/SpartanLabsXyz/simmer-sdk

## Checklist

- [x] DOC.md with valid YAML frontmatter (name, description, metadata)
- [x] Under 500 lines (143 lines)
- [x] Practical code examples with real parameter names
- [x] Progressive disclosure — links to full docs for advanced topics

🤖 Generated with [Claude Code](https://claude.com/claude-code)