### PR TITLE
Separate feedback and telemetry opt-out controls

### DIFF
--- a/cli/src/commands/feedback.js
+++ b/cli/src/commands/feedback.js
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { getEntry } from '../lib/registry.js';
-import { sendFeedback, isTelemetryEnabled, getTelemetryUrl } from '../lib/telemetry.js';
+import { sendFeedback, isFeedbackEnabled, isTelemetryEnabled, getTelemetryUrl } from '../lib/telemetry.js';
 import { getOrCreateClientId } from '../lib/identity.js';
 import { output, error } from '../lib/output.js';
 import { trackEvent } from '../lib/analytics.js';
@@ -32,24 +32,27 @@ export function registerFeedbackCommand(program) {
     .option('--label <label>', 'Feedback label (repeatable: --label outdated --label wrong-examples)', collect, [])
     .option('--agent <name>', 'AI coding tool name')
     .option('--model <model>', 'LLM model name')
-    .option('--status', 'Show telemetry status')
+    .option('--status', 'Show feedback and telemetry status')
     .action(async (id, rating, comment, opts) => {
       const globalOpts = program.optsWithGlobals();
 
       // --status flag
       if (opts.status) {
-        const enabled = isTelemetryEnabled();
+        const feedbackEnabled = isFeedbackEnabled();
+        const telemetryEnabled = isTelemetryEnabled();
         if (globalOpts.json) {
           let clientId = null;
           try { clientId = await getOrCreateClientId(); } catch {}
           console.log(JSON.stringify({
-            telemetry: enabled,
+            feedback: feedbackEnabled,
+            telemetry: telemetryEnabled,
             client_id_prefix: clientId ? clientId.slice(0, 8) : null,
             endpoint: getTelemetryUrl(),
             valid_labels: VALID_LABELS,
           }));
         } else {
-          console.log(`Telemetry: ${enabled ? chalk.green('enabled') : chalk.red('disabled')}`);
+          console.log(`Feedback:  ${feedbackEnabled ? chalk.green('enabled') : chalk.red('disabled')}`);
+          console.log(`Telemetry: ${telemetryEnabled ? chalk.green('enabled') : chalk.red('disabled')}`);
           try {
             const cid = await getOrCreateClientId();
             console.log(`Client ID: ${cid.slice(0, 8)}...`);
@@ -69,10 +72,10 @@ export function registerFeedbackCommand(program) {
         error('Rating must be "up" or "down".', globalOpts);
       }
 
-      if (!isTelemetryEnabled()) {
+      if (!isFeedbackEnabled()) {
         output(
-          { status: 'skipped', reason: 'telemetry_disabled' },
-          () => console.log(chalk.yellow('Telemetry is disabled. Enable with: telemetry: true in ~/.chub/config.yaml')),
+          { status: 'skipped', reason: 'feedback_disabled' },
+          () => console.log(chalk.yellow('Feedback is disabled. Enable with: feedback: true in ~/.chub/config.yaml')),
           globalOpts
         );
         return;

--- a/cli/src/lib/analytics.js
+++ b/cli/src/lib/analytics.js
@@ -4,7 +4,8 @@
  * Tracks: command usage, search patterns, doc/skill popularity, errors.
  * Does NOT track feedback ratings (those go to the custom API via telemetry.js).
  *
- * Respects the same telemetry opt-out: `telemetry: false` in config or CHUB_TELEMETRY=0.
+ * Respects telemetry opt-out: `telemetry: false` in config or CHUB_TELEMETRY=0.
+ * Feedback has a separate opt-out: `feedback: false` in config or CHUB_FEEDBACK=0.
  */
 
 import { isTelemetryEnabled } from './telemetry.js';

--- a/cli/src/lib/config.js
+++ b/cli/src/lib/config.js
@@ -12,6 +12,7 @@ const DEFAULTS = {
   output_format: 'human',
   source: 'official,maintainer,community',
   telemetry: true,
+  feedback: true,
   telemetry_url: DEFAULT_TELEMETRY_URL,
 };
 
@@ -50,6 +51,7 @@ export function loadConfig() {
     output_format: fileConfig.output_format || DEFAULTS.output_format,
     source: fileConfig.source || DEFAULTS.source,
     telemetry: fileConfig.telemetry !== undefined ? fileConfig.telemetry : DEFAULTS.telemetry,
+    feedback: fileConfig.feedback !== undefined ? fileConfig.feedback : DEFAULTS.feedback,
     telemetry_url: fileConfig.telemetry_url || DEFAULTS.telemetry_url,
   };
 

--- a/cli/src/lib/telemetry.js
+++ b/cli/src/lib/telemetry.js
@@ -8,6 +8,12 @@ export function isTelemetryEnabled() {
   return config.telemetry !== false;
 }
 
+export function isFeedbackEnabled() {
+  if (process.env.CHUB_FEEDBACK === '0' || process.env.CHUB_FEEDBACK === 'false') return false;
+  const config = loadConfig();
+  return config.feedback !== false;
+}
+
 export function getTelemetryUrl() {
   const url = process.env.CHUB_TELEMETRY_URL;
   if (url) return url;
@@ -33,7 +39,7 @@ export function getTelemetryUrl() {
  * @param {string} [opts.source] - Registry source name
  */
 export async function sendFeedback(entryId, entryType, rating, opts = {}) {
-  if (!isTelemetryEnabled()) return { status: 'skipped', reason: 'telemetry_disabled' };
+  if (!isFeedbackEnabled()) return { status: 'skipped', reason: 'feedback_disabled' };
 
   const { getOrCreateClientId, detectAgent, detectAgentVersion } = await import('./identity.js');
   const clientId = await getOrCreateClientId();

--- a/cli/src/mcp/tools.js
+++ b/cli/src/mcp/tools.js
@@ -9,7 +9,7 @@ import { dirname, join, resolve, relative } from 'node:path';
 import { searchEntries, getEntry, listEntries, resolveDocPath, resolveEntryFile } from '../lib/registry.js';
 import { fetchDoc, fetchDocFull } from '../lib/cache.js';
 import { readAnnotation, writeAnnotation, clearAnnotation, listAnnotations } from '../lib/annotations.js';
-import { sendFeedback, isTelemetryEnabled } from '../lib/telemetry.js';
+import { sendFeedback, isFeedbackEnabled } from '../lib/telemetry.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 let _cliVersion;
@@ -216,8 +216,8 @@ export async function handleAnnotate({ id, note, clear = false, list = false }) 
 
 export async function handleFeedback({ id, rating, comment, type, lang, version, file, labels }) {
   try {
-    if (!isTelemetryEnabled()) {
-      return textResult({ status: 'skipped', reason: 'telemetry_disabled' });
+    if (!isFeedbackEnabled()) {
+      return textResult({ status: 'skipped', reason: 'feedback_disabled' });
     }
 
     // Auto-detect entry type if not provided

--- a/cli/tests/mcp/tools.test.js
+++ b/cli/tests/mcp/tools.test.js
@@ -204,7 +204,7 @@ describe('chub_annotate (handleAnnotate)', () => {
 
 describe('chub_feedback (handleFeedback)', () => {
   afterEach(() => {
-    delete process.env.CHUB_TELEMETRY;
+    delete process.env.CHUB_FEEDBACK;
   });
 
   it('handles feedback without throwing', async () => {
@@ -218,11 +218,11 @@ describe('chub_feedback (handleFeedback)', () => {
     expect(['sent', 'skipped', 'error']).toContain(data.status);
   });
 
-  it('returns skipped when telemetry is disabled', async () => {
-    process.env.CHUB_TELEMETRY = '0';
+  it('returns skipped when feedback is disabled', async () => {
+    process.env.CHUB_FEEDBACK = '0';
     const result = await handleFeedback({ id: 'test/entry', rating: 'up' });
     const data = parseResult(result);
     expect(data.status).toBe('skipped');
-    expect(data.reason).toBe('telemetry_disabled');
+    expect(data.reason).toBe('feedback_disabled');
   });
 });

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -105,7 +105,7 @@ Rate a doc or skill. Feedback is sent to the registry for maintainers. See [Feed
 | `--file <file>` | Specific file within the entry |
 | `--agent <name>` | AI tool name |
 | `--model <model>` | LLM model name |
-| `--status` | Show telemetry status |
+| `--status` | Show feedback and telemetry status |
 
 Valid labels: `accurate`, `well-structured`, `helpful`, `good-examples`, `outdated`, `inaccurate`, `incomplete`, `wrong-examples`, `wrong-version`, `poorly-structured`.
 
@@ -179,7 +179,8 @@ sources:
 
 source: "official,maintainer,community"   # trust policy
 refresh_interval: 86400                   # cache TTL in seconds (24h)
-telemetry: true                           # anonymous usage analytics
+telemetry: true                           # anonymous usage analytics (passive)
+feedback: true                            # allow chub feedback to send ratings (explicit)
 ```
 
 ### Telemetry
@@ -191,6 +192,16 @@ Opt out:
 telemetry: false
 ```
 Or via environment variable: `CHUB_TELEMETRY=0`
+
+### Feedback
+
+The `chub feedback` command sends doc/skill ratings to maintainers. This is separate from telemetry — you can disable passive analytics while still being able to rate docs.
+
+Opt out:
+```yaml
+feedback: false
+```
+Or via environment variable: `CHUB_FEEDBACK=0`
 
 ### Multi-Source
 

--- a/docs/feedback-and-annotations.md
+++ b/docs/feedback-and-annotations.md
@@ -103,13 +103,14 @@ Labels help authors pinpoint specific issues:
 
 **Negative:** `outdated`, `inaccurate`, `incomplete`, `wrong-examples`, `wrong-version`, `poorly-structured`
 
-### Telemetry
+### Disabling Feedback
 
-Feedback is sent via the telemetry system. If telemetry is disabled, feedback is silently skipped. Check status with:
-
-```bash
-chub feedback --status
+```yaml
+# ~/.chub/config.yaml
+feedback: false
 ```
+
+Or via environment variable: `CHUB_FEEDBACK=0`. Check status with `chub feedback --status`.
 
 ## Annotations vs Feedback
 


### PR DESCRIPTION
## Summary
- Adds independent `feedback` config key (`feedback: true/false` in `~/.chub/config.yaml`) and `CHUB_FEEDBACK` env var
- Users can now disable passive PostHog analytics while still being able to rate docs via `chub feedback`, or vice versa
- `chub feedback --status` now shows both feedback and telemetry status independently

## Changes
- `cli/src/lib/telemetry.js` — new `isFeedbackEnabled()`, `sendFeedback` gates on it
- `cli/src/lib/config.js` — `feedback: true` default, loaded from config
- `cli/src/commands/feedback.js` — uses `isFeedbackEnabled()`, updated `--status` output
- `cli/src/mcp/tools.js` — uses `isFeedbackEnabled()` 
- `cli/tests/mcp/tools.test.js` — updated for `CHUB_FEEDBACK` / `feedback_disabled`
- `docs/cli-reference.md` — documents `feedback` config key
- `docs/feedback-and-annotations.md` — updated disabling instructions

## Test plan
- [x] All 143 existing tests pass
- [x] `CHUB_FEEDBACK=0 chub feedback test/entry up` → "Feedback is disabled"
- [x] `CHUB_TELEMETRY=0 chub feedback --status` → Feedback: enabled, Telemetry: disabled
- [x] `CHUB_FEEDBACK=0 chub feedback --status` → Feedback: disabled, Telemetry: enabled
- [x] `CHUB_FEEDBACK=0 CHUB_TELEMETRY=0 chub feedback --status` → both disabled
- [x] JSON output (`--status --json`) includes both `feedback` and `telemetry` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)