### PR TITLE
Add Oracle Fusion Cloud REST API docs (Procurement, SCM, Best Practices)

### DIFF
--- a/content/oracle/docs/procurement/DOC.md
+++ b/content/oracle/docs/procurement/DOC.md
@@ -1,0 +1,219 @@
+---
+name: procurement
+description: "Oracle Fusion Cloud Procurement REST API guide for automating Suppliers, Addresses, Sites, Site Assignments, Contacts, and Purchase Requisitions on release 26A"
+metadata:
+  languages: "python"
+  versions: "26A"
+  revision: 1
+  updated-on: "2026-03-10"
+  source: community
+  tags: "oracle,fusion,procurement,suppliers,purchase-requisitions,erp,p2p"
+---
+# Oracle Fusion Cloud Procurement — REST API Coding Guide
+
+## 1. Golden Rules
+
+- **Base URL pattern:** `https://{host}/fscmRestApi/resources/11.13.18.05/`
+- **Auth:** Basic auth over HTTPS. Every request must include credentials.
+- **Never hardcode IDs.** Always resolve Business Units, Organizations, and Preparer IDs dynamically via `GET` before creating objects.
+- **Query-before-create.** Always `GET` to check if the object exists before `POST`ing to prevent duplicates.
+- **30-second sync delay.** Oracle indexes new objects asynchronously. Wait 30 seconds after every `POST` before attempting to read or extend the created object.
+
+## 2. Supplier Provisioning (End-to-End)
+
+Creating a usable Supplier requires five sequential steps. Each step depends on the previous one.
+
+### 2.1 Discover Procurement Business Unit
+
+```
+GET /procurementBusinessUnitsLOV
+```
+
+Parse the response to extract a valid `ProcurementBUId`. Halt if zero or ambiguous results.
+
+### 2.2 Query-First Check
+
+```
+GET /suppliers?q=Supplier='{SupplierName}'
+```
+
+If found, capture the existing `SupplierId` and skip creation.
+
+### 2.3 Create Supplier
+
+```
+POST /suppliers
+```
+
+```json
+{
+    "Supplier": "ACME Corp",
+    "TaxOrganizationType": "Corporation",
+    "BusinessRelationship": "Spend Authorized"
+}
+```
+
+**Wait 30 seconds** after a successful `201` response.
+
+### 2.4 Create Address
+
+```
+POST /suppliers/{SupplierId}/child/addresses
+```
+
+```json
+{
+    "AddressName": "HQ_ADDRESS",
+    "Country": "United States",
+    "AddressLine1": "100 System Way",
+    "City": "Austin",
+    "State": "TX",
+    "PostalCode": "78741",
+    "AddressPurposeOrderingFlag": true,
+    "AddressPurposeRemitToFlag": true
+}
+```
+
+**Wait 30 seconds.**
+
+### 2.5 Create Site
+
+```
+POST /suppliers/{SupplierId}/child/sites
+```
+
+```json
+{
+    "SupplierSite": "MAIN_PROC_SITE",
+    "ProcurementBUId": 300000001234567,
+    "SupplierAddressName": "HQ_ADDRESS",
+    "SitePurposePurchasingFlag": true,
+    "SitePurposePayFlag": true
+}
+```
+
+**Wait 30 seconds.** Sites may take extra time to index — implement a polling loop (up to 6 retries at 15-second intervals) for `404` responses before proceeding.
+
+### 2.6 Create Site Assignment (CRITICAL)
+
+A Site is **invisible to Procurement** until assigned to a Business Unit.
+
+```
+POST /suppliers/{SupplierId}/child/sites/{SiteId}/child/assignments
+```
+
+```json
+{
+    "ClientBUId": 300000001234567,
+    "BillToBUId": 300000001234567
+}
+```
+
+- `BillToBUId` is **required**. Omitting it throws error `POZ-2130496`.
+- Site Assignments face race conditions — poll for the Site to be queryable before posting.
+
+### 2.7 Create Contact
+
+```
+POST /suppliers/{SupplierId}/child/contacts
+```
+
+```json
+{
+    "FirstName": "Alex",
+    "LastName": "Vance",
+    "Email": "admin@acme.test",
+    "PhoneAreaCode": "555",
+    "PhoneNumber": "0199",
+    "AdministrativeContactFlag": true
+}
+```
+
+**Known 26A bugs:**
+- `RequestUserAccountFlag` **cannot** be set via REST API — any attempt returns `400`.
+- The email field is `Email`, **not** `EmailAddress`.
+
+## 3. Purchase Requisition Provisioning
+
+### 3.1 API Structure
+
+- **Header:** `POST /purchaseRequisitions`
+- **Lines:** Nested under `/child/lines`
+- **Distributions:** Nested under `/child/lines/{LineId}/child/distributions`
+- **Submit:** `POST /purchaseRequisitions/{RequisitionId}/action/submitRequisition`
+
+### 3.2 Header Payload
+
+```json
+{
+    "PreparerId": 300000001234567,
+    "RequisitioningBUId": 300000001234567,
+    "Description": "Office Supplies Q1",
+    "ExternallyManagedFlag": false
+}
+```
+
+### 3.3 Line Payload
+
+```json
+{
+    "LineTypeId": 1,
+    "DestinationTypeCode": "EXPENSE",
+    "DestinationOrganizationId": 300000001234567,
+    "DeliverToLocationId": 300000001234567,
+    "RequesterId": 300000001234567,
+    "ItemDescription": "Printer Paper A4",
+    "Supplier": "ACME Corp",
+    "SupplierSite": "MAIN_PROC_SITE",
+    "UOM": "Each",
+    "Quantity": 100,
+    "Price": 5.99,
+    "CurrencyCode": "USD",
+    "RequestedDeliveryDate": "2026-04-01"
+}
+```
+
+**Critical field rules:**
+- `Supplier` must be the **string name**, not the numeric ID. Otherwise: `POR-2010896`.
+- `SupplierSite` must be the **string name**, not the numeric ID.
+- `UOM` must be the **full name** (e.g., `"Each"`), not shorthand (`"Ea"`). Otherwise: `POR-2010266`.
+
+### 3.4 Distribution Payload
+
+```json
+{
+    "Quantity": 100,
+    "DistributionNumber": 1,
+    "ChargeAccountId": 300000001234567
+}
+```
+
+### 3.5 Template-Based Provisioning
+
+For reliable payloads, clone architectural IDs from an existing user PR:
+
+1. Fetch the user's latest approved PR via `GET /purchaseRequisitions?q=PreparerId={id}&orderBy=CreationDate:desc&limit=1`
+2. Extract `RequisitioningBUId`, `PreparerId`, `DestinationOrganizationId`, `DeliverToLocationId`, `ChargeAccountId`
+3. Use these values as the structural backbone for new PRs
+
+### 3.6 Submitting
+
+```
+POST /purchaseRequisitions/{RequisitionId}/action/submitRequisition
+```
+
+If the PR remains in `INCOMPLETE` status after submission, escalate — this indicates a workflow configuration issue.
+
+## 4. Common Error Codes
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `POZ-2130496` | Missing `BillToBUId` on Site Assignment | Always include `BillToBUId` |
+| `POR-2010896` | Supplier passed as ID instead of name | Use string name for `Supplier` field |
+| `POR-2010266` | UOM shorthand used instead of full name | Use `"Each"` not `"Ea"` |
+| `400` on Contact | `RequestUserAccountFlag` set | Remove flag — not supported in 26A REST |
+
+## 5. Reference Documentation
+
+- **Procurement User Guide:** https://docs.oracle.com/en/cloud/saas/procurement/26a/use.html
+- **Procurement REST API:** https://docs.oracle.com/en/cloud/saas/procurement/26a/fapra/index.html

--- a/content/oracle/docs/rest-best-practices/DOC.md
+++ b/content/oracle/docs/rest-best-practices/DOC.md
@@ -1,0 +1,100 @@
+---
+name: rest-best-practices
+description: "Oracle Fusion Cloud REST API validation protocols, integration patterns, and common pitfalls for building reliable automated provisioning pipelines"
+metadata:
+  languages: "python"
+  versions: "26A"
+  revision: 1
+  updated-on: "2026-03-10"
+  source: community
+  tags: "oracle,fusion,rest,api,validation,integration,best-practices"
+---
+# Oracle Fusion Cloud REST API — Best Practices & Validation Protocols
+
+## 1. Connectivity Validation (Fail-Fast)
+
+Before any REST pipeline, verify environment health:
+
+1. **Network ping:** Ping the host from `ORACLE_BASE_URL`. Retry up to 10 times at 3-second intervals.
+2. **REST health check:** `GET /procurementBusinessUnitsLOV` (lightweight endpoint).
+   - **Transient failures** (timeout, no response): Retry up to 10 times at 2-second intervals.
+   - **Fatal failures** (`400`, `401`, `403`): Terminate immediately. Credential or configuration issues cannot be retried.
+
+## 2. Dynamic Parent Resolution
+
+**Never hardcode IDs** for Business Units, Organizations, or other parent entities.
+
+- Query the appropriate LOV endpoint first (e.g., `/procurementBusinessUnitsLOV`, `/inventoryOrganizations`).
+- Parse the response to resolve the correct parent ID.
+- For Inventory Organizations, match `OrganizationId == MasterOrganizationId` to find the Item Master.
+- Halt execution if no suitable mapping exists.
+
+## 3. Query-Before-Create
+
+Always check for existing objects before `POST`ing:
+
+```
+GET /suppliers?q=Supplier='{Name}'
+GET /itemsV2?q=ItemNumber='{Number}'
+GET /purchaseRequisitions?q=RequisitionHeaderId={Id}
+```
+
+If the object exists, capture its surrogate ID and skip creation. This prevents duplicates and wasted API calls.
+
+## 4. Asynchronous Sync Delays
+
+Oracle 26A indexes new objects asynchronously. An immediate `GET` after `POST` will return `404`.
+
+**Mandatory protocol:** Wait **30 seconds** after every successful `POST` before:
+- Reading the created object
+- Creating child entities (Addresses, Sites, Lines)
+- Running validation assertions
+
+For Site objects specifically, implement a polling loop: up to 6 retries at 15-second intervals, catching `404` responses.
+
+## 5. Validation-Gated Progression
+
+A `201 Created` response is **not sufficient**. Programmatic confirmation is required.
+
+After the 30-second delay:
+1. `GET` the exact resource URI of the newly created object.
+2. Assert that returned values match your input (e.g., `CustomerOrderFlag == true`, `SupplierName == expectedName`).
+3. **Halt the entire pipeline** if any assertion fails. Never proceed to create child objects on a misconfigured parent.
+
+## 6. API Schema Discovery
+
+**Do NOT use** Oracle's `/describe` endpoints — they frequently timeout on complex payloads.
+
+Instead:
+1. `GET` an existing instance of the target object using a known search string.
+2. Export the response payload to a JSON file.
+3. Read the JSON to extract exact Oracle attribute naming conventions.
+
+## 7. URL Encoding and Special Characters
+
+- Always URL-encode query parameter values.
+- Wrap string values in single quotes within `q=` filters: `q=Supplier='ACME Corp'`
+- Spaces in values need encoding: `q=Supplier='ACME%20Corp'`
+
+## 8. Performance Measurement
+
+Wrap all API calls in timing instrumentation:
+
+- Record `DurationMs` for each call.
+- Calculate `TokensSent` from request payload byte length.
+- Calculate `TokensRecv` from response payload byte length.
+- Log Phase, Method, Duration, and token metrics for benchmarking.
+
+## 9. Common Pitfalls
+
+| Pitfall | Impact | Prevention |
+|---------|--------|------------|
+| Hardcoded BU/Org IDs | Breaks across environments | Always resolve dynamically |
+| Missing 30s sync delay | `404` on child creation | Mandatory sleep after every POST |
+| Using `/describe` endpoints | Timeouts, wasted tokens | Query existing objects instead |
+| Skipping Site Assignment | Supplier invisible to PRs | Always POST assignment after Site |
+| Missing `BillToBUId` | `POZ-2130496` error | Always include on Site Assignment |
+| UOM shorthand ("Ea") | `POR-2010266` error | Use full name ("Each") |
+| Supplier ID instead of name | `POR-2010896` error | Use string name on PR lines |
+| `RequestUserAccountFlag` on Contact | `400` error | Not supported in 26A REST |
+| `Email` vs `EmailAddress` | Silent failure | Use `Email` attribute |

--- a/content/oracle/docs/scm/DOC.md
+++ b/content/oracle/docs/scm/DOC.md
@@ -1,0 +1,86 @@
+---
+name: scm
+description: "Oracle Fusion Cloud SCM REST API guide for creating multi-role Inventory Items enabled for Sales Orders and Purchasing on release 26A"
+metadata:
+  languages: "python"
+  versions: "26A"
+  revision: 1
+  updated-on: "2026-03-10"
+  source: community
+  tags: "oracle,fusion,scm,inventory,items,supply-chain"
+---
+# Oracle Fusion Cloud SCM — Inventory Item REST API Guide
+
+## 1. Golden Rules
+
+- **Base URL pattern:** `https://{host}/fscmRestApi/resources/11.13.18.05/`
+- **Auth:** Basic auth over HTTPS.
+- **Resolve the Item Master Organization dynamically** — never hardcode Organization IDs.
+- **Query-before-create** to prevent duplicate items.
+- **30-second sync delay** after every `POST` before reading or validating.
+
+## 2. Discover Item Master Organization
+
+```
+GET /inventoryOrganizations
+```
+
+Parse the response and find the organization where `OrganizationId == MasterOrganizationId`. This is the root Item Master. Halt if no match exists.
+
+## 3. Query-First Check
+
+```
+GET /itemsV2?q=ItemNumber='{ItemNumber}'
+```
+
+If found, capture the existing item and skip creation.
+
+## 4. Create Inventory Item
+
+```
+POST /itemsV2
+```
+
+```json
+{
+    "OrganizationId": 300000001234567,
+    "ItemNumber": "ACME-INV-1234",
+    "ItemDescription": "Standard Widget",
+    "ItemType": "FINISHED_GOOD",
+    "CustomerOrderFlag": true,
+    "CustomerOrderEnabledFlag": true,
+    "PurchasingFlag": true,
+    "PurchasableFlag": true
+}
+```
+
+### Critical Boolean Flags
+
+By default, items are **not** available for Sales Orders or Purchase Orders. To create a multi-role item, you **must** explicitly set:
+
+| Flag | Purpose |
+|------|---------|
+| `CustomerOrderFlag` | Makes item available on Sales Orders |
+| `CustomerOrderEnabledFlag` | Enables item for customer ordering |
+| `PurchasingFlag` | Makes item available for Procurement |
+| `PurchasableFlag` | Enables item for purchasing transactions |
+
+**Exact attribute names are mandatory.** Oracle will silently drop or reject aliases:
+- `Purchased` — wrong
+- `PurchasingItem` — wrong
+- `PurchasableFlag` — correct
+
+## 5. Validation Protocol
+
+After a successful `201` response:
+
+1. **Wait 30 seconds** for Oracle to index the new item.
+2. **GET the created item** using the returned `itemsV2UniqID`.
+3. **Assert** that all four boolean flags return `true`.
+4. **Halt** if any assertion fails — dependent objects (PR lines, Sales Orders) will break with a misconfigured item.
+
+## 6. Reference Documentation
+
+- **SCM User Guide:** https://docs.oracle.com/en/cloud/saas/supply-chain-and-manufacturing/26a/use.html
+- **SCM REST API:** https://docs.oracle.com/en/cloud/saas/supply-chain-and-manufacturing/26a/fasrp/index.html
+- **Item Creation:** https://docs.oracle.com/en/cloud/saas/supply-chain-and-manufacturing/26a/fapim/create-item.html


### PR DESCRIPTION
## Summary

Community-contributed documentation for **Oracle Fusion Cloud 26A** REST APIs — the first Oracle content in context-hub.

Three docs covering the Procure-to-Pay and Supply Chain domains:

- **`oracle/procurement`** — End-to-end Supplier provisioning (Addresses, Sites, Site Assignments, Contacts) and Purchase Requisition creation with field-level gotchas (error codes, naming traps)
- **`oracle/scm`** — Inventory Item creation with critical boolean flags for multi-role items (Sales + Purchasing)
- **`oracle/rest-best-practices`** — Validation protocols, async sync delays, query-before-create patterns, and a pitfall reference table

All three pass `chub build --validate-only` with zero warnings.

## Why this matters

Oracle Fusion Cloud is one of the largest enterprise ERP platforms with notoriously underdocumented REST APIs. These docs capture hard-won integration knowledge including:
- Mandatory 30-second async indexing delays after POST
- Site Assignment requirements invisible in official docs (POZ-2130496)
- Field naming traps that cause silent failures (Email vs EmailAddress, UOM full names)
- Schema discovery workarounds (avoid /describe endpoints)

## Test plan

- [x] `chub build ./content --validate-only` passes (72 docs, 0 warnings)
- [ ] Maintainer review of frontmatter and content structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)