### PR TITLE
Bump version to 0.1.3

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aisuite/chub",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "CLI for Context Hub - search and retrieve LLM-optimized docs and skills",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump CLI version from 0.1.2 to 0.1.3 for npm publish (includes feedback prompt on `chub get`)

## Test plan
- [ ] Verify `chub -V` outputs 0.1.3
- [ ] Publish to npm after merge