### PR TITLE
Add parts-mcp: electronic parts sourcing MCP server

### DIFF
--- a/content/sourceparts/docs/parts-mcp/python/DOC.md
+++ b/content/sourceparts/docs/parts-mcp/python/DOC.md
@@ -1,0 +1,293 @@
+---
+name: parts-mcp
+description: "MCP server for electronic parts sourcing — search components, compare prices, check availability, process BOMs, read datasheets, submit DFM analysis, and integrate with KiCad"
+metadata:
+  languages: "python"
+  versions: "0.1.3"
+  revision: 1
+  updated-on: "2026-03-15"
+  source: maintainer
+  tags: "mcp,electronics,parts,sourcing,bom,kicad,pcb,components,eda,datasheet,dfm,manufacturing"
+---
+
+# Parts MCP
+
+MCP server for sourcing electronic components. Thin client wrapping the [Source Parts API](https://api.source.parts) — search, pricing, availability, BOM processing, datasheet reading, DFM analysis, and KiCad integration happen server-side. Local tools handle filesystem access (BOM uploads, KiCad project discovery, datasheet PDFs).
+
+## Installation
+
+```bash
+pip install parts-mcp
+```
+
+Requires Python 3.10+.
+
+## Configuration
+
+### Environment Variables
+
+```bash
+SOURCE_PARTS_API_KEY=your_api_key      # Required — get from source.parts
+SOURCE_PARTS_API_URL=https://api.source.parts/v1  # Optional, default shown
+KICAD_SEARCH_PATHS=/path/to/projects   # Optional, for find_kicad_projects
+PARTS_CACHE_DIR=~/.cache/parts-mcp     # Optional
+CACHE_EXPIRY_HOURS=24                  # Optional
+```
+
+### Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "parts": {
+      "command": "parts-mcp",
+      "env": {
+        "SOURCE_PARTS_API_KEY": "your_api_key"
+      }
+    }
+  }
+}
+```
+
+### Claude Code
+
+```json
+{
+  "mcpServers": {
+    "parts": {
+      "command": "parts-mcp",
+      "env": {
+        "SOURCE_PARTS_API_KEY": "your_api_key"
+      }
+    }
+  }
+}
+```
+
+## Tools Quick Reference
+
+### Search
+
+| Tool | Purpose | Key Parameters |
+|------|---------|----------------|
+| `search_parts` | Search by keyword, part number, or description | `query`, `category?`, `filters?`, `limit?` |
+| `search_by_parameters` | Parametric search within a category | `parameters`, `category`, `limit?` |
+| `get_part_details` | Full details for a specific part | `part_number`, `manufacturer?` |
+
+### Sourcing
+
+| Tool | Purpose | Key Parameters |
+|------|---------|----------------|
+| `compare_prices` | Price comparison across suppliers | `part_number`, `quantity?`, `suppliers?` |
+| `check_availability` | Stock check for multiple parts | `part_numbers`, `quantities?` |
+| `find_alternatives` | Find compatible replacements | `part_number`, `parameters?` |
+| `calculate_bom_cost` | Total cost for a bill of materials | `bom`, `quantity?`, `preferred_suppliers?` |
+| `estimate_cost` | Quick cost estimate for a parts list | `parts`, `currency?` |
+
+### Manufacturing
+
+| Tool | Purpose | Key Parameters |
+|------|---------|----------------|
+| `upload_bom` | Upload BOM file for processing | `file_path` (local only) |
+| `check_bom_status` | Poll BOM processing, get matched/unmatched | `job_id` |
+| `submit_dfm` | Queue DFM analysis | `project_id`, `bom_id?`, `priority?` |
+| `check_dfm_status` | Poll DFM job status | `job_id` |
+| `quote_fabrication` | Get PCB fab quote | `project_id`, `quantity?`, `layers?`, etc. |
+| `upload_gerbers_for_quote` | Upload gerbers for fab quote | `file_path`, `quantity?`, etc. (local only) |
+| `quote_assembly` | Combined fab + assembly quote | `gerber_path`, `bom_path`, etc. (local only) |
+| `check_manufacturing_status` | Poll any manufacturing job | `job_id` |
+
+### Datasheet
+
+| Tool | Purpose | Key Parameters |
+|------|---------|----------------|
+| `list_datasheet_sections` | Get TOC without reading full content | `file_path?`, `sku?` |
+| `read_datasheet` | Read/chunk datasheet with optional filtering | `file_path?`, `sku?`, `query?`, `chunk_pages?` |
+
+### KiCad (local mode only)
+
+| Tool | Purpose | Key Parameters |
+|------|---------|----------------|
+| `find_kicad_projects` | Discover projects in search paths | (none) |
+| `extract_bom_from_kicad` | Extract BOM from .kicad_pro | `project_path` |
+| `analyze_kicad_project` | File counts and structure analysis | `project_path` |
+| `extract_netlist_from_project` | Connectivity analysis | `project_path` |
+| `match_components_to_parts` | Match KiCad components to real parts | `components`, `auto_search?` |
+| `export_parts_to_kicad` | Export sourced parts as CSV/JSON | `parts`, `output_path`, `format?` |
+| `highlight_net_traces` | Render highlighted nets as PDFs | `project_path`, `net_names`, `colors?`, `mode?` |
+| `open_in_kicad` | Launch KiCad with a project | `project_path` |
+
+### Identification
+
+| Tool | Purpose | Key Parameters |
+|------|---------|----------------|
+| `identify_pcb` | Identify PCB/component from photo | `file_path`, `project_id?` (local only) |
+| `check_identification_status` | Poll identification job | `job_id` |
+| `get_identified_item` | Get identified item details | `short_code` |
+
+## Core Workflow: Search to Source
+
+```python
+# 1. Search for a part
+result = search_parts(query="STM32F411CEU6")
+
+# 2. Get detailed specs
+details = get_part_details(part_number="STM32F411CEU6", manufacturer="STMicroelectronics")
+
+# 3. Compare prices across suppliers
+prices = compare_prices(part_number="STM32F411CEU6", quantity=100)
+
+# 4. Check if it's in stock
+availability = check_availability(
+    part_numbers=["STM32F411CEU6"],
+    quantities=[100]
+)
+
+# 5. If unavailable or expensive, find alternatives
+alternatives = find_alternatives(
+    part_number="STM32F411CEU6",
+    parameters={"core": "ARM Cortex-M4", "flash": "512KB"}
+)
+```
+
+## BOM Processing
+
+BOM upload is asynchronous — upload, poll, then review results.
+
+```python
+# 1. Upload BOM file (CSV, XLSX, XLS, JSON, or XML)
+upload = upload_bom(file_path="/path/to/bom.csv")
+job_id = upload["job_id"]
+
+# 2. Poll until complete
+status = check_bom_status(job_id=job_id)
+# status["status"] will be "in_progress", "complete", or "failed"
+
+# 3. When complete, review matches
+matched = status["matched_parts"]      # Successfully identified parts
+unmatched = status["unknown_parts"]    # Parts needing manual resolution
+
+# 4. Calculate total cost
+cost = calculate_bom_cost(
+    bom=[{"part_number": p["mpn"], "quantity": p["quantity"]} for p in matched],
+    quantity=100
+)
+```
+
+Supported BOM formats: CSV, XLSX, XLS, JSON, XML. Max file size: 50 MB.
+
+Six EDA tools supported: KiCad, Altium Designer, Autodesk Fusion 360, Eagle, PADS, Protel 99.
+
+## KiCad Integration
+
+```python
+# 1. Discover projects
+projects = find_kicad_projects()
+
+# 2. Extract BOM from a project
+bom = extract_bom_from_kicad(project_path="/path/to/project.kicad_pro")
+
+# 3. Match components to real parts
+matches = match_components_to_parts(
+    components=bom["bom_files"][0]["analysis"]["components"],
+    auto_search=True
+)
+
+# 4. Export sourced parts back to KiCad format
+export_parts_to_kicad(
+    parts=matches["suggestions"],
+    output_path="/path/to/sourced_parts.csv",
+    format="csv"
+)
+```
+
+KiCad tools require local mode (stdio transport). Set `KICAD_SEARCH_PATHS` to directories containing your `.kicad_pro` files.
+
+## Datasheet Reading
+
+Datasheets can be large. Use `list_datasheet_sections` first to see what's available, then `read_datasheet` with a `query` to filter relevant chunks.
+
+```python
+# 1. See what sections exist (lightweight, no content returned)
+sections = list_datasheet_sections(sku="STM32F411CEU6")
+# Returns: [{"title": "Electrical Characteristics", "page": 42}, ...]
+
+# 2. Read only relevant chunks
+data = read_datasheet(
+    sku="STM32F411CEU6",
+    query="maximum input voltage absolute ratings",
+    chunk_pages=5
+)
+# Returns filtered chunks matching the query keywords
+# context_savings shows reduction (e.g., "reduction_pct": 75)
+```
+
+Two input modes: `file_path` (upload local PDF) or `sku` (fetch cached chunks from API). Using `sku` is faster when parts have been previously processed.
+
+## Manufacturing
+
+```python
+# DFM analysis
+dfm = submit_dfm(project_id="proj_123", priority="high")
+dfm_result = check_dfm_status(job_id=dfm["job_id"])
+
+# Fabrication quote
+fab = quote_fabrication(
+    project_id="proj_123",
+    quantity=10,
+    layers=4,
+    thickness=1.6,
+    surface_finish="ENIG",
+    color="black"
+)
+fab_result = check_manufacturing_status(job_id=fab["job_id"])
+
+# Combined fab + assembly quote (local mode)
+assembly = quote_assembly(
+    gerber_path="/path/to/gerbers.zip",
+    bom_path="/path/to/bom.csv",
+    quantity=10,
+    layers=4
+)
+```
+
+All manufacturing operations are asynchronous. Use `check_manufacturing_status` or the specific status tools (`check_dfm_status`, `check_bom_status`) to poll for results.
+
+## Hosted vs Local Mode
+
+| Capability | Local (stdio) | Hosted (HTTP) |
+|-----------|---------------|---------------|
+| Search, pricing, availability | Yes | Yes |
+| BOM cost calculation | Yes | Yes |
+| DFM, fab quoting (by project ID) | Yes | Yes |
+| Manufacturing status checks | Yes | Yes |
+| Datasheet reading (by SKU) | Yes | Yes |
+| Datasheet reading (local PDF) | Yes | No |
+| BOM file upload | Yes | No |
+| Gerber file upload | Yes | No |
+| KiCad integration | Yes | No |
+| PCB identification (photo) | Yes | No |
+| Assembly quoting (file upload) | Yes | No |
+
+Local mode runs via `parts-mcp` (stdio). Hosted mode runs as an HTTP server with OAuth authentication.
+
+## Common Pitfalls
+
+**Missing API key**: All tools except KiCad project discovery require `SOURCE_PARTS_API_KEY`. Set it in your environment or MCP config.
+
+**KiCad CLI not in PATH**: `extract_bom_from_kicad` and `extract_netlist_from_project` invoke `kicad-cli` if no existing BOM/netlist files are found. Ensure KiCad 8+ is installed and `kicad-cli` is accessible.
+
+**Context-heavy datasheet reads**: Always call `list_datasheet_sections` before `read_datasheet`. Use the `query` parameter to filter chunks — an unfiltered read of a 200-page datasheet will consume significant context.
+
+**BOM status polling**: `check_bom_status` should be called repeatedly until `status` is `"complete"` or `"failed"`. Processing time depends on BOM size and part matching complexity.
+
+**File size limits**: BOM and gerber uploads are limited to 50 MB. Image uploads for identification accept: jpg, jpeg, png, gif, heic, webp.
+
+## Resources
+
+- [Source Parts](https://source.parts) — Main platform
+- [GitHub](https://github.com/SourceParts/parts-mcp) — Source code
+- [PyPI](https://pypi.org/project/parts-mcp/) — Package
+- [API Documentation](https://source.parts/docs/api) — API reference
+
+See [tools.md](./references/tools.md) for complete parameter reference and [workflows.md](./references/workflows.md) for multi-step workflow recipes.

--- a/content/sourceparts/docs/parts-mcp/python/references/tools.md
+++ b/content/sourceparts/docs/parts-mcp/python/references/tools.md
@@ -1,0 +1,529 @@
+# Parts MCP — Tool Parameter Reference
+
+Complete parameter reference for all parts-mcp tools. Grouped by category.
+
+## Search Tools
+
+### search_parts
+
+Search for electronic parts across suppliers.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | `str` | required | Search query — part number, description, or keywords |
+| `category` | `str \| None` | `None` | Category filter (e.g., "resistor", "capacitor", "microcontroller") |
+| `filters` | `dict \| None` | `None` | Parametric filters (e.g., `{"resistance": "10k", "tolerance": "1%"}`) |
+| `limit` | `int` | `20` | Maximum results to return |
+
+**Returns:**
+
+```json
+{
+  "query": "STM32F411",
+  "category": null,
+  "filters": {},
+  "results": [
+    {
+      "part_number": "STM32F411CEU6",
+      "manufacturer": "STMicroelectronics",
+      "description": "ARM Cortex-M4 MCU, 512KB Flash, 128KB RAM",
+      "category": "microcontroller"
+    }
+  ],
+  "total_results": 15,
+  "success": true
+}
+```
+
+### search_by_parameters
+
+Parametric search within a specific category.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `parameters` | `dict` | required | Search criteria (e.g., `{"capacitance": "100nF", "voltage": "50V", "package": "0402"}`) |
+| `category` | `str` | required | Part category |
+| `limit` | `int` | `20` | Maximum results |
+
+**Returns:**
+
+```json
+{
+  "category": "capacitor",
+  "parameters": {"capacitance": "100nF", "voltage": "50V"},
+  "results": [...],
+  "total_results": 42,
+  "success": true
+}
+```
+
+### get_part_details
+
+Get detailed information about a specific part.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `part_number` | `str` | required | Part number to look up |
+| `manufacturer` | `str \| None` | `None` | Manufacturer name (disambiguates when multiple manufacturers use same part number) |
+
+**Returns:**
+
+```json
+{
+  "part_number": "STM32F411CEU6",
+  "manufacturer": "STMicroelectronics",
+  "details": {
+    "description": "...",
+    "specifications": {...},
+    "datasheet_url": "...",
+    "lifecycle_status": "active"
+  },
+  "success": true
+}
+```
+
+## Sourcing Tools
+
+### compare_prices
+
+Compare prices across multiple suppliers.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `part_number` | `str` | required | Part number to price |
+| `quantity` | `int` | `1` | Quantity needed (affects price breaks) |
+| `suppliers` | `list[str] \| None` | `None` | Specific suppliers to check (checks all if omitted) |
+
+**Returns:**
+
+```json
+{
+  "part_number": "STM32F411CEU6",
+  "quantity": 100,
+  "suppliers_checked": 5,
+  "prices": [
+    {
+      "supplier": "LCSC",
+      "sku": "C478234",
+      "unit_price": 3.42,
+      "total_price": 342.00,
+      "stock": 15000,
+      "lead_time": "3-5 days"
+    }
+  ],
+  "best_price": {"supplier": "LCSC", "unit_price": 3.42},
+  "success": true
+}
+```
+
+### check_availability
+
+Check stock levels for multiple parts at once.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `part_numbers` | `list[str]` | required | List of part numbers to check |
+| `quantities` | `list[int] \| None` | `None` | Quantities needed per part (defaults to 1 each) |
+
+**Returns:**
+
+```json
+{
+  "parts": ["STM32F411CEU6", "LM1117-3.3"],
+  "quantities": [100, 100],
+  "availability": [
+    {
+      "part_number": "STM32F411CEU6",
+      "quantity_needed": 100,
+      "available": true,
+      "total_stock": 15000,
+      "in_stock_suppliers": 3,
+      "manufacturer": "STMicroelectronics",
+      "description": "ARM Cortex-M4 MCU"
+    }
+  ],
+  "all_available": true,
+  "success": true
+}
+```
+
+### find_alternatives
+
+Find drop-in or compatible replacement parts.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `part_number` | `str` | required | Original part number |
+| `parameters` | `dict \| None` | `None` | Key parameters to match (narrows alternatives) |
+
+**Returns:**
+
+```json
+{
+  "original_part": "STM32F411CEU6",
+  "match_parameters": {"core": "ARM Cortex-M4"},
+  "alternatives": [
+    {
+      "part_number": "STM32F401CEU6",
+      "manufacturer": "STMicroelectronics",
+      "compatibility": "pin-compatible",
+      "differences": ["256KB Flash vs 512KB"]
+    }
+  ],
+  "total_alternatives": 8,
+  "success": true
+}
+```
+
+### calculate_bom_cost
+
+Calculate total cost for a complete bill of materials.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `bom` | `list[dict]` | required | BOM items (see format below) |
+| `quantity` | `int` | `1` | Number of boards/assemblies |
+| `preferred_suppliers` | `list[str] \| None` | `None` | Preferred supplier list |
+
+**BOM item format:**
+
+```json
+{
+  "part_number": "STM32F411CEU6",
+  "quantity": 1,
+  "reference": "U1",
+  "description": "Main MCU"
+}
+```
+
+Fields `part_number` (or `mpn`) and `quantity` are required. `reference` and `description`/`value` are optional.
+
+**Returns:**
+
+```json
+{
+  "bom_items": 25,
+  "priced_items": 23,
+  "quantity": 100,
+  "total_cost": 1250.00,
+  "cost_breakdown": [
+    {
+      "reference": "U1",
+      "part_number": "STM32F411CEU6",
+      "description": "Main MCU",
+      "quantity": 100,
+      "unit_price": 3.42,
+      "line_total": 342.00,
+      "supplier": "LCSC",
+      "sku": "C478234"
+    }
+  ],
+  "errors": [{"part_number": "CUSTOM-PART-1", "error": "not found"}],
+  "currency": "USD",
+  "success": true
+}
+```
+
+### estimate_cost
+
+Quick cost estimate without full BOM processing.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `parts` | `list[dict]` | required | Parts list with `part_number` and `quantity` |
+| `currency` | `str` | `"USD"` | Currency code |
+
+## Manufacturing Tools
+
+### upload_bom
+
+Upload a BOM file for processing and part matching. **Local mode only.**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `file_path` | `str` | required | Local path to BOM file |
+
+Supported formats: CSV, XLSX, XLS, JSON, XML. Max size: 50 MB.
+
+**Returns:** `job_id` for polling with `check_bom_status`.
+
+### check_bom_status
+
+Poll BOM processing status. When complete, returns matched and unmatched parts.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `job_id` | `str` | required | Job ID from `upload_bom` |
+
+**Returns (when complete):**
+
+```json
+{
+  "job_id": "bom_abc123",
+  "status": "complete",
+  "bom_id": "bom_def456",
+  "summary": {"total_lines": 25, "matched": 23, "unmatched": 2},
+  "matched_parts": [...],
+  "unknown_parts": [
+    {
+      "reference": "U3",
+      "value": "CUSTOM-IC",
+      "footprint": "QFP-48",
+      "manufacturer": "",
+      "mpn": "",
+      "status": "unmatched"
+    }
+  ],
+  "success": true
+}
+```
+
+### submit_dfm
+
+Queue a Design for Manufacturability analysis.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `project_id` | `str` | required | Project ID to analyze |
+| `bom_id` | `str \| None` | `None` | BOM ID to include |
+| `revision` | `str \| None` | `None` | Revision identifier |
+| `notes` | `str \| None` | `None` | Analysis notes |
+| `priority` | `str` | `"normal"` | `"low"`, `"normal"`, or `"high"` |
+
+### check_dfm_status
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `job_id` | `str` | required | Job ID from `submit_dfm` |
+
+### quote_fabrication
+
+Get a PCB fabrication quote.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `project_id` | `str` | required | Project ID |
+| `quantity` | `int` | `5` | Number of boards |
+| `layers` | `int` | `2` | PCB layer count |
+| `thickness` | `float` | `1.6` | Board thickness in mm |
+| `surface_finish` | `str` | `"HASL"` | Surface finish (HASL, ENIG, OSP) |
+| `color` | `str` | `"green"` | Solder mask color (green, red, blue, black, white, yellow) |
+| `priority` | `str` | `"normal"` | `"low"`, `"normal"`, or `"high"` |
+
+### upload_gerbers_for_quote
+
+Upload gerber zip for fab quoting. **Local mode only.** Same parameters as `quote_fabrication` except uses `file_path` instead of `project_id`.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `file_path` | `str` | required | Path to gerber zip file |
+| `quantity` | `int` | `5` | Number of boards |
+| `layers` | `int` | `2` | PCB layer count |
+| `thickness` | `float` | `1.6` | Board thickness in mm |
+| `surface_finish` | `str` | `"HASL"` | Surface finish |
+| `color` | `str` | `"green"` | Solder mask color |
+| `priority` | `str` | `"normal"` | Priority level |
+
+### quote_assembly
+
+Combined fabrication + assembly quote. **Local mode only.** Uploads gerbers for fab and BOM for assembly costing. Polls BOM status internally to get `bom_id`, then calculates COGS.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `gerber_path` | `str` | required | Path to gerber zip |
+| `bom_path` | `str` | required | Path to BOM file |
+| `quantity` | `int` | `5` | Number of assemblies |
+| `layers` | `int` | `2` | PCB layer count |
+| `thickness` | `float` | `1.6` | Board thickness in mm |
+| `surface_finish` | `str` | `"HASL"` | Surface finish |
+| `color` | `str` | `"green"` | Solder mask color |
+| `priority` | `str` | `"normal"` | Priority level |
+
+### check_manufacturing_status
+
+Poll status of any manufacturing job (fab, DFM, AOI, QC).
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `job_id` | `str` | required | Job ID from any manufacturing submission |
+
+## Datasheet Tools
+
+### list_datasheet_sections
+
+Lightweight TOC extraction. Returns section titles and page numbers without reading content.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `file_path` | `str \| None` | `None` | Local PDF path (local mode) |
+| `sku` | `str \| None` | `None` | Part SKU for cached data |
+
+One of `file_path` or `sku` is required.
+
+**Returns:**
+
+```json
+{
+  "source": "STM32F411CEU6",
+  "total_pages": 196,
+  "sections": [
+    {"title": "Features", "page": 1},
+    {"title": "Electrical Characteristics", "page": 42},
+    {"title": "Absolute Maximum Ratings", "page": 55}
+  ],
+  "section_count": 28,
+  "success": true
+}
+```
+
+### read_datasheet
+
+Read and chunk a datasheet PDF with optional keyword filtering.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `file_path` | `str \| None` | `None` | Local PDF path |
+| `sku` | `str \| None` | `None` | Part SKU for cached chunks |
+| `query` | `str \| None` | `None` | Keywords to filter chunks (e.g., "maximum input voltage") |
+| `chunk_pages` | `int` | `5` | Pages per chunk |
+
+One of `file_path` or `sku` is required.
+
+**Returns:**
+
+```json
+{
+  "source": "STM32F411CEU6",
+  "total_pages": 196,
+  "method": "cached",
+  "toc": [{"title": "Features", "page": 1}],
+  "chunks": [
+    {
+      "text": "...chunk content...",
+      "start_page": 51,
+      "end_page": 55
+    }
+  ],
+  "query": "maximum input voltage",
+  "context_savings": {
+    "total_chunks": 40,
+    "returned_chunks": 3,
+    "total_chars": 250000,
+    "returned_chars": 18000,
+    "reduction_pct": 92.8
+  },
+  "success": true
+}
+```
+
+## KiCad Tools (Local Mode Only)
+
+### find_kicad_projects
+
+Discover `.kicad_pro` files in configured search paths. No parameters.
+
+**Returns:**
+
+```json
+{
+  "projects": [
+    {
+      "name": "my-board",
+      "path": "/home/user/projects/my-board/my-board.kicad_pro",
+      "modified": "2026-03-10T14:30:00"
+    }
+  ],
+  "total": 5,
+  "search_paths": ["/home/user/projects"]
+}
+```
+
+### extract_bom_from_kicad
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `project_path` | `str` | required | Path to `.kicad_pro` file |
+
+### analyze_kicad_project
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `project_path` | `str` | required | Path to `.kicad_pro` file |
+
+Returns file counts: total, schematics, PCBs, data files.
+
+### extract_netlist_from_project
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `project_path` | `str` | required | Path to `.kicad_pro` file |
+
+### match_components_to_parts
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `components` | `list[dict]` | required | Components from KiCad BOM extraction |
+| `auto_search` | `bool` | `True` | Auto-search for matching parts |
+
+### export_parts_to_kicad
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `parts` | `list[dict]` | required | Parts with: `reference`, `value`, `footprint`, `manufacturer`, `part_number`, `supplier`, `quantity`, `unit_price` |
+| `output_path` | `str` | required | Output file path |
+| `format` | `str` | `"csv"` | `"csv"` or `"json"` |
+
+### highlight_net_traces
+
+Render highlighted net traces as vector PDFs.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `project_path` | `str` | required | Path to `.kicad_pro` or `.kicad_pcb` |
+| `net_names` | `list[str]` | required | Net names to highlight |
+| `colors` | `dict \| None` | `None` | Color mapping `{"net_name": "#rrggbb"}` |
+| `mode` | `str` | `"both"` | `"overlay"`, `"traces_only"`, or `"both"` |
+| `output_dir` | `str \| None` | `None` | Output directory (defaults to project dir) |
+
+### open_in_kicad
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `project_path` | `str` | required | Path to KiCad project file |
+
+## Identification Tools
+
+### identify_pcb
+
+Identify PCB or component from a photo. **Local mode only.**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `file_path` | `str` | required | Image path (jpg, jpeg, png, gif, heic, webp) |
+| `project_id` | `str \| None` | `None` | Project to associate |
+| `box_id` | `str \| None` | `None` | Box/shipment to associate |
+
+### check_identification_status
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `job_id` | `str` | required | Job ID from `identify_pcb` |
+
+### get_identified_item
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `short_code` | `str` | required | Item short code (e.g., `SP-XXXXXX`) |
+
+## Error Patterns
+
+All tools return `{"success": false, "error": "message"}` on failure. Common errors:
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| `"API key not configured"` | Missing `SOURCE_PARTS_API_KEY` | Set env var |
+| `"File not found"` | Invalid `file_path` | Check path exists |
+| `"Unsupported file format"` | Wrong BOM extension | Use CSV, XLSX, XLS, JSON, or XML |
+| `"File too large"` | Exceeds 50 MB limit | Split or compress file |
+| `"Part not found"` | No match for part number | Try broader search or check spelling |
+| `"KiCad CLI not found"` | `kicad-cli` not in PATH | Install KiCad 8+ |

--- a/content/sourceparts/docs/parts-mcp/python/references/workflows.md
+++ b/content/sourceparts/docs/parts-mcp/python/references/workflows.md
@@ -1,0 +1,226 @@
+# Parts MCP — Workflow Recipes
+
+Multi-step workflows for common electronic sourcing tasks.
+
+## End-to-End PCB Sourcing (KiCad to Priced BOM)
+
+Complete workflow from a KiCad project to a fully priced bill of materials.
+
+```
+1. find_kicad_projects()
+   → Pick project from results
+
+2. extract_bom_from_kicad(project_path="...")
+   → Get component list from the project
+
+3. match_components_to_parts(components=bom_components, auto_search=True)
+   → Each component matched to real supplier parts
+
+4. For unmatched components:
+   search_parts(query=component_value)
+   → Manual search with value/footprint keywords
+
+5. check_availability(part_numbers=[all_matched_mpns], quantities=[all_quantities])
+   → Verify everything is in stock
+
+6. For unavailable parts:
+   find_alternatives(part_number=unavailable_mpn)
+   → Get drop-in replacements
+
+7. calculate_bom_cost(bom=final_parts_list, quantity=100)
+   → Total cost at production quantity
+
+8. export_parts_to_kicad(parts=sourced_parts, output_path="sourced_bom.csv")
+   → Export back for KiCad integration
+```
+
+## Obsolete Part Replacement
+
+When a part is end-of-life or unavailable, find and validate a replacement.
+
+```
+1. get_part_details(part_number="OBSOLETE-PART")
+   → Get specifications of the original part
+
+2. find_alternatives(
+     part_number="OBSOLETE-PART",
+     parameters={"package": "TSSOP-20", "voltage": "3.3V"}
+   )
+   → Find parts matching critical parameters
+
+3. For each alternative:
+   get_part_details(part_number=alternative_mpn)
+   → Verify specs match requirements
+
+4. compare_prices(part_number=best_alternative, quantity=needed_qty)
+   → Check pricing for the replacement
+
+5. check_availability(part_numbers=[best_alternative], quantities=[needed_qty])
+   → Confirm stock levels
+```
+
+## Multi-Board Assembly Quoting
+
+Get combined fab + assembly quotes for a multi-board product.
+
+```
+For each board:
+
+1. quote_assembly(
+     gerber_path="/path/to/board_gerbers.zip",
+     bom_path="/path/to/board_bom.csv",
+     quantity=100,
+     layers=4,
+     surface_finish="ENIG"
+   )
+   → Returns fab_job_id, bom_job_id
+
+2. check_manufacturing_status(job_id=fab_job_id)
+   → Poll until fab quote ready
+
+3. check_bom_status(job_id=bom_job_id)
+   → Poll until BOM processed, note unmatched parts
+
+4. For unmatched parts:
+   search_parts(query=part_description)
+   → Resolve manually
+
+Aggregate COGS across all boards for total assembly cost.
+```
+
+## Parametric Search with Filtering
+
+Find parts matching specific electrical parameters.
+
+```
+1. search_by_parameters(
+     parameters={
+       "capacitance": "100nF",
+       "voltage_rating": "50V",
+       "package": "0402",
+       "dielectric": "X7R"
+     },
+     category="capacitor"
+   )
+   → Parts matching all criteria
+
+2. For top candidates:
+   compare_prices(part_number=candidate, quantity=1000)
+   → Price at volume
+
+3. check_availability(part_numbers=top_3_candidates, quantities=[1000, 1000, 1000])
+   → Stock check across candidates
+
+4. Pick the best available option by price and stock.
+```
+
+## Datasheet Deep-Dive
+
+Extract specific parameters from a datasheet efficiently.
+
+```
+1. list_datasheet_sections(sku="LM1117-3.3")
+   → Get table of contents with page numbers
+   → Identify relevant sections (e.g., "Electrical Characteristics" on page 5)
+
+2. read_datasheet(
+     sku="LM1117-3.3",
+     query="dropout voltage output current thermal",
+     chunk_pages=5
+   )
+   → Returns only chunks matching keywords
+   → context_savings shows how much context was saved
+
+3. If you need a specific section not returned by query:
+   read_datasheet(
+     sku="LM1117-3.3",
+     query="absolute maximum ratings",
+     chunk_pages=3
+   )
+   → Targeted follow-up read
+```
+
+## DFM and Fabrication Pipeline
+
+Full manufacturing preparation workflow.
+
+```
+1. submit_dfm(project_id="proj_123", bom_id="bom_456", priority="high")
+   → Queue DFM analysis
+
+2. check_dfm_status(job_id=dfm_job_id)
+   → Poll until complete
+   → Review issues and warnings
+
+3. If DFM passes:
+   quote_fabrication(
+     project_id="proj_123",
+     quantity=10,
+     layers=2,
+     surface_finish="HASL",
+     color="green"
+   )
+   → Get fab pricing
+
+4. check_manufacturing_status(job_id=fab_job_id)
+   → Poll until quote ready
+
+5. For local gerber files:
+   upload_gerbers_for_quote(
+     file_path="/path/to/gerbers.zip",
+     quantity=10,
+     layers=2
+   )
+   → Alternative: upload gerbers directly
+```
+
+## PCB Identification and Cataloging
+
+Identify components on a physical PCB from photos.
+
+```
+1. identify_pcb(
+     file_path="/path/to/pcb_photo.jpg",
+     project_id="proj_123"
+   )
+   → Submits image for barcode/QR detection, OCR, component ID
+
+2. check_identification_status(job_id=id_job_id)
+   → Poll until identification complete
+
+3. For each identified item:
+   get_identified_item(short_code="SP-ABC123")
+   → Get full details including barcodes, OCR text, metadata
+
+4. For identified part numbers:
+   get_part_details(part_number=identified_mpn)
+   → Cross-reference with parts database
+```
+
+## BOM File Upload and Review
+
+Upload a BOM from any supported EDA tool and review matching results.
+
+```
+1. upload_bom(file_path="/path/to/altium_bom.xlsx")
+   → Accepts CSV, XLSX, XLS, JSON, XML
+   → Supports KiCad, Altium, Eagle, PADS, Fusion 360, Protel 99
+
+2. check_bom_status(job_id=bom_job_id)
+   → Poll until "complete"
+   → Returns matched_parts and unknown_parts
+
+3. For each unknown part:
+   search_parts(query=unknown["value"] + " " + unknown["footprint"])
+   → Try to resolve manually
+
+4. calculate_bom_cost(
+     bom=[
+       {"part_number": p["mpn"], "quantity": p["quantity"]}
+       for p in all_resolved_parts
+     ],
+     quantity=50,
+     preferred_suppliers=["LCSC", "Mouser"]
+   )
+   → Get total cost with supplier preferences
+```

--- a/content/sourceparts/skills/electronics-sourcing/SKILL.md
+++ b/content/sourceparts/skills/electronics-sourcing/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: electronics-sourcing
+description: "Guide for AI agents to source electronic components using parts-mcp — tool sequencing, decision patterns, and multi-step workflows"
+metadata:
+  revision: 1
+  updated-on: "2026-03-15"
+  source: maintainer
+  tags: "electronics,sourcing,bom,components,pcb,manufacturing,workflow"
+---
+
+# Electronics Sourcing Skill
+
+This skill teaches you how to source electronic components effectively using parts-mcp tools. It covers tool sequencing, decision patterns, and how to handle common scenarios.
+
+## When to Use Which Search Tool
+
+**`search_parts`** — Use when you have a part number, description, or general keywords. This is your default starting point.
+
+```
+"Find me a 100nF capacitor" → search_parts(query="100nF capacitor")
+"Look up STM32F411" → search_parts(query="STM32F411")
+```
+
+**`search_by_parameters`** — Use when you need to match specific electrical parameters within a category. More precise than keyword search.
+
+```
+"I need a 50V 100nF X7R 0402 cap" → search_by_parameters(
+  parameters={"capacitance": "100nF", "voltage": "50V", "dielectric": "X7R", "package": "0402"},
+  category="capacitor"
+)
+```
+
+**Decision rule**: If the user gives you 3+ specific parameters, use `search_by_parameters`. For part numbers or general queries, use `search_parts`.
+
+## The Search → Price → Availability → Alternative Pattern
+
+This is the core sourcing workflow. Follow this sequence:
+
+```
+1. SEARCH → Find the part
+2. DETAILS → Get full specifications (if needed for validation)
+3. PRICE → Compare across suppliers
+4. AVAILABILITY → Check stock levels
+5. ALTERNATIVE → Find replacements (only if price is too high or stock is insufficient)
+```
+
+Do not skip steps 3 and 4. A part that exists in the database may be out of stock or prohibitively expensive.
+
+When the user asks to "source" or "find" a part, they expect pricing and availability — not just search results. Always follow through to at least step 4.
+
+## BOM Processing Pattern
+
+BOM processing is asynchronous. Always follow this exact sequence:
+
+```
+1. upload_bom(file_path=path)           → Get job_id
+2. check_bom_status(job_id=job_id)      → Poll until status is "complete"
+3. Review matched_parts and unknown_parts
+4. For unmatched: search_parts() to resolve manually
+5. calculate_bom_cost() with all resolved parts
+```
+
+**Polling**: Call `check_bom_status` and check the `status` field. If `"in_progress"`, wait and poll again. Do not assume instant completion.
+
+**Handling unmatched parts**: When `unknown_parts` is not empty, try `search_parts` with the `value` and `footprint` fields as the query. If still unmatched, report them to the user — do not silently skip them.
+
+## Datasheet Reading Strategy
+
+Datasheets can be hundreds of pages. Always use this two-step approach:
+
+```
+1. list_datasheet_sections(sku="PART-NUMBER")
+   → See the table of contents
+   → Identify which sections contain what you need
+
+2. read_datasheet(sku="PART-NUMBER", query="relevant keywords")
+   → Read only matching chunks
+   → Saves significant context window
+```
+
+**Never** call `read_datasheet` without a `query` parameter unless the datasheet is short (< 20 pages). An unfiltered read of a 200-page datasheet will consume excessive context.
+
+**Keyword tips**: Use specific technical terms. "maximum input voltage absolute ratings" is better than "voltage". Multiple keywords narrow the results.
+
+## Manufacturing Pipeline
+
+Manufacturing operations (DFM, fab quoting, assembly) are all asynchronous:
+
+```
+submit_dfm() → check_dfm_status()       # DFM analysis
+quote_fabrication() → check_manufacturing_status()  # Fab quote
+quote_assembly() → polls internally      # Combined fab + assembly
+```
+
+**DFM first**: Always run DFM analysis before requesting a fabrication quote. DFM may reveal issues that affect manufacturability or cost.
+
+**Assembly quotes** combine fabrication and BOM costing in one call. Use `quote_assembly` when the user wants a complete per-unit cost including both PCB fabrication and component assembly.
+
+## Handling Partial Failures
+
+Real-world sourcing often has partial results. Handle gracefully:
+
+**Some parts not found in BOM**:
+- Report the unmatched count clearly
+- Attempt `search_parts` for each unmatched part
+- If still unmatched, list them for the user with their reference designators and values
+- Calculate cost for matched parts, noting the incomplete total
+
+**Some parts unavailable**:
+- Report which parts are out of stock
+- Automatically call `find_alternatives` for each unavailable part
+- Present alternatives with their specifications and pricing
+- Let the user decide on substitutions
+
+**Price comparison with missing suppliers**:
+- Report how many suppliers were checked
+- Note if key suppliers (the user's preferred ones) returned no results
+- Present available pricing data without waiting for all suppliers
+
+## KiCad Project Workflow
+
+When working with KiCad projects:
+
+```
+1. find_kicad_projects()                    → Discover available projects
+2. analyze_kicad_project(project_path=...)  → Understand project structure
+3. extract_bom_from_kicad(project_path=...) → Get component list
+4. match_components_to_parts(components=...) → Match to real parts
+5. Follow the BOM processing pattern above for unmatched components
+```
+
+**KiCad CLI requirement**: BOM extraction may invoke `kicad-cli` if no existing BOM file is found in the project. Ensure KiCad 8+ is installed.
+
+**Local mode only**: All KiCad tools require local mode (stdio transport). They are not available in hosted/HTTP mode.
+
+## Cost Optimization Tips
+
+When helping users optimize costs:
+
+1. **Check quantity breaks**: Call `compare_prices` with different quantities (1, 10, 100, 1000) to show price break curves
+2. **Suggest alternatives**: If a part is expensive, call `find_alternatives` and compare pricing
+3. **Preferred suppliers**: Use `preferred_suppliers` in `calculate_bom_cost` to bias toward the user's existing supplier relationships
+4. **Consolidation**: When multiple parts come from the same supplier, note the potential for consolidated shipping
+
+## Response Patterns
+
+**When a user asks to "source a part"**:
+→ `search_parts` → `get_part_details` → `compare_prices` → `check_availability`
+Present: part details, best price, stock status, and any concerns.
+
+**When a user provides a BOM file**:
+→ `upload_bom` → poll `check_bom_status` → report matched/unmatched → `calculate_bom_cost`
+Present: match rate, unmatched items, total cost, per-line breakdown.
+
+**When a user asks "is this in stock?"**:
+→ `check_availability` with quantities
+Present: stock levels, number of suppliers with stock, whether quantity is meetable.
+
+**When a user asks about a datasheet**:
+→ `list_datasheet_sections` → `read_datasheet` with targeted query
+Present: the specific information requested, citing page numbers.
+
+**When a user asks for a manufacturing quote**:
+→ `submit_dfm` (if not already done) → `quote_fabrication` or `quote_assembly`
+Present: DFM issues (if any), estimated cost, lead time.


### PR DESCRIPTION
## Summary

Adds documentation for [parts-mcp](https://pypi.org/project/parts-mcp/) — a production MCP server for electronic component sourcing. This covers a domain (electronics/EDA/PCB) not yet represented in context-hub.

**parts-mcp** (v0.1.3, MIT, Python 3.10+) is a thin client wrapping the [Source Parts API](https://source.parts) that enables AI agents to:

- **Search** electronic components across suppliers
- **Compare prices** and check real-time **availability**
- **Process BOMs** from 6 EDA tools (KiCad, Altium, Eagle, PADS, Fusion 360, Protel 99)
- **Read datasheets** with query-filtered chunking (saves agent context)
- **Submit DFM analysis** and get fabrication/assembly quotes
- **Integrate with KiCad** — project discovery, BOM extraction, component matching, net trace highlighting

### Files added

| File | Lines | Purpose |
|------|-------|---------|
| `content/sourceparts/docs/parts-mcp/python/DOC.md` | ~400 | Main documentation: installation, config, tool reference, core workflows |
| `.../references/tools.md` | ~370 | Complete parameter reference for all 30 tools with types, defaults, and return structures |
| `.../references/workflows.md` | ~200 | Multi-step recipes: KiCad-to-priced-BOM, obsolete part replacement, assembly quoting, datasheet deep-dives |
| `content/sourceparts/skills/electronics-sourcing/SKILL.md` | ~150 | Agent skill teaching tool sequencing, decision patterns, and partial failure handling |

### Validation

```
$ chub build content/sourceparts/ --validate-only
Valid: 1 docs, 1 skills, 0 warnings
```

Full build passes: `Built: 1545 docs, 6 skills`

### Notes

- **Maintainer-sourced**: We maintain both the MCP server and the underlying API
- **Includes a skill**: Teaches agents optimal tool sequencing (search → price → availability → alternative) and how to handle partial failures — particularly useful for BOM processing where some parts may not match
- **Two transport modes**: stdio (local, full functionality including KiCad/file tools) and HTTP (hosted, API-only tools)