### PR TITLE
Keep client ID generation non-blocking when OS lookup fails

### DIFF
--- a/cli/src/lib/identity.js
+++ b/cli/src/lib/identity.js
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 import { execSync } from 'node:child_process';
 import { platform } from 'node:os';
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
@@ -10,28 +10,57 @@ let _cachedClientId = null;
 /**
  * Get the platform-native machine UUID.
  */
+function ensureNonEmpty(value, context) {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error(`${context} returned an empty value`);
+  }
+  return normalized;
+}
+
+function readFirstAvailableFile(paths) {
+  const errors = [];
+
+  for (const path of paths) {
+    try {
+      return ensureNonEmpty(readFileSync(path, 'utf8'), path);
+    } catch (error) {
+      errors.push(new Error(`Failed to read ${path}: ${error.message}`, { cause: error }));
+    }
+  }
+
+  throw new AggregateError(errors, 'Could not read a machine ID from any known Linux path');
+}
+
+function execMachineUUID(command, context) {
+  try {
+    return ensureNonEmpty(execSync(command, { encoding: 'utf8' }), context);
+  } catch (error) {
+    throw new Error(`Failed to read machine UUID via ${context}`, { cause: error });
+  }
+}
+
 function getMachineUUID() {
   const plat = platform();
 
   if (plat === 'darwin') {
-    return execSync(
+    return execMachineUUID(
       `ioreg -rd1 -c IOPlatformExpertDevice | awk -F'"' '/IOPlatformUUID/{print $4}'`,
-      { encoding: 'utf8' }
-    ).trim();
+      'ioreg'
+    );
   }
 
   if (plat === 'linux') {
-    try {
-      return readFileSync('/etc/machine-id', 'utf8').trim();
-    } catch {
-      return readFileSync('/var/lib/dbus/machine-id', 'utf8').trim();
-    }
+    return readFirstAvailableFile([
+      '/etc/machine-id',
+      '/var/lib/dbus/machine-id',
+    ]);
   }
 
   if (plat === 'win32') {
-    const output = execSync(
+    const output = execMachineUUID(
       'reg query "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Cryptography" /v MachineGuid',
-      { encoding: 'utf8' }
+      'reg'
     );
     const match = output.match(/MachineGuid\s+REG_SZ\s+(.+)/);
     if (match) return match[1].trim();
@@ -63,18 +92,23 @@ export async function getOrCreateClientId() {
     // File doesn't exist or is unreadable
   }
 
-  // Generate from machine UUID
-  const uuid = getMachineUUID();
-  const hash = createHash('sha256').update(uuid).digest('hex');
+  let clientId;
+  try {
+    const uuid = getMachineUUID();
+    clientId = createHash('sha256').update(uuid).digest('hex');
+  } catch {
+    // Keep feedback/telemetry non-blocking when platform ID lookup is unavailable.
+    clientId = randomBytes(32).toString('hex');
+  }
 
   // Ensure directory exists
   if (!existsSync(chubDir)) {
     mkdirSync(chubDir, { recursive: true });
   }
 
-  writeFileSync(idPath, hash, 'utf8');
-  _cachedClientId = hash;
-  return hash;
+  writeFileSync(idPath, clientId, 'utf8');
+  _cachedClientId = clientId;
+  return clientId;
 }
 
 /**

--- a/cli/tests/lib/identity.test.js
+++ b/cli/tests/lib/identity.test.js
@@ -1,0 +1,138 @@
+import { createHash } from 'node:crypto';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const tempRoots = [];
+
+function createTempChubDir() {
+  const root = mkdtempSync(join(tmpdir(), 'chub-identity-'));
+  tempRoots.push(root);
+  return join(root, '.chub');
+}
+
+async function loadIdentityModule({ platformName = 'linux', readFileSyncImpl, execSyncImpl } = {}) {
+  vi.resetModules();
+
+  vi.doMock('node:os', async () => {
+    const actual = await vi.importActual('node:os');
+    return {
+      ...actual,
+      platform: () => platformName,
+    };
+  });
+
+  vi.doMock('node:child_process', async () => {
+    const actual = await vi.importActual('node:child_process');
+    return {
+      ...actual,
+      execSync: execSyncImpl ?? actual.execSync,
+    };
+  });
+
+  vi.doMock('node:fs', async () => {
+    const actual = await vi.importActual('node:fs');
+    return {
+      ...actual,
+      readFileSync: readFileSyncImpl ?? actual.readFileSync,
+    };
+  });
+
+  return import('../../src/lib/identity.js');
+}
+
+describe('identity', () => {
+  beforeEach(() => {
+    delete process.env.CHUB_DIR;
+  });
+
+  afterEach(() => {
+    delete process.env.CHUB_DIR;
+    vi.restoreAllMocks();
+    vi.resetModules();
+    vi.doUnmock('node:os');
+    vi.doUnmock('node:fs');
+    vi.doUnmock('node:child_process');
+
+    for (const root of tempRoots.splice(0)) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('reuses an existing cached client_id without touching platform lookup', async () => {
+    const chubDir = createTempChubDir();
+    mkdirSync(chubDir, { recursive: true });
+
+    const existingId = 'a'.repeat(64);
+    writeFileSync(join(chubDir, 'client_id'), existingId, 'utf8');
+    process.env.CHUB_DIR = chubDir;
+
+    const execSyncImpl = vi.fn(() => {
+      throw new Error('should not be called');
+    });
+
+    const { getOrCreateClientId } = await loadIdentityModule({
+      platformName: 'darwin',
+      execSyncImpl,
+    });
+
+    await expect(getOrCreateClientId()).resolves.toBe(existingId);
+    expect(execSyncImpl).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the secondary Linux machine-id path when needed', async () => {
+    const chubDir = createTempChubDir();
+    process.env.CHUB_DIR = chubDir;
+
+    const readFileSyncImpl = vi.fn((path, encoding) => {
+      if (path === '/etc/machine-id') {
+        throw new Error('primary machine-id missing');
+      }
+      if (path === '/var/lib/dbus/machine-id') {
+        return 'secondary-machine-id';
+      }
+      return readFileSync(path, encoding);
+    });
+
+    const { getOrCreateClientId } = await loadIdentityModule({
+      platformName: 'linux',
+      readFileSyncImpl,
+    });
+
+    const clientId = await getOrCreateClientId();
+    const expected = createHash('sha256').update('secondary-machine-id').digest('hex');
+
+    expect(clientId).toBe(expected);
+    expect(readFileSyncImpl).toHaveBeenCalledWith('/etc/machine-id', 'utf8');
+    expect(readFileSyncImpl).toHaveBeenCalledWith('/var/lib/dbus/machine-id', 'utf8');
+    expect(readFileSync(join(chubDir, 'client_id'), 'utf8').trim()).toBe(expected);
+  });
+
+  it('persists a random client_id when platform UUID lookup fails', async () => {
+    const chubDir = createTempChubDir();
+    process.env.CHUB_DIR = chubDir;
+
+    const execSyncImpl = vi.fn(() => {
+      throw new Error('ioreg failed');
+    });
+
+    const firstLoad = await loadIdentityModule({
+      platformName: 'darwin',
+      execSyncImpl,
+    });
+    const firstId = await firstLoad.getOrCreateClientId();
+
+    expect(firstId).toMatch(/^[0-9a-f]{64}$/);
+    expect(readFileSync(join(chubDir, 'client_id'), 'utf8').trim()).toBe(firstId);
+
+    const secondLoad = await loadIdentityModule({
+      platformName: 'darwin',
+      execSyncImpl,
+    });
+    const secondId = await secondLoad.getOrCreateClientId();
+
+    expect(secondId).toBe(firstId);
+    expect(execSyncImpl).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- wrap machine UUID lookup in small helpers so empty results and OS-specific command failures are handled consistently
- preserve the Linux fallback from `/etc/machine-id` to `/var/lib/dbus/machine-id` while keeping failure context localized
- persist a random anonymous client id if native machine-id lookup is unavailable, so feedback and telemetry paths stay non-blocking
- add regression tests for cached ids, Linux fallback, and the random fallback path

## Validation
- npx vitest run tests/lib/identity.test.js
- npm test
- node cli/bin/chub build content/ --validate-only

Closes #28