### PR TITLE
Bump version to 0.1.2

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aisuite/chub",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "CLI for Context Hub - search and retrieve LLM-optimized docs and skills",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump CLI version from 0.1.1 to 0.1.2 for npm publish

## Test plan
- [x] Verify `chub --version` outputs 0.1.2
- [x] Publish to npm after merge