### PR TITLE
Sanitize cache output paths to prevent directory traversal

### DIFF
--- a/cli/src/commands/get.js
+++ b/cli/src/commands/get.js
@@ -1,5 +1,5 @@
 import { writeFileSync, mkdirSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, join, basename } from 'node:path';
 import chalk from 'chalk';
 import { getEntry, resolveDocPath, resolveEntryFile } from '../lib/registry.js';
 import { fetchDoc, fetchDocFull } from '../lib/cache.js';
@@ -106,16 +106,17 @@ async function fetchEntries(ids, opts, globalOpts) {
     if (opts.full) {
       for (const r of results) {
         if (r.files) {
-          const baseDir = ids.length > 1 ? join(opts.output, r.id) : opts.output;
+          const safeId = basename(r.id);
+          const baseDir = ids.length > 1 ? join(opts.output, safeId) : opts.output;
           mkdirSync(baseDir, { recursive: true });
           for (const f of r.files) {
-            const outPath = join(baseDir, f.name);
+            const outPath = join(baseDir, basename(f.name));
             mkdirSync(dirname(outPath), { recursive: true });
             writeFileSync(outPath, f.content);
           }
           info(`Written ${r.files.length} files to ${baseDir}`);
         } else {
-          const outPath = join(opts.output, `${r.id}.md`);
+          const outPath = join(opts.output, `${basename(r.id)}.md`);
           mkdirSync(dirname(outPath), { recursive: true });
           writeFileSync(outPath, r.content);
           info(`Written to ${outPath}`);
@@ -126,13 +127,14 @@ async function fetchEntries(ids, opts, globalOpts) {
       if (isDir && results.length > 1) {
         mkdirSync(opts.output, { recursive: true });
         for (const r of results) {
-          const outPath = join(opts.output, `${r.id}.md`);
+          const outPath = join(opts.output, `${basename(r.id)}.md`);
           mkdirSync(dirname(outPath), { recursive: true });
           writeFileSync(outPath, r.content);
           info(`Written to ${outPath}`);
         }
       } else {
-        const outPath = isDir ? join(opts.output, `${results[0].id}.md`) : opts.output;
+        const safeId = basename(results[0].id);
+        const outPath = isDir ? join(opts.output, `${safeId}.md`) : opts.output;
         mkdirSync(dirname(outPath), { recursive: true });
         const combined = results.map((r) => r.content).join('\n\n---\n\n');
         writeFileSync(outPath, combined);

--- a/cli/src/lib/cache.js
+++ b/cli/src/lib/cache.js
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync, readdirSync, statSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join, dirname, resolve, relative } from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import { createWriteStream } from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -152,14 +152,31 @@ export async function fetchDoc(source, docPath) {
   // Local source: read directly
   if (source.path) {
     const localPath = join(source.path, docPath);
+    // Prevent path traversal for local sources too
+    const resolvedLocal = resolve(localPath);
+    const resolvedRoot = resolve(source.path);
+    if (!resolvedLocal.startsWith(resolvedRoot)) {
+      throw new Error(`Security Error: Path traversal detected for local source "${docPath}"`);
+    }
+
     if (!existsSync(localPath)) {
       throw new Error(`File not found: ${localPath}`);
     }
     return readFileSync(localPath, 'utf8');
   }
 
+  const dataDir = getSourceDataDir(source.name);
+  const cachedPath = join(dataDir, docPath);
+
+  // Security: Prevent Path Traversal in cache
+  const resolvedCache = resolve(cachedPath);
+  const resolvedDataDir = resolve(dataDir);
+  const rel = relative(resolvedDataDir, resolvedCache);
+  if (rel.startsWith('..') || isAbs(rel)) {
+    throw new Error(`Security Error: Path traversal detected for doc "${docPath}"`);
+  }
+
   // Remote source: check cache first
-  const cachedPath = join(getSourceDataDir(source.name), docPath);
   if (existsSync(cachedPath)) {
     return readFileSync(cachedPath, 'utf8');
   }
@@ -187,11 +204,16 @@ export async function fetchDoc(source, docPath) {
   const content = await res.text();
 
   // Cache locally
-  const dir = cachedPath.substring(0, cachedPath.lastIndexOf('/'));
+  const dir = dirname(cachedPath);
   mkdirSync(dir, { recursive: true });
   writeFileSync(cachedPath, content);
 
   return content;
+}
+
+// Helper for path check
+function isAbs(path) {
+  return resolve(path) === resolve(path) && (process.platform === 'win32' || path.startsWith('/'));
 }
 
 /**


### PR DESCRIPTION
## What

Added path sanitization using `basename` and `path.resolve` for all file-writing operations in the CLI. The changes specifically target the `get` command and the `cache` library.

## Why

Current implementation blindly trusts `docPath` from the remote registry and `f.name` from network results. A compromised or malicious source could return paths like `../../.ssh/id_rsa`, leading to arbitrary file writes on the user's system. By enforcing that all cached files stay within their respective source data directories, the tool is now much more robust against untrusted remote content.

## Testing

- [x] `npm test` passes
- [x] `chub build sample-content/ --validate-only` succeeds
- [x] Verified by mocking a `registry.json` with traversal paths (e.g., `../../target.txt`). The CLI now correctly throws a "Security Error" instead of writing outside the cache directory.

## Notes

The fix handles both remote sources (caching) and local sources (reading) by verifying that the resolved final path is always a child of the intended root directory.