### PR TITLE
fix: update CONTRIBUTING.md to use content/ instead of removed sample-content/

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ npm install
 
 ```bash
 node cli/bin/chub --help
-node cli/bin/chub build sample-content/ --validate-only
+node cli/bin/chub build content/ --validate-only
 ```
 
 ### Running Tests
@@ -41,7 +41,7 @@ npm run test:coverage # with coverage
 2. Make your changes
 3. Add or update tests as needed
 4. Ensure all tests pass: `cd cli && npm test`
-5. Validate the build: `node cli/bin/chub build sample-content/ --validate-only`
+5. Validate the build: `node cli/bin/chub build content/ --validate-only`
 6. Submit a pull request
 
 ### Code Style
@@ -61,7 +61,7 @@ cli/
     commands/           # Command implementations
     lib/                # Core utilities
   tests/                # Vitest tests
-sample-content/         # Test fixtures
+content/                # Curated docs and skills
 docs/                   # Design docs
 ```
 


### PR DESCRIPTION
## Summary

Fixes #47

The `sample-content/` directory was deleted in #1 but `CONTRIBUTING.md` still references it in three places, causing the documented contributor workflow to fail on a fresh clone.

## Changes

- `Running the CLI locally`: `sample-content/` → `content/`
- `Pull Request Process` step 5: `sample-content/` → `content/`
- `Project Structure` diagram: updated label to reflect actual directory name and purpose

## Verified

`content/` exists in the repo and the command runs successfully:
```
node cli/bin/chub build content/ --validate-only
```