### PR TITLE
content: add JACTUS financial contract library docs

### DIFF
--- a/content/jactus/docs/contracts/python/DOC.md
+++ b/content/jactus/docs/contracts/python/DOC.md
@@ -1,0 +1,338 @@
+---
+name: contracts
+description: "JACTUS — JAX-powered ACTUS financial contract library: 18 contract types, array-mode portfolio API, autodiff risk analytics, CLI, and behavioral observers"
+metadata:
+  languages: "python"
+  versions: "0.2.0"
+  revision: 1
+  updated-on: "2026-03-14"
+  source: community
+  tags: "jactus,actus,finance,financial-contracts,jax,autodiff,risk,derivatives,fixed-income,portfolio,cli"
+---
+
+# JACTUS — ACTUS Financial Contracts with JAX (v0.2.0)
+
+## Golden Rule
+
+**Install from PyPI:**
+
+```bash
+pip install jactus
+```
+
+**Core import pattern:**
+```python
+from jactus.contracts import create_contract
+from jactus.core import ContractAttributes, ContractType, ContractRole, ActusDateTime
+from jactus.observers import ConstantRiskFactorObserver
+```
+
+**Critical field names — these are the most common agent mistakes:**
+
+| Wrong | Correct (v0.2.0) |
+|---|---|
+| `cycle_of_interest_payment` | `interest_payment_cycle` |
+| `event.time` | `event.event_time` |
+| `event.type.name` | `event.event_type.name` |
+| `ConstantRiskFactorObserver()` | `ConstantRiskFactorObserver(constant_value=0.0)` |
+
+**DO NOT:**
+- Use `datetime.datetime` for dates — JACTUS uses `ActusDateTime`
+- Import from `actus` or `pyactus` — unrelated packages
+
+**Requires:** Python 3.10–3.12, JAX >= 0.4.20
+
+---
+
+## Installation
+
+```bash
+# Standard (CPU)
+pip install jactus
+
+# GPU — NVIDIA CUDA 13 (recommended)
+pip install jactus "jax[cuda13]"
+
+# GPU — NVIDIA CUDA 12
+pip install jactus "jax[cuda12]"
+
+# TPU
+pip install jactus "jax[tpu]"
+
+# Development
+git clone https://github.com/pedronahum/JACTUS.git
+cd JACTUS
+pip install -e ".[dev,docs,viz]"
+```
+
+**Float64 precision** (CPU/GPU only — TPUs do not support float64):
+```python
+import jax
+jax.config.update("jax_enable_x64", True)
+import jactus  # import AFTER enabling
+```
+
+---
+
+## Quick Start
+
+```python
+from jactus.contracts import create_contract
+from jactus.core import ContractAttributes, ContractType, ContractRole, ActusDateTime
+from jactus.observers import ConstantRiskFactorObserver
+
+attrs = ContractAttributes(
+    contract_id="LOAN-001",
+    contract_type=ContractType.PAM,
+    contract_role=ContractRole.RPA,           # RPA = lender
+    status_date=ActusDateTime(2024, 1, 1),
+    initial_exchange_date=ActusDateTime(2024, 1, 15),
+    maturity_date=ActusDateTime(2025, 1, 15),
+    notional_principal=100_000.0,
+    nominal_interest_rate=0.05,
+    interest_payment_cycle="6M",              # NOT cycle_of_interest_payment
+    day_count_convention="30E360",
+)
+
+observer = ConstantRiskFactorObserver(constant_value=0.0)  # constant_value required
+contract = create_contract(attrs, observer)
+result = contract.simulate()
+
+for event in result.events:
+    if event.payoff != 0:
+        print(f"{event.event_time}: {event.event_type.name:4s}  ${event.payoff:>12,.2f}")
+        #       ^^^^^^^^^^^^^^        ^^^^^^^^^^^^^^^^^
+        # NOT event.time            NOT event.type.name
+
+# 2024-01-15: IED   $-100,000.00
+# 2024-07-15: IP       $2,500.00
+# 2025-01-15: MD    $102,500.00
+```
+
+---
+
+## Contract Types (18 total)
+
+**Principal:** `PAM`, `LAM`, `LAX`, `NAM`, `ANN`, `CLM`
+**Non-Principal:** `UMP`, `CSH`, `STK`, `COM`
+**Derivatives:** `FXOUT`, `OPTNS`, `FUTUR`, `SWPPV`, `SWAPS`, `CAPFL`, `CEG`, `CEC`
+
+See `references/contract-types.md` for full per-contract parameter examples.
+
+---
+
+## SimulationResult
+
+```python
+result = contract.simulate()
+
+result.events                  # List[ContractEvent]
+event.event_time               # ActusDateTime
+event.event_type               # EventType enum
+event.event_type.name          # str: "IED", "IP", "PR", "MD", "FP", "STD", ...
+event.payoff                   # float — positive = cash received
+event.nominal_value            # float — outstanding notional
+event.nominal_rate             # float — applicable interest rate
+```
+
+---
+
+## Risk Factor Observers
+
+### Built-in observers
+
+```python
+from jactus.observers import (
+    ConstantRiskFactorObserver,      # fixed value for all queries
+    DictRiskFactorObserver,          # per-identifier static values
+    TimeSeriesRiskFactorObserver,    # time-varying data, step or linear interp
+    CurveRiskFactorObserver,         # yield/rate curve keyed by tenor
+    CompositeRiskFactorObserver,     # priority-based fallback across observers
+    CallbackRiskFactorObserver,      # delegates to a user callable
+    JaxRiskFactorObserver,           # differentiable JAX-native observer for autodiff
+)
+```
+
+```python
+# Constant — always pass constant_value explicitly
+observer = ConstantRiskFactorObserver(constant_value=0.05)
+
+# Dict — different rate per risk factor ID
+observer = DictRiskFactorObserver({"USD_SOFR": 0.053, "EUR_EURIBOR": 0.038})
+
+# Time-series — interpolated from historical data
+observer = TimeSeriesRiskFactorObserver(
+    risk_factors={"USD_SOFR": [
+        (ActusDateTime(2024, 1, 1), 0.05),
+        (ActusDateTime(2024, 6, 1), 0.052),
+    ]},
+    interpolation="linear",   # or "step"
+)
+```
+
+### Behavioral observers
+
+```python
+from jactus.observers import (
+    PrepaymentSurfaceObserver,       # 2D surface: spread x loan_age -> prepay rate
+    DepositTransactionObserver,      # deposit behavior for UMP contracts
+)
+```
+
+### Scenario management
+
+Bundle market + behavioral observers into a named, reproducible configuration:
+
+```python
+from jactus.observers import Scenario
+
+scenario = Scenario(
+    scenario_id="base_case",
+    market_observers={"rates": DictRiskFactorObserver({"USD_SOFR": 0.053})},
+    behavior_observers={"prepay": PrepaymentSurfaceObserver(...)},
+)
+observer = scenario.get_observer()
+contract = create_contract(attrs, observer)
+```
+
+See `references/risk-factors.md` for custom observer implementation.
+
+---
+
+## Array-Mode Portfolio API (GPU/TPU)
+
+Batch simulation of large portfolios via JIT-compiled kernels over `[B, T]` arrays.
+12 contract types are supported in array mode.
+
+```python
+# See references/array-mode.md for full usage
+# Quick shape reference: inputs are [batch, time_steps], outputs are [batch, time_steps]
+```
+
+See `references/array-mode.md` for the full portfolio API, `vmap` patterns, and GPU benchmark notebook.
+
+---
+
+## JAX Autodiff for Risk Analytics
+
+```python
+import jax
+import jax.numpy as jnp
+from jactus.contracts import create_contract
+from jactus.core import ContractAttributes, ContractType, ContractRole, ActusDateTime
+from jactus.observers import JaxRiskFactorObserver
+
+def contract_pv(rate: float) -> float:
+    attrs = ContractAttributes(
+        contract_id="LOAN",
+        contract_type=ContractType.PAM,
+        contract_role=ContractRole.RPA,
+        status_date=ActusDateTime(2024, 1, 1),
+        initial_exchange_date=ActusDateTime(2024, 1, 15),
+        maturity_date=ActusDateTime(2025, 1, 15),
+        notional_principal=100_000.0,
+        nominal_interest_rate=rate,
+        interest_payment_cycle="6M",
+        day_count_convention="30E360",
+    )
+    observer = JaxRiskFactorObserver(jnp.array([rate]))  # takes jnp.ndarray
+    result = create_contract(attrs, observer).simulate()
+    return sum(e.payoff for e in result.events)
+
+dv01 = jax.grad(contract_pv)(0.05) * 0.0001
+print(f"DV01: ${dv01:,.2f}")
+```
+
+---
+
+## CLI
+
+JACTUS ships a full `jactus` CLI (auto-installed with pip). Outputs JSON when piped, rich tables in TTY.
+
+```bash
+# Explore
+jactus contract list
+jactus contract schema --type PAM
+jactus observer list
+
+# Simulate
+jactus simulate --type PAM --attrs '{
+  "contract_id": "LOAN-001",
+  "status_date": "2024-01-01",
+  "contract_role": "RPA",
+  "initial_exchange_date": "2024-01-15",
+  "maturity_date": "2025-01-15",
+  "notional_principal": 100000,
+  "nominal_interest_rate": 0.05,
+  "interest_payment_cycle": "6M",
+  "day_count_convention": "30E360"
+}'
+
+# Validate before simulating
+jactus contract validate --type PAM --attrs loan.json
+
+# Risk metrics
+jactus risk dv01 --type PAM --attrs loan.json
+jactus risk sensitivities --type PAM --attrs loan.json
+
+# Portfolio
+jactus portfolio simulate --file portfolio.json
+jactus portfolio aggregate --file portfolio.json --frequency quarterly
+
+# JSON / CSV pipelines
+jactus simulate --type PAM --attrs loan.json --output json | jq '.summary'
+jactus simulate --type PAM --attrs loan.json --output csv --nonzero
+```
+
+---
+
+## MCP Server (Claude Code / AI assistants)
+
+```bash
+pip install git+https://github.com/pedronahum/JACTUS.git#subdirectory=tools/mcp-server
+```
+
+Claude Desktop (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+```json
+{
+  "mcpServers": {
+    "jactus": {
+      "command": "python",
+      "args": ["-m", "jactus_mcp"]
+    }
+  }
+}
+```
+
+For Claude Code, `.mcp.json` in the project root enables auto-discovery when opening the JACTUS workspace.
+
+---
+
+## Common Mistakes
+
+1. **Wrong field name for interest cycle** — `interest_payment_cycle="6M"`, not `cycle_of_interest_payment`.
+
+2. **Wrong event attribute names** — `event.event_time` and `event.event_type.name`, not `event.time` / `event.type.name`.
+
+3. **ConstantRiskFactorObserver requires `constant_value`** — `ConstantRiskFactorObserver(constant_value=0.0)`, not `ConstantRiskFactorObserver()`.
+
+4. **Using Python `datetime`** — always use `ActusDateTime(year, month, day)`.
+
+5. **Wrong `ContractRole` sign** — `RPA` = lender/receiver (negative IED payoff, positive IP/MD). `RPL` = borrower/payer (signs flipped). Always set explicitly.
+
+6. **`status_date` is required** — set it to a date on or before `initial_exchange_date`.
+
+7. **TPU + float64** — TPUs do not support float64. Use float32 (default) on TPU, or enable `jax_enable_x64` before importing JACTUS on CPU/GPU only.
+
+---
+
+## Documentation
+
+- Full API docs: https://pedronahum.github.io/JACTUS/
+- Notebooks: `examples/notebooks/` (also on Colab — see GitHub README)
+
+## Reference Files
+
+- `references/contract-types.md` — parameter examples for all 18 contract types
+- `references/risk-factors.md` — observer types and custom observer implementation
+- `references/array-mode.md` — batch/portfolio API, GPU/TPU patterns

--- a/content/jactus/docs/contracts/python/references/array-mode.md
+++ b/content/jactus/docs/contracts/python/references/array-mode.md
@@ -1,0 +1,106 @@
+# JACTUS Array-Mode & Portfolio API
+
+Fetch with: `chub get jactus/contracts --file references/array-mode.md`
+
+Array-mode is the recommended path for GPU/TPU workloads and large portfolios.
+It uses JIT-compiled kernels over `[B, T]` (batch x time_steps) arrays.
+12 contract types are currently supported in array mode.
+
+---
+
+## When to Use Array-Mode vs. Contract-Mode
+
+| Situation | Use |
+|---|---|
+| Single contract, exploratory | `create_contract(...).simulate()` |
+| Portfolio of 100+ contracts, GPU/TPU | Array-mode portfolio API |
+| Autodiff through a single contract | `JaxRiskFactorObserver` + `jax.grad` |
+| Autodiff across a portfolio | Array-mode + `jax.grad` / `jax.vmap` |
+
+---
+
+## Portfolio CLI (no Python required)
+
+```bash
+# Simulate a portfolio from JSON
+jactus portfolio simulate --file portfolio.json
+
+# Aggregate cash flows by quarter
+jactus portfolio aggregate --file portfolio.json --frequency quarterly
+
+# Output as JSON for downstream processing
+jactus portfolio simulate --file portfolio.json --output json | jq '.total_payoff'
+```
+
+Portfolio JSON format:
+```json
+[
+  {
+    "contract_id": "LOAN-001",
+    "contract_type": "PAM",
+    "contract_role": "RPA",
+    "status_date": "2024-01-01",
+    "initial_exchange_date": "2024-01-15",
+    "maturity_date": "2025-01-15",
+    "notional_principal": 100000,
+    "nominal_interest_rate": 0.05,
+    "interest_payment_cycle": "6M",
+    "day_count_convention": "30E360"
+  }
+]
+```
+
+---
+
+## GPU/TPU Benchmark Notebook
+
+A full benchmark notebook (50K PAM contracts on GPU/TPU) is available on Colab:
+
+https://colab.research.google.com/github/pedronahum/JACTUS/blob/main/examples/notebooks/05_gpu_tpu_portfolio_benchmark.ipynb
+
+---
+
+## Precision Notes
+
+- Array-mode uses **float32** for performance
+- TPUs do **not** support float64
+- For CPU/GPU with full double precision, enable before importing JACTUS:
+
+```python
+import jax
+jax.config.update("jax_enable_x64", True)
+import jactus
+```
+
+---
+
+## vmap Pattern for Batching
+
+```python
+import jax
+from jactus.contracts import create_contract
+from jactus.core import ContractAttributes, ContractType, ContractRole, ActusDateTime
+from jactus.observers import JaxRiskFactorObserver
+import jax.numpy as jnp
+
+def single_pv(rate):
+    attrs = ContractAttributes(
+        contract_id="LOAN",
+        contract_type=ContractType.PAM,
+        contract_role=ContractRole.RPA,
+        status_date=ActusDateTime(2024, 1, 1),
+        initial_exchange_date=ActusDateTime(2024, 1, 15),
+        maturity_date=ActusDateTime(2025, 1, 15),
+        notional_principal=100_000.0,
+        nominal_interest_rate=rate,
+        interest_payment_cycle="6M",
+        day_count_convention="30E360",
+    )
+    observer = JaxRiskFactorObserver(jnp.array([rate]))
+    result = create_contract(attrs, observer).simulate()
+    return jnp.sum(jnp.array([e.payoff for e in result.events]))
+
+# Vectorize over a grid of rates
+rates = jnp.linspace(0.03, 0.08, 100)
+pvs = jax.vmap(single_pv)(rates)
+```

--- a/content/jactus/docs/contracts/python/references/contract-types.md
+++ b/content/jactus/docs/contracts/python/references/contract-types.md
@@ -1,0 +1,309 @@
+# JACTUS Contract Types — Full Parameter Reference
+
+## How to Use This File
+
+Fetch with: `chub get jactus/contracts --file references/contract-types.md`
+
+All contracts are created via `create_contract(attrs, observer)` where `attrs` is a
+`ContractAttributes` instance. Below are the key parameters specific to each contract type.
+Common parameters (contract_id, contract_role, status_date, day_count_convention) are
+omitted — always include those.
+
+---
+
+## Principal Contracts
+
+### PAM — Principal at Maturity
+Bullet loan / bond. Interest only during life, full principal at maturity.
+
+```python
+ContractAttributes(
+    contract_type=ContractType.PAM,
+    initial_exchange_date=ActusDateTime(...),
+    maturity_date=ActusDateTime(...),
+    notional_principal=100_000.0,
+    nominal_interest_rate=0.05,
+    interest_payment_cycle="6M",            # optional; omit for zero-coupon
+    day_count_convention="30E360",
+)
+```
+
+### LAM — Linear Amortizer
+Equal principal payments each period, declining interest.
+
+```python
+ContractAttributes(
+    contract_type=ContractType.LAM,
+    initial_exchange_date=ActusDateTime(...),
+    maturity_date=ActusDateTime(...),
+    notional_principal=100_000.0,
+    nominal_interest_rate=0.05,
+    principal_redemption_cycle="1M",        # required — amortization frequency
+    interest_payment_cycle="1M",
+    interest_calculation_base="NT",         # NT | NTIED | NTL — interest base
+    day_count_convention="30E360",
+)
+```
+
+### ANN — Annuity
+Equal total payment (principal + interest) each period. Mortgages.
+
+```python
+ContractAttributes(
+    contract_type=ContractType.ANN,
+    initial_exchange_date=ActusDateTime(...),
+    maturity_date=ActusDateTime(...),
+    notional_principal=500_000.0,
+    nominal_interest_rate=0.065,
+    principal_redemption_cycle="1M",        # payment frequency
+    day_count_convention="AA",              # Actual/Actual ISDA
+)
+```
+
+### NAM — Negative Amortizer
+Payments less than interest due → principal balance grows.
+
+```python
+ContractAttributes(
+    contract_type=ContractType.NAM,
+    initial_exchange_date=ActusDateTime(...),
+    maturity_date=ActusDateTime(...),
+    notional_principal=100_000.0,
+    nominal_interest_rate=0.08,
+    principal_redemption_cycle="1M",
+    next_principal_redemption_amount=500.0,   # fixed payment < interest
+    day_count_convention="30E360",
+)
+```
+
+### LAX — Exotic Linear Amortizer
+Variable amortization schedule (custom redemption amounts per date).
+
+```python
+ContractAttributes(
+    contract_type=ContractType.LAX,
+    initial_exchange_date=ActusDateTime(...),
+    maturity_date=ActusDateTime(...),
+    notional_principal=100_000.0,
+    nominal_interest_rate=0.05,
+    # Amortization defined via schedule in ContractAttributes
+    day_count_convention="30E360",
+)
+```
+
+### CLM — Call Money
+Variable principal, repayable on demand / short notice.
+
+```python
+ContractAttributes(
+    contract_type=ContractType.CLM,
+    initial_exchange_date=ActusDateTime(...),
+    maturity_date=ActusDateTime(...),
+    notional_principal=1_000_000.0,
+    nominal_interest_rate=0.045,
+    day_count_convention="A360",
+)
+```
+
+---
+
+## Non-Principal Contracts
+
+### UMP — Undefined Maturity Profile
+Revolving credit lines with no fixed maturity.
+
+```python
+ContractAttributes(
+    contract_type=ContractType.UMP,
+    initial_exchange_date=ActusDateTime(...),
+    notional_principal=500_000.0,          # credit limit
+    nominal_interest_rate=0.06,
+    interest_payment_cycle="1M",
+    day_count_convention="A365",
+    # No maturity_date required
+)
+```
+
+### CSH — Cash
+Money market account or escrow. Earns interest on balance.
+
+```python
+ContractAttributes(
+    contract_type=ContractType.CSH,
+    initial_exchange_date=ActusDateTime(...),
+    notional_principal=10_000.0,
+    nominal_interest_rate=0.04,
+    day_count_convention="A365",
+)
+```
+
+### STK — Stock
+Equity position tracking. Models dividends and price returns.
+
+```python
+ContractAttributes(
+    contract_type=ContractType.STK,
+    initial_exchange_date=ActusDateTime(...),
+    notional_principal=50_000.0,   # position value at purchase
+    day_count_convention="A365",
+)
+```
+
+### COM — Commodity
+Physical commodity position (futures underlier, warehouse receipt).
+
+```python
+ContractAttributes(
+    contract_type=ContractType.COM,
+    initial_exchange_date=ActusDateTime(...),
+    notional_principal=100_000.0,  # position value
+    day_count_convention="A365",
+)
+```
+
+---
+
+## Derivative Contracts
+
+### SWPPV — Plain Vanilla Interest Rate Swap
+Fixed vs. floating. Use two-leg approach: fix leg via `nominal_interest_rate`.
+
+```python
+ContractAttributes(
+    contract_type=ContractType.SWPPV,
+    contract_role=ContractRole.RPA,         # fixed-rate receiver
+    initial_exchange_date=ActusDateTime(...),
+    maturity_date=ActusDateTime(...),
+    notional_principal=10_000_000.0,
+    nominal_interest_rate=0.04,             # fixed rate
+    interest_payment_cycle="3M",
+    day_count_convention="30E360",
+)
+```
+
+### SWAPS — Generic / Cross-Currency Swap
+Multi-leg swap; cross-currency basis swaps.
+
+```python
+ContractAttributes(
+    contract_type=ContractType.SWAPS,
+    initial_exchange_date=ActusDateTime(...),
+    maturity_date=ActusDateTime(...),
+    notional_principal=10_000_000.0,
+    nominal_interest_rate=0.035,
+    interest_payment_cycle="3M",
+    currency="EUR",                         # base leg currency
+    day_count_convention="A360",
+)
+```
+
+### FXOUT — FX Outright (Forward / Swap)
+FX forward or swap. Two currency exchange at fixed future rate.
+
+```python
+ContractAttributes(
+    contract_type=ContractType.FXOUT,
+    contract_role=ContractRole.RPA,
+    initial_exchange_date=ActusDateTime(...),    # spot leg
+    maturity_date=ActusDateTime(...),             # forward leg
+    notional_principal=1_000_000.0,              # USD amount
+    price_at_purchase_date=1.08,                 # EUR/USD forward rate
+    currency="USD",
+    currency2="EUR",
+    day_count_convention="A360",
+)
+```
+
+### OPTNS — Options (European / American)
+Calls, puts, European or American exercise.
+
+```python
+ContractAttributes(
+    contract_type=ContractType.OPTNS,
+    contract_role=ContractRole.RPA,         # option buyer
+    purchase_date=ActusDateTime(...),
+    maturity_date=ActusDateTime(...),       # expiry
+    notional_principal=100_000.0,
+    price_at_purchase_date=105.0,           # strike price
+    day_count_convention="A365",
+)
+```
+
+### FUTUR — Futures
+Standardized exchange-traded forward.
+
+```python
+ContractAttributes(
+    contract_type=ContractType.FUTUR,
+    contract_role=ContractRole.RPA,
+    initial_exchange_date=ActusDateTime(...),
+    maturity_date=ActusDateTime(...),
+    notional_principal=250_000.0,
+    price_at_purchase_date=4800.0,          # futures entry price
+    day_count_convention="A365",
+)
+```
+
+### CAPFL — Cap / Floor
+Interest rate cap or floor on floating-rate exposure.
+
+```python
+ContractAttributes(
+    contract_type=ContractType.CAPFL,
+    contract_role=ContractRole.RPA,         # cap buyer
+    initial_exchange_date=ActusDateTime(...),
+    maturity_date=ActusDateTime(...),
+    notional_principal=5_000_000.0,
+    nominal_interest_rate=0.05,             # strike / cap rate
+    interest_payment_cycle="3M",
+    day_count_convention="A360",
+)
+```
+
+### CEG — Credit Enhancement Guarantee
+Credit protection / guarantee contract.
+
+```python
+ContractAttributes(
+    contract_type=ContractType.CEG,
+    contract_role=ContractRole.RPA,
+    initial_exchange_date=ActusDateTime(...),
+    maturity_date=ActusDateTime(...),
+    notional_principal=1_000_000.0,
+    nominal_interest_rate=0.01,             # guarantee fee rate
+    day_count_convention="30E360",
+)
+```
+
+### CEC — Credit Enhancement Collateral
+Collateral management contract.
+
+```python
+ContractAttributes(
+    contract_type=ContractType.CEC,
+    contract_role=ContractRole.RPA,
+    initial_exchange_date=ActusDateTime(...),
+    maturity_date=ActusDateTime(...),
+    notional_principal=2_000_000.0,
+    day_count_convention="30E360",
+)
+```
+
+---
+
+## `ContractAttributes` Common Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `contract_id` | str | Unique identifier |
+| `contract_type` | ContractType | Enum — PAM, ANN, SWPPV, etc. |
+| `contract_role` | ContractRole | RPA (lender/receiver) or RPL (borrower/payer) |
+| `status_date` | ActusDateTime | Simulation anchor date (≤ initial_exchange_date) |
+| `initial_exchange_date` | ActusDateTime | When principal is exchanged |
+| `maturity_date` | ActusDateTime | Contract end date |
+| `notional_principal` | float | Principal / notional amount |
+| `nominal_interest_rate` | float | Annual rate as decimal (0.05 = 5%) |
+| `day_count_convention` | str/DayCountConvention | "AA", "A360", "A365", "30E360", "30E360ISDA", "30360", "BUS252" |
+| `interest_payment_cycle` | str | "1M", "3M", "6M", "1Y" |
+| `principal_redemption_cycle` | str | Amortization frequency (LAM, ANN, NAM) |
+| `currency` | str | ISO 4217 code (default "USD") |

--- a/content/jactus/docs/contracts/python/references/risk-factors.md
+++ b/content/jactus/docs/contracts/python/references/risk-factors.md
@@ -1,0 +1,135 @@
+# JACTUS Risk Factor Observers
+
+## What is a RiskFactorObserver?
+
+Every contract needs a `RiskFactorObserver` — an object that provides market data
+(interest rates, FX rates, equity prices) at any given `ActusDateTime`. The observer
+is queried by the simulation engine when computing floating-rate resets, option payoffs,
+and FX conversions.
+
+Fetch with: `chub get jactus/contracts --file references/risk-factors.md`
+
+---
+
+## Built-in Observers
+
+### `ConstantRiskFactorObserver`
+Returns a flat rate for all queries. Good for unit testing and simple fixed-rate contracts.
+
+```python
+from jactus.observers import ConstantRiskFactorObserver
+
+# constant_value is required — cannot be called with no arguments
+observer = ConstantRiskFactorObserver(constant_value=0.0)
+
+# With a specific constant rate
+observer = ConstantRiskFactorObserver(constant_value=0.05)
+```
+
+Use when: contract has no floating-rate dependency, or you want deterministic cash flows.
+
+---
+
+## Custom Observer
+
+Subclass `BaseRiskFactorObserver` and implement `_get_risk_factor` and `_get_event_data`:
+
+```python
+import jax.numpy as jnp
+from jactus.observers import BaseRiskFactorObserver
+from jactus.core import ActusDateTime, ContractState, ContractAttributes
+
+class MyMarketObserver(BaseRiskFactorObserver):
+    def __init__(self, rate_curve: dict):
+        super().__init__(name="my-market")
+        # rate_curve maps date strings to rates, e.g. {"2024-01-15": 0.052}
+        self.rate_curve = rate_curve
+
+    def _get_risk_factor(
+        self,
+        identifier: str,
+        time: ActusDateTime,
+        state: ContractState | None,
+        attributes: ContractAttributes | None,
+    ) -> jnp.ndarray:
+        """Return the rate for a given risk factor at a given date."""
+        key = f"{time.year}-{time.month:02d}-{time.day:02d}"
+        value = self.rate_curve.get(key, 0.05)
+        return jnp.array(value, dtype=jnp.float32)
+
+    def _get_event_data(
+        self,
+        identifier: str,
+        event_type: str,
+        time: ActusDateTime,
+        state: ContractState | None,
+        attributes: ContractAttributes | None,
+    ):
+        """Return event-specific data (optional, return None if unused)."""
+        return None
+
+# Usage
+from jactus.contracts import create_contract
+from jactus.core import ContractAttributes, ContractType, ContractRole, ActusDateTime
+
+rate_curve = {
+    "2024-01-15": 0.050,
+    "2024-07-15": 0.052,
+    "2025-01-15": 0.048,
+}
+
+observer = MyMarketObserver(rate_curve)
+contract = create_contract(attrs, observer)
+result = contract.simulate()
+```
+
+---
+
+## Using Observers with JAX
+
+JACTUS provides `JaxRiskFactorObserver` for differentiable simulation.
+It takes a `jnp.ndarray` of risk factor values indexed by integer:
+
+```python
+import jax
+import jax.numpy as jnp
+from jactus.contracts import create_contract
+from jactus.core import ContractAttributes, ContractType, ContractRole, ActusDateTime
+from jactus.observers import JaxRiskFactorObserver
+
+def contract_pv(rate):
+    attrs = ContractAttributes(
+        contract_id="LOAN",
+        contract_type=ContractType.PAM,
+        contract_role=ContractRole.RPA,
+        status_date=ActusDateTime(2024, 1, 1),
+        initial_exchange_date=ActusDateTime(2024, 1, 15),
+        maturity_date=ActusDateTime(2025, 1, 15),
+        notional_principal=100_000.0,
+        nominal_interest_rate=0.05,
+        interest_payment_cycle="6M",
+        day_count_convention="30E360",
+    )
+    observer = JaxRiskFactorObserver(jnp.array([rate]))
+    result = create_contract(attrs, observer).simulate()
+    return jnp.sum(jnp.array([e.payoff for e in result.events]))
+
+# Compute gradient
+grad_fn = jax.grad(contract_pv)
+dv01 = grad_fn(0.05) * 0.0001
+print(f"DV01: ${float(dv01):,.2f}")
+```
+
+---
+
+## Notes
+
+- The `identifier` parameter is a string key (e.g., `"USD_SOFR"`, `"EUR_EURIBOR"`) defined by
+  your contract's market object reference. For simple single-curve contracts, the observer
+  can ignore this argument.
+- For multi-curve environments (cross-currency swaps, basis swaps), implement
+  `_get_risk_factor` with logic branching on `identifier`.
+- The observer is called once per event date during simulation; it does not need to be
+  vectorized unless you are batching contracts with `jax.vmap`.
+- The public API is `observer.observe_risk_factor(identifier, time)` — subclasses
+  implement `_get_risk_factor` which is called internally.


### PR DESCRIPTION
## What

Adds agent-optimized documentation for [JACTUS](https://github.com/pedronahum/JACTUS) (v0.2.0), a JAX-based implementation of the ACTUS financial contract standard. 1 doc entry (`jactus/contracts`) with 3 reference files.

| File | Description |
|------|-------------|
| `content/jactus/docs/contracts/python/DOC.md` | Main entry: install, quick start, observer API, CLI, JAX autodiff, scenarios |
| `references/contract-types.md` | Parameter examples for all 18 ACTUS contract types |
| `references/risk-factors.md` | Observer types (7 built-in + 2 behavioral) and custom implementation |
| `references/array-mode.md` | Batch portfolio API, GPU/TPU patterns, vmap usage |

## Why

JACTUS covers a domain (financial contract simulation) not yet represented in Context Hub. Agents working with fixed-income, derivatives, or portfolio analytics can use these docs to generate correct JACTUS code without hallucinating field names or API patterns.

## Testing

- [x] `npm test` passes (172/174 — 2 pre-existing timeout failures unrelated to this PR)
- [x] `chub build content/jactus --validate-only` → `Valid: 1 docs, 0 skills, 0 warnings`
- [x] `chub build content/ --validate-only` → `Valid: 1545 docs, 5 skills, 0 warnings`
- [x] `chub build content/jactus -o /tmp/test/` produces correct `registry.json` with 4 files

## Notes

JACTUS is available on [PyPI](https://pypi.org/project/jactus/) (`pip install jactus`). The docs cover 18 ACTUS contract types (loans, bonds, swaps, options, FX forwards, credit enhancement), JAX autodiff for risk analytics, and GPU/TPU batch simulation.
