### PR TITLE
Add IBM Apptio Cloudability API v3 documentation

### DIFF
--- a/content/ibm/docs/cloudability-api/DOC.md
+++ b/content/ibm/docs/cloudability-api/DOC.md
@@ -1,0 +1,326 @@
+---
+name: cloudability-api
+description: "IBM Apptio Cloudability API v3 for cloud cost management — authentication, cost views, business mappings, container clusters, and budgets"
+metadata:
+  languages: "http"
+  versions: "v3"
+  revision: 1
+  updated-on: "2026-03-14"
+  source: community
+  tags: "ibm,apptio,cloudability,finops,cloud-cost,api,rest,kubernetes,containers"
+---
+
+# IBM Apptio Cloudability API v3
+
+REST API for cloud cost management. Retrieve cost views, business dimension/metric mappings, container cluster inventories, and budgets.
+
+Base URL: `https://api.cloudability.com/v3`
+
+## Authentication
+
+### API Key (Basic Auth)
+
+Create a key at `https://app.apptio.com/cloudability#/settings/preferences`. The key is the username; the password is empty.
+
+```bash
+curl https://api.cloudability.com/v3/budgets -u 'YOUR_API_KEY:'
+```
+
+### apptio-opentoken
+
+Required for GovCloud. Obtain from Access Administration.
+
+```bash
+curl https://api.cloudability.com/v3/budgets \
+  -H "apptio-opentoken: YOUR_TOKEN" \
+  -H "apptio-environmentid: YOUR_ENV_ID"
+```
+
+## Regional Endpoints
+
+| Region | Base URL |
+|--------|----------|
+| US | `https://api.cloudability.com/v3` |
+| Europe | `https://api-eu.cloudability.com/v3` |
+| Asia Pacific | `https://api-au.cloudability.com/v3` |
+| Middle East | `https://api-me.cloudability.com/v3` |
+
+## Request Headers
+
+- `Accept: application/json` — required on all requests
+- `Content-Type: application/json` — POST/PUT only; do **not** send on GET requests (some endpoints reject it)
+
+## Response Format
+
+```json
+{
+  "result": {} or [],
+  "meta": {}
+}
+```
+
+- Dates: ISO 8601 (`YYYY-MM-DD` or `YYYY-MM-DDTHH:MM:SSZ`)
+- Missing primitives: `null`
+- Missing collections: `[]` or `{}`
+
+### Error Response
+
+```json
+{
+  "error": {
+    "status": 404,
+    "code": "not_found",
+    "messages": ["Not Found"],
+    "uniqueid": "...",
+    "traceid": "..."
+  }
+}
+```
+
+## Endpoints
+
+### Views
+
+```
+GET /v3/views
+```
+
+Returns all cost views. No pagination parameters.
+
+```bash
+curl https://api.cloudability.com/v3/views -u 'YOUR_API_KEY:'
+```
+
+Response:
+
+```json
+{
+  "result": [
+    {
+      "id": "131863",
+      "title": "Production Costs",
+      "description": "",
+      "ownerId": "113155",
+      "ownerEmail": "user@example.com",
+      "sharedWithUsers": [],
+      "sharedWithOrganization": true,
+      "filters": [
+        {
+          "field": "vendor_account_name",
+          "comparator": "==",
+          "value": "123456"
+        }
+      ],
+      "parentViewId": "-1",
+      "viewSource": "SYSTEM",
+      "defaultUserIds": [169765, 169949]
+    }
+  ]
+}
+```
+
+### Business Mappings
+
+```
+GET /v3/business-mappings
+```
+
+Returns all custom dimension and metric rules. No pagination parameters.
+
+```bash
+curl https://api.cloudability.com/v3/business-mappings -u 'YOUR_API_KEY:'
+```
+
+Response:
+
+```json
+{
+  "result": [
+    {
+      "name": "Environment",
+      "index": 2,
+      "kind": "BUSINESS_DIMENSION",
+      "defaultValue": "Not Set",
+      "updatedAt": "2021-07-14T11:57:33.686Z",
+      "statements": [
+        {
+          "matchExpression": "TAG['Environment'] CONTAINS 'prod'",
+          "valueExpression": "'Production'"
+        },
+        {
+          "matchExpression": "TAG['Environment'] CONTAINS 'dev'",
+          "valueExpression": "'Non-Production'"
+        }
+      ]
+    }
+  ]
+}
+```
+
+`kind` is either `BUSINESS_DIMENSION` (categorical) or `BUSINESS_METRIC` (numeric).
+
+#### Expression Syntax
+
+Match expressions:
+
+- `TAG['tag_name']` — cloud resource tag
+- `DIMENSION['dimension_name']` — cost dimension (e.g. `vendor`, `vendor_account_name`, `vendor_account_identifier`)
+- `METRIC['metric_name']` — cost metric (e.g. `list_cost`, `unblended_cost`)
+
+Operators: `CONTAINS 'value'`, `== 'value'`, `||`, `&&`
+
+Value expressions: string literals (`'Production'`) or metric calculations (`METRIC['list_cost'] - METRIC['unblended_cost']`).
+
+### Container Clusters
+
+```
+GET /v3/containers/clusters
+```
+
+Returns all Kubernetes clusters with node inventories. No query parameters accepted.
+
+```bash
+curl https://api.cloudability.com/v3/containers/clusters -u 'YOUR_API_KEY:'
+```
+
+**Important:** Do not send `Content-Type` header or pagination parameters on this endpoint — it returns 400. Can be slow (up to 60s) for large deployments.
+
+Response (note: nested under `result.clusters`, not `result[]`):
+
+```json
+{
+  "result": {
+    "clusters": [
+      {
+        "id": "3a59440b-d6f9-416a-bb32-ece4c1302c09",
+        "name": "production-singapore",
+        "lastSeen": "2026-03-14T00:00:00Z",
+        "firstSeen": "2023-06-09T00:00:00Z",
+        "provisionedAt": "0001-01-01T00:00:00Z",
+        "metadata": {},
+        "nodes": [
+          {
+            "vendor": "Amazon",
+            "resourceIdentifier": "i-048241ebfab4baa82"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Node vendors include `Amazon` (AWS EKS, identified by EC2 instance IDs) and Google Cloud (GKE/Autopilot clusters).
+
+### Budgets
+
+```
+GET /v3/budgets
+```
+
+Supports pagination, sorting, and filtering.
+
+```bash
+# List all budgets
+curl https://api.cloudability.com/v3/budgets -u 'YOUR_API_KEY:'
+
+# With pagination
+curl "https://api.cloudability.com/v3/budgets?limit=100&offset=0" -u 'YOUR_API_KEY:'
+
+# With filter
+curl "https://api.cloudability.com/v3/budgets?filter=status==active" -u 'YOUR_API_KEY:'
+
+# Sorted descending
+curl "https://api.cloudability.com/v3/budgets?sort=-totalBudget" -u 'YOUR_API_KEY:'
+```
+
+#### Query Parameters
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `limit` | Records per page (default 50, max 500) | `limit=100` |
+| `offset` | Records to skip | `offset=50` |
+| `sort` | `+field` ascending, `-field` descending | `sort=-totalBudget` |
+| `filter` | Comma-separated conditions | `filter=status==active,totalBudget>10000` |
+
+Filter operators: `==`, `!=`, `>`, `<`, `=@` (contains).
+
+### Get Single Record
+
+```bash
+# Budget by ID
+curl https://api.cloudability.com/v3/budgets/{budgetId} -u 'YOUR_API_KEY:'
+
+# View by ID
+curl https://api.cloudability.com/v3/views/{viewId} -u 'YOUR_API_KEY:'
+
+# Business mapping by index
+curl https://api.cloudability.com/v3/business-mappings/{index} -u 'YOUR_API_KEY:'
+
+# Cluster by ID
+curl https://api.cloudability.com/v3/containers/clusters/{clusterId} -u 'YOUR_API_KEY:'
+```
+
+## Permission-Restricted Endpoints
+
+These endpoints exist but require elevated API permissions:
+
+| Endpoint | Status | Description |
+|----------|--------|-------------|
+| `GET /v3/vendors` | 401 | Cloud vendor accounts |
+| `GET /v3/reservations` | 401 | Reserved instance data |
+| `GET /v3/containers` | 401 | Container-level detail |
+| `GET /v3/users` | 401 | User management |
+| `GET /v3/anomalies` | 403 | Cost anomaly detection |
+| `GET /v3/forecast` | 422 | Cost forecasting (needs query params) |
+| `GET /v3/reporting/cost/run` | 422/403 | Cost reporting (needs params + permissions) |
+
+## HTTP Status Codes
+
+| Code | Meaning |
+|------|---------|
+| 200 | Success |
+| 201 | Created |
+| 204 | Successful delete |
+| 400 | Bad request (invalid params or headers) |
+| 401 | Unauthorized (bad/expired credentials) |
+| 403 | Forbidden (insufficient permissions) |
+| 404 | Not found |
+| 422 | Missing required parameters |
+| 500 | Server error |
+
+## Python Client Example
+
+```python
+import os
+import requests
+import base64
+
+api_key = os.environ["APPTIO_KEY"]
+auth = base64.b64encode(f"{api_key}:".encode()).decode()
+headers = {"Authorization": f"Basic {auth}", "Accept": "application/json"}
+base = "https://api.cloudability.com/v3"
+
+# List views
+views = requests.get(f"{base}/views", headers=headers).json()["result"]
+
+# List business mappings
+mappings = requests.get(f"{base}/business-mappings", headers=headers).json()["result"]
+
+# List clusters
+clusters = requests.get(
+    f"{base}/containers/clusters", headers=headers, timeout=60
+).json()["result"]["clusters"]
+
+# List budgets with filter
+budgets = requests.get(
+    f"{base}/budgets",
+    headers=headers,
+    params={"filter": "status==active", "limit": 100},
+).json()["result"]
+```
+
+## Official Documentation
+
+- [Getting Started](https://www.ibm.com/docs/en/cloudability-commercial/cloudability-premium/saas?topic=api-getting-started-cloudability-v3)
+- [IBM Cloudability Docs](https://www.ibm.com/docs/en/cloudability-commercial/cloudability-premium/saas)

--- a/content/ibm/docs/cloudability-api/references/business-mappings.md
+++ b/content/ibm/docs/cloudability-api/references/business-mappings.md
@@ -1,0 +1,114 @@
+# Business Mappings Endpoint Reference
+
+## GET /v3/business-mappings
+
+Returns all custom business dimension and metric mapping rules. No pagination.
+
+## GET /v3/business-mappings/{index}
+
+Returns a single mapping by its index number.
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Mapping name |
+| `index` | integer | Position index |
+| `kind` | string | `BUSINESS_DIMENSION` or `BUSINESS_METRIC` |
+| `defaultValue` | string | Default when no rule matches |
+| `updatedAt` | string | ISO 8601 timestamp of last update |
+| `statements` | array | Ordered list of match/value rules |
+| `statements[].matchExpression` | string | Rule condition |
+| `statements[].valueExpression` | string | Value to assign when matched |
+
+### Expression Functions
+
+| Function | Description | Example |
+|----------|-------------|---------|
+| `TAG['name']` | Cloud resource tag value | `TAG['Environment']` |
+| `DIMENSION['name']` | Cost dimension value | `DIMENSION['vendor_account_name']` |
+| `METRIC['name']` | Cost metric value | `METRIC['unblended_cost']` |
+
+### Expression Operators
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `CONTAINS 'val'` | Substring match | `TAG['Env'] CONTAINS 'prod'` |
+| `== 'val'` | Exact match | `DIMENSION['vendor'] == 'Amazon'` |
+| `\|\|` | Logical OR | `TAG['Env'] CONTAINS 'dev' \|\| TAG['Env'] CONTAINS 'test'` |
+| `&&` | Logical AND | `TAG['Env'] == 'prod' && DIMENSION['vendor'] == 'Amazon'` |
+
+### Value Expressions
+
+- String literal: `'Production'`
+- Empty string: `''`
+- Metric calculation: `METRIC['list_cost'] - METRIC['unblended_cost']`
+- For `BUSINESS_METRIC` kind, value expressions return numbers; default is typically `"0"`
+- For `BUSINESS_DIMENSION` kind, value expressions return strings; default is typically `"not set"` or `"n/a"`
+
+### Common Dimension Names
+
+Observed in production:
+
+| Name | Kind | Purpose |
+|------|------|---------|
+| `Environment` | BUSINESS_DIMENSION | Production vs Non-Production classification |
+| `FO_Archetype` | BUSINESS_DIMENSION | Financial owner by account |
+| `FO_Team` | BUSINESS_DIMENSION | Team ownership mapping |
+| `FO_OpCo` | BUSINESS_DIMENSION | Operating company mapping |
+| `FO_Product` | BUSINESS_DIMENSION | Product classification |
+| `FO_Region` | BUSINESS_DIMENSION | Regional mapping |
+| `Azure Tenant Id` | BUSINESS_DIMENSION | Azure tenant identification |
+| `SP/RI/Spot Savings` | BUSINESS_METRIC | Savings plan/reserved instance savings |
+| `FO_RightsizingSavings` | BUSINESS_METRIC | Rightsizing savings calculations |
+
+### Full Response Example
+
+```json
+{
+  "result": [
+    {
+      "name": "Environment",
+      "index": 2,
+      "kind": "BUSINESS_DIMENSION",
+      "defaultValue": "Not Set",
+      "updatedAt": "2021-07-14T11:57:33.686Z",
+      "statements": [
+        {
+          "matchExpression": "TAG['Environment'] CONTAINS 'backup' || DIMENSION['vendor_account_name'] CONTAINS 'backup'",
+          "valueExpression": "'Backup & Disaster Recovery'"
+        },
+        {
+          "matchExpression": "TAG['Environment'] CONTAINS 'dev' || TAG['Environment'] CONTAINS 'test' || TAG['Environment'] CONTAINS 'poc' || TAG['Environment'] CONTAINS 'sand'",
+          "valueExpression": "'Non-Production'"
+        },
+        {
+          "matchExpression": "TAG['Environment'] CONTAINS 'prod'",
+          "valueExpression": "'Production'"
+        },
+        {
+          "matchExpression": "DIMENSION['vendor_account_name'] CONTAINS 'test' || DIMENSION['vendor_account_name'] CONTAINS 'dev'",
+          "valueExpression": "'Non-Production'"
+        },
+        {
+          "matchExpression": "DIMENSION['vendor_account_name'] CONTAINS 'prod' || DIMENSION['vendor_account_name'] CONTAINS 'prd'",
+          "valueExpression": "'Production'"
+        }
+      ]
+    },
+    {
+      "name": "SP/RI/Spot Savings",
+      "index": 2,
+      "kind": "BUSINESS_METRIC",
+      "defaultValue": "0",
+      "updatedAt": "2023-01-15T10:30:00.000Z",
+      "statements": [
+        {
+          "matchExpression": "DIMENSION['vendor'] == 'Amazon'",
+          "valueExpression": "METRIC['list_cost'] - METRIC['unblended_cost']"
+        }
+      ]
+    }
+  ]
+}
+```

--- a/content/ibm/docs/cloudability-api/references/clusters.md
+++ b/content/ibm/docs/cloudability-api/references/clusters.md
@@ -1,0 +1,96 @@
+# Container Clusters Endpoint Reference
+
+## GET /v3/containers/clusters
+
+Returns all Kubernetes clusters with full node inventories.
+
+**Quirks:**
+- Do NOT send `Content-Type: application/json` header — returns 400
+- Do NOT send pagination parameters (`limit`, `offset`) — returns 400
+- Response can take up to 60 seconds for large deployments
+- Response is nested under `result.clusters[]`, unlike other endpoints that use `result[]`
+
+## GET /v3/containers/clusters/{clusterId}
+
+Returns a single cluster by UUID.
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string (UUID) | Unique cluster identifier |
+| `name` | string | Cluster name |
+| `lastSeen` | string | ISO 8601 timestamp of last data collection |
+| `firstSeen` | string | ISO 8601 timestamp of first appearance |
+| `provisionedAt` | string | Provisioning timestamp (`0001-01-01T00:00:00Z` if unknown) |
+| `metadata` | object | Additional cluster metadata |
+| `nodes` | array | Nodes in the cluster |
+| `nodes[].vendor` | string | Cloud provider (e.g. `Amazon`) |
+| `nodes[].resourceIdentifier` | string | Provider instance ID (e.g. `i-048241ebfab4baa82`) |
+
+### Cloud Providers
+
+| Vendor | Platform | Identifier Format |
+|--------|----------|-------------------|
+| Amazon | AWS EKS | EC2 instance ID (`i-*`) |
+| Google Cloud | GCP GKE / Autopilot | GCE instance name |
+
+### Cluster Naming Conventions (observed)
+
+| Pattern | Description |
+|---------|-------------|
+| `k8s-{cloud}-{org}-{product}-{env}-{region}-{n}` | Standard clusters |
+| `k8s-{cloud}-{org}-{product}-autopilot-{env}-{region}-{n}` | GCP Autopilot clusters |
+| `production-{location}` | Legacy AWS production clusters |
+| `{platform}-gke-{env}-{region}` | Platform-specific GKE clusters |
+
+### Scale
+
+Node counts range from 0 (inactive/decommissioned) to several thousand for large Autopilot clusters.
+
+### Full Response Example
+
+```json
+{
+  "result": {
+    "clusters": [
+      {
+        "id": "3a59440b-d6f9-416a-bb32-ece4c1302c09",
+        "name": "production-singapore",
+        "lastSeen": "2026-03-14T00:00:00Z",
+        "firstSeen": "2023-06-09T00:00:00Z",
+        "provisionedAt": "0001-01-01T00:00:00Z",
+        "metadata": {},
+        "nodes": [
+          {
+            "vendor": "Amazon",
+            "resourceIdentifier": "i-048241ebfab4baa82"
+          },
+          {
+            "vendor": "Amazon",
+            "resourceIdentifier": "i-0eb68fb0e0b6a7d1f"
+          },
+          {
+            "vendor": "Amazon",
+            "resourceIdentifier": "i-060eadc10c842ed69"
+          }
+        ]
+      },
+      {
+        "id": "bb52e86d-b7fb-4b59-ab32-861feb9f6dd6",
+        "name": "nonproduction",
+        "lastSeen": "2026-03-14T00:00:00Z",
+        "firstSeen": "2022-01-15T00:00:00Z",
+        "provisionedAt": "0001-01-01T00:00:00Z",
+        "metadata": {},
+        "nodes": [
+          {
+            "vendor": "Amazon",
+            "resourceIdentifier": "i-0fca6ba155416ceb0"
+          }
+        ]
+      }
+    ]
+  }
+}
+```

--- a/content/ibm/docs/cloudability-api/references/views.md
+++ b/content/ibm/docs/cloudability-api/references/views.md
@@ -1,0 +1,56 @@
+# Views Endpoint Reference
+
+## GET /v3/views
+
+Returns all configured cost views. No pagination.
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Unique view identifier |
+| `title` | string | View name |
+| `description` | string | View description |
+| `ownerId` | string | User ID of the owner |
+| `ownerEmail` | string | Email of the owner |
+| `sharedWithUsers` | array | User IDs this view is shared with |
+| `derivedUserIds` | array | Derived user IDs |
+| `derivedOrgUnitIDs` | array | Derived org unit IDs |
+| `sharedWithOrganization` | boolean | Shared with entire organisation |
+| `filters` | array | Filter rules applied to the view |
+| `filters[].field` | string | Dimension or field name (e.g. `vendor_account_name`) |
+| `filters[].comparator` | string | Comparison operator (e.g. `==`) |
+| `filters[].value` | string | Value to match |
+| `parentViewId` | string | Parent view ID (`-1` for root) |
+| `viewSource` | string | Origin: `SYSTEM` or user-created |
+| `defaultUserIds` | array | User IDs for whom this is the default view |
+
+### Full Response Example
+
+```json
+{
+  "result": [
+    {
+      "id": "131863",
+      "title": "No Data Access",
+      "description": "",
+      "ownerId": "113155",
+      "sharedWithUsers": [],
+      "derivedUserIds": [],
+      "derivedOrgUnitIDs": [],
+      "sharedWithOrganization": true,
+      "filters": [
+        {
+          "field": "vendor_account_name",
+          "comparator": "==",
+          "value": "123456"
+        }
+      ],
+      "parentViewId": "-1",
+      "viewSource": "SYSTEM",
+      "ownerEmail": "admin@example.com",
+      "defaultUserIds": [169765, 169949]
+    }
+  ]
+}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
     },
     "cli": {
       "name": "@aisuite/chub",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
@@ -23,7 +23,8 @@
         "zod": "^4.3.6"
       },
       "bin": {
-        "chub": "bin/chub"
+        "chub": "bin/chub",
+        "chub-mcp": "bin/chub-mcp"
       },
       "devDependencies": {
         "vitest": "^4.0.18"
@@ -1475,7 +1476,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1713,7 +1713,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
       "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2032,7 +2031,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2509,7 +2507,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2709,7 +2706,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -2725,7 +2721,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary

Adds community documentation for the **IBM Apptio Cloudability API v3**, a cloud cost management REST API.

## Content

### DOC.md (main entry)
- Authentication methods (API key via Basic Auth, apptio-opentoken)
- Regional endpoints (US, EU, APAC, ME)
- Request/response format with gotchas (e.g. no Content-Type on GET for certain endpoints)
- All verified endpoints: views, business mappings, container clusters, budgets
- Permission-restricted endpoints documented with observed status codes
- Python client example
- Query parameters (pagination, sorting, filtering with operators)

### Reference files
- **references/views.md** — Full response schema for cost views
- **references/business-mappings.md** — Expression syntax (TAG[], DIMENSION[], METRIC[]), operators, common dimension names, full response examples
- **references/clusters.md** — Container cluster response schema, cloud provider details, endpoint quirks

## Verification
- Response schemas verified against a live Cloudability instance
- Endpoint quirks (e.g. `/v3/containers/clusters` rejecting Content-Type headers and pagination params) discovered through testing
- `chub build content/ --validate-only`: 1545 docs, 0 warnings
- `npm test`: 174/174 tests pass

## Metadata
- **languages:** http
- **versions:** v3
- **source:** community
- **tags:** ibm, apptio, cloudability, finops, cloud-cost, api, rest, kubernetes, containers