### PR TITLE
Add Accredible credentials API documentation

### DIFF
--- a/content/accredible/docs/credentials/DOC.md
+++ b/content/accredible/docs/credentials/DOC.md
@@ -3,7 +3,7 @@ name: credentials
 description: "Digital credential platform API for issuing, managing, and verifying certificates and badges — covers credential CRUD, bulk operations, search, and group management"
 metadata:
   languages: "http"
-  versions: "1.0.0"
+  versions: "v1"
   revision: 1
   updated-on: "2026-03-12"
   source: community


### PR DESCRIPTION

## Summary

  Adds Accredible Credentials API documentation to the context hub. Covers credential CRUD, bulk issuance (v1/v2), search, evidence items, and error handling.

  ## About Accredible

  Accredible is a digital credentialing platform for issuing, managing, and verifying certificates and badges. Used by organizations including Google, AWS, and HubSpot.

  - **API docs:** https://docs.api.accredible.com/
  - **Dashboard:** https://dashboard.accredible.com/

  ## Files Added

  | Entry | Path | Lines |
  |-------|------|-------|
  | `accredible/credentials` | `content/accredible/docs/credentials/DOC.md` | 391 |

  ## Checklist
  - [x] Valid YAML frontmatter (name, description, metadata with tags/source/updated-on)
  - [x] Under 500 lines (391)
  - [x] `chub build content/ --validate-only` passes (80 docs, 5 skills, 0 warnings)
  - [x] `chub build content/` succeeds — `accredible/credentials` appears in local registry.json
  - [x] Practical code examples (Python `requests`, Java `HttpsURLConnection`)
  - [x] Covers: auth, create/get/update/delete, bulk create, search, evidence items, error codes, rate limits
  - [x] Tests pass at same rate as `main` (14 pre-existing failures, none introduced by this PR)

