### PR TITLE
Add LAP Registry as built-in default content source

### DIFF
--- a/cli/src/lib/config.js
+++ b/cli/src/lib/config.js
@@ -41,7 +41,7 @@ export function loadConfig() {
   } else {
     // Backward compat: single cdn_url becomes a single source
     const url = process.env.CHUB_BUNDLE_URL || fileConfig.cdn_url || DEFAULT_CDN_URL;
-    sources = [{ name: 'default', url }];
+    sources = [{ name: 'default', url }, { name: 'lap', url: 'https://registry.lap.sh/chub' }];
   }
 
   _config = {


### PR DESCRIPTION
## Summary
- Adds [LAP Registry](https://registry.lap.sh) (`registry.lap.sh/chub`) as a second default source, giving chub users access to 1500+ compressed agent-native API specs as skills out of the box
- LAP Registry serves chub-compatible endpoints (`registry.json`, `search-index.json`, `SKILL.md` files) -- all integration work is on the LAP side, this PR is a single line change
- Users can `chub search stripe` and get LAP specs alongside existing docs

```
$ chub search stripe

4 results for "stripe":

  lap/stripe  [skill]    [official] (lap)
       Stripe API
  stripe/package  [doc]  py  [maintainer] (default)
       Stripe Python package guide...
  stripe/api  [doc]  js  [maintainer] (default)
       Payment processing platform...
```

- Users with custom `sources` in `config.yaml` are unaffected (the explicit sources array takes precedence over defaults)

## Test plan
- [ ] Run `chub update` - should fetch from both default and lap sources
- [ ] Run `chub search stripe` - should show `lap/stripe` alongside existing results
- [ ] Run `chub get lap/stripe` - should display the API spec as a skill
- [ ] Users with custom `sources` in config.yaml are unaffected (line 39-40 takes precedence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)