### PR TITLE
fix: increase timeout for annotate e2e tests

### DIFF
--- a/cli/test/e2e.test.js
+++ b/cli/test/e2e.test.js
@@ -237,7 +237,8 @@ describe('chub CLI e2e', () => {
     });
   });
 
-  describe('annotate', () => {
+  // Annotation tests make multiple CLI calls (~3s each), so need a longer timeout
+  describe('annotate', { timeout: 30_000 }, () => {
     it('saves and displays annotation on get', () => {
       chub(['annotate', 'acme/widgets', 'Use batch mode for large datasets']);
       const out = chub(['get', 'acme/widgets', '--lang', 'js']);


### PR DESCRIPTION
## Summary

- 5 annotation e2e tests fail on `main` due to Vitest's default 5s timeout being too short for tests making 2–5 CLI calls (~3s each)
- Adds a 30s describe-level timeout scoped to the `annotate` block — no impact on other tests

## Details

Each `chub` CLI invocation spawns a new Node.js process. Annotation tests that make multiple calls (e.g., annotate then get) exceed the 5s default:

| Test | CLI Calls | ~Wall Time |
|------|-----------|-----------|
| saves and displays annotation on get | 2 | ~6s |
| replaces annotation on re-annotate | 2 | ~6s |
| clears annotation | 2 | ~6s |
| --list shows all annotations | 5 | ~15s |
| --json includes annotation in get output | 3 | ~9s |

## Test plan

- [x] All 167 tests pass locally (including the 5 previously failing annotation tests)
- [x] Non-annotation tests retain their default 5s timeout