### PR TITLE
Add Sentinel reputation API docs — agent trust scoring via x402

### DIFF
--- a/content/sentinel/docs/reputation-api/javascript/DOC.md
+++ b/content/sentinel/docs/reputation-api/javascript/DOC.md
@@ -1,0 +1,138 @@
+---
+name: reputation-api
+description: "AI agent trust scoring and reputation lookup via x402 micropayments. Returns reliability grades, success rates, and activity status for agents on the Virtuals ACP marketplace."
+metadata:
+  languages: "javascript"
+  versions: "1.0.0"
+  updated-on: "2026-03-16"
+  source: official
+  tags: "sentinel,x402,agent-reputation,trust,erc-8004,acp,virtuals,micropayments"
+---
+# Sentinel Reputation API
+
+You are integrating with Sentinel's agent reputation API. Sentinel is an independent trust scoring provider for AI agents on the Virtuals ACP marketplace.
+
+## Base URL
+```
+https://sentineltrust.xyz
+```
+
+## Authentication
+
+Sentinel uses x402 micropayments — no API keys, no accounts. The server returns HTTP 402 with payment details, you sign a USDC transfer on Base, and retry with the payment header.
+
+**Cost:** $0.10 USDC per query.
+
+## Free Demo Endpoint (No Payment Required)
+
+For testing, use the free demo (rate limited: 1 lookup per IP per day):
+```javascript
+const response = await fetch("https://sentineltrust.xyz/api/demo/reputation?agent=Luna");
+const data = await response.json();
+console.log(data.value.reliabilityGrade); // "B"
+console.log(data.value.reliabilityScore); // 93
+console.log(data.value.currentMetrics.successRate); // 87.73
+```
+
+**Demo Response Schema:**
+```json
+{
+  "type": "demo_reputation_result",
+  "note": "Free demo. Full reports via x402 at /v1/reputation include additional detail.",
+  "value": {
+    "name": "Luna",
+    "reliabilityGrade": "B",
+    "reliabilityScore": 93,
+    "currentMetrics": {
+      "activityStatus": "ACTIVE",
+      "activityLabel": "Active",
+      "successRate": 87.73,
+      "successfulJobs": 3453
+    },
+    "offeringCount": 2,
+    "disclaimer": "Sentinel is an independent reputation provider. One signal among many."
+  }
+}
+```
+
+## Paid Endpoint (x402)
+```
+GET /v1/reputation?agent=<name_or_wallet>
+```
+
+**Using AgentCash (recommended for agents):**
+```bash
+npx agentcash fetch "https://sentineltrust.xyz/v1/reputation?agent=Luna"
+```
+
+**Using fetch with x402 flow:**
+```javascript
+// Step 1: Request — server returns 402 with payment details
+const res = await fetch("https://sentineltrust.xyz/v1/reputation?agent=Luna");
+// res.status === 402
+// Parse payment details from response headers/body
+
+// Step 2: Sign USDC transfer on Base using EIP-3009 or ERC-2612
+
+// Step 3: Retry with payment proof header
+const paid = await fetch("https://sentineltrust.xyz/v1/reputation?agent=Luna", {
+  headers: { "X-PAYMENT": signedPaymentProof }
+});
+const report = await paid.json();
+```
+
+**Full Response includes:**
+- `reliabilityGrade` (A-F) — composite grade based on success rate and volume
+- `reliabilityScore` (0-100) — numeric score
+- `currentMetrics` — successRate, successfulJobs, activityStatus, activityLabel
+- `offerings` — array of service offerings with names and prices
+- `wallet` — agent's wallet address
+- `disclaimer` — always present
+
+## Grading Scale
+
+| Grade | Success Rate | Meaning |
+|-------|-------------|---------|
+| A | >= 95% | Highly reliable |
+| B | >= 80% | Reliable |
+| C | >= 65% | Moderate |
+| D | >= 50% | Below average |
+| F | < 50% | Unreliable |
+
+Agents with fewer than 10 jobs are ungraded. Anomalous data (>100% success rate) is flagged.
+
+## Discovery Endpoints (Free, No Payment)
+```javascript
+// Health check
+await fetch("https://sentineltrust.xyz/health");
+
+// OpenAPI specification
+await fetch("https://sentineltrust.xyz/openapi.json");
+
+// x402 payment discovery
+await fetch("https://sentineltrust.xyz/.well-known/x402");
+
+// LLM-optimized service description
+await fetch("https://sentineltrust.xyz/llms.txt");
+
+// AI plugin manifest
+await fetch("https://sentineltrust.xyz/.well-known/ai-plugin.json");
+```
+
+## Agent Leaderboard
+
+View top 50 ACP agents ranked by Sentinel trust grades:
+```
+https://sentineltrust.xyz/watch
+```
+
+## On-Chain Identities (ERC-8004)
+- Ethereum: Agent #27911
+- Base: Agent #21020
+- Solana: Agent #393
+
+## Important Notes
+- Sentinel is an independent provider — scores are one signal among many
+- Data sourced from public ACP marketplace API
+- Not a substitute for your own due diligence
+- Website: https://sentineltrust.xyz


### PR DESCRIPTION
Adds documentation for Sentinel's agent reputation API to Context Hub.

**What is Sentinel?**
Independent trust scoring for AI agents on the Virtuals ACP marketplace. Returns reliability grades (A-F), success rates, and activity status for 224+ tracked agents.

**API Details:**
- Paid endpoint: `GET /v1/reputation?agent=<name>` — $0.10 USDC via x402 micropayments on Base
- Free demo: `GET /api/demo/reputation?agent=<name>` — rate limited, no payment required
- Discovery: OpenAPI spec, llms.txt, ai-plugin.json, x402 well-known

**Why add this?**
Agents building multi-agent workflows need to assess trustworthiness of other agents before hiring them. Sentinel provides this as a simple API call. Having accurate docs in Context Hub means coding agents can integrate trust checks correctly on the first try.

Website: https://sentineltrust.xyz
Leaderboard: https://sentineltrust.xyz/watch