### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/content/minimax/docs/chat/javascript/DOC.md
+++ b/content/minimax/docs/chat/javascript/DOC.md
@@ -47,10 +47,12 @@ const client = new OpenAI({
 
 | Model | Context Window | Notes |
 |-------|---------------|-------|
-| `MiniMax-M2.5` | 204K tokens | Flagship model, best quality |
-| `MiniMax-M2.5-highspeed` | 204K tokens | Optimized for speed, lower latency |
+| `MiniMax-M2.7` | 204K tokens | Latest flagship model with enhanced reasoning and coding |
+| `MiniMax-M2.7-highspeed` | 204K tokens | High-speed version of M2.7 for low-latency scenarios |
+| `MiniMax-M2.5` | 204K tokens | Previous generation flagship model |
+| `MiniMax-M2.5-highspeed` | 204K tokens | Previous generation high-speed model |
 
-Use `MiniMax-M2.5` for quality-sensitive tasks. Use `MiniMax-M2.5-highspeed` when latency matters more than peak quality.
+Use `MiniMax-M2.7` for quality-sensitive tasks. Use `MiniMax-M2.7-highspeed` when latency matters more than peak quality.
 
 ## Core Usage
 
@@ -65,7 +67,7 @@ const client = new OpenAI({
 });
 
 const completion = await client.chat.completions.create({
-  model: "MiniMax-M2.5",
+  model: "MiniMax-M2.7",
   messages: [
     { role: "system", content: "You are a helpful assistant." },
     { role: "user", content: "Explain the difference between TCP and UDP." },
@@ -89,7 +91,7 @@ const client = new OpenAI({
 });
 
 const stream = await client.chat.completions.create({
-  model: "MiniMax-M2.5",
+  model: "MiniMax-M2.7",
   messages: [{ role: "user", content: "Write a haiku about programming." }],
   stream: true,
   temperature: 0.7,
@@ -137,7 +139,7 @@ const tools = [
 ];
 
 const completion = await client.chat.completions.create({
-  model: "MiniMax-M2.5",
+  model: "MiniMax-M2.7",
   messages: [{ role: "user", content: "What's the weather in Tokyo?" }],
   tools,
   temperature: 0.7,
@@ -161,7 +163,7 @@ MiniMax requires `temperature` to be strictly between 0.0 (exclusive) and 1.0 (i
 ```javascript
 // Valid
 const completion = await client.chat.completions.create({
-  model: "MiniMax-M2.5",
+  model: "MiniMax-M2.7",
   messages: [{ role: "user", content: "Hello" }],
   temperature: 0.01, // near-deterministic
 });
@@ -186,7 +188,7 @@ const client = new OpenAI({
 
 try {
   const completion = await client.chat.completions.create({
-    model: "MiniMax-M2.5",
+    model: "MiniMax-M2.7",
     messages: [{ role: "user", content: "Hello" }],
     temperature: 0.7,
   });
@@ -207,7 +209,7 @@ try {
 ## Common Pitfalls
 
 - **Temperature must be > 0.** Setting `temperature: 0.0` raises an error. Use `0.01` for near-deterministic behavior.
-- **Model names are case-sensitive.** Use `MiniMax-M2.5`, not `minimax-m2.5`.
+- **Model names are case-sensitive.** Use `MiniMax-M2.7`, not `minimax-m2.7`.
 - **Always set `baseURL`.** Without `baseURL: "https://api.minimax.io/v1"`, requests go to OpenAI instead of MiniMax.
 - **Use a dedicated env var.** Store the key in `MINIMAX_API_KEY` (not `OPENAI_API_KEY`) to avoid confusion when working with multiple providers.
 - **Large context window.** MiniMax supports up to 204K tokens, but longer inputs cost more and take longer to process. Only send what you need.

--- a/content/minimax/docs/chat/javascript/DOC.md
+++ b/content/minimax/docs/chat/javascript/DOC.md
@@ -1,0 +1,219 @@
+---
+name: chat
+description: "MiniMax API for chat completions, streaming, function calling, and vision via OpenAI-compatible endpoint"
+metadata:
+  languages: "javascript"
+  versions: "1.0.0"
+  revision: 1
+  updated-on: "2026-03-14"
+  source: community
+  tags: "minimax,llm,chat,streaming,openai-compatible"
+---
+
+# MiniMax Chat API — JavaScript Guide
+
+## When To Use
+
+Use the MiniMax API when you need high-performance text generation with large context windows (up to 204K tokens). MiniMax exposes an OpenAI-compatible endpoint, so you can use the standard `openai` Node.js SDK with a custom `baseURL`.
+
+## Install
+
+MiniMax uses the OpenAI Node.js SDK. No additional package is needed.
+
+```bash
+npm install openai
+```
+
+## Authentication And Setup
+
+Get an API key from the MiniMax platform at `https://platform.minimaxi.com`. Set it as an environment variable:
+
+```bash
+export MINIMAX_API_KEY="your-api-key"
+```
+
+Create the client with the MiniMax base URL:
+
+```javascript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  apiKey: process.env.MINIMAX_API_KEY,
+  baseURL: "https://api.minimax.io/v1",
+});
+```
+
+## Models
+
+| Model | Context Window | Notes |
+|-------|---------------|-------|
+| `MiniMax-M2.5` | 204K tokens | Flagship model, best quality |
+| `MiniMax-M2.5-highspeed` | 204K tokens | Optimized for speed, lower latency |
+
+Use `MiniMax-M2.5` for quality-sensitive tasks. Use `MiniMax-M2.5-highspeed` when latency matters more than peak quality.
+
+## Core Usage
+
+### Chat Completions
+
+```javascript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  apiKey: process.env.MINIMAX_API_KEY,
+  baseURL: "https://api.minimax.io/v1",
+});
+
+const completion = await client.chat.completions.create({
+  model: "MiniMax-M2.5",
+  messages: [
+    { role: "system", content: "You are a helpful assistant." },
+    { role: "user", content: "Explain the difference between TCP and UDP." },
+  ],
+  temperature: 0.7,
+});
+
+console.log(completion.choices[0].message.content);
+```
+
+### Streaming
+
+Set `stream: true` and iterate over the chunks:
+
+```javascript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  apiKey: process.env.MINIMAX_API_KEY,
+  baseURL: "https://api.minimax.io/v1",
+});
+
+const stream = await client.chat.completions.create({
+  model: "MiniMax-M2.5",
+  messages: [{ role: "user", content: "Write a haiku about programming." }],
+  stream: true,
+  temperature: 0.7,
+});
+
+for await (const chunk of stream) {
+  const delta = chunk.choices[0]?.delta?.content || "";
+  if (delta) {
+    process.stdout.write(delta);
+  }
+}
+console.log();
+```
+
+## Function Calling (Tools)
+
+MiniMax supports OpenAI-style function calling:
+
+```javascript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  apiKey: process.env.MINIMAX_API_KEY,
+  baseURL: "https://api.minimax.io/v1",
+});
+
+const tools = [
+  {
+    type: "function",
+    function: {
+      name: "get_weather",
+      description: "Get the current weather for a location",
+      parameters: {
+        type: "object",
+        properties: {
+          location: {
+            type: "string",
+            description: "City name, e.g. San Francisco",
+          },
+        },
+        required: ["location"],
+      },
+    },
+  },
+];
+
+const completion = await client.chat.completions.create({
+  model: "MiniMax-M2.5",
+  messages: [{ role: "user", content: "What's the weather in Tokyo?" }],
+  tools,
+  temperature: 0.7,
+});
+
+const message = completion.choices[0].message;
+if (message.tool_calls) {
+  for (const toolCall of message.tool_calls) {
+    console.log(`Function: ${toolCall.function.name}`);
+    console.log(`Arguments: ${toolCall.function.arguments}`);
+  }
+}
+```
+
+## Configuration Options
+
+### Temperature
+
+MiniMax requires `temperature` to be strictly between 0.0 (exclusive) and 1.0 (inclusive). A value of exactly `0.0` is rejected.
+
+```javascript
+// Valid
+const completion = await client.chat.completions.create({
+  model: "MiniMax-M2.5",
+  messages: [{ role: "user", content: "Hello" }],
+  temperature: 0.01, // near-deterministic
+});
+
+// Invalid — will be rejected
+// temperature: 0.0
+```
+
+For near-deterministic output, use a very small value like `0.01`.
+
+## Error Handling
+
+Since MiniMax uses the OpenAI SDK, error handling follows the same patterns:
+
+```javascript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  apiKey: process.env.MINIMAX_API_KEY,
+  baseURL: "https://api.minimax.io/v1",
+});
+
+try {
+  const completion = await client.chat.completions.create({
+    model: "MiniMax-M2.5",
+    messages: [{ role: "user", content: "Hello" }],
+    temperature: 0.7,
+  });
+  console.log(completion.choices[0].message.content);
+} catch (error) {
+  if (error instanceof OpenAI.AuthenticationError) {
+    console.error("Invalid API key.");
+  } else if (error instanceof OpenAI.RateLimitError) {
+    console.error("Rate limit exceeded.");
+  } else if (error instanceof OpenAI.APIConnectionError) {
+    console.error("Failed to connect to MiniMax API.");
+  } else if (error instanceof OpenAI.APIError) {
+    console.error(`API error: ${error.status}`);
+  }
+}
+```
+
+## Common Pitfalls
+
+- **Temperature must be > 0.** Setting `temperature: 0.0` raises an error. Use `0.01` for near-deterministic behavior.
+- **Model names are case-sensitive.** Use `MiniMax-M2.5`, not `minimax-m2.5`.
+- **Always set `baseURL`.** Without `baseURL: "https://api.minimax.io/v1"`, requests go to OpenAI instead of MiniMax.
+- **Use a dedicated env var.** Store the key in `MINIMAX_API_KEY` (not `OPENAI_API_KEY`) to avoid confusion when working with multiple providers.
+- **Large context window.** MiniMax supports up to 204K tokens, but longer inputs cost more and take longer to process. Only send what you need.
+
+## Official Resources
+
+- MiniMax platform: `https://platform.minimaxi.com`
+- MiniMax API documentation: `https://platform.minimaxi.com/document/introduction`
+- MiniMax website: `https://www.minimaxi.com`

--- a/content/minimax/docs/chat/javascript/DOC.md
+++ b/content/minimax/docs/chat/javascript/DOC.md
@@ -4,8 +4,8 @@ description: "MiniMax API for chat completions, streaming, function calling, and
 metadata:
   languages: "javascript"
   versions: "1.0.0"
-  revision: 1
-  updated-on: "2026-03-14"
+  revision: 2
+  updated-on: "2026-06-03"
   source: community
   tags: "minimax,llm,chat,streaming,openai-compatible"
 ---
@@ -14,7 +14,7 @@ metadata:
 
 ## When To Use
 
-Use the MiniMax API when you need high-performance text generation with large context windows (up to 204K tokens). MiniMax exposes an OpenAI-compatible endpoint, so you can use the standard `openai` Node.js SDK with a custom `baseURL`.
+Use the MiniMax API when you need high-performance text generation with large context windows (up to 512K tokens). MiniMax exposes an OpenAI-compatible endpoint, so you can use the standard `openai` Node.js SDK with a custom `baseURL`.
 
 ## Install
 
@@ -47,12 +47,11 @@ const client = new OpenAI({
 
 | Model | Context Window | Notes |
 |-------|---------------|-------|
-| `MiniMax-M2.7` | 204K tokens | Latest flagship model with enhanced reasoning and coding |
-| `MiniMax-M2.7-highspeed` | 204K tokens | High-speed version of M2.7 for low-latency scenarios |
-| `MiniMax-M2.5` | 204K tokens | Previous generation flagship model |
-| `MiniMax-M2.5-highspeed` | 204K tokens | Previous generation high-speed model |
+| `MiniMax-M3` | 512K tokens | Latest flagship model with 128K max output and image input support (default) |
+| `MiniMax-M2.7` | 204K tokens | Previous generation flagship model |
+| `MiniMax-M2.7-highspeed` | 204K tokens | Previous generation high-speed model for low-latency scenarios |
 
-Use `MiniMax-M2.7` for quality-sensitive tasks. Use `MiniMax-M2.7-highspeed` when latency matters more than peak quality.
+Use `MiniMax-M3` for quality-sensitive tasks. Use `MiniMax-M2.7-highspeed` when latency matters more than peak quality.
 
 ## Core Usage
 
@@ -67,7 +66,7 @@ const client = new OpenAI({
 });
 
 const completion = await client.chat.completions.create({
-  model: "MiniMax-M2.7",
+  model: "MiniMax-M3",
   messages: [
     { role: "system", content: "You are a helpful assistant." },
     { role: "user", content: "Explain the difference between TCP and UDP." },
@@ -91,7 +90,7 @@ const client = new OpenAI({
 });
 
 const stream = await client.chat.completions.create({
-  model: "MiniMax-M2.7",
+  model: "MiniMax-M3",
   messages: [{ role: "user", content: "Write a haiku about programming." }],
   stream: true,
   temperature: 0.7,
@@ -139,7 +138,7 @@ const tools = [
 ];
 
 const completion = await client.chat.completions.create({
-  model: "MiniMax-M2.7",
+  model: "MiniMax-M3",
   messages: [{ role: "user", content: "What's the weather in Tokyo?" }],
   tools,
   temperature: 0.7,
@@ -163,7 +162,7 @@ MiniMax requires `temperature` to be strictly between 0.0 (exclusive) and 1.0 (i
 ```javascript
 // Valid
 const completion = await client.chat.completions.create({
-  model: "MiniMax-M2.7",
+  model: "MiniMax-M3",
   messages: [{ role: "user", content: "Hello" }],
   temperature: 0.01, // near-deterministic
 });
@@ -188,7 +187,7 @@ const client = new OpenAI({
 
 try {
   const completion = await client.chat.completions.create({
-    model: "MiniMax-M2.7",
+    model: "MiniMax-M3",
     messages: [{ role: "user", content: "Hello" }],
     temperature: 0.7,
   });
@@ -209,10 +208,10 @@ try {
 ## Common Pitfalls
 
 - **Temperature must be > 0.** Setting `temperature: 0.0` raises an error. Use `0.01` for near-deterministic behavior.
-- **Model names are case-sensitive.** Use `MiniMax-M2.7`, not `minimax-m2.7`.
+- **Model names are case-sensitive.** Use `MiniMax-M3`, not `minimax-m3`.
 - **Always set `baseURL`.** Without `baseURL: "https://api.minimax.io/v1"`, requests go to OpenAI instead of MiniMax.
 - **Use a dedicated env var.** Store the key in `MINIMAX_API_KEY` (not `OPENAI_API_KEY`) to avoid confusion when working with multiple providers.
-- **Large context window.** MiniMax supports up to 204K tokens, but longer inputs cost more and take longer to process. Only send what you need.
+- **Large context window.** MiniMax-M3 supports up to 512K tokens with 128K max output, but longer inputs cost more and take longer to process. Only send what you need.
 
 ## Official Resources
 

--- a/content/minimax/docs/chat/python/DOC.md
+++ b/content/minimax/docs/chat/python/DOC.md
@@ -48,10 +48,12 @@ client = OpenAI(
 
 | Model | Context Window | Notes |
 |-------|---------------|-------|
-| `MiniMax-M2.5` | 204K tokens | Flagship model, best quality |
-| `MiniMax-M2.5-highspeed` | 204K tokens | Optimized for speed, lower latency |
+| `MiniMax-M2.7` | 204K tokens | Latest flagship model with enhanced reasoning and coding |
+| `MiniMax-M2.7-highspeed` | 204K tokens | High-speed version of M2.7 for low-latency scenarios |
+| `MiniMax-M2.5` | 204K tokens | Previous generation flagship model |
+| `MiniMax-M2.5-highspeed` | 204K tokens | Previous generation high-speed model |
 
-Use `MiniMax-M2.5` for quality-sensitive tasks. Use `MiniMax-M2.5-highspeed` when latency matters more than peak quality.
+Use `MiniMax-M2.7` for quality-sensitive tasks. Use `MiniMax-M2.7-highspeed` when latency matters more than peak quality.
 
 ## Core Usage
 
@@ -67,7 +69,7 @@ client = OpenAI(
 )
 
 completion = client.chat.completions.create(
-    model="MiniMax-M2.5",
+    model="MiniMax-M2.7",
     messages=[
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "Explain the difference between TCP and UDP."},
@@ -92,7 +94,7 @@ client = OpenAI(
 )
 
 stream = client.chat.completions.create(
-    model="MiniMax-M2.5",
+    model="MiniMax-M2.7",
     messages=[
         {"role": "user", "content": "Write a haiku about programming."},
     ],
@@ -123,7 +125,7 @@ client = AsyncOpenAI(
 
 async def main():
     completion = await client.chat.completions.create(
-        model="MiniMax-M2.5",
+        model="MiniMax-M2.7",
         messages=[
             {"role": "user", "content": "What are three tips for writing clean code?"},
         ],
@@ -169,7 +171,7 @@ tools = [
 ]
 
 completion = client.chat.completions.create(
-    model="MiniMax-M2.5",
+    model="MiniMax-M2.7",
     messages=[{"role": "user", "content": "What's the weather in Tokyo?"}],
     tools=tools,
     temperature=0.7,
@@ -191,7 +193,7 @@ MiniMax requires `temperature` to be strictly between 0.0 (exclusive) and 1.0 (i
 ```python
 # Valid
 completion = client.chat.completions.create(
-    model="MiniMax-M2.5",
+    model="MiniMax-M2.7",
     messages=[{"role": "user", "content": "Hello"}],
     temperature=0.01,  # near-deterministic
 )
@@ -206,7 +208,7 @@ For near-deterministic output, use a very small value like `0.01`.
 
 ```python
 completion = client.chat.completions.create(
-    model="MiniMax-M2.5",
+    model="MiniMax-M2.7",
     messages=[{"role": "user", "content": "Summarize this text."}],
     temperature=0.7,
     top_p=0.9,
@@ -229,7 +231,7 @@ client = OpenAI(
 
 try:
     completion = client.chat.completions.create(
-        model="MiniMax-M2.5",
+        model="MiniMax-M2.7",
         messages=[{"role": "user", "content": "Hello"}],
         temperature=0.7,
     )
@@ -246,7 +248,7 @@ except openai.APIStatusError as e:
 ## Common Pitfalls
 
 - **Temperature must be > 0.** Setting `temperature=0.0` raises an error. Use `0.01` for near-deterministic behavior.
-- **Model names are case-sensitive.** Use `MiniMax-M2.5`, not `minimax-m2.5`.
+- **Model names are case-sensitive.** Use `MiniMax-M2.7`, not `minimax-m2.7`.
 - **Always set `base_url`.** Without `base_url="https://api.minimax.io/v1"`, requests go to OpenAI instead of MiniMax.
 - **Use a dedicated env var.** Store the key in `MINIMAX_API_KEY` (not `OPENAI_API_KEY`) to avoid confusion when working with multiple providers.
 - **Large context window.** MiniMax supports up to 204K tokens, but longer inputs cost more and take longer to process. Only send what you need.

--- a/content/minimax/docs/chat/python/DOC.md
+++ b/content/minimax/docs/chat/python/DOC.md
@@ -1,0 +1,258 @@
+---
+name: chat
+description: "MiniMax API for chat completions, streaming, function calling, and vision via OpenAI-compatible endpoint"
+metadata:
+  languages: "python"
+  versions: "1.0.0"
+  revision: 1
+  updated-on: "2026-03-14"
+  source: community
+  tags: "minimax,llm,chat,streaming,openai-compatible"
+---
+
+# MiniMax Chat API — Python Guide
+
+## When To Use
+
+Use the MiniMax API when you need high-performance text generation with large context windows (up to 204K tokens). MiniMax exposes an OpenAI-compatible endpoint, so you can use the standard `openai` Python SDK with a custom `base_url`.
+
+## Install
+
+MiniMax uses the OpenAI Python SDK. No additional package is needed.
+
+```bash
+pip install openai
+```
+
+## Authentication And Setup
+
+Get an API key from the MiniMax platform at `https://platform.minimaxi.com`. Set it as an environment variable:
+
+```bash
+export MINIMAX_API_KEY="your-api-key"
+```
+
+Create the client with the MiniMax base URL:
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ["MINIMAX_API_KEY"],
+    base_url="https://api.minimax.io/v1",
+)
+```
+
+## Models
+
+| Model | Context Window | Notes |
+|-------|---------------|-------|
+| `MiniMax-M2.5` | 204K tokens | Flagship model, best quality |
+| `MiniMax-M2.5-highspeed` | 204K tokens | Optimized for speed, lower latency |
+
+Use `MiniMax-M2.5` for quality-sensitive tasks. Use `MiniMax-M2.5-highspeed` when latency matters more than peak quality.
+
+## Core Usage
+
+### Chat Completions
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ["MINIMAX_API_KEY"],
+    base_url="https://api.minimax.io/v1",
+)
+
+completion = client.chat.completions.create(
+    model="MiniMax-M2.5",
+    messages=[
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Explain the difference between TCP and UDP."},
+    ],
+    temperature=0.7,
+)
+
+print(completion.choices[0].message.content)
+```
+
+### Streaming
+
+Set `stream=True` and iterate over the chunks:
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ["MINIMAX_API_KEY"],
+    base_url="https://api.minimax.io/v1",
+)
+
+stream = client.chat.completions.create(
+    model="MiniMax-M2.5",
+    messages=[
+        {"role": "user", "content": "Write a haiku about programming."},
+    ],
+    stream=True,
+    temperature=0.7,
+)
+
+for chunk in stream:
+    delta = chunk.choices[0].delta.content or ""
+    if delta:
+        print(delta, end="", flush=True)
+print()
+```
+
+### Async Client
+
+Use `AsyncOpenAI` inside async code:
+
+```python
+import asyncio
+import os
+from openai import AsyncOpenAI
+
+client = AsyncOpenAI(
+    api_key=os.environ["MINIMAX_API_KEY"],
+    base_url="https://api.minimax.io/v1",
+)
+
+async def main():
+    completion = await client.chat.completions.create(
+        model="MiniMax-M2.5",
+        messages=[
+            {"role": "user", "content": "What are three tips for writing clean code?"},
+        ],
+        temperature=0.7,
+    )
+    print(completion.choices[0].message.content)
+
+asyncio.run(main())
+```
+
+## Function Calling (Tools)
+
+MiniMax supports OpenAI-style function calling:
+
+```python
+import json
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ["MINIMAX_API_KEY"],
+    base_url="https://api.minimax.io/v1",
+)
+
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the current weather for a location",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {
+                        "type": "string",
+                        "description": "City name, e.g. San Francisco",
+                    },
+                },
+                "required": ["location"],
+            },
+        },
+    }
+]
+
+completion = client.chat.completions.create(
+    model="MiniMax-M2.5",
+    messages=[{"role": "user", "content": "What's the weather in Tokyo?"}],
+    tools=tools,
+    temperature=0.7,
+)
+
+message = completion.choices[0].message
+if message.tool_calls:
+    for tool_call in message.tool_calls:
+        print(f"Function: {tool_call.function.name}")
+        print(f"Arguments: {tool_call.function.arguments}")
+```
+
+## Configuration Options
+
+### Temperature
+
+MiniMax requires `temperature` to be strictly between 0.0 (exclusive) and 1.0 (inclusive). A value of exactly `0.0` is rejected.
+
+```python
+# Valid
+completion = client.chat.completions.create(
+    model="MiniMax-M2.5",
+    messages=[{"role": "user", "content": "Hello"}],
+    temperature=0.01,  # near-deterministic
+)
+
+# Invalid — will be rejected
+# temperature=0.0
+```
+
+For near-deterministic output, use a very small value like `0.01`.
+
+### Top-P and Max Tokens
+
+```python
+completion = client.chat.completions.create(
+    model="MiniMax-M2.5",
+    messages=[{"role": "user", "content": "Summarize this text."}],
+    temperature=0.7,
+    top_p=0.9,
+    max_tokens=1024,
+)
+```
+
+## Error Handling
+
+Since MiniMax uses the OpenAI SDK, error handling follows the same patterns:
+
+```python
+import openai
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="your-api-key",
+    base_url="https://api.minimax.io/v1",
+)
+
+try:
+    completion = client.chat.completions.create(
+        model="MiniMax-M2.5",
+        messages=[{"role": "user", "content": "Hello"}],
+        temperature=0.7,
+    )
+except openai.AuthenticationError:
+    print("Invalid API key.")
+except openai.RateLimitError:
+    print("Rate limit exceeded. Wait before retrying.")
+except openai.APIConnectionError:
+    print("Failed to connect to MiniMax API.")
+except openai.APIStatusError as e:
+    print(f"API error: {e.status_code}")
+```
+
+## Common Pitfalls
+
+- **Temperature must be > 0.** Setting `temperature=0.0` raises an error. Use `0.01` for near-deterministic behavior.
+- **Model names are case-sensitive.** Use `MiniMax-M2.5`, not `minimax-m2.5`.
+- **Always set `base_url`.** Without `base_url="https://api.minimax.io/v1"`, requests go to OpenAI instead of MiniMax.
+- **Use a dedicated env var.** Store the key in `MINIMAX_API_KEY` (not `OPENAI_API_KEY`) to avoid confusion when working with multiple providers.
+- **Large context window.** MiniMax supports up to 204K tokens, but longer inputs cost more and take longer to process. Only send what you need.
+
+## Official Resources
+
+- MiniMax platform: `https://platform.minimaxi.com`
+- MiniMax API documentation: `https://platform.minimaxi.com/document/introduction`
+- MiniMax website: `https://www.minimaxi.com`

--- a/content/minimax/docs/chat/python/DOC.md
+++ b/content/minimax/docs/chat/python/DOC.md
@@ -4,8 +4,8 @@ description: "MiniMax API for chat completions, streaming, function calling, and
 metadata:
   languages: "python"
   versions: "1.0.0"
-  revision: 1
-  updated-on: "2026-03-14"
+  revision: 2
+  updated-on: "2026-06-03"
   source: community
   tags: "minimax,llm,chat,streaming,openai-compatible"
 ---
@@ -14,7 +14,7 @@ metadata:
 
 ## When To Use
 
-Use the MiniMax API when you need high-performance text generation with large context windows (up to 204K tokens). MiniMax exposes an OpenAI-compatible endpoint, so you can use the standard `openai` Python SDK with a custom `base_url`.
+Use the MiniMax API when you need high-performance text generation with large context windows (up to 512K tokens). MiniMax exposes an OpenAI-compatible endpoint, so you can use the standard `openai` Python SDK with a custom `base_url`.
 
 ## Install
 
@@ -48,12 +48,11 @@ client = OpenAI(
 
 | Model | Context Window | Notes |
 |-------|---------------|-------|
-| `MiniMax-M2.7` | 204K tokens | Latest flagship model with enhanced reasoning and coding |
-| `MiniMax-M2.7-highspeed` | 204K tokens | High-speed version of M2.7 for low-latency scenarios |
-| `MiniMax-M2.5` | 204K tokens | Previous generation flagship model |
-| `MiniMax-M2.5-highspeed` | 204K tokens | Previous generation high-speed model |
+| `MiniMax-M3` | 512K tokens | Latest flagship model with 128K max output and image input support (default) |
+| `MiniMax-M2.7` | 204K tokens | Previous generation flagship model |
+| `MiniMax-M2.7-highspeed` | 204K tokens | Previous generation high-speed model for low-latency scenarios |
 
-Use `MiniMax-M2.7` for quality-sensitive tasks. Use `MiniMax-M2.7-highspeed` when latency matters more than peak quality.
+Use `MiniMax-M3` for quality-sensitive tasks. Use `MiniMax-M2.7-highspeed` when latency matters more than peak quality.
 
 ## Core Usage
 
@@ -69,7 +68,7 @@ client = OpenAI(
 )
 
 completion = client.chat.completions.create(
-    model="MiniMax-M2.7",
+    model="MiniMax-M3",
     messages=[
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "Explain the difference between TCP and UDP."},
@@ -94,7 +93,7 @@ client = OpenAI(
 )
 
 stream = client.chat.completions.create(
-    model="MiniMax-M2.7",
+    model="MiniMax-M3",
     messages=[
         {"role": "user", "content": "Write a haiku about programming."},
     ],
@@ -125,7 +124,7 @@ client = AsyncOpenAI(
 
 async def main():
     completion = await client.chat.completions.create(
-        model="MiniMax-M2.7",
+        model="MiniMax-M3",
         messages=[
             {"role": "user", "content": "What are three tips for writing clean code?"},
         ],
@@ -171,7 +170,7 @@ tools = [
 ]
 
 completion = client.chat.completions.create(
-    model="MiniMax-M2.7",
+    model="MiniMax-M3",
     messages=[{"role": "user", "content": "What's the weather in Tokyo?"}],
     tools=tools,
     temperature=0.7,
@@ -193,7 +192,7 @@ MiniMax requires `temperature` to be strictly between 0.0 (exclusive) and 1.0 (i
 ```python
 # Valid
 completion = client.chat.completions.create(
-    model="MiniMax-M2.7",
+    model="MiniMax-M3",
     messages=[{"role": "user", "content": "Hello"}],
     temperature=0.01,  # near-deterministic
 )
@@ -208,7 +207,7 @@ For near-deterministic output, use a very small value like `0.01`.
 
 ```python
 completion = client.chat.completions.create(
-    model="MiniMax-M2.7",
+    model="MiniMax-M3",
     messages=[{"role": "user", "content": "Summarize this text."}],
     temperature=0.7,
     top_p=0.9,
@@ -231,7 +230,7 @@ client = OpenAI(
 
 try:
     completion = client.chat.completions.create(
-        model="MiniMax-M2.7",
+        model="MiniMax-M3",
         messages=[{"role": "user", "content": "Hello"}],
         temperature=0.7,
     )
@@ -248,10 +247,10 @@ except openai.APIStatusError as e:
 ## Common Pitfalls
 
 - **Temperature must be > 0.** Setting `temperature=0.0` raises an error. Use `0.01` for near-deterministic behavior.
-- **Model names are case-sensitive.** Use `MiniMax-M2.7`, not `minimax-m2.7`.
+- **Model names are case-sensitive.** Use `MiniMax-M3`, not `minimax-m3`.
 - **Always set `base_url`.** Without `base_url="https://api.minimax.io/v1"`, requests go to OpenAI instead of MiniMax.
 - **Use a dedicated env var.** Store the key in `MINIMAX_API_KEY` (not `OPENAI_API_KEY`) to avoid confusion when working with multiple providers.
-- **Large context window.** MiniMax supports up to 204K tokens, but longer inputs cost more and take longer to process. Only send what you need.
+- **Large context window.** MiniMax-M3 supports up to 512K tokens with 128K max output, but longer inputs cost more and take longer to process. Only send what you need.
 
 ## Official Resources
 


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to use M3 as the default model.

## Changes
- Set `MiniMax-M3` as the new default model in all Python and JavaScript code examples
- Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as alternatives in the model table
- Remove older models (`MiniMax-M2.5`, `MiniMax-M2.5-highspeed`)
- Update context window descriptions to reflect M3's 512K capability
- Update common pitfalls and case-sensitivity examples to reference M3

## Why
`MiniMax-M3` is the latest flagship model, with a 512K context window, up to 128K max output, and image input support via the OpenAI-compatible endpoint. Existing M2.7 entries are retained so users can still select it explicitly when needed.

## Testing
- All model references reviewed in both Python and JavaScript guides
- Model table includes M3 (default), M2.7, and M2.7-highspeed
- No stale M2.5/M2.1/M2/M1 references remain
