### PR TITLE
fix: use dirname() for cache path — fixes Windows/exFAT

### DIFF
--- a/cli/src/lib/cache.js
+++ b/cli/src/lib/cache.js
@@ -187,7 +187,7 @@ export async function fetchDoc(source, docPath) {
   const content = await res.text();
 
   // Cache locally
-  const dir = cachedPath.substring(0, cachedPath.lastIndexOf('/'));
+  const dir = dirname(cachedPath);
   mkdirSync(dir, { recursive: true });
   writeFileSync(cachedPath, content);
 


### PR DESCRIPTION
## Summary

- `fetchDoc()` in `cli/src/lib/cache.js` uses `cachedPath.substring(0, cachedPath.lastIndexOf('/'))` to derive the parent directory for caching fetched docs
- On Windows, `cachedPath` uses backslashes (`C:\Users\...`), so `lastIndexOf('/')` returns `-1`, producing `substring(0, -1)` → empty string → `mkdirSync('')` → `ENOENT` crash
- Replaced with `dirname(cachedPath)` which is already imported from `node:path` and handles both separators correctly

## Repro

On Windows (especially exFAT filesystems):
```
> chub get svelte/svelte --lang js
Error: Failed to load "svelte/svelte": ENOENT: no such file or directory, mkdir ''
```

After fix: fetches and caches correctly.

## Test plan

- [x] Verified `chub get svelte/svelte --lang js` works on Windows (exFAT) after the fix
- [x] Verified `chub get tailwindcss/tailwindcss --lang js` works on Windows (exFAT) after the fix
- [ ] Verify no regression on macOS/Linux (should be no-op since `dirname()` handles forward slashes identically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)