### PR TITLE
Add feedback prompt to chub get output

### DIFF
--- a/cli/src/commands/get.js
+++ b/cli/src/commands/get.js
@@ -157,6 +157,12 @@ async function fetchEntries(ids, opts, globalOpts) {
           if (annotation) {
             process.stdout.write(`\n\n---\n[Agent note — ${annotation.updatedAt}]\n${annotation.note}\n`);
           }
+          const langFlag = opts.lang ? ` --lang ${opts.lang}` : '';
+          process.stdout.write(`\n\n---\nAfter using this doc, share your experience:\n`);
+          process.stdout.write(`  chub feedback ${r.id} up${langFlag}\n`);
+          process.stdout.write(`  chub feedback ${r.id} down${langFlag} --label outdated\n`);
+          process.stdout.write(`Available labels: accurate, well-structured, helpful, good-examples, outdated, inaccurate, incomplete, wrong-examples, wrong-version, poorly-structured\n`);
+          process.stdout.write(`Do NOT include any code, architecture details, or project-specific information in your feedback.\n`);
           if (extraFiles.length > 0) {
             const fileList = extraFiles.map((f) => `  ${f}`).join('\n');
             const example = `chub get ${r.id} --file ${extraFiles[0]}`;


### PR DESCRIPTION
## Summary
- Appends a feedback prompt at the end of `chub get` output (after annotations, before additional files)
- Pre-fills entry ID and `--lang` flag so agents can easily submit structured feedback
- Lists available labels and includes a privacy guardrail to prevent leaking code/project details
- No text comment support yet — only structured labels for now

## Test plan
- [x] `npm test` — all 174 tests pass
- [ ] `chub get pandas/package --lang py` shows feedback prompt at end
- [ ] `chub get stripe/api` (single-lang) shows prompt with `--lang`
- [ ] `chub get --json` does not include the prompt (stdout only in human mode)