### PR TITLE
Add LetsFG MCP server docs - flight search and booking

### DIFF
--- a/_pr_body.md
+++ b/_pr_body.md
@@ -1,0 +1,22 @@
+## What
+
+Adds curated documentation for the [LetsFG](https://github.com/LetsFG/LetsFG) MCP server.
+
+**LetsFG** is an MCP server for live flight search and booking across 400+ airlines. It runs 102 direct airline connectors locally via Playwright (Ryanair, EasyJet, Wizz Air, Southwest, AirAsia, Norwegian, and more) — no API key needed. An optional API key adds GDS/NDC sources (Amadeus, Duffel, Sabre, Travelport).
+
+### Content added
+
+- `content/letsfg/docs/mcp/javascript/DOC.md` — Full MCP tool reference including:
+  - Installation and MCP client configuration
+  - All 8 tools documented (search_flights, resolve_location, unlock_flight_offer, book_flight, start_checkout, setup_payment, get_agent_profile, system_info)
+  - Response structures with JSON examples
+  - Typical agent flow (search → unlock → book)
+  - List of 102 covered airlines
+  - Python SDK alternative
+
+### Package info
+
+- npm: [letsfg-mcp](https://www.npmjs.com/package/letsfg-mcp) (v1.0.2)
+- PyPI: [letsfg](https://pypi.org/project/letsfg/) (v1.0.6)
+- GitHub: [LetsFG/LetsFG](https://github.com/LetsFG/LetsFG)
+- Source: maintainer

--- a/content/letsfg/docs/mcp/javascript/DOC.md
+++ b/content/letsfg/docs/mcp/javascript/DOC.md
@@ -1,17 +1,17 @@
 ---
 name: mcp
-description: "MCP server for live flight search across 400+ airlines. 75 direct airline connectors run locally (no API key), plus GDS/NDC sources (Amadeus, Duffel, Sabre) with optional API key. Search, compare, unlock, and book flights."
+description: "MCP server for live flight search across 400+ airlines. 102 direct airline connectors run locally (no API key), plus GDS/NDC sources (Amadeus, Duffel, Sabre) with optional API key. Search, compare, unlock, and book flights."
 metadata:
   languages: "javascript"
-  versions: "1.0.1"
-  revision: 1
-  updated-on: "2026-03-16"
+  versions: "1.0.2"
+  revision: 2
+  updated-on: "2026-03-18"
   source: maintainer
   tags: "letsfg,mcp,flights,travel,airlines,booking,search"
 ---
 # LetsFG MCP Server
 
-MCP server for real-time flight search and booking. 75 airline connectors run locally via Playwright (Ryanair, EasyJet, Wizz Air, Southwest, AirAsia, Norwegian, and 69 more). Optional API key adds GDS/NDC sources (Amadeus, Duffel, Sabre, Travelport) covering 400+ airlines total.
+MCP server for real-time flight search and booking. 102 airline connectors run locally via Playwright (Ryanair, EasyJet, Wizz Air, Southwest, AirAsia, Norwegian, Qatar Airways, LATAM, Finnair, and 93 more). Optional API key adds GDS/NDC sources (Amadeus, Duffel, Sabre, Travelport) covering 400+ airlines total.
 
 ## Installation
 
@@ -55,7 +55,7 @@ Add to your MCP client config (Claude Desktop, VS Code, Cursor, etc.):
 
 ### search_flights
 
-Search live flight availability and prices. Fires 75 airline connectors in parallel on the local machine — no API key needed.
+Search live flight availability and prices. Fires 102 airline connectors in parallel on the local machine — no API key needed.
 
 ```javascript
 // Minimal search
@@ -244,9 +244,9 @@ Use this to determine optimal `max_browsers` for `search_flights`.
    OR → start_checkout(off_abc, checkout_token) for manual completion
 ```
 
-## Covered Airlines (75 Local Connectors)
+## Covered Airlines (102 Local Connectors)
 
-Ryanair, EasyJet, Wizz Air, Norwegian, Vueling, Transavia, Eurowings, Volotea, Pegasus, SunExpress, Condor, airBaltic, Play, SmartWings, Flyr, AirAsia, Scoot, Cebu Pacific, IndiGo, SpiceJet, Spring Airlines, Lucky Air, 9 Air, Jeju Air, T'way Air, Peach, Jetstar, Southwest, Spirit, Frontier, Allegiant, JetBlue, Avelo, Sun Country, Flair, WestJet, Porter, Flybondi, JetSMART, Viva Aerobus, Volaris, SKY Airline, Azul, GOL, Copa, LATAM, Jazeera Airways, flynas, Air Arabia, Salam Air, flydubai, Emirates, Cathay Pacific, ANA, Singapore Airlines, Turkish Airlines, Biman Bangladesh, US-Bangla, Batik Air, Nok Air, Lion Air, Thai AirAsia, VietJet, Bamboo Airways, FlySafair, fastjet, Air Austral, Fiji Airways, Rex Airlines, and more.
+Ryanair, EasyJet, Wizz Air, Norwegian, Vueling, Transavia, Eurowings, Volotea, Pegasus, SunExpress, Condor, airBaltic, Play, SmartWings, Flyr, AirAsia, Scoot, Cebu Pacific, IndiGo, SpiceJet, Spring Airlines, Lucky Air, 9 Air, Jeju Air, T'way Air, Peach, Jetstar, Southwest, Spirit, Frontier, Allegiant, JetBlue, Avelo, Sun Country, Flair, WestJet, Porter, Flybondi, JetSMART, Viva Aerobus, Volaris, SKY Airline, Azul, GOL, Copa, LATAM, Jazeera Airways, flynas, Air Arabia, Salam Air, flydubai, Emirates, Cathay Pacific, ANA, Singapore Airlines, Turkish Airlines, Biman Bangladesh, US-Bangla, Batik Air, Nok Air, Lion Air, Thai AirAsia, VietJet, Bamboo Airways, FlySafair, fastjet, Air Austral, Fiji Airways, Rex Airlines, Qantas, Virgin Australia, Bangkok Airways, Qatar Airways, Air Canada, Air India, Finnair, SAS, Aegean, Aer Lingus, ITA Airways, TAP Portugal, Icelandair, EgyptAir, Ethiopian, Kenya Airways, Royal Air Maroc, South African Airways, JAL, Air New Zealand, Garuda Indonesia, Philippine Airlines, LOT Polish, Arajet, Wingo, Avianca, and more.
 
 With `LETSFG_API_KEY`, adds GDS/NDC sources covering 400+ airlines including all major full-service carriers.
 


### PR DESCRIPTION
## What

Adds curated documentation for the [LetsFG](https://github.com/LetsFG/LetsFG) MCP server.

**LetsFG** is an MCP server for live flight search and booking across 400+ airlines. It runs 75 direct airline connectors locally via Playwright (Ryanair, EasyJet, Wizz Air, Southwest, AirAsia, Norwegian, and more) — no API key needed. An optional API key adds GDS/NDC sources (Amadeus, Duffel, Sabre, Travelport).

### Content added

- `content/letsfg/docs/mcp/javascript/DOC.md` — Full MCP tool reference including:
  - Installation and MCP client configuration
  - All 8 tools documented (search_flights, resolve_location, unlock_flight_offer, book_flight, start_checkout, setup_payment, get_agent_profile, system_info)
  - Response structures with JSON examples
  - Typical agent flow (search → unlock → book)
  - List of 75 covered airlines
  - Python SDK alternative

### Package info

- npm: [letsfg-mcp](https://www.npmjs.com/package/letsfg-mcp) (v1.0.1)
- PyPI: [letsfg](https://pypi.org/project/letsfg/) (v1.0.2)
- GitHub: [LetsFG/LetsFG](https://github.com/LetsFG/LetsFG)
- Source: maintainer
