### PR TITLE
Fix Windows path bug in fetchDoc cache directory creation

### DIFF
--- a/cli/src/lib/cache.js
+++ b/cli/src/lib/cache.js
@@ -187,8 +187,7 @@ export async function fetchDoc(source, docPath) {
   const content = await res.text();
 
   // Cache locally
-  const dir = cachedPath.substring(0, cachedPath.lastIndexOf('/'));
-  mkdirSync(dir, { recursive: true });
+  mkdirSync(dirname(cachedPath), { recursive: true });
   writeFileSync(cachedPath, content);
 
   return content;


### PR DESCRIPTION
## Summary
- `fetchDoc` in `cache.js` uses `lastIndexOf('/')` to extract the parent directory from a cached file path, but `path.join()` produces backslash separators on Windows
- `lastIndexOf('/')` returns `-1`, so `substring(0, -1)` yields an empty string, causing `mkdirSync('')` to throw ENOENT
- Fix: replace with `dirname()` (already imported), which handles both `/` and `\` correctly on all platforms

## Test plan
- [ ] Run `chub get <any-skill>` on Windows - should cache and display content
- [ ] Run `chub get <any-skill>` on macOS/Linux - should still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)