### PR TITLE
Add Anysite API docs and skills

### DIFF
--- a/content/anysite/docs/crunchbase/python/DOC.md
+++ b/content/anysite/docs/crunchbase/python/DOC.md
@@ -1,0 +1,206 @@
+---
+name: crunchbase
+description: "Extract Crunchbase company profiles, funding rounds, employee data, and search companies"
+metadata:
+  languages: "python"
+  versions: "0.0.1"
+  revision: 1
+  updated-on: "2026-03-16"
+  source: community
+  tags: "startup,funding,valuation,investor,venture-capital,techcrunch"
+---
+
+# Crunchbase API Coding Guidelines (Python)
+
+You are a Crunchbase API coding expert. Help me write Python code using the Anysite REST API for Crunchbase data extraction.
+
+API documentation: https://api.anysite.io/docs
+
+## Golden Rule: All Endpoints Use POST with JSON Body
+
+- **Base URL:** `https://api.anysite.io`
+- **Method:** All endpoints use `POST`
+- **Auth:** Pass your API key in the `access-token` header
+- **Content-Type:** `application/json`
+- **Identifiers:** Companies use slugs, names, or URLs
+
+## Authentication
+
+```python
+import requests
+
+BASE_URL = "https://api.anysite.io"
+API_KEY = "your-api-key"  # Use env vars in production
+
+HEADERS = {
+    "access-token": API_KEY,
+    "Content-Type": "application/json"
+}
+
+
+def anysite_post(endpoint: str, payload: dict) -> dict:
+    """Make a POST request to the Anysite API."""
+    response = requests.post(
+        f"{BASE_URL}{endpoint}",
+        headers=HEADERS,
+        json=payload
+    )
+    response.raise_for_status()
+    return response.json()
+```
+
+Store your API key in an environment variable:
+
+```python
+import os
+API_KEY = os.environ["ANYSITE_API_KEY"]
+```
+
+## Crunchbase Endpoints
+
+### Get Crunchbase Company
+
+Retrieve detailed company information from Crunchbase. Costs 20 credits.
+
+**POST** `/api/crunchbase/company`
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `company` | string | Yes | Company slug, name, or Crunchbase URL |
+
+```python
+result = anysite_post("/api/crunchbase/company", {
+    "company": "openai"
+})
+
+company = result[0]
+print(company["name"])
+print(company["short_description"])
+print(company["founded_on"])
+print(company["employee_count_range"])
+print(company["website"])
+print(company["categories"])
+print(company["location"]["city"], company["location"]["country"])
+print(company["contacts"]["email"])
+```
+
+**Key response fields (`CrunchbaseCompany`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Crunchbase entity ID |
+| `name` | string | Company name |
+| `alias` | string | Company slug |
+| `url` | string | Crunchbase profile URL |
+| `short_description` | string | Brief company description |
+| `description` | string | Detailed company description |
+| `legal_name` | string | Legal entity name |
+| `founded_on` | string | Founding date |
+| `employee_count_range` | string | Employee count range (e.g. `"5001-10000"`) |
+| `revenue_range` | string | Revenue range estimate (may be null) |
+| `website` | string | Company website |
+| `operating_status` | string | Active, closed, etc. |
+| `company_type` | string | Company type (e.g. `"for_profit"`) |
+| `ipo_status` | string | IPO status (`"private"`, `"public"`) |
+| `categories` | array | Industry categories |
+| `location` | object | Location with `city`, `region`, `country`, `country_code`, `continent`, `groups` |
+| `contacts` | object | Contact info with `email`, `phone`, `facebook_url`, `linkedin_url`, `twitter_url`, `num_contacts` |
+| `logo_url` | string | Company logo URL |
+
+### Search Crunchbase Companies
+
+Search Crunchbase companies by filters. Costs 20 credits per 50 results.
+
+**POST** `/api/crunchbase/search`
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `keywords` | array or string | No | Search keywords |
+| `count` | integer | Yes | Number of results to return |
+| `location` | array or string | No | Location filter |
+| `industry` | array or string | No | Industry filter |
+| `employee_count_min` | integer | No | Minimum employee count |
+| `employee_count_max` | integer | No | Maximum employee count |
+| `funding_total_min` | integer | No | Minimum total funding (USD) |
+| `funding_total_max` | integer | No | Maximum total funding (USD) |
+| `last_funding_type` | array or string | No | Last funding round type filter |
+| `founded_after` | string | No | Founded after date |
+| `founded_before` | string | No | Founded before date |
+
+```python
+results = anysite_post("/api/crunchbase/search", {
+    "keywords": ["artificial intelligence", "healthcare"],
+    "count": 20
+})
+
+for company in results:
+    print(company["name"])
+    print(company["short_description"])
+    print(company["employee_count_range"])
+    print(company["location"]["city"], company["location"]["country"])
+    print("---")
+```
+
+**Key response fields (`CrunchbaseSearchCompany`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Crunchbase entity ID |
+| `name` | string | Company name |
+| `alias` | string | Company slug |
+| `url` | string | Crunchbase profile URL |
+| `cb_rank` | integer | Crunchbase rank |
+| `short_description` | string | Brief description |
+| `description` | string | Detailed description |
+| `employee_count_range` | string | Employee count range (e.g. `"1001-5000"`) |
+| `categories` | array | Industry categories |
+| `founded_on` | string | Founding date |
+| `location` | object | Location with `city`, `region`, `country`, etc. |
+| `logo_url` | string | Company logo URL |
+
+## Error Handling
+
+```python
+import requests
+
+
+def anysite_post_safe(endpoint: str, payload: dict) -> dict | None:
+    try:
+        response = requests.post(
+            f"{BASE_URL}{endpoint}",
+            headers=HEADERS,
+            json=payload,
+            timeout=60
+        )
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.HTTPError as e:
+        status = e.response.status_code
+        if status == 401:
+            print("Invalid or missing access-token")
+        elif status == 422:
+            print("Validation error:", e.response.json())
+        elif status == 429:
+            print("Rate limit exceeded - wait and retry")
+        elif status >= 500:
+            print("Server error - retry later")
+        else:
+            print(f"HTTP {status}:", e.response.text)
+        return None
+    except requests.exceptions.Timeout:
+        print("Request timed out")
+        return None
+```
+
+### Common Error Codes
+
+| Status Code | Meaning | Action |
+|---|---|---|
+| 401 | Invalid or missing `access-token` header | Check your API key |
+| 422 | Validation error (bad parameters) | Check parameter names and types |
+| 429 | Rate limit exceeded | Back off and retry |
+| 500 | Server error | Retry after a delay |
+
+## Optional Request Header
+
+All endpoints accept an optional `x-request-id` header (UUID format) for request tracing and deduplication.

--- a/content/anysite/docs/instagram-api/python/DOC.md
+++ b/content/anysite/docs/instagram-api/python/DOC.md
@@ -1,0 +1,365 @@
+---
+name: instagram-api
+description: "Extract Instagram profiles, posts, reels, comments, likes, and search content"
+metadata:
+  languages: "python"
+  versions: "0.0.1"
+  revision: 1
+  updated-on: "2026-03-16"
+  source: community
+  tags: "scraping,stories,followers,engagement,hashtag,media"
+---
+
+# Anysite Instagram API Coding Guidelines (Python)
+
+You are an Anysite Instagram API coding expert. Help me write Python code using the Anysite REST API for Instagram data extraction.
+
+API documentation: https://api.anysite.io/docs
+
+## Golden Rule: All Endpoints Use POST with JSON Body
+
+- **Base URL:** `https://api.anysite.io`
+- **Method:** All endpoints use `POST`
+- **Auth:** Pass your API key in the `access-token` header
+- **Content-Type:** `application/json`
+- **Identifiers:** Instagram entities use usernames, post shortcodes, or full URLs
+
+## Authentication
+
+```python
+import requests
+
+BASE_URL = "https://api.anysite.io"
+API_KEY = "your-api-key"  # Use env vars in production
+
+HEADERS = {
+    "access-token": API_KEY,
+    "Content-Type": "application/json"
+}
+
+
+def anysite_post(endpoint: str, payload: dict) -> dict:
+    """Make a POST request to the Anysite Instagram API."""
+    response = requests.post(
+        f"{BASE_URL}{endpoint}",
+        headers=HEADERS,
+        json=payload
+    )
+    response.raise_for_status()
+    return response.json()
+```
+
+Store your API key in an environment variable:
+
+```python
+import os
+API_KEY = os.environ["ANYSITE_API_KEY"]
+```
+
+## Endpoints
+
+### Get User Profile
+
+Retrieve an Instagram user profile by username. Costs 1 credit.
+
+**POST** `/api/instagram/user`
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `user` | string | Yes | Instagram username |
+| `with_creation_date` | boolean | No | Include account creation date (default: false) |
+
+```python
+result = anysite_post("/api/instagram/user", {
+    "user": "natgeo"
+})
+
+user = result[0]
+print(user["alias"])
+print(user["name"])
+print(user["description"])
+print(user["follower_count"])
+print(user["following_count"])
+print(user["media_count"])
+print(user["is_verified"])
+print(user["image"])
+```
+
+**Key response fields (`InstagramUser`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `alias` | string | Instagram handle |
+| `name` | string | Display name |
+| `description` | string | Bio text |
+| `follower_count` | integer | Number of followers |
+| `following_count` | integer | Number of accounts followed |
+| `media_count` | integer | Total number of posts |
+| `is_verified` | boolean | Blue check verification status |
+| `is_private` | boolean | Whether account is private |
+| `is_business` | boolean | Whether account is a business account |
+| `image` | string | Profile picture URL |
+| `url` | string | Profile URL |
+| `external_url` | string | Link in bio |
+| `id` | string | Instagram user ID |
+| `category` | string | Account category (e.g. "Media") |
+| `email` | string | Contact email (if available) |
+| `phone` | string | Contact phone (if available) |
+| `whatsapp_number` | string | WhatsApp number (if available) |
+| `location` | object | User location info |
+| `links` | array | Bio links |
+| `mentions` | array | Bio mentions |
+| `hashtags` | array | Bio hashtags |
+| `created_at` | string | Account creation date (if requested) |
+
+### Get User Followers or Following
+
+Retrieve a user's followers or following list. Costs 1 credit per 25 results.
+
+**POST** `/api/instagram/user/friendships`
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `user` | string | Yes | Username or user ID |
+| `type` | string | Yes | `"followers"` or `"following"` |
+| `count` | integer | Yes | Number of results to return |
+
+```python
+followers = anysite_post("/api/instagram/user/friendships", {
+    "user": "natgeo",
+    "type": "followers",
+    "count": 50
+})
+
+for follower in followers:
+    print(follower["alias"], "-", follower["name"])
+    print(follower["is_verified"])
+```
+
+**Key response fields (`InstagramUserPreview`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `alias` | string | Instagram handle |
+| `name` | string | Display name |
+| `image` | string | Profile picture URL |
+| `is_verified` | boolean | Verification status |
+| `is_private` | boolean | Whether account is private |
+| `id` | string | Instagram user ID |
+
+### Get User Posts
+
+Retrieve posts from an Instagram user's feed. Costs 1 credit per 12 results.
+
+**POST** `/api/instagram/user/posts`
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `user` | string | Yes | Username or user ID |
+| `count` | integer | Yes | Number of posts to return |
+
+```python
+posts = anysite_post("/api/instagram/user/posts", {
+    "user": "natgeo",
+    "count": 12
+})
+
+for post in posts:
+    print(post["code"])
+    print(post["text"])
+    print(post["like_count"], "likes")
+    print(post["comment_count"], "comments")
+```
+
+### Get User Reels
+
+Retrieve reels from an Instagram user. Costs 1 credit per 12 results.
+
+**POST** `/api/instagram/user/reels`
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `user` | string | Yes | Username or user ID |
+| `count` | integer | Yes | Number of reels to return |
+
+```python
+reels = anysite_post("/api/instagram/user/reels", {
+    "user": "natgeo",
+    "count": 12
+})
+
+for reel in reels:
+    print(reel["code"])
+    print(reel["text"])
+    print(reel["url"])
+    print(reel["like_count"], "likes")
+```
+
+### Get Post
+
+Retrieve a single Instagram post by its ID or shortcode. Costs 1 credit.
+
+**POST** `/api/instagram/post`
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `post` | string | Yes | Post shortcode or media ID |
+
+```python
+result = anysite_post("/api/instagram/post", {
+    "post": "CxLp3AAMet6"
+})
+
+post = result[0]
+print(post["code"])
+print(post["text"])
+print(post["like_count"], "likes")
+print(post["comment_count"], "comments")
+print(post["user"]["name"])
+print(post["created_at"])
+```
+
+**Key response fields (`InstagramPost`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Media ID (format: `{media_id}_{user_id}`) |
+| `code` | string | Post shortcode (used in URLs) |
+| `url` | string | Full post URL |
+| `image` | string | Image/thumbnail URL |
+| `text` | string | Post caption text |
+| `created_at` | integer | Unix timestamp of post creation |
+| `like_count` | integer | Number of likes |
+| `comment_count` | integer | Number of comments |
+| `reshare_count` | integer | Number of shares |
+| `view_count` | integer | Number of views (null for non-video) |
+| `user` | object | Author info (`@instagram_user_preview` with `id`, `name`, `alias`) |
+| `type` | string | Type of media (`"clips"`, `"image"`, `"carousel"`, etc.) |
+| `media` | array | Attached media objects |
+
+### Get Post Comments
+
+Retrieve comments on an Instagram post. Costs 1 credit per 15 results.
+
+**POST** `/api/instagram/post/comments`
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `post` | string | Yes | Post shortcode or media ID |
+| `count` | integer | Yes | Number of comments to return |
+
+```python
+comments = anysite_post("/api/instagram/post/comments", {
+    "post": "CxLp3AAMet6",
+    "count": 30
+})
+
+for comment in comments:
+    print(comment["user"]["alias"], ":", comment["text"])
+    print(comment["like_count"], "likes")
+    print(comment["created_at"])
+```
+
+**Key response fields (`InstagramComment`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `text` | string | Comment text |
+| `user` | object | Commenter info (`@instagram_user_preview` with `id`, `name`, `alias`) |
+| `like_count` | integer | Number of likes on the comment |
+| `created_at` | integer | Unix timestamp |
+| `id` | string | Comment ID |
+
+### Get Post Likes
+
+Retrieve users who liked a post. Costs 1 credit per 100 results.
+
+**POST** `/api/instagram/post/likes`
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `post` | string | Yes | Post shortcode or media ID |
+| `count` | integer | Yes | Number of results to return |
+
+```python
+likers = anysite_post("/api/instagram/post/likes", {
+    "post": "CxLp3AAMet6",
+    "count": 100
+})
+
+for user in likers:
+    print(user["alias"], "-", user["name"])
+```
+
+Returns an array of `InstagramUserPreview` (same schema as followers/following).
+
+### Search Posts
+
+Search Instagram posts by query. Costs 1 credit per 30 results.
+
+**POST** `/api/instagram/search/posts`
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `query` | string | Yes | - | Search query (hashtag, keyword) |
+| `count` | integer | Yes | - | Number of results to return |
+
+```python
+results = anysite_post("/api/instagram/search/posts", {
+    "query": "climate change",
+    "count": 30
+})
+
+for post in results:
+    print(post["code"], "-", post["text"][:80])
+    print(post["like_count"], "likes")
+```
+
+Returns an array of `InstagramPost`.
+
+## Error Handling
+
+```python
+import requests
+
+
+def anysite_post_safe(endpoint: str, payload: dict) -> dict | None:
+    try:
+        response = requests.post(
+            f"{BASE_URL}{endpoint}",
+            headers=HEADERS,
+            json=payload,
+            timeout=60
+        )
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.HTTPError as e:
+        status = e.response.status_code
+        if status == 401:
+            print("Invalid or missing access-token")
+        elif status == 422:
+            print("Validation error:", e.response.json())
+        elif status == 429:
+            print("Rate limit exceeded - wait and retry")
+        elif status >= 500:
+            print("Server error - retry later")
+        else:
+            print(f"HTTP {status}:", e.response.text)
+        return None
+    except requests.exceptions.Timeout:
+        print("Request timed out")
+        return None
+```
+
+### Common Error Codes
+
+| Status Code | Meaning | Action |
+|---|---|---|
+| 401 | Invalid or missing `access-token` header | Check your API key |
+| 422 | Validation error (bad parameters) | Check parameter names and types |
+| 429 | Rate limit exceeded | Back off and retry |
+| 500 | Server error | Retry after a delay |
+
+## Optional Request Header
+
+All endpoints accept an optional `x-request-id` header (UUID format) for request tracing and deduplication.

--- a/content/anysite/docs/linkedin-company/python/DOC.md
+++ b/content/anysite/docs/linkedin-company/python/DOC.md
@@ -1,0 +1,170 @@
+---
+name: linkedin-company
+description: "Extract LinkedIn company profiles, employee statistics, workforce data, and company posts"
+metadata:
+  languages: "python"
+  versions: "0.0.1"
+  revision: 1
+  updated-on: "2026-03-16"
+  source: community
+  tags: "organization,employer,headcount,hiring,corporate"
+---
+
+# Anysite LinkedIn Company API (Python)
+
+You are an Anysite LinkedIn API coding expert. Help me write Python code to extract LinkedIn company profiles, employee statistics, workforce data, and company posts.
+
+API documentation: https://api.anysite.io/docs
+
+## Golden Rule: All Endpoints Use POST with JSON Body
+
+- **Base URL:** `https://api.anysite.io`
+- **Method:** All endpoints use `POST`
+- **Auth:** Pass your API key in the `access-token` header
+- **Content-Type:** `application/json`
+- **Identifiers:** LinkedIn companies use a single `company` parameter that accepts URNs (e.g., `company:1035`), aliases (URL slugs), or full URLs
+
+## Authentication
+
+```python
+import requests
+import os
+
+BASE_URL = "https://api.anysite.io"
+API_KEY = os.environ["ANYSITE_API_KEY"]
+
+HEADERS = {
+    "access-token": API_KEY,
+    "Content-Type": "application/json"
+}
+
+
+def anysite_post(endpoint: str, payload: dict) -> dict:
+    """Make a POST request to the Anysite LinkedIn API."""
+    response = requests.post(
+        f"{BASE_URL}{endpoint}",
+        headers=HEADERS,
+        json=payload
+    )
+    response.raise_for_status()
+    return response.json()
+```
+
+## Common Operations
+
+### Get Company Info
+
+Fetch company details by passing a `company` identifier (alias, URL, or URN). Returns company profile with description, employee count, locations, and website.
+
+```python
+result = anysite_post("/api/linkedin/company", {
+    "company": "microsoft"
+})
+
+company = result[0]
+print(company["name"])
+print(company["employee_count"])
+print(company["website"])
+print(company["urn"])  # object: {"type": "fsd_company", "value": "1035"}
+```
+
+### Get Employee Stats
+
+Retrieve employee distribution statistics by location, function, seniority, and growth trends.
+
+```python
+stats = anysite_post("/api/linkedin/company/employee_stats", {
+    "urn": {"type": "company", "value": "1035"}
+})
+
+for loc in stats[0]["locations"]:
+    print(loc["name"], "-", loc["count"])
+```
+
+### Get Company Posts
+
+Retrieve posts from a company page.
+
+```python
+posts = anysite_post("/api/linkedin/company/posts", {
+    "urn": {"type": "company", "value": "1035"},
+    "count": 10
+})
+
+for post in posts:
+    print(post["url"])
+    print(post["share_url"])
+    print(post["author"]["name"])
+    print(post["created_at"])
+```
+
+### Get Company Employees
+
+Retrieve a list of employees for one or more companies. Cost: 150 credits per 100 results.
+
+```python
+employees = anysite_post("/api/linkedin/company/employees", {
+    "companies": ["company:1035"],
+    "count": 50
+})
+
+for emp in employees:
+    print(emp["name"])
+    print(emp["urn"])   # {"type": "fsd_profile", "value": "..."}
+    print(emp["url"])
+    print(emp["image"])
+```
+
+## Error Handling
+
+```python
+def anysite_post_safe(endpoint: str, payload: dict) -> dict | None:
+    try:
+        response = requests.post(
+            f"{BASE_URL}{endpoint}",
+            headers=HEADERS,
+            json=payload,
+            timeout=60
+        )
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.HTTPError as e:
+        status = e.response.status_code
+        if status == 401:
+            print("Invalid or missing access-token")
+        elif status == 422:
+            print("Validation error:", e.response.json())
+        elif status == 429:
+            print("Rate limit exceeded - wait and retry")
+        elif status >= 500:
+            print("Server error - retry later")
+        else:
+            print(f"HTTP {status}:", e.response.text)
+        return None
+    except requests.exceptions.Timeout:
+        print("Request timed out")
+        return None
+```
+
+| Status Code | Meaning | Action |
+|---|---|---|
+| 401 | Invalid or missing `access-token` header | Check your API key |
+| 422 | Validation error (bad parameters) | Check parameter names and types |
+| 429 | Rate limit exceeded | Back off and retry |
+| 500 | Server error | Retry after a delay |
+
+### URN Formats
+
+| Entity | URN Format | Example |
+|---|---|---|
+| Company | `company:{id}` | `company:1035` |
+
+## Optional Request Header
+
+All endpoints accept an optional `x-request-id` header (UUID format) for request tracing and deduplication.
+
+## Reference
+
+Detailed endpoint documentation with full parameter tables and response schemas:
+
+- [Company Endpoints](references/company-endpoints.md) - 4 endpoints for company profiles, employees, posts, and stats

--- a/content/anysite/docs/linkedin-company/python/references/company-endpoints.md
+++ b/content/anysite/docs/linkedin-company/python/references/company-endpoints.md
@@ -1,0 +1,160 @@
+# LinkedIn Company Endpoints
+
+All endpoints: `POST` to `https://api.anysite.io`. Require `access-token` header.
+
+---
+
+## Get Company
+
+**`POST /api/linkedin/company`**
+
+Retrieve company profile by alias, URL, or URN. Cost: 1 credit.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `company` | string | yes | Company slug, full LinkedIn company URL, or URN (e.g., `microsoft` or `company:1035`) |
+
+### Example
+
+```python
+result = anysite_post("/api/linkedin/company", {
+    "company": "microsoft"
+})
+company = result[0]
+print(company["name"])
+print("Employees:", company["employee_count"])
+print("URN:", company["urn"]["type"], company["urn"]["value"])
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Company name |
+| `urn` | object | Company URN object with `type` (e.g. `"fsd_company"`) and `value` (e.g. `"1035"`) |
+| `alias` | string | URL slug |
+| `url` | string | LinkedIn company URL |
+| `description` | string | Company description |
+| `short_description` | string | Brief company description |
+| `employee_count` | integer | Total employees |
+| `website` | string | Company website |
+| `locations` | array | Office locations (objects with `name`, `is_headquarter`, `location`, `postal_code`, `country_code`, `city`, `latitude`, `longitude`) |
+| `founded_on` | string | Founding date |
+| `phone` | string | Company phone number |
+| `logo_url` | string | Logo image URL |
+| `organizational_urn` | string | Organizational URN |
+| `page_verification_status` | string | Page verification status |
+
+---
+
+## Get Company Employee Stats
+
+**`POST /api/linkedin/company/employee_stats`**
+
+Retrieve employee distribution statistics by function, seniority, and growth trends. Cost: 1 credit.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `urn` | object | yes | Company URN object, e.g. `{"type": "company", "value": "1035"}` |
+
+### Example
+
+```python
+stats = anysite_post("/api/linkedin/company/employee_stats", {
+    "urn": {"type": "company", "value": "1035"}
+})
+for loc in stats[0]["locations"]:
+    print(loc["name"], "-", loc["count"])
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `locations` | array | Employee count by location (objects with `name` and `count`) |
+
+---
+
+## Get Company Employees
+
+**`POST /api/linkedin/company/employees`**
+
+Retrieve a list of employees for one or more companies. Cost: 150 credits per 100 results.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `companies` | array[string] | yes | List of company URNs in format `company:{id}` |
+| `count` | integer | yes | Max results to return |
+| `keywords` | string | no | Filter employees by keyword |
+| `first_name` | string | no | Filter by first name |
+| `last_name` | string | no | Filter by last name |
+
+### Example
+
+```python
+employees = anysite_post("/api/linkedin/company/employees", {
+    "companies": ["company:1035"],
+    "count": 50
+})
+for emp in employees:
+    print(emp["name"])
+    print(emp["urn"])   # {"type": "fsd_profile", "value": "..."}
+    print(emp["url"])
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Employee name |
+| `urn` | object | User URN object with `type` (e.g. `"fsd_profile"`) and `value` |
+| `internal_id` | object | Internal ID object with `type` (e.g. `"member"`) and `value` |
+| `url` | string | LinkedIn profile URL |
+| `image` | string | Profile image URL |
+
+---
+
+## Get Company Posts
+
+**`POST /api/linkedin/company/posts`**
+
+Retrieve posts from a company page. Supports date filtering. Cost: 1 credit per 10 results.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `urn` | object | yes | Company URN object, e.g. `{"type": "company", "value": "1035"}` |
+| `count` | integer | yes | Max results to return |
+
+### Example
+
+```python
+posts = anysite_post("/api/linkedin/company/posts", {
+    "urn": {"type": "company", "value": "1035"},
+    "count": 10
+})
+for post in posts:
+    print(post["url"])
+    print(post["share_url"])
+    print(post["author"]["name"])
+    print(post["created_at"])
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `urn` | object | Post URN object with `type` and `value` |
+| `url` | string | Post URL |
+| `share_url` | string | Shareable post URL |
+| `author` | object | Author object with `name`, `url`, etc. |
+| `created_at` | integer | Post timestamp (unix) |
+| `share_urn` | string | Share URN |
+| `is_empty_repost` | boolean | Whether this is an empty repost |

--- a/content/anysite/docs/linkedin-search/python/DOC.md
+++ b/content/anysite/docs/linkedin-search/python/DOC.md
@@ -1,0 +1,196 @@
+---
+name: linkedin-search
+description: "Search LinkedIn users, companies, jobs, posts, industries, and locations with filters"
+metadata:
+  languages: "python"
+  versions: "0.0.1"
+  revision: 1
+  updated-on: "2026-03-16"
+  source: community
+  tags: "find,lookup,filter,people,recruitment,discovery"
+---
+
+# Anysite LinkedIn Search API (Python)
+
+You are an Anysite LinkedIn API coding expert. Help me write Python code to search LinkedIn users, companies, jobs, posts, industries, and locations.
+
+API documentation: https://api.anysite.io/docs
+
+## Golden Rule: All Endpoints Use POST with JSON Body
+
+- **Base URL:** `https://api.anysite.io`
+- **Method:** All endpoints use `POST`
+- **Auth:** Pass your API key in the `access-token` header
+- **Content-Type:** `application/json`
+
+## Authentication
+
+```python
+import requests
+import os
+
+BASE_URL = "https://api.anysite.io"
+API_KEY = os.environ["ANYSITE_API_KEY"]
+
+HEADERS = {
+    "access-token": API_KEY,
+    "Content-Type": "application/json"
+}
+
+
+def anysite_post(endpoint: str, payload: dict) -> dict:
+    """Make a POST request to the Anysite LinkedIn API."""
+    response = requests.post(
+        f"{BASE_URL}{endpoint}",
+        headers=HEADERS,
+        json=payload
+    )
+    response.raise_for_status()
+    return response.json()
+```
+
+## Common Operations
+
+### Search Users
+
+Search LinkedIn users with filters. Returns paginated results (1 credit per 10 results).
+
+```python
+results = anysite_post("/api/linkedin/search/users", {
+    "keywords": "machine learning",
+    "title": "Engineer",
+    "location": "San Francisco",
+    "current_company": "Google",
+    "count": 20
+})
+
+for user in results:
+    print(user["name"], "-", user["headline"])
+    print(user["urn"])
+```
+
+### Search Companies
+
+Search for companies by keyword. Supports location, industry, and employee count filters.
+
+```python
+results = anysite_post("/api/linkedin/search/companies", {
+    "keywords": "artificial intelligence",
+    "location": "San Francisco",
+    "employee_count": ["51-200", "201-500"],
+    "count": 20
+})
+
+for company in results:
+    print(company["name"], "-", company["alias"])
+```
+
+### Search Jobs
+
+Search for LinkedIn job postings. Cost: 1 credit per 25 results.
+
+```python
+jobs = anysite_post("/api/linkedin/search/jobs", {
+    "keywords": "python developer",
+    "location": "New York",
+    "count": 25
+})
+
+for job in jobs:
+    print(job["title"], "at", job["company_name"])
+    print(job["location"])
+```
+
+### Search Posts
+
+Search for LinkedIn posts by keyword. Cost: 1 credit per 50 results.
+
+```python
+posts = anysite_post("/api/linkedin/search/posts", {
+    "keywords": "generative AI startups",
+    "count": 20
+})
+
+for post in posts:
+    print(post["author_name"], ":", post["text"][:100])
+```
+
+### Helper Searches (Educations, Industries, Locations)
+
+Use these to get URN filter values for the main search endpoints:
+
+```python
+# Search educational institutions
+schools = anysite_post("/api/linkedin/search/educations", {
+    "name": "Stanford", "count": 10
+})
+
+# Search industries
+industries = anysite_post("/api/linkedin/search/industries", {
+    "name": "software", "count": 10
+})
+
+# Search locations
+locations = anysite_post("/api/linkedin/search/locations", {
+    "name": "San Francisco", "count": 10
+})
+```
+
+## Pagination
+
+Endpoints that return lists use a `count` parameter to control how many results to return:
+
+```python
+results = anysite_post("/api/linkedin/search/users", {
+    "keywords": "data scientist",
+    "count": 50
+})
+```
+
+## Error Handling
+
+```python
+def anysite_post_safe(endpoint: str, payload: dict) -> dict | None:
+    try:
+        response = requests.post(
+            f"{BASE_URL}{endpoint}",
+            headers=HEADERS,
+            json=payload,
+            timeout=60
+        )
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.HTTPError as e:
+        status = e.response.status_code
+        if status == 401:
+            print("Invalid or missing access-token")
+        elif status == 422:
+            print("Validation error:", e.response.json())
+        elif status == 429:
+            print("Rate limit exceeded - wait and retry")
+        elif status >= 500:
+            print("Server error - retry later")
+        else:
+            print(f"HTTP {status}:", e.response.text)
+        return None
+    except requests.exceptions.Timeout:
+        print("Request timed out")
+        return None
+```
+
+| Status Code | Meaning | Action |
+|---|---|---|
+| 401 | Invalid or missing `access-token` header | Check your API key |
+| 422 | Validation error (bad parameters) | Check parameter names and types |
+| 429 | Rate limit exceeded | Back off and retry |
+| 500 | Server error | Retry after a delay |
+
+## Optional Request Header
+
+All endpoints accept an optional `x-request-id` header (UUID format) for request tracing and deduplication.
+
+## Reference
+
+Detailed endpoint documentation with full parameter tables and response schemas:
+
+- [Search Endpoints](references/search-endpoints.md) - 7 endpoints for searching users, companies, jobs, posts, and more

--- a/content/anysite/docs/linkedin-search/python/references/search-endpoints.md
+++ b/content/anysite/docs/linkedin-search/python/references/search-endpoints.md
@@ -1,0 +1,287 @@
+# LinkedIn Search Endpoints
+
+All endpoints: `POST` to `https://api.anysite.io`. Require `access-token` header.
+
+---
+
+## Search Companies
+
+**`POST /api/linkedin/search/companies`**
+
+Search for LinkedIn companies. Cost: 1 credit per 10 results.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `keywords` | string | no | Search keywords (company name, industry, etc.) |
+| `location` | array or string | no | Location filter |
+| `industry` | array or string | no | Industry filter |
+| `employee_count` | array[string] | no | Employee count filter. Values: `"1-10"`, `"11-50"`, `"51-200"`, `"201-500"`, `"501-1000"`, `"1001-5000"`, `"5001-10000"`, `"10001+"` |
+| `count` | integer | yes | Max results to return |
+
+### Example
+
+```python
+results = anysite_post("/api/linkedin/search/companies", {
+    "keywords": "artificial intelligence",
+    "location": "San Francisco",
+    "employee_count": ["51-200", "201-500"],
+    "count": 20
+})
+for company in results:
+    print(company["name"], "-", company["alias"])
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Company name |
+| `alias` | string | Company URL slug |
+| `url` | string | LinkedIn company URL |
+| `urn` | object | Company URN object with `type` and `value` |
+| `image` | string | Company logo URL |
+| `industry` | string | Company industry |
+
+---
+
+## Search Educations
+
+**`POST /api/linkedin/search/educations`**
+
+Search for educational institutions (for use as filter values). Cost: 1 credit.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Search keywords (school name) |
+| `count` | integer | yes | Max results to return |
+
+### Example
+
+```python
+results = anysite_post("/api/linkedin/search/educations", {
+    "name": "Stanford",
+    "count": 10
+})
+for school in results:
+    print(school["name"], "-", school["urn"])
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Institution name |
+| `urn` | string | Education URN |
+
+---
+
+## Search Industries
+
+**`POST /api/linkedin/search/industries`**
+
+Search for LinkedIn industries (for use as filter values). Cost: 1 credit.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Search keywords (industry name) |
+| `count` | integer | yes | Max results to return |
+
+### Example
+
+```python
+results = anysite_post("/api/linkedin/search/industries", {
+    "name": "software",
+    "count": 10
+})
+for industry in results:
+    print(industry["name"], "-", industry["urn"])
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Industry name |
+| `urn` | string | Industry URN |
+
+---
+
+## Search Jobs
+
+**`POST /api/linkedin/search/jobs`**
+
+Search for LinkedIn job postings. Cost: 1 credit per 25 results.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `keywords` | string | no | Search keywords (job title, skill, etc.) |
+| `location` | string | no | Location filter (default: `"worldwide"`) |
+| `industry` | array or string | no | Industry filter |
+| `company` | array | no | Company filter |
+| `experience_level` | array | no | Experience level filter |
+| `job_types` | array | no | Job type filter |
+| `work_types` | array | no | Work type filter (remote, on-site, etc.) |
+| `sort` | string | no | Sort order |
+| `count` | integer | yes | Max results to return |
+
+### Example
+
+```python
+jobs = anysite_post("/api/linkedin/search/jobs", {
+    "keywords": "python developer",
+    "location": "New York",
+    "count": 25
+})
+for job in jobs:
+    print(job["title"], "at", job["company_name"])
+    print(job["location"])
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `title` | string | Job title |
+| `company_name` | string | Hiring company |
+| `company_urn` | string | Company URN |
+| `location` | string | Job location |
+| `url` | string | Job posting URL |
+| `posted_at` | string | Posting date |
+| `description` | string | Job description snippet |
+
+---
+
+## Search Locations
+
+**`POST /api/linkedin/search/locations`**
+
+Search for LinkedIn locations (for use as filter values). Cost: 1 credit.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Search keywords (city, region, country) |
+| `count` | integer | yes | Max results to return |
+
+### Example
+
+```python
+results = anysite_post("/api/linkedin/search/locations", {
+    "name": "San Francisco",
+    "count": 10
+})
+for loc in results:
+    print(loc["name"], "-", loc["urn"])
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Location name |
+| `urn` | string | Location URN |
+
+---
+
+## Search Posts
+
+**`POST /api/linkedin/search/posts`**
+
+Search for LinkedIn posts by keyword. Cost: 1 credit per 50 results.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `keywords` | string | no | Search keywords |
+| `sort` | string | no | Sort order (default: `"relevance"`) |
+| `date_posted` | string | no | Date filter (default: `"past-month"`) |
+| `content_type` | string | no | Filter by content type |
+| `author_title` | string | no | Filter by author's title |
+| `count` | integer | yes | Max results to return |
+
+### Example
+
+```python
+posts = anysite_post("/api/linkedin/search/posts", {
+    "keywords": "generative AI startups",
+    "count": 20
+})
+for post in posts:
+    print(post["author_name"], ":", post["text"][:100])
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `urn` | string | Post URN |
+| `text` | string | Post content |
+| `author_name` | string | Author name |
+| `author_urn` | string | Author URN |
+| `num_likes` | integer | Like count |
+| `num_comments` | integer | Comment count |
+| `created_at` | string | Post timestamp |
+
+---
+
+## Search Users
+
+**`POST /api/linkedin/search/users`**
+
+Search for LinkedIn users with multiple filters. Cost: 1 credit per 10 results.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `keywords` | string | no | General search keywords |
+| `first_name` | string | no | Filter by first name |
+| `last_name` | string | no | Filter by last name |
+| `title` | string | no | Filter by job title |
+| `company_keywords` | string | no | Filter by company keywords |
+| `school_keywords` | string | no | Filter by school/education keywords |
+| `current_company` | array or string | no | Filter by current company (URN or name) |
+| `past_company` | array or string | no | Filter by past company (URN or name) |
+| `location` | array or string | no | Filter by location |
+| `industry` | array or string | no | Filter by industry |
+| `education` | array or string | no | Filter by education institution |
+| `count` | integer | yes | Max results to return |
+
+### Example
+
+```python
+results = anysite_post("/api/linkedin/search/users", {
+    "keywords": "machine learning",
+    "title": "Senior Engineer",
+    "current_company": "Google",
+    "location": "San Francisco Bay Area",
+    "count": 20
+})
+for user in results:
+    print(user["name"], "-", user["headline"])
+    print(user["urn"])
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Full name |
+| `alias` | string | Username slug |
+| `url` | string | LinkedIn profile URL |
+| `urn` | object | User URN object with `type` (e.g. `"fsd_profile"`) and `value` |
+| `internal_id` | object | Internal ID object with `type` (e.g. `"member"`) and `value` |
+| `headline` | string | Profile headline |
+| `location` | string | Location |
+| `image` | string | Avatar URL |
+| `open_to_work` | boolean | Whether user is open to work |

--- a/content/anysite/docs/linkedin-user/python/DOC.md
+++ b/content/anysite/docs/linkedin-user/python/DOC.md
@@ -1,0 +1,195 @@
+---
+name: linkedin-user
+description: "Extract LinkedIn profiles, work history, education, skills, posts, comments, and reactions"
+metadata:
+  languages: "python"
+  versions: "0.0.1"
+  revision: 1
+  updated-on: "2026-03-16"
+  source: community
+  tags: "scraping,profile,experience,education,employment,resume"
+---
+
+# Anysite LinkedIn User & Posts API (Python)
+
+You are an Anysite LinkedIn API coding expert. Help me write Python code to extract LinkedIn user profiles, work history, education, skills, posts, comments, and reactions.
+
+API documentation: https://api.anysite.io/docs
+
+## Golden Rule: All Endpoints Use POST with JSON Body
+
+- **Base URL:** `https://api.anysite.io`
+- **Method:** All endpoints use `POST`
+- **Auth:** Pass your API key in the `access-token` header
+- **Content-Type:** `application/json`
+- **Identifiers:** LinkedIn entities use a single `user` or `urn` parameter that accepts URNs (e.g., `fsd_profile:ACoAABXy1234`), aliases (URL slugs), or full URLs
+
+## Authentication
+
+```python
+import requests
+import os
+
+BASE_URL = "https://api.anysite.io"
+API_KEY = os.environ["ANYSITE_API_KEY"]
+
+HEADERS = {
+    "access-token": API_KEY,
+    "Content-Type": "application/json"
+}
+
+
+def anysite_post(endpoint: str, payload: dict) -> dict:
+    """Make a POST request to the Anysite LinkedIn API."""
+    response = requests.post(
+        f"{BASE_URL}{endpoint}",
+        headers=HEADERS,
+        json=payload
+    )
+    response.raise_for_status()
+    return response.json()
+```
+
+## Common Operations
+
+### Get User Profile
+
+Retrieve a full LinkedIn profile by passing a `user` identifier (alias, URL, or URN). Toggle sections with boolean flags to reduce response size and credit cost (1-9 credits depending on sections).
+
+```python
+result = anysite_post("/api/linkedin/user", {
+    "user": "williamhgates",
+    "with_experience": True,
+    "with_education": True,
+    "with_skills": True,
+    "with_honors": False,
+    "with_certificates": False,
+    "with_languages": False,
+    "with_patents": False,
+    "with_description_and_top_skills": True
+})
+
+user = result[0]
+print(user["name"])
+print(user["headline"])
+print(user["urn"])  # object: {"type": "fsd_profile", "value": "ACoAABXy1234"}
+```
+
+The `user` parameter accepts an alias (URL slug), full LinkedIn profile URL, or URN:
+
+```python
+result = anysite_post("/api/linkedin/user", {
+    "user": "https://www.linkedin.com/in/williamhgates"
+})
+```
+
+### Get User Experience
+
+Retrieve work history for a user by URN. Returns an array of positions.
+
+```python
+experience = anysite_post("/api/linkedin/user/experience", {
+    "urn": "fsd_profile:ACoAABXy1234",
+    "count": 50
+})
+
+for position in experience:
+    print(position["company_name"], "-", position["title"])
+    print(position["start_date"], "to", position.get("end_date", "Present"))
+```
+
+### Get Post
+
+Retrieve a LinkedIn post by URN or URL. Returns post content, author info, and engagement metrics.
+
+```python
+result = anysite_post("/api/linkedin/post", {
+    "urn": "activity:7234173400267538433"
+})
+
+post = result[0]
+print(post["text"])
+print(post["num_likes"], "likes")
+print(post["num_comments"], "comments")
+```
+
+### Get Post Comments
+
+Retrieve comments on a post. Paginated with `count` (1 credit per 10 results).
+
+```python
+comments = anysite_post("/api/linkedin/post/comments", {
+    "urn": "activity:7234173400267538433",
+    "count": 20
+})
+
+for comment in comments:
+    print(comment["author_name"], ":", comment["text"])
+```
+
+## Pagination
+
+Endpoints that return lists use a `count` parameter to control how many results to return:
+
+```python
+posts = anysite_post("/api/linkedin/user/posts", {
+    "urn": "fsd_profile:ACoAABXy1234",
+    "count": 50
+})
+```
+
+## Error Handling
+
+```python
+def anysite_post_safe(endpoint: str, payload: dict) -> dict | None:
+    try:
+        response = requests.post(
+            f"{BASE_URL}{endpoint}",
+            headers=HEADERS,
+            json=payload,
+            timeout=60
+        )
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.HTTPError as e:
+        status = e.response.status_code
+        if status == 401:
+            print("Invalid or missing access-token")
+        elif status == 422:
+            print("Validation error:", e.response.json())
+        elif status == 429:
+            print("Rate limit exceeded - wait and retry")
+        elif status >= 500:
+            print("Server error - retry later")
+        else:
+            print(f"HTTP {status}:", e.response.text)
+        return None
+    except requests.exceptions.Timeout:
+        print("Request timed out")
+        return None
+```
+
+| Status Code | Meaning | Action |
+|---|---|---|
+| 401 | Invalid or missing `access-token` header | Check your API key |
+| 422 | Validation error (bad parameters) | Check parameter names and types |
+| 429 | Rate limit exceeded | Back off and retry |
+| 500 | Server error | Retry after a delay |
+
+### URN Formats
+
+| Entity | URN Format | Example |
+|---|---|---|
+| User profile | `fsd_profile:{id}` | `fsd_profile:ACoAABXy1234` |
+| Post/Activity | `activity:{id}` | `activity:7234173400267538433` |
+
+## Optional Request Header
+
+All endpoints accept an optional `x-request-id` header (UUID format) for request tracing and deduplication.
+
+## Reference
+
+Detailed endpoint documentation with full parameter tables and response schemas:
+
+- [User Endpoints](references/user-endpoints.md) - 12 endpoints for profiles, experience, education, skills, posts, and more
+- [Post Endpoints](references/post-endpoints.md) - 4 endpoints for post details, comments, reactions, and reposts

--- a/content/anysite/docs/linkedin-user/python/references/post-endpoints.md
+++ b/content/anysite/docs/linkedin-user/python/references/post-endpoints.md
@@ -1,0 +1,155 @@
+# LinkedIn Post Endpoints
+
+All endpoints: `POST` to `https://api.anysite.io`. Require `access-token` header.
+
+---
+
+## Get Post
+
+**`POST /api/linkedin/post`**
+
+Retrieve a LinkedIn post by URN or URL. Cost: 1 credit.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `urn` | string | yes | Post URN (e.g., `activity:7234173400267538433`) |
+| `include_all_document_images` | boolean | no | Include all images from document posts (default: false) |
+
+### Example
+
+```python
+post = anysite_post("/api/linkedin/post", {
+    "urn": "activity:7234173400267538433"
+})
+print(post["text"])
+print(f"{post['num_likes']} likes, {post['num_comments']} comments")
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `urn` | string | Post URN |
+| `text` | string | Post content |
+| `author_name` | string | Author display name |
+| `author_urn` | string | Author URN |
+| `num_likes` | integer | Total like count |
+| `num_comments` | integer | Comment count |
+| `num_shares` | integer | Share/repost count |
+| `created_at` | string | Timestamp |
+| `reactions` | object | Breakdown by type (LIKE, CELEBRATE, LOVE, etc.) |
+| `images` | array | Attached image URLs |
+| `article_url` | string | Linked article URL (if any) |
+
+---
+
+## Get Post Comments
+
+**`POST /api/linkedin/post/comments`**
+
+Retrieve comments on a post. Cost: 1 credit per 10 results.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `urn` | string | yes | Post URN |
+| `count` | integer | yes | Max results to return |
+| `sort` | string | no | Sort order (default: `"recent"`) |
+
+### Example
+
+```python
+comments = anysite_post("/api/linkedin/post/comments", {
+    "urn": "activity:7234173400267538433",
+    "count": 20
+})
+for comment in comments:
+    print(comment["author_name"], ":", comment["text"])
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `text` | string | Comment text |
+| `author_name` | string | Commenter name |
+| `author_urn` | string | Commenter URN |
+| `created_at` | string | Timestamp |
+| `num_likes` | integer | Likes on the comment |
+| `reply_count` | integer | Number of replies |
+
+---
+
+## Get Post Reactions
+
+**`POST /api/linkedin/post/reactions`**
+
+Retrieve users who reacted to a post. Cost: 1 credit per 10 results.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `urn` | string | yes | Post URN |
+| `count` | integer | yes | Max results to return |
+
+### Example
+
+```python
+reactions = anysite_post("/api/linkedin/post/reactions", {
+    "urn": "activity:7234173400267538433",
+    "count": 50
+})
+for reaction in reactions:
+    print(reaction["name"], "-", reaction["reaction_type"])
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Reactor's name |
+| `urn` | string | Reactor's URN |
+| `headline` | string | Reactor's headline |
+| `reaction_type` | string | LIKE, CELEBRATE, LOVE, INSIGHTFUL, CURIOUS, FUNNY |
+
+---
+
+## Get Post Reposts
+
+**`POST /api/linkedin/post/reposts`**
+
+Retrieve reposts (shares) of a post. Cost: 1 credit per 10 results.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `urn` | string | yes | Post URN |
+| `count` | integer | yes | Max results to return |
+
+### Example
+
+```python
+reposts = anysite_post("/api/linkedin/post/reposts", {
+    "urn": "activity:7234173400267538433",
+    "count": 20
+})
+for repost in reposts:
+    print(repost["author_name"], "reposted")
+    print(repost.get("text", "(no added text)"))
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `urn` | string | Repost URN |
+| `text` | string | Added commentary (if any) |
+| `author_name` | string | Reposter's name |
+| `author_urn` | string | Reposter's URN |
+| `created_at` | string | Repost timestamp |
+| `num_likes` | integer | Likes on the repost |

--- a/content/anysite/docs/linkedin-user/python/references/user-endpoints.md
+++ b/content/anysite/docs/linkedin-user/python/references/user-endpoints.md
@@ -1,0 +1,458 @@
+# LinkedIn User Endpoints
+
+All endpoints: `POST` to `https://api.anysite.io`. Require `access-token` header.
+
+---
+
+## Get User Profile
+
+**`POST /api/linkedin/user`**
+
+Retrieve a full LinkedIn user profile. Cost: 1-9 credits depending on included sections.
+
+### Parameters
+
+| Name | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `user` | string | yes | - | LinkedIn username slug, full profile URL, or URN (e.g., `williamhgates`) |
+| `with_experience` | boolean | no | `true` | Include work experience |
+| `with_education` | boolean | no | `true` | Include education history |
+| `with_honors` | boolean | no | `true` | Include honors and awards |
+| `with_certificates` | boolean | no | `true` | Include certifications |
+| `with_languages` | boolean | no | `true` | Include languages |
+| `with_patents` | boolean | no | `true` | Include patents |
+| `with_skills` | boolean | no | `true` | Include skills |
+| `with_description_and_top_skills` | boolean | no | `true` | Include profile summary and top skills |
+| `fast_mode` | boolean | no | `false` | Skip some enrichment for faster response |
+
+### Example
+
+```python
+result = anysite_post("/api/linkedin/user", {
+    "user": "williamhgates",
+    "with_experience": True,
+    "with_education": True,
+    "with_skills": True,
+    "with_honors": False,
+    "with_certificates": False,
+    "with_languages": False,
+    "with_patents": False
+})
+user = result[0]
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Full name |
+| `headline` | string | Profile headline |
+| `urn` | object | User URN object with `type` (e.g. `"fsd_profile"`) and `value` |
+| `alias` | string | Username slug |
+| `url` | string | LinkedIn profile URL |
+| `location` | string | Location |
+| `description` | string | Profile summary |
+| `image` | string | Avatar URL |
+| `experience` | array | Work positions (if requested) |
+| `education` | array | Education entries (if requested) |
+| `skills` | array | Skills list (if requested) |
+| `honors` | array | Awards (if requested) |
+| `certificates` | array | Certifications (if requested) |
+| `languages` | array | Languages (if requested) |
+| `patents` | array | Patents (if requested) |
+
+---
+
+## Get User Certificates
+
+**`POST /api/linkedin/user/certificates`**
+
+Retrieve certifications for a user. Cost: 1 credit.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `urn` | string | yes | User URN (e.g., `fsd_profile:ACoAABXy1234`) |
+| `count` | integer | yes | Max results to return |
+
+### Example
+
+```python
+certs = anysite_post("/api/linkedin/user/certificates", {
+    "urn": "fsd_profile:ACoAABXy1234",
+    "count": 50
+})
+for cert in certs:
+    print(cert["name"], "-", cert["authority"])
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Certificate name |
+| `authority` | string | Issuing organization |
+| `license_number` | string | License/credential ID |
+| `url` | string | Certificate URL |
+| `start_date` | string | Issue date |
+| `end_date` | string | Expiry date |
+
+---
+
+## Get User Comments
+
+**`POST /api/linkedin/user/comments`**
+
+Retrieve comments posted by a user. Cost: 1 credit per 10 results.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `urn` | string | yes | User URN |
+| `count` | integer | yes | Max results to return |
+| `commented_after` | integer | no | Unix timestamp; only return comments after this time |
+
+### Example
+
+```python
+comments = anysite_post("/api/linkedin/user/comments", {
+    "urn": "fsd_profile:ACoAABXy1234",
+    "count": 20
+})
+for comment in comments:
+    print(comment["text"])
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `text` | string | Comment text |
+| `created_at` | string | Timestamp |
+| `post_urn` | string | URN of the post commented on |
+| `num_likes` | integer | Number of likes on the comment |
+
+---
+
+## Get User Education
+
+**`POST /api/linkedin/user/education`**
+
+Retrieve education history. Cost: 1 credit.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `urn` | string | yes | User URN |
+| `count` | integer | yes | Max results to return |
+
+### Example
+
+```python
+education = anysite_post("/api/linkedin/user/education", {
+    "urn": "fsd_profile:ACoAABXy1234",
+    "count": 50
+})
+for entry in education:
+    print(entry["school_name"], "-", entry["degree"])
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `school_name` | string | Institution name |
+| `degree` | string | Degree type |
+| `field_of_study` | string | Major/field |
+| `start_date` | string | Start date |
+| `end_date` | string | End date |
+| `description` | string | Additional details |
+
+---
+
+## Get User Endorsers
+
+**`POST /api/linkedin/user/endorsers`**
+
+Retrieve users who endorsed this user's skills. Cost: 1 credit.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `urn` | string | yes | User URN |
+| `count` | integer | yes | Max results to return |
+
+### Example
+
+```python
+endorsers = anysite_post("/api/linkedin/user/endorsers", {
+    "urn": "fsd_profile:ACoAABXy1234",
+    "count": 50
+})
+for endorser in endorsers:
+    print(endorser["name"], "endorsed", endorser["skill_name"])
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Endorser's name |
+| `urn` | string | Endorser's URN |
+| `skill_name` | string | Endorsed skill |
+| `headline` | string | Endorser's headline |
+
+---
+
+## Get User Experience
+
+**`POST /api/linkedin/user/experience`**
+
+Retrieve work experience. Cost: 1 credit.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `urn` | string | yes | User URN |
+| `count` | integer | yes | Max results to return |
+
+### Example
+
+```python
+experience = anysite_post("/api/linkedin/user/experience", {
+    "urn": "fsd_profile:ACoAABXy1234",
+    "count": 50
+})
+for pos in experience:
+    print(pos["company_name"], "-", pos["title"])
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `title` | string | Job title |
+| `company_name` | string | Company name |
+| `company_urn` | string | Company URN |
+| `location` | string | Position location |
+| `start_date` | string | Start date |
+| `end_date` | string | End date (null if current) |
+| `description` | string | Role description |
+
+---
+
+## Get User Honors
+
+**`POST /api/linkedin/user/honors`**
+
+Retrieve honors and awards. Cost: 1 credit.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `urn` | string | yes | User URN |
+| `count` | integer | yes | Max results to return |
+
+### Example
+
+```python
+honors = anysite_post("/api/linkedin/user/honors", {
+    "urn": "fsd_profile:ACoAABXy1234",
+    "count": 50
+})
+for honor in honors:
+    print(honor["title"], "-", honor["issuer"])
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `title` | string | Award title |
+| `issuer` | string | Issuing organization |
+| `issued_on` | string | Date issued |
+| `description` | string | Details |
+
+---
+
+## Get User Languages
+
+**`POST /api/linkedin/user/languages`**
+
+Retrieve languages. Cost: 1 credit.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `urn` | string | yes | User URN |
+| `count` | integer | yes | Max results to return |
+
+### Example
+
+```python
+languages = anysite_post("/api/linkedin/user/languages", {
+    "urn": "fsd_profile:ACoAABXy1234",
+    "count": 50
+})
+for lang in languages:
+    print(lang["name"], "-", lang["proficiency"])
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Language name |
+| `proficiency` | string | Proficiency level |
+
+---
+
+## Get User Patents
+
+**`POST /api/linkedin/user/patents`**
+
+Retrieve patents. Cost: 1 credit.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `urn` | string | yes | User URN |
+| `count` | integer | yes | Max results to return |
+
+### Example
+
+```python
+patents = anysite_post("/api/linkedin/user/patents", {
+    "urn": "fsd_profile:ACoAABXy1234",
+    "count": 50
+})
+for patent in patents:
+    print(patent["title"], "-", patent["patent_number"])
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `title` | string | Patent title |
+| `patent_number` | string | Patent number |
+| `issuer` | string | Patent office |
+| `issued_on` | string | Date issued |
+| `url` | string | Patent URL |
+| `description` | string | Patent description |
+
+---
+
+## Get User Posts
+
+**`POST /api/linkedin/user/posts`**
+
+Retrieve posts by a user. Accepts URN or profile URL. Cost: 1 credit per 10 results.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `urn` | string | yes | User URN (`fsd_profile:ACoAABXy1234`) or profile URL |
+| `count` | integer | yes | Max results to return |
+| `posted_after` | integer | no | Unix timestamp; only return posts after this time |
+
+### Example
+
+```python
+posts = anysite_post("/api/linkedin/user/posts", {
+    "urn": "fsd_profile:ACoAABXy1234",
+    "count": 10
+})
+for post in posts:
+    print(post["text"][:100])
+    print(post["num_likes"], "likes,", post["num_comments"], "comments")
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `urn` | string | Post URN |
+| `text` | string | Post content |
+| `author_name` | string | Author name |
+| `num_likes` | integer | Like count |
+| `num_comments` | integer | Comment count |
+| `num_shares` | integer | Share count |
+| `created_at` | string | Post timestamp |
+| `reactions` | object | Breakdown by reaction type |
+
+---
+
+## Get User Reactions
+
+**`POST /api/linkedin/user/reactions`**
+
+Retrieve posts a user has reacted to. Cost: 1 credit per 10 results.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `urn` | string | yes | User URN |
+| `count` | integer | yes | Max results to return |
+
+### Example
+
+```python
+reactions = anysite_post("/api/linkedin/user/reactions", {
+    "urn": "fsd_profile:ACoAABXy1234",
+    "count": 20
+})
+for reaction in reactions:
+    print(reaction["reaction_type"], "-", reaction["post_urn"])
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `reaction_type` | string | Type (LIKE, CELEBRATE, LOVE, etc.) |
+| `post_urn` | string | URN of the reacted post |
+| `post_text` | string | Post content snippet |
+
+---
+
+## Get User Skills
+
+**`POST /api/linkedin/user/skills`**
+
+Retrieve skills. Cost: 1 credit.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `urn` | string | yes | User URN |
+| `count` | integer | yes | Max results to return |
+
+### Example
+
+```python
+skills = anysite_post("/api/linkedin/user/skills", {
+    "urn": "fsd_profile:ACoAABXy1234",
+    "count": 50
+})
+for skill in skills:
+    print(skill["name"], "-", skill.get("endorsement_count", 0), "endorsements")
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Skill name |
+| `endorsement_count` | integer | Number of endorsements |

--- a/content/anysite/docs/reddit-api/python/DOC.md
+++ b/content/anysite/docs/reddit-api/python/DOC.md
@@ -1,0 +1,279 @@
+---
+name: reddit-api
+description: "Extract Reddit user posts, comments, subreddit content, and search discussions"
+metadata:
+  languages: "python"
+  versions: "0.0.1"
+  revision: 1
+  updated-on: "2026-03-16"
+  source: community
+  tags: "subreddit,threads,discussion,community,scraping,forum"
+---
+
+# Anysite Reddit API Coding Guidelines (Python)
+
+You are an Anysite Reddit API coding expert. Help me write Python code using the Anysite REST API for Reddit data extraction.
+
+API documentation: https://api.anysite.io/docs
+
+## Golden Rule: All Endpoints Use POST with JSON Body
+
+- **Base URL:** `https://api.anysite.io`
+- **Method:** All endpoints use `POST`
+- **Auth:** Pass your API key in the `access-token` header
+- **Content-Type:** `application/json`
+- **Identifiers:** Reddit entities use usernames, post URLs, or subreddit names
+
+## Authentication
+
+```python
+import requests
+
+BASE_URL = "https://api.anysite.io"
+API_KEY = "your-api-key"  # Use env vars in production
+
+HEADERS = {
+    "access-token": API_KEY,
+    "Content-Type": "application/json"
+}
+
+
+def anysite_post(endpoint: str, payload: dict) -> dict:
+    """Make a POST request to the Anysite Reddit API."""
+    response = requests.post(
+        f"{BASE_URL}{endpoint}",
+        headers=HEADERS,
+        json=payload
+    )
+    response.raise_for_status()
+    return response.json()
+```
+
+Store your API key in an environment variable:
+
+```python
+import os
+API_KEY = os.environ["ANYSITE_API_KEY"]
+```
+
+## Endpoints
+
+### Get User Comments
+
+Retrieve recent public comments by a Reddit user. Costs 1 credit per batch.
+
+**POST** `/api/reddit/user/comments`
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `username` | string | Yes | - | Reddit username |
+| `count` | integer | No | 25 | Number of comments to return |
+
+```python
+comments = anysite_post("/api/reddit/user/comments", {
+    "username": "spez",
+    "count": 20
+})
+
+for comment in comments:
+    print(comment["text"])
+    print(comment["subreddit"], "-", comment["score"], "points")
+    print(comment["created_at"])
+    print("---")
+```
+
+**Key response fields (`RedditUserComment`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `text` | string | Comment text (may contain markdown) |
+| `subreddit` | string | Subreddit name where comment was posted |
+| `score` | integer | Net upvotes (upvotes minus downvotes) |
+| `created_at` | integer | Unix timestamp of comment creation |
+| `permalink` | string | Relative URL path to the comment |
+| `post_url` | string | Relative URL path to the parent post |
+| `id` | string | Comment ID (prefixed with `t1_`) |
+| `author` | object | Author object with `id` and `name` fields (`@reddit_author`) |
+
+### Get User Posts
+
+Retrieve posts submitted by a Reddit user. Costs 1 credit per batch.
+
+**POST** `/api/reddit/user/posts`
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `username` | string | Yes | - | Reddit username |
+| `count` | integer | No | 25 | Number of posts to return |
+
+```python
+posts = anysite_post("/api/reddit/user/posts", {
+    "username": "spez",
+    "count": 10
+})
+
+for post in posts:
+    print(post["title"])
+    print(f"r/{post['subreddit']} - {post['score']} points")
+    print(post["comment_count"], "comments")
+    print(post["post_type"])
+    print("---")
+```
+
+**Key response fields (`RedditPostDetail`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Post ID (prefixed with `t3_`) |
+| `title` | string | Post title |
+| `subreddit` | string | Subreddit name (e.g. `"r/redditstock"`) |
+| `subreddit_id` | string | Subreddit ID (prefixed with `t5_`) |
+| `score` | integer | Net upvotes |
+| `comment_count` | integer | Number of comments |
+| `post_type` | string | Post type |
+| `author` | object | Author object with `id` and `name` fields (`@reddit_author`) |
+| `created_at` | integer | Unix timestamp |
+| `url` | string | Relative URL path to the post |
+
+### Get Post Details
+
+Retrieve a Reddit post by its URL. Costs 1 credit.
+
+**POST** `/api/reddit/posts`
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `post_url` | string | Yes | Full URL to the Reddit post |
+
+```python
+result = anysite_post("/api/reddit/posts", {
+    "post_url": "https://www.reddit.com/r/technology/comments/abc123/example_post/"
+})
+
+post = result[0]
+print(post["title"])
+print(post["selftext"])
+print(post["score"], "points,", post["comment_count"], "comments")
+print(post["author"]["name"])
+```
+
+Returns an array of `RedditPostDetail`.
+
+### Get Post Comments
+
+Retrieve comments on a Reddit post. Costs 1 credit.
+
+**POST** `/api/reddit/posts/comments`
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `post_url` | string | Yes | Full URL to the Reddit post |
+
+```python
+comments = anysite_post("/api/reddit/posts/comments", {
+    "post_url": "https://www.reddit.com/r/technology/comments/abc123/example_post/"
+})
+
+for comment in comments:
+    print(comment["author"]["name"], ":", comment["text"][:100])
+    print(comment["score"], "points")
+    print("---")
+```
+
+**Key response fields (`RedditComment`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `text` | string | Comment text (may contain markdown) |
+| `author` | object | Author object with `id` and `name` fields (`@reddit_author`) |
+| `score` | integer | Net upvotes |
+| `created_at` | integer | Unix timestamp |
+| `permalink` | string | Relative URL path |
+| `post_url` | string | Relative URL path to the parent post |
+| `subreddit` | string | Subreddit name |
+| `id` | string | Comment ID (prefixed with `t1_`) |
+
+### Search Posts
+
+Search Reddit posts by query. Costs 1 credit per batch.
+
+**POST** `/api/reddit/search/posts`
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `query` | string | Yes | - | Search query keywords |
+| `count` | integer | Yes | - | Number of results to return |
+| `sort` | string | No | `"relevance"` | Sort order |
+| `time_filter` | string | No | `"all"` | Time filter |
+
+```python
+results = anysite_post("/api/reddit/search/posts", {
+    "query": "python web framework",
+    "count": 20
+})
+
+for post in results:
+    print(post["title"])
+    print(f"r/{post['subreddit']['alias']} - {post['vote_count']} points")
+    print(post["comment_count"], "comments")
+    print("---")
+```
+
+**Key response fields (`RedditPost`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Post ID (prefixed with `t3_`) |
+| `title` | string | Post title |
+| `url` | string | Full post URL |
+| `subreddit` | object | Subreddit object (`@reddit_subreddit`) with `id`, `alias`, `url`, etc. |
+| `vote_count` | integer | Net upvotes |
+| `comment_count` | integer | Number of comments |
+| `created_at` | integer | Unix timestamp |
+
+## Error Handling
+
+```python
+import requests
+
+
+def anysite_post_safe(endpoint: str, payload: dict) -> dict | None:
+    try:
+        response = requests.post(
+            f"{BASE_URL}{endpoint}",
+            headers=HEADERS,
+            json=payload,
+            timeout=60
+        )
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.HTTPError as e:
+        status = e.response.status_code
+        if status == 401:
+            print("Invalid or missing access-token")
+        elif status == 422:
+            print("Validation error:", e.response.json())
+        elif status == 429:
+            print("Rate limit exceeded - wait and retry")
+        elif status >= 500:
+            print("Server error - retry later")
+        else:
+            print(f"HTTP {status}:", e.response.text)
+        return None
+    except requests.exceptions.Timeout:
+        print("Request timed out")
+        return None
+```
+
+### Common Error Codes
+
+| Status Code | Meaning | Action |
+|---|---|---|
+| 401 | Invalid or missing `access-token` header | Check your API key |
+| 422 | Validation error (bad parameters) | Check parameter names and types |
+| 429 | Rate limit exceeded | Back off and retry |
+| 500 | Server error | Retry after a delay |
+
+## Optional Request Header
+
+All endpoints accept an optional `x-request-id` header (UUID format) for request tracing and deduplication.

--- a/content/anysite/docs/sec-filings/python/DOC.md
+++ b/content/anysite/docs/sec-filings/python/DOC.md
@@ -1,0 +1,180 @@
+---
+name: sec-filings
+description: "Retrieve SEC EDGAR filings, 10-K, 10-Q reports, and search public company disclosures"
+metadata:
+  languages: "python"
+  versions: "0.0.1"
+  revision: 1
+  updated-on: "2026-03-16"
+  source: community
+  tags: "edgar,10k,10q,annual-report,public-company,regulatory"
+---
+
+# SEC Filings API Coding Guidelines (Python)
+
+You are a SEC Filings API coding expert. Help me write Python code using the Anysite REST API for SEC data extraction.
+
+API documentation: https://api.anysite.io/docs
+
+## Golden Rule: All Endpoints Use POST with JSON Body
+
+- **Base URL:** `https://api.anysite.io`
+- **Method:** All endpoints use `POST`
+- **Auth:** Pass your API key in the `access-token` header
+- **Content-Type:** `application/json`
+
+## Authentication
+
+```python
+import requests
+
+BASE_URL = "https://api.anysite.io"
+API_KEY = "your-api-key"  # Use env vars in production
+
+HEADERS = {
+    "access-token": API_KEY,
+    "Content-Type": "application/json"
+}
+
+
+def anysite_post(endpoint: str, payload: dict) -> dict:
+    """Make a POST request to the Anysite API."""
+    response = requests.post(
+        f"{BASE_URL}{endpoint}",
+        headers=HEADERS,
+        json=payload
+    )
+    response.raise_for_status()
+    return response.json()
+```
+
+Store your API key in an environment variable:
+
+```python
+import os
+API_KEY = os.environ["ANYSITE_API_KEY"]
+```
+
+## SEC Endpoints
+
+### Get SEC Document
+
+Retrieve the full content of a SEC filing document by its URL. Costs 1 credit.
+
+**POST** `/api/sec/document`
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `document_url` | string | Yes | Full URL to the SEC document (e.g. EDGAR filing URL) |
+
+```python
+result = anysite_post("/api/sec/document", {
+    "document_url": "https://www.sec.gov/Archives/edgar/data/1234567/000123456789012345/filing.htm"
+})
+
+doc = result[0]
+print(doc["content"])
+print(doc["filing_type"])
+print(doc["company_name"])
+```
+
+**Key response fields (`SECDocumentResponse`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `content` | string | Full document text content |
+| `filing_type` | string | Filing form type (e.g. "10-K", "10-Q") |
+| `company_name` | string | Company name from filing |
+| `filing_date` | string | Date of the filing |
+| `document_url` | string | Source URL |
+
+### Search SEC Companies
+
+Search SEC registered companies by entity name, form types, location, and date range. Costs 1 credit per batch.
+
+**POST** `/api/sec/search/companies`
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `count` | integer | Yes | - | Number of results to return |
+| `entity_name` | string | No | `""` | Company or entity name to search |
+| `forms` | array of string | No | null | Filter by form types (e.g. `["10-K", "10-Q", "8-K"]`) |
+| `location_codes` | array of string | No | null | Filter by state/location codes (e.g. `["CA", "NY"]`) |
+| `date_from` | string | No | null | Start date filter (YYYY-MM-DD) |
+| `date_to` | string | No | null | End date filter (YYYY-MM-DD) |
+
+```python
+results = anysite_post("/api/sec/search/companies", {
+    "entity_name": "Tesla",
+    "forms": ["10-K"],
+    "count": 10
+})
+
+for filing in results:
+    print(filing["display_names"])
+    print(filing["filing_type"])
+    print(filing["file_date"])
+    print(filing["document_url"])
+    print("---")
+```
+
+**Key response fields (`SECFiling`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `accession_number` | string | SEC accession number |
+| `file_name` | string | Filing document file name |
+| `document_url` | string | URL to the filing document |
+| `filing_type` | string | Filing form type (e.g. `"10-K"`, `"4"`) |
+| `file_date` | string | Date the filing was made (YYYY-MM-DD) |
+| `period_ending` | string | Period ending date (YYYY-MM-DD) |
+| `ciks` | array | List of CIK identifiers (strings) |
+| `display_names` | array | List of entity display names with CIK |
+| `file_description` | string | Filing description |
+
+## Error Handling
+
+```python
+import requests
+
+
+def anysite_post_safe(endpoint: str, payload: dict) -> dict | None:
+    try:
+        response = requests.post(
+            f"{BASE_URL}{endpoint}",
+            headers=HEADERS,
+            json=payload,
+            timeout=60
+        )
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.HTTPError as e:
+        status = e.response.status_code
+        if status == 401:
+            print("Invalid or missing access-token")
+        elif status == 422:
+            print("Validation error:", e.response.json())
+        elif status == 429:
+            print("Rate limit exceeded - wait and retry")
+        elif status >= 500:
+            print("Server error - retry later")
+        else:
+            print(f"HTTP {status}:", e.response.text)
+        return None
+    except requests.exceptions.Timeout:
+        print("Request timed out")
+        return None
+```
+
+### Common Error Codes
+
+| Status Code | Meaning | Action |
+|---|---|---|
+| 401 | Invalid or missing `access-token` header | Check your API key |
+| 422 | Validation error (bad parameters) | Check parameter names and types |
+| 429 | Rate limit exceeded | Back off and retry |
+| 500 | Server error | Retry after a delay |
+
+## Optional Request Header
+
+All endpoints accept an optional `x-request-id` header (UUID format) for request tracing and deduplication.

--- a/content/anysite/docs/token-usage/python/DOC.md
+++ b/content/anysite/docs/token-usage/python/DOC.md
@@ -1,0 +1,213 @@
+---
+name: token-usage
+description: "Monitor Anysite API credit consumption, request history, and usage statistics"
+metadata:
+  languages: "python"
+  versions: "0.0.1"
+  revision: 1
+  updated-on: "2026-03-16"
+  source: community
+  tags: "billing,credits,quota,monitoring,account,rate-limit"
+---
+
+# Token Usage API Coding Guidelines (Python)
+
+You are a Token Usage API coding expert. Help me write Python code using the Anysite REST API for monitoring API usage and credit consumption.
+
+API documentation: https://api.anysite.io/docs
+
+## Golden Rule: Token Endpoints Use GET
+
+- **Base URL:** `https://api.anysite.io`
+- **Method:** Token/account endpoints use `GET`
+- **Auth:** Pass your API key in the `access-token` header
+
+## Authentication
+
+```python
+import requests
+
+BASE_URL = "https://api.anysite.io"
+API_KEY = "your-api-key"  # Use env vars in production
+
+HEADERS = {
+    "access-token": API_KEY,
+    "Content-Type": "application/json"
+}
+
+
+def anysite_get(endpoint: str, params: dict = None) -> dict:
+    """Make a GET request to the Anysite API."""
+    response = requests.get(
+        f"{BASE_URL}{endpoint}",
+        headers=HEADERS,
+        params=params
+    )
+    response.raise_for_status()
+    return response.json()
+```
+
+Store your API key in an environment variable:
+
+```python
+import os
+API_KEY = os.environ["ANYSITE_API_KEY"]
+```
+
+## Token/Account Endpoints
+
+### Get Token Request History
+
+Retrieve your recent API request history. Uses `GET`.
+
+**GET** `/token/requests`
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `start_time` | string (datetime) | No | - | Filter start time (ISO 8601) |
+| `end_time` | string (datetime) | No | - | Filter end time (ISO 8601) |
+| `limit` | integer | No | 10 | Number of records (1-100) |
+| `cursor` | string (datetime) | No | - | Pagination cursor |
+
+```python
+history = anysite_get("/token/requests", {
+    "limit": 20
+})
+
+for entry in history:
+    print(entry["endpoint"])
+    print(entry["response_status_code"])
+    print(entry["started_at"])
+    print(entry["cost"], "credits")
+    print(entry["points_left"], "remaining")
+    print(entry["duration"], "seconds")
+    print("---")
+```
+
+**Key response fields (`TokenHistory`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Request record ID |
+| `endpoint` | string | API endpoint called |
+| `cost` | integer | Number of credits consumed |
+| `points_left` | integer | Remaining credit points after request |
+| `is_paid` | boolean | Whether this was a paid request |
+| `token_id` | string | API token ID |
+| `plan` | string | Account plan (e.g. `"API"`) |
+| `started_at` | string | Timestamp of the request (ISO 8601) |
+| `duration` | number | Total request duration in seconds |
+| `response_status_code` | integer | HTTP response status code |
+| `response_error_text` | string | Error text (null if successful) |
+| `response_count` | integer | Number of results returned |
+| `response_execution_time` | number | Execution time in seconds |
+| `response_request_id` | string | Unique request identifier |
+
+### Get Token Request Count
+
+Get the total number of API requests in a time range. Uses `GET`.
+
+**GET** `/token/requests/count`
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `start_time` | string (datetime) | No | Filter start time (ISO 8601) |
+| `end_time` | string (datetime) | No | Filter end time (ISO 8601) |
+
+```python
+count = anysite_get("/token/requests/count", {
+    "start_time": "2026-03-01T00:00:00Z",
+    "end_time": "2026-03-16T00:00:00Z"
+})
+
+print(count["total"])
+```
+
+**Key response fields (`TokenRequestsCount`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `total` | integer | Total number of requests in the time range |
+
+### Get Token Statistics
+
+Retrieve usage statistics for your API token. Uses `GET`.
+
+**GET** `/token/statistic`
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `include_mcp` | boolean | No | false | Include MCP-related usage |
+
+```python
+stats = anysite_get("/token/statistic", {
+    "include_mcp": True
+})
+
+print(stats["points"])            # remaining credit points
+print(stats["purchase_credits"])  # purchased credits
+print(stats["plan"])              # account plan (e.g. "API")
+print(stats["is_primary"])        # whether this is the primary token
+print(stats["usage_context"])     # usage context (e.g. "standard")
+print(stats["user"]["login"])     # account login
+print(stats["user"]["email"])     # account email
+```
+
+**Key response fields (`TokenStatistic`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Token ID |
+| `user` | object | User account info with `id`, `login`, `role`, `email` |
+| `is_primary` | boolean | Whether this is the primary API token |
+| `points` | integer | Remaining credit points |
+| `purchase_credits` | integer | Purchased credits balance |
+| `plan` | string | Account plan (e.g. `"API"`) |
+| `usage_context` | string | Usage context (e.g. `"standard"`) |
+
+## Error Handling
+
+```python
+import requests
+
+
+def anysite_get_safe(endpoint: str, params: dict = None) -> dict | None:
+    try:
+        response = requests.get(
+            f"{BASE_URL}{endpoint}",
+            headers=HEADERS,
+            params=params,
+            timeout=60
+        )
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.HTTPError as e:
+        status = e.response.status_code
+        if status == 401:
+            print("Invalid or missing access-token")
+        elif status == 422:
+            print("Validation error:", e.response.json())
+        elif status == 429:
+            print("Rate limit exceeded - wait and retry")
+        elif status >= 500:
+            print("Server error - retry later")
+        else:
+            print(f"HTTP {status}:", e.response.text)
+        return None
+    except requests.exceptions.Timeout:
+        print("Request timed out")
+        return None
+```
+
+### Common Error Codes
+
+| Status Code | Meaning | Action |
+|---|---|---|
+| 401 | Invalid or missing `access-token` header | Check your API key |
+| 422 | Validation error (bad parameters) | Check parameter names and types |
+| 429 | Rate limit exceeded | Back off and retry |
+| 500 | Server error | Retry after a delay |
+
+## Optional Request Header
+
+All endpoints accept an optional `x-request-id` header (UUID format) for request tracing and deduplication.

--- a/content/anysite/docs/twitter-api/python/DOC.md
+++ b/content/anysite/docs/twitter-api/python/DOC.md
@@ -1,0 +1,251 @@
+---
+name: twitter-api
+description: "Extract Twitter/X user profiles, tweets, and search posts and users"
+metadata:
+  languages: "python"
+  versions: "0.0.1"
+  revision: 1
+  updated-on: "2026-03-16"
+  source: community
+  tags: "x.com,tweets,timeline,social-media,scraping,microblog"
+---
+
+# Anysite Twitter/X API Coding Guidelines (Python)
+
+You are an Anysite Twitter API coding expert. Help me write Python code using the Anysite REST API for Twitter/X data extraction.
+
+API documentation: https://api.anysite.io/docs
+
+## Golden Rule: All Endpoints Use POST with JSON Body
+
+- **Base URL:** `https://api.anysite.io`
+- **Method:** All endpoints use `POST`
+- **Auth:** Pass your API key in the `access-token` header
+- **Content-Type:** `application/json`
+- **Identifiers:** Twitter entities use handles (usernames), tweet IDs, or full URLs
+
+## Authentication
+
+```python
+import requests
+
+BASE_URL = "https://api.anysite.io"
+API_KEY = "your-api-key"  # Use env vars in production
+
+HEADERS = {
+    "access-token": API_KEY,
+    "Content-Type": "application/json"
+}
+
+
+def anysite_post(endpoint: str, payload: dict) -> dict:
+    """Make a POST request to the Anysite Twitter API."""
+    response = requests.post(
+        f"{BASE_URL}{endpoint}",
+        headers=HEADERS,
+        json=payload
+    )
+    response.raise_for_status()
+    return response.json()
+```
+
+Store your API key in an environment variable:
+
+```python
+import os
+API_KEY = os.environ["ANYSITE_API_KEY"]
+```
+
+## Endpoints
+
+### Get User Profile
+
+Retrieve a Twitter/X user profile by handle or URL. Costs 1 credit.
+
+**POST** `/api/twitter/user`
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `user` | string | Yes | Twitter handle (e.g. `"elonmusk"`) or profile URL |
+
+```python
+result = anysite_post("/api/twitter/user", {
+    "user": "elonmusk"
+})
+
+user = result[0]
+print(user["name"])
+print(user["alias"])
+print(user["description"])
+print(user["follower_count"])
+print(user["following_count"])
+print(user["tweet_count"])
+print(user["is_blue_verified"])
+print(user["image"])
+```
+
+**Key response fields (`TwitterUser`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Display name |
+| `alias` | string | Twitter handle (without @) |
+| `description` | string | Bio text |
+| `follower_count` | integer | Number of followers |
+| `following_count` | integer | Number of accounts followed |
+| `tweet_count` | integer | Total tweets posted |
+| `favorites_count` | integer | Total tweets liked |
+| `media_count` | integer | Total media posted |
+| `listed_count` | integer | Number of lists the user is on |
+| `verified` | boolean | Legacy verification status |
+| `verified_type` | string | Verification type |
+| `is_blue_verified` | boolean | Twitter Blue verification status |
+| `image` | string | Profile picture URL |
+| `banner_url` | string | Banner image URL |
+| `created_at` | integer | Account creation date (unix timestamp) |
+| `location` | string | User-set location |
+| `url` | string | Profile URL |
+| `rest_id` | string | Twitter user ID |
+| `internal_id` | string | Internal identifier |
+| `professional` | object | Professional account info (if applicable) |
+
+### Get User Posts
+
+Retrieve recent posts (tweets) from a Twitter/X user. Costs 1 credit per batch.
+
+**POST** `/api/twitter/user/posts`
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `user` | string | Yes | Twitter handle or profile URL |
+| `count` | integer | Yes | Number of tweets to return |
+
+```python
+tweets = anysite_post("/api/twitter/user/posts", {
+    "user": "elonmusk",
+    "count": 20
+})
+
+for tweet in tweets:
+    print(tweet["text"])
+    print(tweet["favorite_count"], "likes,", tweet["retweet_count"], "retweets")
+    print(tweet["created_at"])  # unix timestamp
+    print("---")
+```
+
+**Key response fields (`TwitterPost`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `text` | string | Tweet text content |
+| `favorite_count` | integer | Number of likes |
+| `retweet_count` | integer | Number of retweets |
+| `reply_count` | integer | Number of replies |
+| `quote_count` | integer | Number of quote tweets |
+| `bookmark_count` | integer | Number of bookmarks |
+| `views_count` | integer | Number of views |
+| `created_at` | integer | Tweet creation timestamp (unix) |
+| `id` | string | Tweet ID |
+| `user` | object | Author info (`name`, `alias`, etc.) |
+| `media` | array | Attached media objects (images, videos) |
+| `urls` | array | URLs mentioned in the tweet |
+| `is_retweet` | boolean | Whether this is a retweet |
+| `is_quote` | boolean | Whether this is a quote tweet |
+| `lang` | string | Detected language code |
+
+### Search Posts
+
+Search Twitter/X posts by keyword or query. Costs 1 credit per batch.
+
+**POST** `/api/twitter/search/posts`
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `query` | string | No | `""` | Search query (keywords, hashtags, operators) |
+| `count` | integer | Yes | - | Number of results to return |
+| `search_type` | string | No | `"Top"` | Search type filter |
+
+```python
+results = anysite_post("/api/twitter/search/posts", {
+    "query": "artificial intelligence",
+    "count": 20
+})
+
+for tweet in results:
+    print(f"@{tweet['user']['alias']}: {tweet['text'][:100]}")
+    print(tweet["favorite_count"], "likes")
+    print("---")
+```
+
+### Search Users
+
+Search for Twitter/X user profiles. Costs 1 credit per batch.
+
+**POST** `/api/twitter/search/users`
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `query` | string | No | `""` | Search query (name, keyword, topic) |
+| `count` | integer | Yes | - | Number of results to return |
+
+```python
+results = anysite_post("/api/twitter/search/users", {
+    "query": "machine learning researcher",
+    "count": 10
+})
+
+for user in results:
+    print(user["name"], f"(@{user['alias']})")
+    print(user["description"][:100])
+    print(user["follower_count"], "followers")
+    print("---")
+```
+
+Returns an array of `TwitterUser`.
+
+## Error Handling
+
+```python
+import requests
+
+
+def anysite_post_safe(endpoint: str, payload: dict) -> dict | None:
+    try:
+        response = requests.post(
+            f"{BASE_URL}{endpoint}",
+            headers=HEADERS,
+            json=payload,
+            timeout=60
+        )
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.HTTPError as e:
+        status = e.response.status_code
+        if status == 401:
+            print("Invalid or missing access-token")
+        elif status == 422:
+            print("Validation error:", e.response.json())
+        elif status == 429:
+            print("Rate limit exceeded - wait and retry")
+        elif status >= 500:
+            print("Server error - retry later")
+        else:
+            print(f"HTTP {status}:", e.response.text)
+        return None
+    except requests.exceptions.Timeout:
+        print("Request timed out")
+        return None
+```
+
+### Common Error Codes
+
+| Status Code | Meaning | Action |
+|---|---|---|
+| 401 | Invalid or missing `access-token` header | Check your API key |
+| 422 | Validation error (bad parameters) | Check parameter names and types |
+| 429 | Rate limit exceeded | Back off and retry |
+| 500 | Server error | Retry after a delay |
+
+## Optional Request Header
+
+All endpoints accept an optional `x-request-id` header (UUID format) for request tracing and deduplication.

--- a/content/anysite/docs/webparser/python/DOC.md
+++ b/content/anysite/docs/webparser/python/DOC.md
@@ -1,0 +1,239 @@
+---
+name: webparser
+description: "Scrape web pages, extract content and contacts, parse sitemaps, and search via DuckDuckGo"
+metadata:
+  languages: "python"
+  versions: "0.0.1"
+  revision: 1
+  updated-on: "2026-03-16"
+  source: community
+  tags: "scraping,html,crawling,duckduckgo,sitemap,extract"
+---
+
+# Web Parser API Coding Guidelines (Python)
+
+You are a Web Parser API coding expert. Help me write Python code using the Anysite REST API for web parsing, sitemap extraction, and DuckDuckGo search.
+
+API documentation: https://api.anysite.io/docs
+
+## Golden Rule: All Endpoints Use POST with JSON Body
+
+- **Base URL:** `https://api.anysite.io`
+- **Method:** All endpoints use `POST`
+- **Auth:** Pass your API key in the `access-token` header
+- **Content-Type:** `application/json`
+
+## Authentication
+
+```python
+import requests
+
+BASE_URL = "https://api.anysite.io"
+API_KEY = "your-api-key"  # Use env vars in production
+
+HEADERS = {
+    "access-token": API_KEY,
+    "Content-Type": "application/json"
+}
+
+
+def anysite_post(endpoint: str, payload: dict) -> dict:
+    """Make a POST request to the Anysite API."""
+    response = requests.post(
+        f"{BASE_URL}{endpoint}",
+        headers=HEADERS,
+        json=payload
+    )
+    response.raise_for_status()
+    return response.json()
+```
+
+Store your API key in an environment variable:
+
+```python
+import os
+API_KEY = os.environ["ANYSITE_API_KEY"]
+```
+
+## Web Parser Endpoints
+
+### Parse Webpage
+
+Extract content from a webpage with flexible filtering options. Costs 1 credit.
+
+**POST** `/api/webparser/parse`
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `url` | string | Yes | - | Full URL of the page to parse |
+| `only_main_content` | boolean | No | false | Extract only the main content area |
+| `strip_all_tags` | boolean | No | false | Remove all HTML tags from output |
+| `return_full_html` | boolean | No | false | Return the full raw HTML |
+| `extract_contacts` | boolean | No | false | Extract emails and phone numbers |
+| `social_links_only` | boolean | No | false | Extract only social media links |
+| `same_origin_links` | boolean | No | false | Extract only links to the same domain |
+| `remove_comments` | boolean | No | true | Remove HTML comments |
+| `remove_base64_images` | boolean | No | true | Remove base64-encoded images |
+| `min_text_block` | integer | No | 200 | Minimum text block size |
+| `extract_minimal` | boolean | No | false | Extract minimal content |
+
+```python
+result = anysite_post("/api/webparser/parse", {
+    "url": "https://example.com/article",
+    "only_main_content": True,
+    "strip_all_tags": True
+})
+
+page = result[0]
+print(page["title"])
+print(page["cleaned_html"])
+print(page["url"])
+```
+
+**Key response fields (`WebParserResult`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `title` | string | Page title |
+| `cleaned_html` | string | Extracted/cleaned HTML content |
+| `url` | string | Final URL (after redirects) |
+| `meta_description` | string | Page meta description (may be null) |
+| `metadata` | object | Additional page metadata |
+| `links` | array | Extracted links from the page (may be null) |
+| `emails` | array | Extracted email addresses (if `extract_contacts` is true, may be null) |
+| `phones` | array | Extracted phone numbers (if `extract_contacts` is true, may be null) |
+
+Extract contacts and social links:
+
+```python
+result = anysite_post("/api/webparser/parse", {
+    "url": "https://example.com/contact",
+    "extract_contacts": True,
+    "social_links_only": True
+})
+
+page = result[0]
+print(page.get("emails"))   # extracted email addresses
+print(page.get("phones"))   # extracted phone numbers
+print(page.get("links"))    # social media links
+```
+
+### Get Sitemap
+
+Retrieve and parse a website's sitemap. Costs 1 credit.
+
+**POST** `/api/webparser/sitemap`
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `url` | string | Yes | - | Website URL (sitemap is auto-discovered) |
+| `count` | integer | No | null | Maximum number of URLs to return |
+| `same_host_only` | boolean | No | true | Only return URLs from the same host |
+| `respect_robots` | boolean | No | true | Respect robots.txt directives |
+| `return_details` | boolean | No | false | Return full sitemap entry details |
+| `include_patterns` | array | No | null | URL patterns to include |
+| `exclude_patterns` | array | No | null | URL patterns to exclude |
+
+```python
+result = anysite_post("/api/webparser/sitemap", {
+    "url": "https://example.com",
+    "count": 100
+})
+
+sitemap = result[0]
+print("Total found:", sitemap["total_found"])
+for url in sitemap["urls"]:
+    print(url)
+for loc in sitemap["sitemap_locations"]:
+    print("Sitemap:", loc)
+```
+
+**Key response fields (`SitemapResult`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `urls` | array | List of discovered page URLs |
+| `entries` | array | Detailed sitemap entries (when `return_details` is true) |
+| `total_found` | integer | Total number of URLs found |
+| `sitemap_locations` | array | Discovered sitemap XML URLs |
+
+## Search Endpoint
+
+### DuckDuckGo Search
+
+Search the web using DuckDuckGo. Results are ordered by relevance (first result is the most relevant). Costs 1 credit.
+
+**POST** `/api/duckduckgo/search`
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `query` | string | Yes | - | Search query |
+| `count` | integer | No | 10 | Number of results to return |
+
+```python
+results = anysite_post("/api/duckduckgo/search", {
+    "query": "python requests library tutorial",
+    "count": 10
+})
+
+for item in results:
+    print(item["title"])
+    print(item["url"])
+    print(item["description"])
+    print("---")
+```
+
+**Key response fields (`DuckDuckGoSearchResult`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `title` | string | Page title |
+| `url` | string | Result URL |
+| `description` | string | Snippet/description text |
+
+## Error Handling
+
+```python
+import requests
+
+
+def anysite_post_safe(endpoint: str, payload: dict) -> dict | None:
+    try:
+        response = requests.post(
+            f"{BASE_URL}{endpoint}",
+            headers=HEADERS,
+            json=payload,
+            timeout=60
+        )
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.HTTPError as e:
+        status = e.response.status_code
+        if status == 401:
+            print("Invalid or missing access-token")
+        elif status == 422:
+            print("Validation error:", e.response.json())
+        elif status == 429:
+            print("Rate limit exceeded - wait and retry")
+        elif status >= 500:
+            print("Server error - retry later")
+        else:
+            print(f"HTTP {status}:", e.response.text)
+        return None
+    except requests.exceptions.Timeout:
+        print("Request timed out")
+        return None
+```
+
+### Common Error Codes
+
+| Status Code | Meaning | Action |
+|---|---|---|
+| 401 | Invalid or missing `access-token` header | Check your API key |
+| 422 | Validation error (bad parameters) | Check parameter names and types |
+| 429 | Rate limit exceeded | Back off and retry |
+| 500 | Server error | Retry after a delay |
+
+## Optional Request Header
+
+All endpoints accept an optional `x-request-id` header (UUID format) for request tracing and deduplication.

--- a/content/anysite/docs/yc-startups/python/DOC.md
+++ b/content/anysite/docs/yc-startups/python/DOC.md
@@ -1,0 +1,244 @@
+---
+name: yc-startups
+description: "Search Y Combinator companies, founders, batches, and startup ecosystem data"
+metadata:
+  languages: "python"
+  versions: "0.0.1"
+  revision: 1
+  updated-on: "2026-03-16"
+  source: community
+  tags: "ycombinator,accelerator,founder,batch,seed,incubator"
+---
+
+# Y Combinator API Coding Guidelines (Python)
+
+You are a Y Combinator API coding expert. Help me write Python code using the Anysite REST API for Y Combinator data extraction.
+
+API documentation: https://api.anysite.io/docs
+
+## Golden Rule: All Endpoints Use POST with JSON Body
+
+- **Base URL:** `https://api.anysite.io`
+- **Method:** All endpoints use `POST`
+- **Auth:** Pass your API key in the `access-token` header
+- **Content-Type:** `application/json`
+- **Identifiers:** Companies use slugs
+
+## Authentication
+
+```python
+import requests
+
+BASE_URL = "https://api.anysite.io"
+API_KEY = "your-api-key"  # Use env vars in production
+
+HEADERS = {
+    "access-token": API_KEY,
+    "Content-Type": "application/json"
+}
+
+
+def anysite_post(endpoint: str, payload: dict) -> dict:
+    """Make a POST request to the Anysite API."""
+    response = requests.post(
+        f"{BASE_URL}{endpoint}",
+        headers=HEADERS,
+        json=payload
+    )
+    response.raise_for_status()
+    return response.json()
+```
+
+Store your API key in an environment variable:
+
+```python
+import os
+API_KEY = os.environ["ANYSITE_API_KEY"]
+```
+
+## Y Combinator Endpoints
+
+### Get YC Company
+
+Retrieve Y Combinator company details by slug. Costs 1 credit.
+
+**POST** `/api/yc/company`
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `company` | string | Yes | YC company slug (e.g. `"airbnb"`, `"stripe"`) |
+
+```python
+result = anysite_post("/api/yc/company", {
+    "company": "openai"
+})
+
+company = result[0]
+print(company["name"])
+print(company["one_liner"])
+print(company["long_description"])
+print(company["batch"])
+print(company["team_size"])
+print(company["website"])
+print(company["industries"])
+print(company["status"])
+```
+
+**Key response fields (`YCCompany`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Company name |
+| `slug` | string | URL slug on YC |
+| `one_liner` | string | One-line description |
+| `long_description` | string | Detailed description |
+| `batch` | string | YC batch (e.g. "W21", "S19") |
+| `team_size` | integer | Current team size |
+| `website` | string | Company website URL |
+| `industries` | array | Industry tags |
+| `status` | string | Company status (Active, Acquired, etc.) |
+| `regions` | array | Geographic regions |
+| `is_hiring` | boolean | Whether actively hiring |
+| `top_company` | boolean | Whether it is a YC Top Company |
+| `nonprofit` | boolean | Whether it is a nonprofit |
+| `small_logo_thumb_url` | string | Company logo thumbnail URL |
+| `all_locations` | string | Office locations |
+| `launched_at` | integer | Unix timestamp of YC launch |
+| `industry` | string | Primary industry |
+| `subindustry` | string | Sub-industry classification |
+| `stage` | string | Company stage (e.g. `"Growth"`) |
+| `tags` | array | Tags |
+| `former_names` | array | Previous company names |
+| `founders` | array | List of founder objects |
+
+### Search YC Companies
+
+Search Y Combinator companies with advanced filters. Costs 1 credit per batch.
+
+**POST** `/api/yc/search/companies`
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `query` | string | No | null | Search query keywords |
+| `count` | integer | Yes | - | Number of results to return |
+| `batches` | array of string | No | null | Filter by YC batches (e.g. `["W24", "S23"]`) |
+| `industries` | array of string | No | null | Filter by industries |
+| `regions` | array of string | No | null | Filter by geographic regions |
+| `is_hiring` | boolean | No | null | Filter to companies that are hiring |
+| `top_company` | boolean | No | null | Filter to YC Top Companies |
+| `nonprofit` | boolean | No | null | Filter to nonprofits |
+| `team_size_min` | integer | No | null | Minimum team size |
+| `team_size_max` | integer | No | null | Maximum team size |
+| `sort_by` | string | No | `"relevance"` | Sort order |
+
+```python
+results = anysite_post("/api/yc/search/companies", {
+    "query": "AI",
+    "batches": ["W24", "S24"],
+    "is_hiring": True,
+    "count": 50,
+    "sort_by": "relevance"
+})
+
+for company in results:
+    print(company["name"], f"({company['batch']})")
+    print(company["one_liner"])
+    print(company["team_size"], "employees")
+    print("---")
+```
+
+Returns an array of `YCCompany`.
+
+### Search YC Founders
+
+Search Y Combinator founders with filters. Costs 1 credit per batch.
+
+**POST** `/api/yc/search/founders`
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `query` | string | No | null | Search query (name, keyword) |
+| `count` | integer | Yes | - | Number of results to return |
+| `batches` | array of string | No | null | Filter by YC batches |
+| `industries` | array of string | No | null | Filter by industries |
+| `titles` | array of string | No | null | Filter by titles (e.g. `["CEO", "CTO"]`) |
+| `top_company` | boolean | No | null | Filter to founders of YC Top Companies |
+
+```python
+results = anysite_post("/api/yc/search/founders", {
+    "query": "machine learning",
+    "titles": ["CEO"],
+    "count": 20
+})
+
+for founder in results:
+    print(founder["first_name"], founder["last_name"])
+    print(founder["current_title"])
+    print(founder["current_company"])
+    print(founder["company_slug"])
+    print(founder.get("hnid"))
+    print("---")
+```
+
+**Key response fields (`YCFounderSearchResult`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | integer | Founder ID |
+| `first_name` | string | Founder first name |
+| `last_name` | string | Founder last name (may include title and company) |
+| `current_title` | string | Current title/role |
+| `current_company` | string | Current company name |
+| `company_slug` | string | Company slug on YC |
+| `top_company` | boolean | Whether it is a YC Top Company |
+| `hnid` | string | Hacker News ID |
+| `avatar_thumb` | string | Profile photo thumbnail URL |
+| `url_slug` | string | URL slug for the founder |
+| `all_companies_text` | string | Text listing all associated companies |
+
+## Error Handling
+
+```python
+import requests
+
+
+def anysite_post_safe(endpoint: str, payload: dict) -> dict | None:
+    try:
+        response = requests.post(
+            f"{BASE_URL}{endpoint}",
+            headers=HEADERS,
+            json=payload,
+            timeout=60
+        )
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.HTTPError as e:
+        status = e.response.status_code
+        if status == 401:
+            print("Invalid or missing access-token")
+        elif status == 422:
+            print("Validation error:", e.response.json())
+        elif status == 429:
+            print("Rate limit exceeded - wait and retry")
+        elif status >= 500:
+            print("Server error - retry later")
+        else:
+            print(f"HTTP {status}:", e.response.text)
+        return None
+    except requests.exceptions.Timeout:
+        print("Request timed out")
+        return None
+```
+
+### Common Error Codes
+
+| Status Code | Meaning | Action |
+|---|---|---|
+| 401 | Invalid or missing `access-token` header | Check your API key |
+| 422 | Validation error (bad parameters) | Check parameter names and types |
+| 429 | Rate limit exceeded | Back off and retry |
+| 500 | Server error | Retry after a delay |
+
+## Optional Request Header
+
+All endpoints accept an optional `x-request-id` header (UUID format) for request tracing and deduplication.

--- a/content/anysite/docs/youtube-api/python/DOC.md
+++ b/content/anysite/docs/youtube-api/python/DOC.md
@@ -1,0 +1,290 @@
+---
+name: youtube-api
+description: "Extract YouTube video details, comments, subtitles, channel videos, and search results"
+metadata:
+  languages: "python"
+  versions: "0.0.1"
+  revision: 1
+  updated-on: "2026-03-16"
+  source: community
+  tags: "video,transcript,captions,channel,streaming,scraping"
+---
+
+# Anysite YouTube API Coding Guidelines (Python)
+
+You are an Anysite YouTube API coding expert. Help me write Python code using the Anysite REST API for YouTube data extraction.
+
+API documentation: https://api.anysite.io/docs
+
+## Golden Rule: All Endpoints Use POST with JSON Body
+
+- **Base URL:** `https://api.anysite.io`
+- **Method:** All endpoints use `POST`
+- **Auth:** Pass your API key in the `access-token` header
+- **Content-Type:** `application/json`
+- **Identifiers:** YouTube entities use video IDs, channel handles/IDs, or full URLs
+
+## Authentication
+
+```python
+import requests
+
+BASE_URL = "https://api.anysite.io"
+API_KEY = "your-api-key"  # Use env vars in production
+
+HEADERS = {
+    "access-token": API_KEY,
+    "Content-Type": "application/json"
+}
+
+
+def anysite_post(endpoint: str, payload: dict) -> dict:
+    """Make a POST request to the Anysite YouTube API."""
+    response = requests.post(
+        f"{BASE_URL}{endpoint}",
+        headers=HEADERS,
+        json=payload
+    )
+    response.raise_for_status()
+    return response.json()
+```
+
+Store your API key in an environment variable:
+
+```python
+import os
+API_KEY = os.environ["ANYSITE_API_KEY"]
+```
+
+## Endpoints
+
+### Get Video Details
+
+Retrieve details for a YouTube video by ID or URL. Costs 1 credit.
+
+**POST** `/api/youtube/video`
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `video` | string | Yes | Video ID (e.g. `"dQw4w9WgXcQ"`) or full YouTube URL |
+
+```python
+result = anysite_post("/api/youtube/video", {
+    "video": "dQw4w9WgXcQ"
+})
+
+video = result[0]
+print(video["title"])
+print(video["description"])
+print(video["author"])
+print(video["view_count"], "views")
+print(video["like_count"], "likes")
+print(video["duration"])
+print(video["publish_date"])
+```
+
+**Key response fields (`YoutubeVideo`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `title` | string | Video title |
+| `description` | string | Video description |
+| `author` | string | Channel name |
+| `channel_id` | string | YouTube channel ID |
+| `view_count` | integer | Number of views |
+| `like_count` | integer | Number of likes |
+| `comment_count` | integer | Number of comments |
+| `duration` | string | Video duration |
+| `publish_date` | string | Publication date |
+| `thumbnail_url` | string | Thumbnail image URL |
+| `tags` | array | Video tags |
+| `category` | string | Video category |
+| `id` | string | Video ID |
+
+### Get Video Comments
+
+Retrieve comments on a YouTube video. Costs 1 credit per batch.
+
+**POST** `/api/youtube/video/comments`
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `video` | string | Yes | Video ID or full URL |
+| `count` | integer | Yes | Number of comments to return |
+
+```python
+comments = anysite_post("/api/youtube/video/comments", {
+    "video": "dQw4w9WgXcQ",
+    "count": 20
+})
+
+for comment in comments:
+    print(comment["author"]["name"], ":", comment["text"])
+    print(comment["like_count"], "likes")
+    print(comment["published_at"])
+    print(comment["reply_count"], "replies")
+    print("---")
+```
+
+**Key response fields (`YoutubeComment`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Comment ID |
+| `text` | string | Comment text |
+| `author` | object | Author object with `id`, `name`, `url`, `avatar`, `is_verified`, `is_creator` |
+| `like_count` | integer | Number of likes on the comment |
+| `published_at` | string | Comment publication timestamp |
+| `reply_count` | integer | Number of replies |
+| `reply_level` | integer | Nesting level of the reply |
+
+### Get Video Subtitles
+
+Retrieve subtitles/captions for a YouTube video in a specified language. Costs 1 credit.
+
+**POST** `/api/youtube/video/subtitles`
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `video` | string | Yes | - | Video ID or full URL |
+| `lang` | string | No | `"en"` | Language code (e.g. `"en"`, `"es"`, `"fr"`) |
+
+```python
+subtitles = anysite_post("/api/youtube/video/subtitles", {
+    "video": "dQw4w9WgXcQ",
+    "lang": "en"
+})
+
+for segment in subtitles:
+    print(f"[{segment['start']}] {segment['text']}")
+```
+
+**Key response fields (`YoutubeSubtitle`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `text` | string | Subtitle text segment |
+| `start` | number | Start time in seconds |
+| `duration` | number | Duration of the segment in seconds |
+
+### Get Channel Videos
+
+Retrieve videos from a YouTube channel. Costs 1 credit per batch.
+
+**POST** `/api/youtube/channel/videos`
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `channel` | string | Yes | - | Channel handle (e.g. `"@MrBeast"`), channel ID, or URL |
+| `count` | integer | No | 30 | Number of videos to return |
+
+```python
+videos = anysite_post("/api/youtube/channel/videos", {
+    "channel": "@MrBeast",
+    "count": 20
+})
+
+for video in videos:
+    print(video["title"])
+    print(video["view_count"], "views")
+    print(video["published_at"])
+    print("---")
+```
+
+**Key response fields (`YoutubeChannelVideo`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | YouTube video ID |
+| `title` | string | Video title |
+| `url` | string | Full YouTube video URL |
+| `author` | object | Author object with `id`, `name`, `alias`, `url` |
+| `duration_seconds` | integer | Video duration in seconds |
+| `view_count` | integer | Number of views |
+| `published_at` | integer | Publication timestamp (unix) |
+| `image` | string | Thumbnail image URL |
+
+### Search Videos
+
+Search YouTube videos by query. Costs 1 credit per batch.
+
+**POST** `/api/youtube/search/videos`
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `query` | string | Yes | - | Search query keywords |
+| `count` | integer | No | 10 | Number of results to return |
+
+```python
+results = anysite_post("/api/youtube/search/videos", {
+    "query": "machine learning tutorial",
+    "count": 10
+})
+
+for video in results:
+    print(video["title"])
+    print(video["author"]["alias"])
+    print(video["view_count"], "views")
+    print(video["url"])
+    print("---")
+```
+
+**Key response fields (`YoutubeSearchVideo`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | YouTube video ID |
+| `title` | string | Video title |
+| `url` | string | Full YouTube video URL |
+| `author` | object | Author object with `id`, `name`, `alias`, `url` |
+| `duration_seconds` | integer | Video duration in seconds |
+| `view_count` | integer | Number of views |
+| `published_at` | integer | Publication timestamp (unix) |
+| `image` | string | Thumbnail image URL |
+
+## Error Handling
+
+```python
+import requests
+
+
+def anysite_post_safe(endpoint: str, payload: dict) -> dict | None:
+    try:
+        response = requests.post(
+            f"{BASE_URL}{endpoint}",
+            headers=HEADERS,
+            json=payload,
+            timeout=60
+        )
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.HTTPError as e:
+        status = e.response.status_code
+        if status == 401:
+            print("Invalid or missing access-token")
+        elif status == 422:
+            print("Validation error:", e.response.json())
+        elif status == 429:
+            print("Rate limit exceeded - wait and retry")
+        elif status >= 500:
+            print("Server error - retry later")
+        else:
+            print(f"HTTP {status}:", e.response.text)
+        return None
+    except requests.exceptions.Timeout:
+        print("Request timed out")
+        return None
+```
+
+### Common Error Codes
+
+| Status Code | Meaning | Action |
+|---|---|---|
+| 401 | Invalid or missing `access-token` header | Check your API key |
+| 422 | Validation error (bad parameters) | Check parameter names and types |
+| 429 | Rate limit exceeded | Back off and retry |
+| 500 | Server error | Retry after a delay |
+
+## Optional Request Header
+
+All endpoints accept an optional `x-request-id` header (UUID format) for request tracing and deduplication.

--- a/content/anysite/skills/anysite-audience-analysis/SKILL.md
+++ b/content/anysite/skills/anysite-audience-analysis/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: anysite-audience-analysis
+description: "Analyze follower demographics, engagement patterns, and audience quality across platforms"
+metadata:
+  revision: 1
+  updated-on: "2026-03-16"
+  source: community
+  tags: "demographics,followers,growth,segments,instagram,youtube"
+---
+
+# anysite Audience Analysis
+
+Understand your audience through demographic analysis, engagement patterns, and follower behavior across Instagram, YouTube, and LinkedIn.
+
+## Overview
+
+- **Analyze follower demographics** and characteristics
+- **Track engagement patterns** and behavior
+- **Evaluate audience quality** and authenticity
+- **Identify content preferences** by audience segment
+- **Optimize targeting** based on audience insights
+
+**Coverage**: 60% - Focused on Instagram, YouTube, LinkedIn
+
+## Supported Platforms
+
+- Instagram: Follower analysis, engagement patterns, audience location
+- YouTube: Subscriber insights, comment demographics, viewer behavior
+- LinkedIn: Connection analysis, professional demographics, engagement
+
+## Quick Start
+
+**Step 1: Identify Audience Source**
+
+Choose platform:
+- Instagram: `get_instagram_user` + `get_instagram_user_friendships`
+- YouTube: `get_youtube_channel_videos` + comment analysis
+- LinkedIn: `get_linkedin_user_posts` + engagement analysis
+
+**Step 2: Collect Audience Data**
+
+Gather:
+- Follower/subscriber counts
+- Engagement metrics
+- Demographics (from profiles)
+- Behavior patterns
+
+**Step 3: Analyze Patterns**
+
+Look for:
+- Audience segments
+- Engagement drivers
+- Content preferences
+- Peak activity times
+
+**Step 4: Generate Insights**
+
+Deliver:
+- Audience profile summary
+- Engagement patterns
+- Content recommendations
+- Targeting suggestions
+
+## Common Workflows
+
+### Workflow 1: Instagram Audience Analysis
+
+**Steps**:
+
+1. **Get Profile Overview**
+```
+get_instagram_user(username)
+```
+
+2. **Analyze Followers** (sample)
+```
+get_instagram_user_friendships(
+  user=username,
+  type="followers",
+  count=100
+)
+
+For each follower (sample):
+- Profile type (personal, business, creator)
+- Bio indicators (interests, location)
+- Follower count (influence level)
+```
+
+3. **Engagement Pattern Analysis**
+```
+get_instagram_user_posts(username, count=50)
+
+For each post:
+  get_instagram_post_likes(post_id, count=100)
+  get_instagram_post_comments(post_id, count=50)
+
+Analyze:
+- Who engages most (power users)
+- When engagement happens (timing)
+- What content drives engagement
+- Comment quality and topics
+```
+
+4. **Audience Segmentation**
+```
+Group followers by:
+- Engagement level (active, passive, ghost)
+- Interests (from bios)
+- Location (from profiles)
+- Influence (follower counts)
+```
+
+### Workflow 2: YouTube Audience Insights
+
+1. Channel overview via `get_youtube_channel_videos`
+2. Viewer engagement analysis via video metrics and comments
+3. Audience demographics from comment analysis
+4. Content performance correlation
+
+### Workflow 3: LinkedIn Audience Profiling
+
+1. Get post history via `get_linkedin_user_posts`
+2. Analyze engagement patterns (reactions, comments, shares)
+3. Profile engagers (job titles, industries, companies)
+4. Content-audience mapping
+
+## MCP Tools Reference
+
+### Instagram
+- `get_instagram_user` - Profile stats
+- `get_instagram_user_friendships` - Follower/following lists
+- `get_instagram_user_posts` - Post history
+- `get_instagram_post_likes` - Who liked posts
+- `get_instagram_post_comments` - Comment analysis
+
+### YouTube
+- `get_youtube_channel_videos` - Channel content
+- `get_youtube_video` - Video metrics
+- `get_youtube_video_comments` - Audience engagement
+
+### LinkedIn
+- `get_linkedin_user_posts` - Post history
+- `get_linkedin_profile` - Profile insights
+
+## Audience Analysis Framework
+
+**Demographic Analysis**:
+- Age range (inferred from profiles)
+- Location (from bio/profiles)
+- Interests (from bio keywords)
+- Professional level (LinkedIn titles)
+
+**Behavioral Analysis**:
+- Engagement frequency
+- Content preferences
+- Peak activity times
+- Interaction patterns
+
+**Quality Metrics**:
+- Real vs. fake followers
+- Engagement authenticity
+- Audience overlap
+- Influence distribution
+
+## Output Formats
+
+**Chat Summary**: Audience profile highlights, key engagement patterns, content recommendations
+**CSV Export**: Follower sample data, engagement metrics, segment distribution
+**JSON Export**: Complete audience data, engagement time series, segmentation details
+
+## Reference Documentation
+
+- **[PLATFORM_COVERAGE.md](references/PLATFORM_COVERAGE.md)** - Platform-specific audience analysis capabilities
+- **[TOOL_MAPPING.md](references/TOOL_MAPPING.md)** - Mapping analysis needs to MCP tools

--- a/content/anysite/skills/anysite-audience-analysis/references/PLATFORM_COVERAGE.md
+++ b/content/anysite/skills/anysite-audience-analysis/references/PLATFORM_COVERAGE.md
@@ -1,0 +1,53 @@
+# Platform-Specific Audience Analysis
+
+## Instagram Capabilities
+
+**Direct Audience Data**:
+- Follower/following lists (sample)
+- Engagement on posts (likes, comments)
+- Profile information from followers
+
+**Analysis Techniques**:
+- Follower quality assessment
+- Engagement pattern tracking
+- Content preference analysis
+- Audience segmentation
+
+**Limitations**:
+- Can't access full follower list (privacy)
+- Limited demographic data
+- Engagement sample-based
+
+## YouTube Capabilities
+
+**Direct Audience Data**:
+- Comment analysis
+- Video engagement metrics
+- Channel growth indicators
+
+**Analysis Techniques**:
+- Viewer interest profiling
+- Content performance analysis
+- Community engagement assessment
+
+**Limitations**:
+- No direct subscriber access
+- Demographics inferred from comments
+- Limited geographic data
+
+## LinkedIn Capabilities
+
+**Direct Audience Data**:
+- Post engagement metrics
+- Follower professional information
+- Connection quality
+
+**Analysis Techniques**:
+- Professional demographic profiling
+- Industry and seniority analysis
+- Content-audience matching
+
+**Limitations**:
+- Privacy settings limit visibility
+- Sample-based analysis
+- Connections vs. followers distinction

--- a/content/anysite/skills/anysite-audience-analysis/references/TOOL_MAPPING.md
+++ b/content/anysite/skills/anysite-audience-analysis/references/TOOL_MAPPING.md
@@ -1,0 +1,27 @@
+# Audience Analysis Tool Mapping
+
+## Analysis Need -> MCP Tool
+
+**Follower Demographics**:
+- Instagram: `get_instagram_user_friendships` -> sample analysis
+- LinkedIn: `get_linkedin_profile` -> professional data
+
+**Engagement Patterns**:
+- Instagram: `get_instagram_user_posts` + `get_instagram_post_likes/comments`
+- YouTube: `get_youtube_video` + `get_youtube_video_comments`
+- LinkedIn: `get_linkedin_user_posts`
+
+**Audience Growth**:
+- Track follower counts over time
+- Monitor engagement velocity
+- Analyze new vs. existing engagement
+
+**Content Preferences**:
+- Correlate content types with engagement
+- Analyze top-performing posts
+- Track topic performance
+
+**Audience Quality**:
+- Analyze follower profiles
+- Check engagement authenticity
+- Assess comment quality

--- a/content/anysite/skills/anysite-brand-reputation/SKILL.md
+++ b/content/anysite/skills/anysite-brand-reputation/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: anysite-brand-reputation
+description: "Monitor brand mentions, customer sentiment, and social conversations across platforms"
+metadata:
+  revision: 1
+  updated-on: "2026-03-16"
+  source: community
+  tags: "sentiment,mentions,crisis,social-listening,nps"
+---
+
+# anysite Brand Reputation Monitoring
+
+Monitor and protect your brand reputation across social media platforms. Track mentions, analyze sentiment, and identify issues before they escalate.
+
+## Overview
+
+- **Track brand mentions** across social platforms
+- **Analyze sentiment** (positive, negative, neutral)
+- **Monitor conversations** about your brand
+- **Identify reputation risks** and crisis signals
+- **Measure brand health** over time
+
+**Coverage**: 65% - Strong for Twitter, Reddit, Instagram, YouTube, LinkedIn
+
+## Supported Platforms
+
+- Twitter/X: Real-time mentions, sentiment, viral content
+- Reddit: Community discussions, detailed feedback, sentiment
+- Instagram: Visual brand mentions, hashtag tracking, influencer posts
+- YouTube: Video mentions, comment sentiment, brand coverage
+- LinkedIn: Professional mentions, company updates, B2B sentiment
+
+## Quick Start
+
+**Step 1: Set Up Monitoring**
+
+Define:
+- Brand keywords (company name, product names, misspellings)
+- Platforms to monitor (Twitter, Reddit, Instagram, etc.)
+- Monitoring frequency (real-time, daily, weekly)
+- Alert thresholds (negative sentiment, volume spikes)
+
+**Step 2: Search for Mentions**
+
+Platform searches:
+```
+Twitter: search_twitter_posts(query="brand name", count=100)
+Reddit: search_reddit_posts(query="brand name", count=100)
+Instagram: search_instagram_posts(query="#brandname", count=100)
+LinkedIn: search_linkedin_posts(keywords="brand name", count=50)
+```
+
+**Step 3: Analyze Sentiment**
+
+For each mention:
+- Classify: Positive, negative, neutral
+- Categorize: Complaint, praise, question, general
+- Prioritize: Urgency, reach, influence
+
+**Step 4: Take Action**
+
+Based on findings:
+- Respond to negative mentions
+- Amplify positive feedback
+- Address product issues
+- Engage with community
+
+## Common Workflows
+
+### Workflow 1: Daily Brand Monitoring
+
+1. Search all platforms for recent mentions
+2. Classify mentions by sentiment and category
+3. Prioritize issues (High: viral negative, Medium: individual complaints, Low: positive)
+4. Generate daily report with mention count, sentiment breakdown, top issues
+
+### Workflow 2: Crisis Detection and Management
+
+1. Monitor for anomalies (mentions >2x baseline, negative sentiment >50%)
+2. Deep dive on spikes with expanded searches
+3. Assess crisis severity (volume, velocity, reach, sentiment, validity)
+4. Track crisis evolution with hourly monitoring
+5. Measure resolution (volume returns to baseline, sentiment improves)
+
+### Workflow 3: Competitive Reputation Benchmarking
+
+1. Define 3-5 main competitors
+2. Gather mentions for all brands across platforms
+3. Calculate brand health scores (mention volume, sentiment score, engagement rate, share of voice)
+4. Analyze strengths/weaknesses
+5. Identify opportunities from competitor weaknesses
+
+## MCP Tools Reference
+
+### Twitter/X
+- `search_twitter_posts(query, count)` - Find brand mentions
+- `get_twitter_user(user)` - Check brand profile stats
+- `get_twitter_user_posts(user, count)` - Monitor brand account
+
+### Reddit
+- `search_reddit_posts(query, subreddit, count)` - Find discussions
+- `get_reddit_post(url)` - Get post details and sentiment
+- `get_reddit_post_comments(url)` - Deep dive on discussions
+
+### Instagram
+- `search_instagram_posts(query, count)` - Find visual mentions
+- `get_instagram_post(post_id)` - Analyze mention engagement
+- `get_instagram_post_comments(post, count)` - Read feedback
+
+### YouTube
+- `search_youtube_videos(query, count)` - Find video mentions
+- `get_youtube_video(video)` - Get video details
+- `get_youtube_video_comments(video, count)` - Analyze sentiment
+
+### LinkedIn
+- `search_linkedin_posts(keywords, count)` - Professional mentions
+- `get_linkedin_company_posts(urn, count)` - Monitor own posts
+
+## Sentiment Analysis Framework
+
+**Positive Indicators**: "Love", "great", "amazing", "best", recommendations, repeat purchase, favorable comparisons
+**Negative Indicators**: "Disappointed", "worst", "terrible", problems, unfavorable comparisons, demands
+**Neutral Indicators**: Questions without sentiment, factual statements, general mentions
+
+**Sentiment Score**:
+```
+Score = (Positive mentions - Negative mentions) / Total mentions x 100
+
++50 to +100: Excellent
++20 to +49: Good
+-19 to +19: Neutral/Mixed
+-20 to -49: Poor
+-50 to -100: Critical
+```
+
+## Monitoring Metrics
+
+**Volume**: Total mentions per day/week/month, mentions by platform, trend over time
+**Sentiment**: Distribution (% positive/negative/neutral), score, trend over time
+**Engagement**: Average likes/shares per mention, viral mentions (>1000 engagements), influencer mentions
+**Issue Tracking**: Top complaints by frequency, product/service issues, feature requests
+
+## Output Formats
+
+**Chat Summary**: Daily mention highlights, sentiment overview, top issues, recommended actions
+**CSV Export**: Mention list with sentiment, platform, date, reach, issue categorization
+**JSON Export**: Complete mention data, time-series sentiment, engagement metrics
+
+## Reference Documentation
+
+- **[MONITORING_GUIDE.md](references/MONITORING_GUIDE.md)** - Best practices for brand monitoring, crisis response protocols, and sentiment analysis techniques

--- a/content/anysite/skills/anysite-brand-reputation/references/MONITORING_GUIDE.md
+++ b/content/anysite/skills/anysite-brand-reputation/references/MONITORING_GUIDE.md
@@ -1,0 +1,84 @@
+# Brand Reputation Monitoring Guide
+
+## Monitoring Best Practices
+
+**Daily Monitoring**:
+- Twitter: Real-time mentions, trending topics
+- Reddit: Community discussions, detailed feedback
+- Frequency: 2-3x per day minimum
+
+**Weekly Monitoring**:
+- Instagram: Visual brand mentions
+- YouTube: Video reviews and coverage
+- LinkedIn: Professional discussions
+- Frequency: Once per week
+
+**Monthly Monitoring**:
+- Deep sentiment analysis
+- Trend identification
+- Competitive benchmarking
+- Strategic planning
+
+## Crisis Response Protocol
+
+**Level 1: Monitor** (Mentions <2x baseline, sentiment >70% positive)
+- Continue regular monitoring
+- No action needed
+
+**Level 2: Investigate** (Mentions 2-3x baseline OR sentiment 50-70% positive)
+- Deep dive on issue
+- Prepare response
+- Alert team
+
+**Level 3: Respond** (Mentions >3x baseline OR sentiment <50% positive)
+- Immediate team notification
+- Public response within 2-4 hours
+- Hourly monitoring
+- Stakeholder communication
+
+**Level 4: Crisis Management** (Viral negative content OR major issue)
+- Executive notification
+- Crisis team activation
+- Official statement
+- Real-time monitoring
+- Media coordination
+
+## Response Guidelines
+
+**When to Respond Publicly**:
+- Widespread misinformation
+- Product safety concerns
+- Major feature issues
+- High-reach negative mentions
+
+**When to Respond Privately**:
+- Individual customer issues
+- Account-specific problems
+- Sensitive matters
+- Competitor trolling
+
+**When Not to Respond**:
+- Clear trolling
+- Spam
+- Extremely low reach
+- Already resolved
+
+## Sentiment Analysis Tips
+
+**Context Matters**:
+- Sarcasm detection
+- Cultural nuances
+- Platform-specific language
+- Emoji interpretation
+
+**Look for Patterns**:
+- Multiple mentions of same issue
+- Geographic clustering
+- Temporal patterns
+- Platform-specific issues
+
+**Weight by Influence**:
+- Influencer mentions = 10x weight
+- Media coverage = 20x weight
+- Viral content = based on reach
+- Regular user = 1x weight

--- a/content/anysite/skills/anysite-cli/SKILL.md
+++ b/content/anysite/skills/anysite-cli/SKILL.md
@@ -1,0 +1,386 @@
+---
+name: anysite-cli
+description: "Command-line tool for web data extraction, dataset pipelines, batch processing, and database operations"
+metadata:
+  revision: 1
+  updated-on: "2026-03-16"
+  source: community
+  tags: "command-line,terminal,pipeline,batch,parquet,sql,scheduling"
+---
+
+# Anysite CLI
+
+Command-line tool for web data extraction, dataset pipelines, and database operations.
+
+## Agent Planning Workflow
+
+**BEFORE planning any data collection task, follow this sequence:**
+
+1. **Discover available endpoints**
+   ```bash
+   anysite describe --search "<keyword>"   # Search by domain (linkedin, company, user, etc.)
+   ```
+
+2. **Select endpoints needed for the task** -- identify which endpoints will provide the required data
+
+3. **Inspect each selected endpoint**
+   ```bash
+   anysite describe /api/linkedin/company  # View input params and output fields
+   ```
+
+4. **Only then plan** -- now you know the exact parameters, field names, and data structure to build your config or API calls
+
+This prevents errors from wrong endpoint paths, missing required parameters, or incorrect field names in dependencies.
+
+## Best Practices
+
+1. **Use dataset pipelines for multi-step tasks**
+   - If a task requires sequential API calls, LLM enrichment, or chained data processing -- create a `dataset.yaml` config instead of running multiple ad-hoc commands
+   - Dataset pipelines handle dependencies, incremental collection, and error recovery automatically
+   - Even for "simple" tasks that grow in scope, a dataset config is easier to maintain
+   - Benefits: run history, incremental sync, scheduling, notifications, DB loading
+
+2. **Save data in Parquet format by default** -- unless user requests another format or CSV/JSON fits better
+
+3. **Prefer datasets over ad-hoc scripts** -- one dataset.yaml replaces dozens of shell commands
+
+## Quick Start Checklist
+
+Before any data collection task:
+
+```bash
+# 1. Check CLI is available and see latest changes
+anysite --version
+anysite changelog --last 1 --json            # Check what's new in this version
+# If not found: source .venv/bin/activate or pip install anysite-cli
+
+# 2. Update schema cache (required for endpoint discovery)
+anysite schema update
+
+# 3. Verify API key
+anysite config get api_key
+# If not set: anysite config set api_key sk-xxxxx
+```
+
+After upgrading, run `anysite changelog --since <old_version> --json` to discover new features.
+
+## Endpoint Discovery
+
+**ALWAYS discover endpoints before writing API calls or dataset configs:**
+
+```bash
+anysite describe                          # List all endpoints
+anysite describe --search "company"       # Search with dependency context
+anysite describe /api/linkedin/company    # Full details: params, output, connections
+```
+
+Search returns matched endpoints plus upstream providers (who can supply input IDs) and downstream consumers (who can use output IDs). Use this to plan endpoint chains for dataset pipelines.
+
+Input params show type, description, examples, and defaults. Array params show item structure:
+```
+Input parameters:
+  * urn                            string      User URN, only fsd_profile urn type is allowed
+                                               example: "urn:li:fsd_profile:ACoAABXy1234"
+    count                          integer     Number of posts to return
+                                               default: 20
+    companies                      array[object{type,value}]  Company URNs
+                                               example: [{"type": "company", "value": "14064608"}]
+```
+
+## Prerequisites
+
+```bash
+pip install "anysite-cli[data]"        # DuckDB + PyArrow for dataset commands
+pip install "anysite-cli[llm]"         # LLM analysis (openai/anthropic)
+pip install "anysite-cli[postgres]"    # PostgreSQL adapter
+pip install "anysite-cli[clickhouse]"  # ClickHouse adapter
+
+anysite config set api_key sk-xxxxx   # Configure API key
+anysite schema update                  # Update schema cache
+anysite llm setup                      # Interactive setup (human)
+anysite llm setup --provider openai --api-key sk-xxx --no-test    # Non-interactive (agent)
+anysite llm setup --provider anthropic --api-key-env ANTHROPIC_API_KEY --no-test
+anysite db add pg --type postgres --host localhost --database mydb --user app --password secret
+# Or via env var: anysite db add pg ... --password-env PGPASS
+anysite db add ch --type clickhouse --host ch.example.com --port 8443 --database analytics --user app --password secret --ssl
+```
+
+## Authentication
+
+```bash
+anysite auth login                        # Interactive browser-based OAuth2 (human)
+anysite auth login --force --no-browser   # Re-authenticate without confirmation (agent)
+anysite auth status                       # Check current auth status
+anysite auth status --json                # Machine-readable auth status
+anysite auth logout                       # Interactive logout (human)
+anysite auth logout --force               # Logout without confirmation (agent)
+```
+
+## Single API Call
+
+```bash
+anysite api /api/linkedin/user user=satyanadella
+anysite api /api/linkedin/company company=anthropic --format table
+anysite api /api/linkedin/search/users keywords="CTO" count=50 --format csv --output ctos.csv
+anysite api /api/linkedin/user user=satyanadella --fields "name,headline,urn.value" -q | jq
+```
+
+### URN/Name Parameter Formats
+
+Parameters like `location`, `current_companies`, `industry` accept two formats:
+
+```bash
+# Single name (text search) -- resolves to URNs automatically
+location="London"
+current_companies="Microsoft"
+
+# Multiple URNs (direct) -- use JSON array in single quotes
+'location=["urn:li:geo:101165590", "urn:li:geo:101282230"]'
+'current_companies=["urn:li:company:1035", "urn:li:company:1441"]'
+```
+
+**Note:** List of names `["Microsoft", "Google"]` is NOT supported -- use either one name OR multiple URNs.
+
+## Batch Processing
+
+```bash
+anysite api /api/linkedin/user --from-file users.txt --input-key user \
+  --parallel 5 --rate-limit "10/s" --on-error skip --progress --stats
+```
+
+## Dataset Pipeline (Multi-Source Collection)
+
+For complex data collection with dependencies, LLM enrichment, scheduling -- use dataset pipelines.
+
+### Initialize
+
+```bash
+anysite dataset init my-dataset
+# Creates my-dataset/dataset.yaml with template config
+```
+
+### Six Source Types
+
+1. **Independent** -- single API call with static `input`
+2. **from_file** -- batch calls iterating over input file values
+3. **Dependent** -- batch calls using values extracted from a parent source
+4. **Union (type: union)** -- combine records from multiple parent sources into one
+5. **LLM (type: llm)** -- process parent data through LLM without API calls
+6. **SQL (type: sql)** -- query a database connection or dataset Parquet files via DuckDB
+
+### Comprehensive Dataset YAML Reference
+
+```yaml
+name: my-dataset                    # Dataset name (required)
+description: Optional description   # Human-readable description
+
+sources:
+  # === TYPE 1: Independent source (single API call) ===
+  - id: search_results              # Unique identifier (required)
+    endpoint: /api/linkedin/search/users  # API endpoint (required for type: api)
+    input:                          # Static API parameters
+      keywords: "software engineer"
+      count: 50
+    parallel: 1                     # Concurrent requests: 1-10 (default: 1)
+    rate_limit: "10/s"              # Rate limit: "N/s", "N/m", "N/h"
+    on_error: stop                  # Error handling: stop | skip (default: stop)
+
+  # === TYPE 2: from_file source (batch from file) ===
+  - id: companies
+    endpoint: /api/linkedin/company
+    from_file: companies.txt        # Input file: .txt (line per value), .csv, .jsonl
+    file_field: company_slug        # CSV column name (for CSV files only)
+    input_key: company              # API parameter to fill with each value
+    parallel: 3
+
+  # === TYPE 3: Dependent source (values from parent) ===
+  - id: employees
+    endpoint: /api/linkedin/company/employees
+    dependency:
+      from_source: companies        # Parent source ID (required)
+      field: urn.value              # Dot-notation path to extract from parent records
+      dedupe: true                  # Remove duplicate values (default: false)
+    input_key: companies            # API parameter for extracted values
+    input_template:                 # Transform values before API call
+      companies:
+        - type: company
+          value: "{value}"          # {value} = extracted value placeholder
+      count: 5
+    refresh: auto                   # Incremental behavior: auto (default) | always | never
+
+  # === Shorthand for dependent sources ===
+  - id: profiles
+    endpoint: /api/linkedin/user
+    input:
+      user: ${companies.urn.value}    # Equivalent to dependency + input_key above
+
+  # === TYPE 4: Union source (combine multiple sources) ===
+  - id: all_search_results
+    type: union                     # Source type: api (default) | union | llm | sql
+    sources: [search_results, search_extra]  # Parent source IDs to combine
+    dedupe_by: urn.value            # Optional: field path for deduplication
+
+  # === TYPE 5: LLM source (process parent data without API) ===
+  - id: employees_analyzed
+    type: llm
+    dependency:
+      from_source: employees
+      field: name
+    llm:
+      - type: classify
+        categories: "developer,recruiter,executive"
+        output_column: role_type
+        fields: [headline]
+      - type: enrich
+        add:
+          - "sentiment:positive/negative/neutral"
+          - "language:string"
+          - "quality_score:1-10"
+        fields: [headline, summary]
+      - type: summarize
+        max_length: 50
+        output_column: bio
+      - type: generate
+        prompt: "Write pitch for {name}"
+        output_column: pitch
+        temperature: 0.7
+
+  # === TYPE 6: SQL source (query a database) ===
+  - id: billing_users
+    type: sql
+    connection: billing
+    query: "SELECT name, email FROM subscriptions WHERE status = 'inactive'"
+
+  # === OPTIONAL BLOCKS (any source type) ===
+  - id: profiles
+    endpoint: /api/linkedin/user
+    dependency: { from_source: employees, field: internal_id.value }
+    input_key: user
+    filter: '.follower_count > 100'  # Level 1: early filter
+    transform:
+      filter: '.location != ""'
+      fields:
+        - name
+        - urn.value AS urn_id
+        - headline
+      add_columns:
+        batch: "q1-2026"
+    export:
+      - type: file
+        path: ./output/profiles.csv
+        format: csv
+    db_load:
+      filter: '.active == true'
+      table: people
+      key: urn.value
+      sync: full
+      fields:
+        - name
+        - urn.value AS urn_id
+        - headline
+
+storage:
+  format: parquet
+  path: ./data/
+
+schedule:
+  cron: "0 9 * * *"
+
+notifications:
+  on_complete:
+    - url: "https://hooks.slack.com/xxx"
+      headers: { Authorization: "Bearer token" }
+  on_failure:
+    - url: "https://alerts.example.com/fail"
+```
+
+### Validate & Collect Commands
+
+```bash
+anysite dataset validate dataset.yaml                    # Validate config
+anysite dataset collect dataset.yaml --dry-run          # Preview plan
+anysite dataset collect dataset.yaml                     # Run collection
+anysite dataset collect dataset.yaml --load-db pg       # Collect + auto-load to DB
+anysite dataset collect dataset.yaml --incremental      # Skip already-collected inputs
+anysite dataset collect dataset.yaml --source employees # Single source + dependencies
+anysite dataset collect dataset.yaml --no-llm           # Skip LLM enrichment steps
+anysite dataset collect dataset.yaml --limit 100        # Pilot run: max 100 inputs per source
+```
+
+### Query with DuckDB
+
+```bash
+anysite dataset query dataset.yaml --sql "SELECT * FROM companies LIMIT 10"
+anysite dataset query dataset.yaml --source profiles --fields "name, urn.value AS id"
+anysite dataset query dataset.yaml --interactive        # SQL shell
+anysite dataset stats dataset.yaml --source companies
+anysite dataset profile dataset.yaml
+```
+
+### Load into Database
+
+```bash
+anysite dataset load-db dataset.yaml -c pg --drop-existing  # Full load
+anysite dataset load-db dataset.yaml -c pg                   # Incremental sync
+anysite dataset load-db dataset.yaml -c pg --snapshot 2026-01-15
+```
+
+### Scheduling & History
+
+```bash
+anysite dataset schedule dataset.yaml --incremental --load-db pg  # Generate cron entry
+anysite dataset history my-dataset
+anysite dataset logs my-dataset --run 42
+anysite dataset reset-cursor dataset.yaml                         # Clear incremental state
+```
+
+## Database Operations
+
+```bash
+# Connection management
+anysite db add pg --type postgres --host localhost --database mydb --user app --password secret
+anysite db add local --type sqlite --path ./data.db
+anysite db list
+anysite db test pg
+
+# Data operations
+cat data.jsonl | anysite db insert pg --table users --stdin --auto-create
+anysite db query pg --sql "SELECT * FROM users" --format table
+
+# Pipe API output to database
+anysite api /api/linkedin/user user=satyanadella -q --format jsonl \
+  | anysite db insert pg --table profiles --stdin --auto-create
+
+# Database discovery
+anysite db discover mydb                              # Discover schema
+anysite db discover mydb --with-llm                   # Add LLM descriptions
+anysite db catalog mydb --json                        # JSON output for agents
+```
+
+## LLM Analysis Commands
+
+```bash
+anysite llm summarize dataset.yaml --source profiles --fields "name,headline" --format table
+anysite llm classify dataset.yaml --source posts --categories "positive,negative,neutral"
+anysite llm enrich dataset.yaml --source profiles \
+  --add "seniority:junior/mid/senior" --add "is_technical:boolean"
+anysite llm generate dataset.yaml --source profiles \
+  --prompt "Write intro for {name} who works as {headline}" --temperature 0.7
+anysite llm match dataset.yaml --source-a profiles --source-b companies --top-k 3
+anysite llm deduplicate dataset.yaml --source profiles --key name --threshold 0.8
+```
+
+## Key Patterns
+
+- **Output formats**: `--format json|jsonl|csv|table|parquet` (parquet requires `--output`)
+- **Array params**: `keywords=a,b,c` auto-wraps as `["a","b","c"]`
+- **Field selection**: `--fields "name,headline,urn.value"` (dot-notation for nested)
+- **Error handling**: `--on-error stop|skip|retry`
+- **Config priority**: CLI args > ENV vars > `~/.anysite/config.yaml` > defaults
+
+## References
+
+For detailed option tables and advanced configuration:
+- [api-reference.md](references/api-reference.md) -- all CLI options
+- [llm-reference.md](references/llm-reference.md) -- LLM provider config, cache, prompts
+- [dataset-guide.md](references/dataset-guide.md) -- full YAML schema, advanced features

--- a/content/anysite/skills/anysite-cli/references/api-reference.md
+++ b/content/anysite/skills/anysite-cli/references/api-reference.md
@@ -1,0 +1,225 @@
+# Anysite CLI API Reference
+
+## anysite api
+
+Call any API endpoint. Parameters are `key=value` pairs, auto-typed via schema cache.
+
+```
+anysite api <endpoint> [key=value ...] [OPTIONS]
+```
+
+### Output Options
+```
+--format, -f TEXT        json|jsonl|csv|table|parquet (default: json)
+--fields TEXT            Comma-separated fields to include (dot-notation supported)
+--exclude TEXT           Comma-separated fields to exclude
+--fields-preset TEXT     Built-in preset: minimal|contact|recruiting
+--compact                Compact JSON (no indentation)
+--output, -o PATH        Save to file (supports {{date}}/{{datetime}} templates)
+--append                 Append to existing output file
+--quiet, -q              Suppress non-data output (use for piping)
+```
+
+### Batch Input Options
+```
+--from-file PATH         Input file (txt/JSONL/CSV)
+--stdin                  Read from stdin
+--input-key TEXT         Parameter name for input values
+--parallel, -j INT       Parallel requests (default: 1)
+--delay FLOAT            Delay between requests (seconds)
+--rate-limit TEXT        Rate limit: "10/s", "100/m", "1000/h"
+--on-error TEXT          Error handling: stop|skip|retry (default: stop)
+```
+
+### Progress Options
+```
+--progress/--no-progress   Show/hide progress bar
+--stats                    Display statistics after completion
+--verbose                  Detailed debug output
+```
+
+### Examples
+```bash
+# Single call
+anysite api /api/linkedin/user user=satyanadella --format table
+
+# Batch with rate limiting
+anysite api /api/linkedin/user --from-file users.txt --input-key user \
+  --parallel 5 --rate-limit "10/s" --on-error skip --format csv --output results.csv
+
+# Pipe to jq
+anysite api /api/linkedin/company company=anthropic -q | jq '.employee_count'
+
+# Pipe to database
+anysite api /api/linkedin/user user=satyanadella -q --format jsonl \
+  | anysite db insert mydb --table profiles --stdin --auto-create
+
+# Array/set parameters accept comma-separated values
+anysite api /api/linkedin/google/company keywords=fuzzy.so        # auto-wrapped to ["fuzzy.so"]
+anysite api /api/linkedin/google/company keywords=saas,fintech    # becomes ["saas","fintech"]
+```
+
+---
+
+## anysite describe
+
+Discover and inspect API endpoints.
+
+```
+anysite describe [endpoint] [OPTIONS]
+```
+
+```
+--search, -s TEXT    Search endpoints by keyword
+--json               Output as JSON
+--quiet, -q          Show only paths
+```
+
+### Examples
+```bash
+anysite describe                          # List all endpoints
+anysite describe /api/linkedin/company    # Full endpoint details
+anysite describe --search "company"       # Search by keyword
+anysite describe --json -q                # Machine-readable output
+```
+
+Output shows: endpoint path, description, input parameters (name, type, required), output fields (name, type). Nested objects and arrays are expanded with dot-notation:
+
+```
+Output fields (15):
+    name                           string
+    urn                            object
+      .type                        string
+      .value                       string
+    experience                     array[object]
+      .title                       string
+      .company_urn                 string
+```
+
+Use these dot-notation paths in `--fields`, `dependency.field`, and `db_load.fields`.
+
+---
+
+## anysite config
+
+Manage configuration in `~/.anysite/config.yaml`.
+
+```bash
+anysite config set <key> <value>    # Set value (supports nesting: defaults.format)
+anysite config get <key>            # Get value
+anysite config list                 # Show all settings
+anysite config path                 # Show config file location
+anysite config init                 # Interactive setup
+anysite config reset --force        # Reset to defaults
+```
+
+### Config Priority
+1. CLI arguments (`--api-key`)
+2. Environment variables (`ANYSITE_API_KEY`, `ANYSITE_BASE_URL`)
+3. Config file (`~/.anysite/config.yaml`)
+4. Defaults
+
+---
+
+## anysite schema
+
+Manage the API schema cache.
+
+```bash
+anysite schema update    # Fetch and cache OpenAPI spec
+```
+
+Schema is cached to `~/.anysite/schema.json`. Required for `anysite describe` and auto-type conversion in `anysite api`.
+
+---
+
+## Global Options
+
+```
+--api-key TEXT       Override API key
+--base-url TEXT      Override API base URL
+--debug              Enable debug output
+--no-color           Disable colored output
+--json               Force JSON envelope output (auto-enabled in pipes)
+--human              Force human-readable output (override auto-JSON in pipes)
+--non-interactive    Disable interactive prompts (auto-enabled when stdin is not a TTY)
+--version, -v        Show version
+```
+
+---
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | General error |
+| 2 | Usage error (invalid args, missing params) |
+| 3 | Authentication failed |
+| 4 | Resource not found |
+| 5 | Network / timeout / rate limit |
+
+---
+
+## Common API Endpoints
+
+### LinkedIn
+```
+/api/linkedin/user                    user=<username>
+/api/linkedin/company                 company=<alias>
+/api/linkedin/search/users            keywords=<text> count=<n>
+/api/linkedin/company/employees       companies=[{type,value}] count=<n>
+/api/linkedin/user/posts              urn=<urn> count=<n>
+/api/linkedin/post/comments           urn=<urn> count=<n>
+```
+
+### Instagram
+```
+/api/instagram/user                   user=<username>
+/api/instagram/user/posts             user=<username> count=<n>
+```
+
+### Twitter/X
+```
+/api/twitter/user                     user=<username>
+/api/twitter/user/posts               user_id=<id> count=<n>
+```
+
+### Web
+```
+/api/web/parse                        url=<url>
+```
+
+Use `anysite describe --search <keyword>` to discover more endpoints.
+
+---
+
+## anysite dataset guide
+
+Show comprehensive dataset configuration reference with examples.
+
+```
+anysite dataset guide [OPTIONS]
+```
+
+```
+--section, -s TEXT    Show specific section (e.g., sources, llm, db_load)
+--example, -e TEXT    Show a complete example config (e.g., basic, advanced)
+--list               List available sections and examples
+--json               Output as machine-readable JSON
+```
+
+### Examples
+```bash
+anysite dataset guide                        # full reference
+anysite dataset guide --section sources      # source types only
+anysite dataset guide --section llm          # LLM enrichment config
+anysite dataset guide --example basic        # basic config example
+anysite dataset guide --example advanced     # multi-source pipeline
+anysite dataset guide --list                 # list all sections and examples
+anysite dataset guide --json                 # structured JSON for agents
+```
+
+Available sections: `sources`, `params`, `dependencies`, `llm`, `transform`, `export`, `db_load`, `storage`, `schedule`, `notifications`, `incremental`.
+
+Available examples: `basic`, `advanced`, `from_file`, `llm_enrichment`.

--- a/content/anysite/skills/anysite-cli/references/dataset-guide.md
+++ b/content/anysite/skills/anysite-cli/references/dataset-guide.md
@@ -1,0 +1,870 @@
+# Dataset Pipeline & Database Guide
+
+## Agent Workflow
+
+Follow these steps when building a new dataset pipeline:
+
+1. **Discover endpoint fields**: `anysite describe <endpoint> --json` -- see input params (with examples, defaults) and output fields (with nested structure)
+2. **Draft YAML config** -- use output fields from step 1 for `dependency.field` paths
+3. **Validate**: `anysite dataset validate dataset.yaml --json` -- catches structural errors in < 0.1s
+4. **Dry run**: `anysite dataset collect dataset.yaml --dry-run` -- preview plan with estimated request counts
+5. **Collect**: `anysite dataset collect dataset.yaml` or `anysite dataset collect dataset.yaml --load-db mydb`
+
+**Key rule**: ALWAYS run `anysite describe` before setting `dependency.field`. The output fields show exactly which paths exist. For example, `/api/linkedin/user/posts` output has `author` as `object{@type,internal_id,urn,...}` -- so the author's URN is `author.urn.value`, NOT `urn.value` (which is the post's own URN).
+
+---
+
+## Dataset YAML Configuration
+
+### Full Structure
+
+```yaml
+name: my-dataset
+description: Optional description
+
+sources:
+  - id: source_id              # Unique identifier
+    endpoint: /api/...         # API endpoint path
+    input: {}                  # Static API parameters
+    from_file: inputs.txt      # Input file (txt/JSONL/CSV)
+    file_field: column_name    # CSV column to extract
+    input_key: param_name      # API parameter for input values
+    input_template: {}         # Transform values before API call
+    dependency:                # Link to parent source
+      from_source: parent_id
+      field: urn.value         # Dot-notation field to extract
+      match_by: name           # Alternative: fuzzy match by name
+      dedupe: true             # Remove duplicate values
+    parallel: 3                # Concurrent requests
+    rate_limit: "10/s"         # Rate limiting
+    on_error: skip             # stop or skip
+    refresh: always            # auto (default), always, or never (skip if data exists)
+    filter: '.count > 10'     # Source filter (before LLM + Parquet write)
+    transform:                 # Export filter (after Parquet write, for exports only)
+      filter: '.status == "active"'
+      fields: [name, url]     # Field selection with aliases
+      add_columns:             # Static columns to inject
+        batch: "q1-2026"
+    export:                    # Per-source export destinations
+      - type: file
+        path: ./output/{{source}}-{{date}}.csv
+        format: csv            # json, jsonl, csv
+      - type: webhook
+        url: https://example.com/hook
+        headers: {X-Token: abc}
+    llm:                       # LLM enrichment (after collection, before Parquet)
+      - type: enrich           # enrich, classify, summarize, generate
+        add:                   # Field specs for enrich type
+          - "sentiment:positive/negative/neutral"
+          - "language:string"
+        fields: [name, headline]  # Record fields to include in LLM prompt
+      - type: classify
+        categories: "dev,recruiter,exec"  # Omit for auto-detect
+        output_column: role    # Default: "category"
+      - type: summarize
+        max_length: 50
+        output_column: bio     # Default: "summary"
+      - type: generate
+        prompt: "Pitch for {name}"  # Required for generate
+        output_column: pitch   # Default: "text"
+        temperature: 0.7       # Per-step overrides
+    db_load:                   # Database loading config
+      filter: '.active == true'  # DB load filter (only matching records to DB)
+      table: custom_name       # Override table name
+      key: urn.value           # Unique key for diff-based incremental sync
+      sync: full               # full (INSERT/DELETE/UPDATE) or append (no DELETE)
+      fields: [name, url, sentiment, language, role, bio, pitch]
+      exclude: [_input_value]  # Fields to exclude
+
+storage:
+  format: parquet
+  path: ./data/
+  partition_by: [source_id, collected_date]
+
+schedule:                      # Collection schedule
+  cron: "0 9 * * *"           # Standard cron expression
+
+notifications:                 # Webhook notifications
+  on_complete:
+    - url: "https://hooks.slack.com/xxx"
+      headers: {X-Token: abc}
+  on_failure:
+    - url: "https://alerts.example.com/fail"
+```
+
+### Six Source Types
+
+**Independent** -- single API call with static input:
+```yaml
+- id: search_results
+  endpoint: /api/linkedin/search/users
+  input:
+    keywords: "software engineer"
+    count: 50
+```
+
+**from_file** -- iterate over values from a file:
+```yaml
+- id: companies
+  endpoint: /api/linkedin/company
+  from_file: companies.txt      # One value per line
+  input_key: company             # API parameter name
+  parallel: 3
+```
+
+**Dependent** -- extract values from parent source output:
+```yaml
+- id: employees
+  endpoint: /api/linkedin/company/employees
+  dependency:
+    from_source: companies       # Parent source ID
+    field: urn.value             # Dot-notation path in parent records
+    dedupe: true                 # Deduplicate extracted values
+  input_key: companies           # API parameter name
+  input_template:                # Transform value before API call
+    companies:
+      - type: company
+        value: "{value}"         # {value} is replaced with extracted value
+    count: 5
+```
+
+**Union** -- combine multiple sources into one:
+```yaml
+- id: all_results
+  type: union
+  sources: [search_cto, search_vp]    # Parent source IDs to combine
+  dedupe_by: urn.value                 # Optional: remove duplicates by field
+```
+All parent sources must have the same endpoint. Records are annotated with `_union_source` (parent source ID). Cannot have `endpoint`, `dependency`, `from_file`, `input_key`, or `input`.
+
+**LLM Source (type: llm)** -- process parent data through LLM without API calls:
+```yaml
+- id: profiles_analyzed
+  type: llm                       # Source type: api (default) | llm
+  dependency:
+    from_source: profiles         # Parent source (required)
+    field: name                   # Optional -- omit if not extracting values
+  llm:                            # LLM enrichment steps (required for type: llm)
+    - type: classify
+      categories: "strong_fit,moderate_fit,weak_fit"
+      output_column: fit_category
+      fields: [headline, experience]
+    - type: enrich
+      add:
+        - "fit_score:1-10"
+        - "key_strengths:string"
+        - "concerns:string"
+      fields: [name, headline, experience, skills]
+  export:
+    - type: file
+      path: ./output/analyzed-{{date}}.csv
+      format: csv
+```
+
+**type: llm source rules:**
+- **Requires**: `dependency` (parent source) and non-empty `llm` list
+- **Cannot have**: `endpoint`, `from_file`, `input_key`, `input`
+- **Use case**: Run LLM enrichment on already-collected data without re-calling the API
+- **Run with**: `anysite dataset collect dataset.yaml --source profiles_analyzed`
+
+The LLM source reads the parent's Parquet data directly, applies LLM steps, and writes enriched records to its own Parquet file. This allows re-analyzing data with different prompts or categories without re-collecting from the API.
+
+**SQL (type: sql)** -- query a named database connection:
+```yaml
+- id: billing_users
+  type: sql
+  connection: billing
+  query: "SELECT name, email FROM subscriptions WHERE status = 'inactive'"
+```
+Runs the query and stores results as records. Downstream sources can depend on SQL output. Uses connections from `anysite db add`. Supports `query_file` for external `.sql` files.
+
+**type: sql source rules:**
+- **Requires**: `connection` and either `query` or `query_file`
+- **Cannot have**: `endpoint`, `from_file`, `input_key`, `input`, `parallel`, `rate_limit`, `on_error`
+- **Use case**: Bring external DB data into the pipeline for API enrichment
+
+### Dependency Chains
+
+Sources are topologically sorted -- parents always run before children. Multi-level chains work automatically:
+
+```
+companies -> employees -> profiles -> posts -> comments
+```
+
+**Common dependency fields:**
+- `/api/linkedin/company/employees` returns: `name`, `headline`, `url`, `image`, `location`, `internal_id`, `urn` -- use `urn.value` (not `alias`) to chain into `/api/linkedin/user`
+- `/api/linkedin/user` accepts both human-readable aliases (`satyanadella`) and URN values as the `user` parameter
+
+Always run `anysite describe <endpoint>` to verify available fields before setting up dependencies.
+
+**Note:** You can also use the `${source.field}` shorthand instead of explicit `dependency` + `input_key`. See the "Shorthand Syntax" section below.
+
+### input_template
+
+Transforms extracted values before passing to the API. Use `{value}` placeholder:
+
+```yaml
+input_template:
+  urn: "urn:li:fsd_profile:{value}"
+  count: 5
+```
+
+If `field: urn.value` extracts `"ACoAABCDEF"`, the API receives:
+```json
+{"urn": "urn:li:fsd_profile:ACoAABCDEF", "count": 5}
+```
+
+### Dot-Notation Field Extraction
+
+When Parquet stores nested objects as JSON strings, dot-notation traverses them:
+
+- `urn.value` -- parses JSON string in `urn` field, extracts `.value`
+- `experience[0].company_urn` -- array index + nested field
+- `internal_id.value` -- nested object access
+
+### Common Dependency Chains
+
+Quick reference for popular endpoint combinations. Always verify with `anysite describe <endpoint>`.
+
+| Parent endpoint | Child endpoint | `field` | `input_key` | Notes |
+|----------------|---------------|---------|-------------|-------|
+| `/api/linkedin/search/users` | `/api/linkedin/user` | `urn.value` | `user` | |
+| `/api/linkedin/user` | `/api/linkedin/user/posts` | `urn.value` | `urn` | |
+| `/api/linkedin/user/posts` | `/api/linkedin/post/comments` | `urn.value` | `urn` | |
+| `/api/linkedin/user/posts` | `/api/linkedin/user` (author) | `author.urn.value` | `user` | NOT `urn.value` |
+| `/api/linkedin/user` | `/api/linkedin/company` | `company.universalName` | `company` | |
+| `/api/linkedin/company` | `/api/linkedin/company/posts` | `universalName` | `company` | needs `input_template` |
+| `/api/linkedin/company` | `/api/linkedin/company/employees` | `urn.value` | `companies` | needs `input_template` |
+
+**Posts -> Author Profiles** (most common mistake -- using wrong field):
+```yaml
+- id: author_profiles
+  endpoint: /api/linkedin/user
+  dependency:
+    from_source: posts
+    field: author.urn.value       # AUTHOR's URN, not post URN
+    dedupe: true
+  input_key: user
+  parallel: 5
+```
+
+**Companies -> Employees** (requires array input_template):
+```yaml
+- id: employees
+  endpoint: /api/linkedin/company/employees
+  dependency:
+    from_source: companies
+    field: urn.value
+  input_key: companies
+  input_template:
+    companies:
+      - type: company
+        value: "{value}"
+    count: 5
+  parallel: 2
+```
+
+### Shorthand Syntax (`${source.field}`)
+
+Instead of writing explicit `dependency` + `input_key`, you can use `${source.field}` directly in `input`:
+
+```yaml
+# Shorthand (auto-expands to dependency + input_key):
+- id: profiles
+  endpoint: /api/linkedin/user
+  input:
+    user: ${search_results.urn.value}
+    count: 20
+```
+
+This is equivalent to:
+```yaml
+- id: profiles
+  endpoint: /api/linkedin/user
+  dependency:
+    from_source: search_results
+    field: urn.value
+  input_key: user
+  input:
+    count: 20
+```
+
+The `${source.field}` syntax extracts the source ID and field path automatically. Static parameters (like `count: 20`) are passed through as-is.
+
+### Required Fields by Source Type
+
+| Field | `api` (default) | `llm` | `union` | `sql` |
+|-------|-----------------|-------|---------|-------|
+| `id` | required | required | required | required |
+| `type` | optional (defaults to "api") | required: `llm` | required: `union` | required: `sql` |
+| `endpoint` | required | N/A | N/A | N/A |
+| `connection` | N/A | N/A | N/A | **required** |
+| `query` | N/A | N/A | N/A | required (or `query_file`) |
+| `query_file` | N/A | N/A | N/A | required (or `query`) |
+| `dependency` | optional | **required** | N/A | optional |
+| `llm` | optional | **required** (>= 1 step) | optional | optional |
+| `sources` | N/A | N/A | **required** | N/A |
+| `input` | optional | N/A | N/A | N/A |
+| `input_key` | optional | N/A | N/A | N/A |
+| `input_template` | optional | N/A | N/A | N/A |
+| `from_file` | optional | N/A | N/A | N/A |
+| `parallel` | optional (default: 1) | N/A | N/A | N/A |
+| `filter` | optional | optional | optional | optional |
+| `transform` | optional | optional | optional | optional |
+| `export` | optional | optional | optional | optional |
+| `db_load` | optional | optional | optional | optional |
+| `dedupe_by` | N/A | N/A | optional | N/A |
+
+**Key notes:**
+- `dependency.field` is optional (not required) -- needed for value extraction but not for LLM sources
+- `endpoint` must start with `/` (e.g., `/api/linkedin/user`)
+- `categories` in classify steps is a comma-separated **string**, not an array
+- `partition_by` in storage config is accepted but not currently used -- layout is always `raw/<source_id>/<date>.parquet`
+
+---
+
+## Validation
+
+Validate dataset config before collecting. Catches structural errors, missing dependencies, invalid filters, and bad LLM specs.
+
+```bash
+anysite dataset validate dataset.yaml                    # Validate config
+anysite dataset validate dataset.yaml --json             # Machine-readable output
+```
+
+---
+
+## Collection Commands
+
+```bash
+# Validate config first (recommended)
+anysite dataset validate dataset.yaml
+
+# Preview collection plan with estimated request counts
+anysite dataset collect dataset.yaml --dry-run
+
+# Full collection
+anysite dataset collect dataset.yaml
+
+# Collect and auto-load into database
+anysite dataset collect dataset.yaml --load-db pg
+
+# Incremental -- skip inputs already collected
+anysite dataset collect dataset.yaml --incremental --load-db pg
+
+# Single source + its dependencies
+anysite dataset collect dataset.yaml --source employees
+
+# Quiet mode
+anysite dataset collect dataset.yaml --quiet
+
+# Pilot run: max 100 inputs per source
+anysite dataset collect dataset.yaml --limit 100
+```
+
+### Provenance Tracking
+
+Dependent and from_file records automatically get metadata columns:
+- `_input_value` -- the raw extracted value that produced this record
+- `_parent_source` -- parent source ID (dependent sources only)
+
+These enable FK linking when loading into a database.
+
+### Incremental Collection
+
+With `--incremental`:
+1. Independent sources: skipped if already collected today
+2. Dependent/from_file sources: skips individual input values already in `metadata.json`
+3. New values are still collected and tracked
+
+### Refresh Mode
+
+Per-source `refresh` field controls behavior with `--incremental`:
+
+```yaml
+- id: posts
+  endpoint: /api/linkedin/user/posts
+  dependency: { from_source: profiles, field: urn.value }
+  input_key: user
+  refresh: always    # Re-collect every run even with --incremental
+```
+
+| Setting | `--incremental` | No flag |
+|---------|----------------|---------|
+| `refresh: auto` (default) | Skip collected inputs | Collect all |
+| `refresh: always` | Collect all (ignore cache) | Collect all |
+| `refresh: never` | Skip if data exists | Skip if data exists |
+
+Use `refresh: always` for sources with frequently changing data (e.g., posts, activity feeds) where you want fresh snapshots each run while still caching stable parent data. Use `refresh: never` for stable reference data that only needs to be collected once.
+
+### Storage Layout
+
+```
+<storage.path>/
+  raw/<source_id>/<YYYY-MM-DD>.parquet
+  metadata.json
+```
+
+---
+
+## Query Commands (DuckDB)
+
+Each source becomes a DuckDB view named after its ID. Hyphens and dots in source IDs are replaced with underscores (e.g., `search-results` -> `search_results`).
+
+```bash
+# Direct SQL
+anysite dataset query dataset.yaml --sql "SELECT * FROM companies LIMIT 10"
+
+# Shorthand: --source auto-generates SELECT
+anysite dataset query dataset.yaml --source profiles
+
+# Dot-notation field extraction
+anysite dataset query dataset.yaml --source profiles \
+  --fields "name, urn.value AS urn_id, headline"
+# Generates: SELECT name, json_extract_string(urn, '$.value') AS urn_id, headline FROM profiles
+
+# Exclude internal columns
+anysite dataset query dataset.yaml --source profiles --exclude "_input_value,_parent_source"
+
+# Output options
+anysite dataset query dataset.yaml --sql "SELECT * FROM companies" \
+  --format csv --output companies.csv
+
+# Interactive SQL shell
+anysite dataset query dataset.yaml --interactive
+
+# Column statistics
+anysite dataset stats dataset.yaml --source companies
+
+# Data profiling (completeness, record counts)
+anysite dataset profile dataset.yaml
+```
+
+---
+
+## Database Loading (load-db)
+
+Load Parquet data into a relational database with automatic FK linking.
+
+```bash
+anysite dataset load-db dataset.yaml -c <connection_name> [OPTIONS]
+```
+
+### Options
+```
+--connection, -c TEXT    Database connection name (required)
+--source, -s TEXT        Load specific source + dependencies
+--drop-existing          Drop tables before creating
+--snapshot TEXT           Load a specific snapshot date (YYYY-MM-DD)
+--dry-run                Show plan without executing
+--quiet, -q              Suppress output
+```
+
+### What load-db Does
+
+1. Reads Parquet files for each source (in topological order)
+2. Infers SQL schema from data (integer, float, text, json, etc.)
+3. Creates tables with auto-increment `id` primary key
+4. Inserts rows, tracking which `_input_value` maps to which `id`
+5. For child sources: adds `{parent_source}_id` FK column using provenance
+
+### Incremental Sync with `db_load.key`
+
+When `db_load.key` is set and the table already exists with >=2 snapshots, `load-db` uses diff-based incremental sync instead of full re-insertion:
+
+1. Compares the two most recent Parquet snapshots using `DatasetDiffer`
+2. **Added** records -> INSERT into DB
+3. **Removed** records -> DELETE from DB (by key) -- only in `sync: full` mode
+4. **Changed** records -> UPDATE modified fields (by key)
+
+This keeps the database in sync without duplicates.
+
+**Sync modes** (`db_load.sync`):
+- `full` (default) -- applies INSERT, DELETE, and UPDATE from diff
+- `append` -- applies INSERT and UPDATE only, skips DELETE. Use for sources where the API returns only the latest N items (e.g., posts, comments) and you want to accumulate records over time.
+
+| Scenario | Behavior |
+|----------|----------|
+| First load (table doesn't exist) | Full INSERT of latest snapshot |
+| Table exists + `db_load.key` + >=2 snapshots | Diff-based sync (INSERT/DELETE/UPDATE delta) |
+| `--drop-existing` | Drop table, full INSERT of latest snapshot |
+| `--snapshot 2026-01-15` | Full INSERT of that specific snapshot |
+| No `db_load.key` set | Full INSERT of latest snapshot (no diff) |
+
+### db_load Config
+
+Control which fields go to the database per source:
+
+```yaml
+db_load:
+  table: people                    # Custom table name (default: source ID)
+  key: urn.value                   # Unique key for diff-based incremental sync
+  sync: append                     # full (default) or append (no DELETE on diff)
+  fields:                          # Explicit field list
+    - name
+    - url
+    - urn.value AS urn_id          # Dot-notation with alias
+    - experience                   # JSON columns stored as TEXT/JSONB
+  exclude:                         # Fields to skip (default: _input_value, _parent_source)
+    - _input_value
+    - _parent_source
+    - raw_html
+```
+
+Without `db_load`: all fields except `_input_value` and `_parent_source` are loaded.
+
+### FK Linking Example
+
+Given: companies -> employees -> posts
+
+Result in database:
+- `companies` table: `id`, name, url, ...
+- `employees` table: `id`, name, ..., `companies_id` (FK to companies.id)
+- `posts` table: `id`, text, ..., `employees_id` (FK to employees.id)
+
+---
+
+## Database Commands (anysite db)
+
+### Connection Management
+```bash
+anysite db add <name> --type postgres --host localhost --database mydb --user app --password secret
+anysite db add <name> --type postgres --host localhost --database mydb --user app --password-env DB_PASS
+anysite db list                    # List all connections
+anysite db test <name>             # Test connectivity
+anysite db info <name>             # Show connection details
+anysite db remove <name>           # Delete connection
+```
+
+Connections stored in `~/.anysite/connections.yaml`. Passwords use env var references for security.
+
+### Schema Inspection
+```bash
+anysite db schema <name>                  # List all tables
+anysite db schema <name> --table users    # Show columns
+```
+
+### Data Operations
+```bash
+# Insert from stdin (auto-create table)
+cat data.jsonl | anysite db insert <name> --table users --stdin --auto-create
+
+# Insert from file
+anysite db insert <name> --table users --file data.jsonl
+
+# Upsert (update on conflict)
+anysite db upsert <name> --table users --conflict-columns id --stdin
+
+# Insert with conflict handling
+anysite db insert <name> --table users --file data.jsonl \
+  --on-conflict ignore --conflict-columns email
+```
+
+### SQL Queries
+```bash
+anysite db query <name> --sql "SELECT * FROM users" --format table
+anysite db query <name> --file report.sql --format csv --output report.csv
+```
+
+### Supported Databases
+- **SQLite** -- `--type sqlite --path ./data.db`
+- **PostgreSQL** -- `--type postgres --host localhost --database mydb --user app --password-env DB_PASS`
+- PostgreSQL also supports `--url-env DATABASE_URL` for connection strings
+
+---
+
+## Three-Level Filtering
+
+The pipeline supports filtering at three independent stages:
+
+```
+Collection -> [source.filter] -> LLM -> Parquet -> [transform.filter] -> Export
+                                                    [db_load.filter]  -> DB
+```
+
+| Level | Config | When | Effect |
+|-------|--------|------|--------|
+| 1 | `source.filter` | After collection, before LLM + Parquet | Drops records entirely |
+| 2 | `transform.filter` | After Parquet, before exports | Parquet keeps all |
+| 3 | `db_load.filter` | Before DB loading | Parquet keeps all |
+
+```yaml
+- id: analyzed
+  type: llm
+  dependency: { from_source: comments, field: urn.value }
+  filter: '.is_commenter_post_author == false'   # Level 1
+  llm:
+    - type: enrich
+      add: ["score:1-10"]
+  transform:
+    filter: '.score > 5'                          # Level 2
+    fields: [text, author, score]
+  db_load:
+    filter: '.score > 8'                          # Level 3
+    fields: [text, author, score]
+```
+
+### Filter Syntax
+Safe expression parser (no `eval()`). Supported operators: `==`, `!=`, `>`, `<`, `>=`, `<=`. Connectors: `and`, `or`. Values: strings (`"..."`), numbers, booleans (`true`/`false`), `null`.
+
+```
+.field > 10
+.status == "active"
+.active == true
+.hidden == false
+.location != ""
+.name != null
+.count > 5 and .count < 100
+.status == "active" or .status == "pending"
+```
+
+### Per-Source Transform
+
+`transform` block applies to export destinations only. Parquet always stores full records.
+
+```yaml
+transform:
+  filter: '.employee_count > 10 and .status == "active"'
+  fields:
+    - name
+    - url
+    - urn.value AS urn_id          # Dot-notation with alias
+    - employee_count
+  add_columns:
+    batch: "q1-2026"
+    source: "linkedin"
+```
+
+---
+
+## LLM Enrichment
+
+Optional `llm` list per source. Steps run **after collection, before Parquet write**, so enriched fields are stored in Parquet and flow to DB via `db_load.fields`.
+
+### Step Types
+
+| Type | Purpose | Required | Output |
+|------|---------|----------|--------|
+| `enrich` | Extract structured attributes | `add` specs | One column per spec |
+| `classify` | Categorize records | `categories` (optional -- auto-detects if omitted) | `category` + `category_confidence` |
+| `summarize` | Concise text summary | -- | `summary` |
+| `generate` | Custom text from prompt template | `prompt` | `text` |
+
+### Config Example
+
+```yaml
+sources:
+  - id: profiles
+    endpoint: /api/linkedin/user
+    llm:
+      - type: enrich
+        add:
+          - "sentiment:positive/negative/neutral"
+          - "language:string"
+          - "quality_score:1-10"
+        fields: [headline, summary]     # Fields sent to LLM (empty = all)
+      - type: classify
+        categories: "developer,recruiter,executive"
+        output_column: role_type        # Default: "category"
+        fields: [headline]
+      - type: summarize
+        max_length: 50
+        output_column: bio              # Default: "summary"
+      - type: generate
+        prompt: "Write a pitch for {name} who works as {headline}"
+        output_column: pitch            # Default: "text"
+        temperature: 0.7                # Higher for creative generation
+    db_load:
+      fields: [name, headline, sentiment, language, quality_score, role_type, bio, pitch]
+```
+
+### Enrich Field Spec Formats
+
+| Format | Example | JSON Schema Type |
+|--------|---------|-----------------|
+| Enum | `sentiment:positive/negative/neutral` | `string` with `enum` |
+| String | `language:string` | `string` |
+| Integer | `count:integer` | `integer` |
+| Range | `score:1-10` | `integer` |
+| Number | `weight:number` | `number` |
+| Boolean | `active:boolean` | `boolean` |
+
+### Per-Step Overrides
+
+Each step supports: `provider`, `model`, `temperature`, `max_tokens`, `fields`, `output_column`.
+
+### Collect Flags
+
+```bash
+# Collect with LLM enrichment (default when llm: is configured)
+anysite dataset collect dataset.yaml
+
+# Skip LLM steps
+anysite dataset collect dataset.yaml --no-llm
+
+# Dry run shows LLM step count per source
+anysite dataset collect dataset.yaml --dry-run
+```
+
+### LLM Response Caching
+
+LLM responses are cached in SQLite (`~/.anysite/llm_cache.db`). Re-running collection on the same data reuses cached results without calling the LLM provider. Clear with `anysite llm cache-clear`.
+
+### Incremental Behavior
+
+`--incremental` skips already-collected inputs at collection stage -- only new records reach LLM enrichment. LLM response cache provides additional savings for repeated content.
+
+---
+
+## Per-Source Export
+
+Export destinations run after Parquet write. Transform is applied to export records if configured.
+
+### File Export
+```yaml
+export:
+  - type: file
+    path: ./output/{{source}}-{{date}}.csv
+    format: csv                    # json, jsonl, csv
+```
+
+Template variables: `{{date}}` (YYYY-MM-DD), `{{datetime}}` (ISO), `{{source}}` (source ID), `{{dataset}}` (dataset name).
+
+### Webhook Export
+```yaml
+export:
+  - type: webhook
+    url: https://example.com/hook
+    headers:
+      X-Token: abc
+```
+
+Sends POST with JSON body: `{dataset, source, count, records, timestamp}`.
+
+---
+
+## Run History & Logs
+
+Every `collect` run is automatically recorded in SQLite (`~/.anysite/dataset_history.db`).
+
+```bash
+# View run history
+anysite dataset history my-dataset
+anysite dataset history my-dataset --limit 5
+
+# View logs for a specific run
+anysite dataset logs my-dataset --run 42
+
+# View latest run logs
+anysite dataset logs my-dataset
+```
+
+---
+
+## Scheduling
+
+Generate cron or systemd entries from the `schedule.cron` config.
+
+```bash
+# Crontab entry (default)
+anysite dataset schedule dataset.yaml --incremental --load-db pg
+
+# Systemd timer units
+anysite dataset schedule dataset.yaml --systemd --incremental --load-db pg
+```
+
+Output example:
+```
+0 9 * * * /path/to/anysite dataset collect dataset.yaml --incremental --load-db pg >> ~/.anysite/logs/my-dataset_cron.log 2>&1
+```
+
+---
+
+## Notifications
+
+Webhook notifications sent on collection complete or failure.
+
+```yaml
+notifications:
+  on_complete:
+    - url: "https://hooks.slack.com/services/xxx"
+      headers: {Authorization: "Bearer token"}
+  on_failure:
+    - url: "https://alerts.example.com/fail"
+```
+
+Payload: `{event: "complete"|"failure", dataset, timestamp, record_count, source_count, duration, error}`.
+
+---
+
+## Comparing Snapshots (Diff)
+
+Compare two collection snapshots to find added, removed, and changed records.
+
+```bash
+# Compare two most recent snapshots (auto-detect dates)
+anysite dataset diff dataset.yaml --source profiles --key _input_value
+
+# Compare with dot-notation key (JSON fields)
+anysite dataset diff dataset.yaml --source profiles --key urn.value
+
+# Compare specific dates
+anysite dataset diff dataset.yaml --source profiles --key urn.value --from 2026-01-30 --to 2026-02-01
+
+# Only compare specific fields
+anysite dataset diff dataset.yaml --source profiles --key urn --fields "name,headline,follower_count"
+
+# Output as JSON/CSV
+anysite dataset diff dataset.yaml --source profiles --key urn --format json --output diff.json
+```
+
+**Options:**
+- `--source, -s` (required) -- source to compare
+- `--key, -k` (required) -- field to match records by. Supports dot-notation for JSON fields (e.g., `urn.value`)
+- `--from` / `--to` -- snapshot dates (default: two most recent)
+- `--fields, -f` -- restrict both comparison and output to these fields
+- `--format` -- output format (table, json, jsonl, csv)
+- `--output, -o` -- write to file
+
+**Output** shows summary counts and a table of changes:
+- **added** -- records in the new snapshot but not the old
+- **removed** -- records in the old snapshot but not the new
+- **changed** -- records with the same key but different values (shows `old -> new`)
+
+---
+
+## Reset Incremental State
+
+Clear collected input tracking to force re-collection.
+
+```bash
+# Reset all sources
+anysite dataset reset-cursor dataset.yaml
+
+# Reset specific source
+anysite dataset reset-cursor dataset.yaml --source profiles
+```
+
+---
+
+## Common Mistakes
+
+| # | Mistake | Fix |
+|---|---------|-----|
+| 1 | `field: urn.value` for author profiles (wrong URN) | Use `field: author.urn.value` -- run `anysite describe` to find correct path |
+| 2 | `input_template: { company: "microsoft" }` (missing placeholder) | Use `company: "{value}"` -- `{value}` is replaced with extracted value |
+| 3 | `endpoint: api/linkedin/user` (no leading `/`) | Use `endpoint: /api/linkedin/user` |
+| 4 | `categories: ["pos", "neg"]` (array) | Use `categories: "pos,neg"` -- comma-separated string |
+| 5 | `parallel: 50` (too high) | Use `parallel: 3` to `5` -- higher causes rate limiting |
+| 6 | Confusing `field` and `input_key` | `field` = WHAT to extract from parent; `input_key` = WHERE to put it in API call |
+| 7 | `type: llm` without `dependency` | LLM sources require `dependency` (parent source) and `llm` (>= 1 step) |
+| 8 | SQL query uses `search-results` view name | Hyphens -> underscores in DuckDB views: use `search_results` |
+
+**Validate catches most errors:**
+```bash
+anysite dataset validate dataset.yaml --json
+# "Endpoint must start with '/'"           -> add leading /
+# "enrich step requires 'add'"             -> add 'add' list to enrich step
+# "LLM source must have a dependency"      -> add dependency block
+# "did you mean '=='?"                     -> replace = with == in filter
+```

--- a/content/anysite/skills/anysite-cli/references/llm-reference.md
+++ b/content/anysite/skills/anysite-cli/references/llm-reference.md
@@ -1,0 +1,274 @@
+# LLM Analysis Reference
+
+## Setup
+
+```bash
+anysite llm setup
+```
+
+Interactive configuration: selects provider (`openai` or `anthropic`), API key environment variable, default model, and optionally tests the connection. Writes to `~/.anysite/config.yaml` under the `llm:` key.
+
+### Configuration Format
+
+```yaml
+llm:
+  default_provider: openai
+  providers:
+    openai:
+      provider: openai
+      api_key_env: OPENAI_API_KEY
+      default_model: gpt-4.1-mini
+    anthropic:
+      provider: anthropic
+      api_key_env: ANTHROPIC_API_KEY
+      default_model: claude-sonnet-4-5-20250514
+  cache_enabled: true
+  default_temperature: 0.0
+  default_max_tokens: 4096
+  rate_limit: "50/m"
+```
+
+### Provider Support
+
+| Provider | SDK | Structured Output | Default Model |
+|----------|-----|-------------------|---------------|
+| OpenAI | `openai` (AsyncOpenAI) | JSON Schema via `response_format` | `gpt-4.1-mini` |
+| Anthropic | `anthropic` (AsyncAnthropic) | System-prompt with JSON schema instruction | `claude-sonnet-4-5-20250514` |
+
+## Commands
+
+### `anysite llm summarize`
+
+Summarize each record in a dataset source.
+
+```bash
+anysite llm summarize <dataset.yaml> --source <source_id> [OPTIONS]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--source, -s` | Source to summarize (required) |
+| `--max-length` | Max words in summary (default: 100) |
+| `--output-column` | Column name for summary (default: `summary`) |
+| `--prompt` | Custom prompt override |
+| `--prompt-file` | Read prompt from file |
+| `--dry-run` | Show prompt without calling LLM |
+
+### `anysite llm classify`
+
+Classify records into categories.
+
+```bash
+anysite llm classify <dataset.yaml> --source <source_id> [OPTIONS]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--source, -s` | Source to classify (required) |
+| `--categories, -c` | Comma-separated categories (auto-detects if omitted) |
+| `--multi` | Allow multiple categories per record |
+| `--output-column` | Column name for category (default: `category`) |
+| `--prompt` | Custom prompt override |
+| `--prompt-file` | Read prompt from file |
+| `--dry-run` | Show prompt without calling LLM |
+
+When `--categories` is omitted, the classifier auto-detects 3-7 categories from the first 20 records.
+
+### `anysite llm enrich`
+
+Enrich records with LLM-extracted attributes.
+
+```bash
+anysite llm enrich <dataset.yaml> --source <source_id> --add <spec> [OPTIONS]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--source, -s` | Source to enrich (required) |
+| `--add` | Field spec: `name:type_or_values` (repeatable, at least one required) |
+| `--prompt` | Custom prompt override |
+| `--prompt-file` | Read prompt from file |
+| `--dry-run` | Show prompt without calling LLM |
+
+**Field spec formats:**
+
+| Format | Example | Description |
+|--------|---------|-------------|
+| Enum | `sentiment:positive/negative/neutral` | Constrained to listed values |
+| Type | `language:string` | Free-form string |
+| Range | `quality_score:1-10` | Integer value |
+| Boolean | `is_technical:boolean` | True/false |
+| Number | `relevance:number` | Floating point |
+
+### `anysite llm generate`
+
+Generate text for each record using a custom prompt.
+
+```bash
+anysite llm generate <dataset.yaml> --source <source_id> --prompt <template> [OPTIONS]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--source, -s` | Source to process (required) |
+| `--prompt` | Prompt with `{field}` placeholders (required unless `--prompt-file`) |
+| `--prompt-file` | Read prompt from file |
+| `--output-column` | Column name for generated text (default: `text`) |
+| `--dry-run` | Show prompt without calling LLM |
+
+The prompt template supports `{field_name}` placeholders that are replaced with record values. Example: `"Write a bio for {name} who works as {headline}"`.
+
+Default temperature is 0.7 (higher than other commands).
+
+### `anysite llm match`
+
+Match records between two dataset sources.
+
+```bash
+anysite llm match <dataset.yaml> --source-a <id> --source-b <id> [OPTIONS]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--source-a` | First source (required) |
+| `--source-b` | Second source (required) |
+| `--fields-a` | Fields from source A to include |
+| `--fields-b` | Fields from source B to include |
+| `--top-k` | Max matches per source-a record (default: 3) |
+| `--threshold` | Min match score 0.0-1.0 (default: 0.5) |
+| `--prompt` | Custom prompt override |
+| `--prompt-file` | Read prompt from file |
+| `--dry-run` | Show prompt without calling LLM |
+
+Processes each source-a record against batches of 10 source-b records. Returns matches with score and reason.
+
+### `anysite llm deduplicate`
+
+Find semantic duplicates in a dataset source.
+
+```bash
+anysite llm deduplicate <dataset.yaml> --source <source_id> [OPTIONS]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--source, -s` | Source to deduplicate (required) |
+| `--key, -k` | Field for blocking (grouping similar records) (default: `name`) |
+| `--threshold` | Min confidence for duplicate (default: 0.8) |
+| `--prompt` | Custom prompt override |
+| `--prompt-file` | Read prompt from file |
+| `--dry-run` | Show prompt without calling LLM |
+
+Uses a blocking pass (first 3 chars of key field) to group candidate duplicates before LLM evaluation.
+
+### `anysite llm cache-stats`
+
+Show LLM cache statistics (entry count, total input/output tokens).
+
+```bash
+anysite llm cache-stats
+anysite llm cache-stats --json    # Machine-readable JSON output
+```
+
+### `anysite llm cache-clear`
+
+Clear all cached LLM responses.
+
+```bash
+anysite llm cache-clear
+anysite llm cache-clear --json    # Machine-readable JSON output
+```
+
+## Common Options
+
+These options are shared across `summarize`, `classify`, `enrich`, `generate`, `match`, and `deduplicate`:
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--provider` | LLM provider name | From config |
+| `--model` | Model ID override | From config |
+| `--parallel, -j` | Concurrent LLM calls | 5 |
+| `--rate-limit` | Rate limit (e.g., `"50/m"`, `"10/s"`) | From config |
+| `--temperature` | LLM temperature | 0.0 (0.7 for generate) |
+| `--max-tokens` | Max response tokens | 4096 |
+| `--no-cache` | Skip cache lookup | false |
+| `--format, -f` | Output format: json/jsonl/csv/table | json |
+| `--output, -o` | Write results to file | stdout |
+| `--fields` | Record fields to include in LLM prompt | All fields |
+| `--quiet, -q` | Suppress progress/stats output | false |
+| `--dry-run` | Show prompt without calling LLM | false |
+| `--prompt` | Custom prompt template | Built-in |
+| `--prompt-file` | Read prompt from file | - |
+
+## Prompt System
+
+### Built-in Prompts
+
+| Key | Used by | Description |
+|-----|---------|-------------|
+| `summarize` | `summarize` | Summarize record in N words |
+| `classify` | `classify` | Classify records into categories |
+| `classify_auto_detect` | `classify` (no categories) | Auto-detect categories from sample |
+| `match` | `match` | Rank candidates by relevance |
+| `deduplicate` | `deduplicate` | Identify semantic duplicates |
+| `enrich` | `enrich` | Extract specified attributes |
+
+### Custom Prompts
+
+Use `--prompt` for inline templates or `--prompt-file` to read from a file.
+
+Template variables:
+- `{record}` -- formatted record (all non-underscore fields)
+- `{records}` -- formatted batch of records with indices
+- `{field_name}` -- individual record field value
+- Command-specific variables: `{max_length}`, `{categories}`, `{field_descriptions}`, `{source_a_name}`, `{source_b_name}`, etc.
+
+### Field Filtering
+
+`--fields "name,headline,location"` restricts which record fields are sent to the LLM. Supports dot-notation for nested fields (e.g., `urn.value`).
+
+## Cache System
+
+SQLite database at `~/.anysite/llm_cache.db` with WAL mode. Cache keys are SHA256 hashes of `{provider}:{system_prompt+user_prompt}:{input_data}`.
+
+Disable per-command with `--no-cache`. Disable globally by setting `cache_enabled: false` in config.
+
+## Examples
+
+```bash
+# Classify LinkedIn posts by sentiment
+anysite llm classify dataset.yaml --source posts \
+  --categories "positive,negative,neutral" \
+  --fields "text,title" --format table --output sentiment.csv
+
+# Summarize company profiles
+anysite llm summarize dataset.yaml --source companies \
+  --fields "name,description,industry" --max-length 50 --format table
+
+# Enrich profiles with multiple attributes
+anysite llm enrich dataset.yaml --source profiles \
+  --add "seniority:junior/mid/senior/executive" \
+  --add "department:string" \
+  --add "is_technical:boolean" \
+  --format csv --output enriched.csv
+
+# Generate personalized messages
+anysite llm generate dataset.yaml --source profiles \
+  --prompt "Write a cold outreach message for {name}, {headline} at {company}" \
+  --temperature 0.7 --model gpt-4.1
+
+# Match people to companies
+anysite llm match dataset.yaml --source-a profiles --source-b companies \
+  --fields-a "name,headline,skills" --fields-b "name,industry,description" \
+  --top-k 3 --threshold 0.6
+
+# Find duplicate profiles
+anysite llm deduplicate dataset.yaml --source profiles \
+  --key name --threshold 0.8 --fields "name,headline,location"
+
+# Preview prompt without calling LLM
+anysite llm classify dataset.yaml --source posts --dry-run
+
+# Use a custom prompt from file
+anysite llm generate dataset.yaml --source profiles --prompt-file my_prompt.txt
+```

--- a/content/anysite/skills/anysite-competitor-analyzer/SKILL.md
+++ b/content/anysite/skills/anysite-competitor-analyzer/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: anysite-competitor-analyzer
+description: "Deep competitive intelligence: leadership analysis, product comparison, and strategic assessment"
+metadata:
+  revision: 1
+  updated-on: "2026-03-16"
+  source: community
+  tags: "swot,leadership,pricing,product-comparison,glassdoor"
+---
+
+# Competitor Analyzer
+
+Systematic framework for gathering and analyzing competitive intelligence using Anysite MCP tools.
+
+## When to Use This Skill
+
+Trigger this skill when users ask to:
+- "Analyze [competitor name]"
+- "Research our competitors"
+- "Create a competitive analysis of [company]"
+- "How does [competitor] position themselves?"
+- "What are [competitor]'s strengths and weaknesses?"
+- "Compare our product with [competitor]"
+- "Build a battle card for [competitor]"
+
+## Analysis Workflow
+
+### Phase 1: Foundation (15-20 min)
+
+**Step 1: Initialize Analysis Structure**
+```bash
+python scripts/analyze_competitor.py "Competitor Name" "https://competitor.com" > /tmp/analysis.json
+```
+
+**Step 2: Web Presence Reconnaissance**
+
+Scrape key pages to understand positioning:
+```python
+# Homepage - core messaging
+Anysite:parse_webpage({"url": "https://competitor.com", "only_main_content": true, "strip_all_tags": true})
+
+# Pricing - cost structure
+Anysite:parse_webpage({"url": "https://competitor.com/pricing", "only_main_content": true})
+
+# About - company background
+Anysite:parse_webpage({"url": "https://competitor.com/about", "only_main_content": true, "extract_contacts": true})
+```
+
+**Extract from homepage:** H1/H2 headlines -> positioning, feature bullets -> core_features, customer logos, value prop
+**Extract from pricing:** Tier names/prices, cost per unit, free tier limits, entry price
+**Extract from about:** Company description, location, team size hints
+
+### Phase 2: LinkedIn Intelligence (10-15 min)
+
+**Step 3: Find Company Profile**
+```python
+Anysite:search_linkedin_companies({"keywords": "competitor name", "count": 5})
+Anysite:get_linkedin_company({"company": "company-slug-from-search"})
+```
+
+Extract: `follower_count`, `employee_count`, `description`, `headquarters`, `specialties`
+
+**Step 4: Analyze Team & Growth**
+```python
+Anysite:get_linkedin_company_employees({"companies": ["company-slug"], "keywords": "engineer developer", "count": 50})
+Anysite:get_linkedin_company_employees({"companies": ["company-slug"], "keywords": "CEO founder", "count": 10})
+```
+
+Assess: Team size, eng:sales ratio (GTM strategy signal), recent hires (growth phase indicator)
+
+**Step 5: Content Strategy**
+```python
+Anysite:get_linkedin_company_posts({"urn": "company-urn-from-profile", "count": 20})
+```
+
+Analyze posts for: Frequency, themes, engagement, tone of voice
+
+### Phase 3: Deep Social & Community Research (20-30 min)
+
+**Step 6: Twitter Deep Dive** - Analyze company account, founder accounts, brand mentions, sentiment
+**Step 7: Reddit Community Intelligence** - Brand presence, competitive discussions, deep thread analysis
+**Step 7.5: Cross-Platform Insight Synthesis** - Compare Twitter vs Reddit for authentic signals
+
+See **[references/DEEP_ANALYSIS.md](references/DEEP_ANALYSIS.md)** for detailed Twitter sentiment scoring, Reddit mining workflows, and cross-platform synthesis methodology.
+
+### Phase 4: Leadership & Founders Intelligence (15-20 min)
+
+**Step 8:** Identify key leaders via LinkedIn search
+**Step 9:** Analyze leadership activity (posts, comments, reactions)
+**Step 10:** Twitter leadership presence analysis
+
+### Phase 5: Technical & Data Discovery (10-15 min)
+
+**Step 11:** Documentation quality assessment
+**Step 12:** GitHub presence (stars, forks, commit frequency)
+**Step 13:** Alternative data sources (Glassdoor reviews)
+**Step 14:** Integration ecosystem analysis
+
+### Phase 6: Synthesis (15-20 min)
+
+**Step 15: Competitive Analysis**
+
+Compare findings against your own product:
+- **Strengths**: 3-5 clear advantages (features, pricing, market position, execution)
+- **Weaknesses**: 3-5 clear gaps (missing features, high prices, poor UX)
+- **Opportunities**: Their weaknesses you can capitalize on, underserved segments
+- **Threats**: Their strengths that could hurt you, recent funding or growth
+
+**Step 16: Strategic Insights**
+
+- **Key Takeaways** (3-5 bullets): Most important findings, clear and actionable
+- **Competitive Threats** (2-3 bullets): What they could do to hurt your position
+- **Opportunities to Exploit** (3-5 bullets): How to position against them, their vulnerabilities
+- **Watch Areas**: Things to monitor quarterly, signals of strategic shifts
+
+**Step 17: Generate Final Report**
+
+Update JSON template with findings, generate markdown report.
+
+## Common Patterns
+
+### Pattern 1: Rapid Assessment (30-45 min)
+Homepage + pricing scrape, LinkedIn company profile, 20 recent social posts, brief summary (1 page)
+
+### Pattern 2: Deep Intelligence (2-3 hours)
+Full web presence (7-10 pages), complete LinkedIn intelligence, 50-100 social posts/mentions, community sentiment, technical documentation review, full report
+
+### Pattern 3: Pricing Focus
+All pricing pages, unit economics calculation, tier structure mapping, market comparison, pricing strategy identification
+
+### Pattern 4: Leadership Focus
+All founders and C-level identified, deep LinkedIn profiles, 50+ personal posts analyzed, Twitter presence mapped, previous company experience tracked
+
+## Tips for Effective Analysis
+
+- **Be Systematic:** Follow the phase order, don't skip LinkedIn (best growth signals), always check pricing
+- **Think Strategically:** Not just "what" but "why", look for patterns, consider constraints
+- **Verify Claims:** Marketing copy != reality, cross-reference sources, note confidence levels
+- **Focus on Actionable Insights:** Analyze implications, recommend actions, identify immediate threats
+- **Document Data Freshness:** Always note analysis date, mark recent vs stale data
+
+## Troubleshooting
+
+**"Can't find LinkedIn company":** Try name variations, search for CEO and find company from profile
+**"Pricing page missing":** Check /plans, /buy, /subscribe; note "Contact Sales" as enterprise signal
+**"No social media presence":** Document the absence (itself a signal), check founder personal accounts
+**"Too much data":** Start with Phase 1 & 2 only, generate partial report, add depth if needed
+
+## Reference Documentation
+
+- **[DEEP_ANALYSIS.md](references/DEEP_ANALYSIS.md)** - Detailed social media analysis, leadership intelligence, technical discovery, and advanced techniques

--- a/content/anysite/skills/anysite-competitor-analyzer/references/DEEP_ANALYSIS.md
+++ b/content/anysite/skills/anysite-competitor-analyzer/references/DEEP_ANALYSIS.md
@@ -1,0 +1,199 @@
+# Deep Competitor Analysis Workflows
+
+## Phase 3: Deep Social & Community Research
+
+### Twitter Deep Dive
+
+**A. Company Account Analysis**
+```python
+Anysite:get_twitter_user({"user": "competitor_handle"})
+Anysite:get_twitter_user_posts({"user": "competitor_handle", "count": 100})
+```
+
+Extract: Followers, tweet frequency, content mix, response time, tone, most engaging tweets.
+
+**B. Founder/Executive Twitter Presence**
+```python
+Anysite:get_twitter_user({"user": "founder_handle"})
+Anysite:get_twitter_user_posts({"user": "founder_handle", "count": 100})
+```
+
+Leadership signals: Personal brand strength, technical credibility, customer engagement, follower quality.
+
+**C. Brand Mentions & Sentiment**
+```python
+# Comprehensive mention search
+Anysite:search_twitter_posts({"query": "competitor_name OR @handle", "count": 200})
+
+# Problem/complaint mentions
+Anysite:search_twitter_posts({"query": "competitor_name (problem OR issue OR bug OR expensive)", "count": 100})
+
+# Positive sentiment
+Anysite:search_twitter_posts({"query": "competitor_name (love OR great OR amazing OR best)", "count": 100})
+
+# Competitive mentions
+Anysite:search_twitter_posts({"query": "competitor_name vs OR alternative OR switching from", "count": 100})
+```
+
+**Sentiment scoring:**
+```
+For each mention batch, calculate:
+- Positive mentions: praise, recommendations, success stories
+- Negative mentions: complaints, frustrations, churn signals
+- Neutral mentions: questions, feature discussions
+Sentiment Score = (Positive - Negative) / Total
+Range: -1.0 (very negative) to +1.0 (very positive)
+```
+
+### Reddit Deep Community Intelligence
+
+**A. Brand Presence Mapping**
+```python
+Anysite:search_reddit_posts({"query": "competitor_name", "count": 100})
+
+# Search relevant subreddits
+relevant_subs = ["SaaS", "startups", "webdev", "programming", "datascience"]
+```
+
+**B. Competitive Discussions**
+```python
+Anysite:search_reddit_posts({"query": "competitor_name vs", "count": 100})
+Anysite:search_reddit_posts({"query": "alternative to competitor_name", "count": 100})
+Anysite:search_reddit_posts({"query": "better than competitor_name", "count": 50})
+```
+
+**C. Deep Thread Analysis**
+```python
+Anysite:get_reddit_post({"post_url": "reddit.com/r/subreddit/comments/..."})
+Anysite:get_reddit_post_comments({"post_url": "reddit.com/r/subreddit/comments/..."})
+```
+
+**D. Sentiment & Voice Analysis**
+
+Positive signals: "I love [competitor]", "Works perfectly for...", "Best tool for...", "Highly recommend"
+Negative signals: "Disappointed with...", "Overpriced", "Customer support is...", "Looking for alternative"
+
+**E. Cross-Platform Insight Synthesis**
+
+Twitter typically shows: Official narrative, marketing messaging, surface-level sentiment
+Reddit typically reveals: Unfiltered opinions, detailed technical discussions, pricing sensitivity, real problems
+
+Look for disconnects between platforms as signals of product-market fit quality.
+
+## Phase 4: Leadership & Founders Intelligence
+
+### Identify Key Leaders
+```python
+Anysite:search_linkedin_users({
+    "company_keywords": "competitor-name",
+    "title": "founder OR CEO OR CTO OR CPO",
+    "count": 10
+})
+
+Anysite:get_linkedin_profile({
+    "user": "founder-linkedin-username",
+    "with_experience": true,
+    "with_education": true,
+    "with_skills": true
+})
+```
+
+Extract: Full career history, previous companies, education, skills, languages, recommendations.
+
+### Analyze Leadership Activity
+```python
+Anysite:get_linkedin_user_posts({"urn": "user-urn", "count": 50})
+Anysite:get_linkedin_user_comments({"urn": "user-urn", "count": 30})
+Anysite:get_linkedin_user_reactions({"urn": "user-urn", "count": 50})
+```
+
+Analyze: Posting frequency, themes, technical depth, customer engagement, thought leadership quality.
+
+### Twitter Leadership Presence
+```python
+Anysite:get_twitter_user({"user": "founder_handle"})
+Anysite:get_twitter_user_posts({"user": "founder_handle", "count": 100})
+```
+
+Indicators: Personal brand strength, technical credibility, customer relationships, industry influence.
+
+## Phase 5: Technical & Data Discovery
+
+### Documentation Quality
+```python
+Anysite:parse_webpage({"url": "https://competitor.com/docs", "only_main_content": true})
+Anysite:parse_webpage({"url": "https://competitor.com/api", "only_main_content": true})
+```
+
+Assess: Documentation completeness, code examples, interactive explorer, SDK availability.
+
+### GitHub Presence
+```python
+Anysite:parse_webpage({"url": "https://github.com/competitor-org", "only_main_content": true})
+Anysite:parse_webpage({"url": "https://github.com/competitor-org/main-repo", "only_main_content": true})
+```
+
+Extract: Star count, fork count, commit frequency, contributors, issue response time, open source components.
+
+### Alternative Data Sources
+```python
+Anysite:parse_webpage({"url": "https://www.glassdoor.com/Reviews/competitor-name", "only_main_content": true})
+```
+
+Extract: Overall rating, CEO approval, salary ranges, interview difficulty, work-life balance, recent reviews.
+
+### Integration Ecosystem
+```python
+Anysite:get_sitemap({"url": "https://competitor.com/sitemap.xml", "count": 50})
+Anysite:parse_webpage({"url": "https://competitor.com/integrations", "only_main_content": true})
+```
+
+Extract: Integration partners, platform focus, API-first vs GUI-first approach.
+
+## Advanced Techniques
+
+### Multi-Competitor Analysis
+
+For analyzing 3-5 competitors simultaneously:
+1. Run analysis workflow for each competitor
+2. Create comparison matrix: pricing table, feature matrix, market position map, social presence
+3. Focus on key differentiators
+
+### Ongoing Monitoring (Quarterly)
+
+Quick check (30 min):
+```python
+Anysite:parse_webpage({"url": "competitor.com/pricing"})
+Anysite:get_linkedin_company_posts({"urn": "...", "count": 10})
+Anysite:get_linkedin_company_employees({"companies": ["..."], "count": 20})
+Anysite:search_twitter_posts({"query": "competitor", "count": 50})
+```
+
+### Battle Card Creation
+
+Focus on:
+1. Quick facts (1-2 sentences)
+2. Head-to-head feature comparison (table format)
+3. Pricing comparison (clear numbers)
+4. 3 reasons we win
+5. 3 reasons we might lose
+6. Talk tracks ("When they say X, we say Y")
+
+Keep to 1-2 pages maximum.
+
+## Output Quality Standards
+
+**Good competitive analysis includes:**
+- Clear positioning statement
+- Quantified metrics (prices, follower counts, team size)
+- Specific examples (actual quotes, feature lists)
+- Strategic implications explained
+- Data sources noted
+- Confidence levels indicated
+
+**Avoid:**
+- Vague assessments ("they seem good at X")
+- Unsupported claims ("probably losing money")
+- Missing pricing details
+- Outdated data without date stamps
+- Pure feature lists without analysis

--- a/content/anysite/skills/anysite-competitor-intelligence/SKILL.md
+++ b/content/anysite/skills/anysite-competitor-intelligence/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: anysite-competitor-intelligence
+description: "Track competitor activities, hiring patterns, content strategies, and market positioning"
+metadata:
+  revision: 1
+  updated-on: "2026-03-16"
+  source: community
+  tags: "benchmarking,hiring,strategy,market-share,monitoring"
+---
+
+# anysite Competitor Intelligence
+
+Comprehensive competitive intelligence gathering using anysite MCP server. Track competitors across LinkedIn, social media, and the web to understand their strategies, monitor their activities, and identify competitive opportunities.
+
+## Overview
+
+- **Track competitor companies** on LinkedIn and Y Combinator
+- **Monitor hiring patterns** to identify growth areas and strategic priorities
+- **Analyze content strategies** across social platforms
+- **Benchmark positioning** and messaging
+- **Identify key employees** and leadership changes
+- **Track competitive movements** like funding, launches, partnerships
+
+## Supported Platforms
+
+- **LinkedIn** (Primary): Company pages, employee search, post monitoring, growth tracking
+- **Y Combinator**: Startup competitor research, funding data, batch analysis
+- **Twitter/X**: Social presence monitoring, content strategy, engagement analysis
+- **Reddit**: Community sentiment, product discussions, competitor mentions
+- **Instagram**: Brand presence, visual content strategy, influencer partnerships
+- **YouTube**: Video content, channel growth, community engagement
+- **Web Scraping**: Company websites, press releases, blog content
+- **SEC**: Public company filings for competitors
+
+## Quick Start
+
+### Step 1: Identify Competitors
+
+| Goal | Primary Tool | Output |
+|------|-------------|--------|
+| Find similar companies | `search_linkedin_companies` | Company list with metrics |
+| Research startup competitors | `search_yc_companies` | YC startups by industry/batch |
+| Discover by employee search | `search_linkedin_users` -> companies | Companies from profiles |
+| Find by keywords/industry | `search_linkedin_companies` + keywords | Filtered company list |
+
+### Step 2: Gather Competitive Intelligence
+
+**Company Profile Analysis**
+```
+Tool: mcp__anysite__get_linkedin_company
+Parameters:
+- company: "competitor-name" or LinkedIn URL
+Returns: Description, size, location, website, specialties
+```
+
+**Employee Intelligence**
+```
+Tool: mcp__anysite__search_linkedin_users
+Parameters:
+- company_keywords: "Competitor Inc"
+- title: "VP OR Director OR Head" (for leadership)
+- count: 50
+```
+
+**Hiring Velocity Analysis**
+```
+Tool: mcp__anysite__get_linkedin_company_employee_stats
+Parameters:
+- urn: <company URN from search>
+Returns: Growth metrics, department distribution
+```
+
+**Content Strategy**
+```
+Tool: mcp__anysite__get_linkedin_company_posts
+Parameters:
+- urn: <company URN>
+- count: 20
+Returns: Recent posts, engagement, messaging themes
+```
+
+### Step 3: Analyze
+
+- **Growth signals**: Hiring velocity, funding, expansion
+- **Strategic priorities**: Department hiring, job postings, content themes
+- **Market positioning**: Messaging, target audience, value props
+- **Competitive threats**: New products, partnerships, key hires
+
+## Common Workflows
+
+### Workflow 1: Comprehensive Competitor Profile
+
+1. **Company Overview**: `get_linkedin_company` -> Size, industry, description, website
+2. **Leadership Team**: `search_linkedin_users` with company + C-level/VP titles
+3. **Organizational Structure**: `get_linkedin_company_employee_stats` + department searches
+4. **Content Strategy**: `get_linkedin_company_posts` + `get_twitter_user_posts`
+5. **Product/Market Intel**: `parse_webpage` on competitor site + `search_reddit_posts`
+
+### Workflow 2: Competitive Landscape Mapping
+
+1. **Identify Competitors**: `search_linkedin_companies` with industry keywords
+2. **Filter and Prioritize**: Review company descriptions, filter by relevance
+3. **Categorize**: Direct, Indirect, Potential competitors
+4. **Size and Growth**: `get_linkedin_company_employee_stats` for each
+5. **Positioning**: Company posts + website analysis
+6. **Funding** (startups): `search_yc_companies` + `get_yc_company`
+
+### Workflow 3: Hiring Velocity Tracking
+
+1. **Baseline**: `get_linkedin_company_employee_stats` for current count
+2. **Open Positions**: `search_linkedin_jobs` for competitor
+3. **Recent Hires**: `search_linkedin_users` + experience date analysis
+4. **Key Departures**: Track "Former" employees, identify patterns
+5. **Talent Pipeline**: Analyze where competitors hire from
+
+### Workflow 4: Content Strategy Benchmarking
+
+1. **LinkedIn**: `get_linkedin_company_posts(urn, count=50)` -> frequency, themes, engagement
+2. **Twitter/X**: `get_twitter_user_posts` -> tweet frequency, content themes
+3. **YouTube**: `get_youtube_channel_videos` -> upload frequency, views, topics
+4. **Instagram**: `get_instagram_user_posts` -> visual style, engagement rates
+5. **Blog**: `parse_webpage` + `get_sitemap` -> publishing frequency, topics
+6. **Community**: `search_reddit_posts` -> customer feedback, sentiment
+
+## MCP Tools Reference
+
+### LinkedIn Company Intelligence
+- `search_linkedin_companies` - Search by keywords, location, industry, size
+- `get_linkedin_company` - Detailed company profile
+- `get_linkedin_company_employee_stats` - Employee statistics and growth
+- `get_linkedin_company_posts` - Recent posts with engagement
+
+### LinkedIn People Intelligence
+- `search_linkedin_users` - Find employees by title, department
+- `get_linkedin_profile` - Detailed employee profile
+- `get_linkedin_user_experience` - Detailed work history
+
+### Y Combinator Intelligence
+- `search_yc_companies` - Search by industry, batch
+- `get_yc_company` - Detailed profile with founders, batch, status
+- `search_yc_founders` - Founder research
+
+### Social Media Monitoring
+- Twitter/X: `search_twitter_posts`, `get_twitter_user`, `get_twitter_user_posts`
+- Instagram: `search_instagram_posts`, `get_instagram_user`, `get_instagram_user_posts`
+- Reddit: `search_reddit_posts`, `get_reddit_post`
+- YouTube: `search_youtube_videos`, `get_youtube_channel_videos`, `get_youtube_video`
+
+### Web Intelligence
+- `parse_webpage` - Extract content from competitor websites
+- `get_sitemap` - Get all pages on competitor site
+- `duckduckgo_search` - Search for competitor mentions across the web
+
+## Advanced Features
+
+### SWOT Analysis Framework
+
+**Strengths** (LinkedIn, website, reviews): Team expertise, product features, market position, brand recognition
+**Weaknesses** (reviews, job postings, turnover): Customer complaints, hiring challenges, product gaps
+**Opportunities** (market analysis): Underserved segments, geographic expansion, product expansion
+**Threats** (competitive monitoring): New entrants (YC), competitive hiring, product launches
+
+### Win/Loss Analysis
+
+For each competitor in deals:
+1. `get_linkedin_company` -> Current positioning
+2. `parse_webpage(website + "/pricing")` -> Pricing strategy
+3. `parse_webpage(website + "/features")` -> Feature set
+4. `search_reddit_posts(competitor)` -> Customer feedback
+5. `get_linkedin_company_posts` -> Recent messaging
+
+## Output Formats
+
+**Chat Summary**: Key findings, competitive threats, growth signals, recommended actions
+**CSV Export**: Competitor comparison matrix with size, growth, engagement, threat score
+**JSON Export**: Complete data for time-series tracking and dashboard visualization
+
+## Reference Documentation
+
+- **[ANALYSIS_PATTERNS.md](references/ANALYSIS_PATTERNS.md)** - Competitive analysis frameworks, SWOT templates, and intelligence gathering patterns

--- a/content/anysite/skills/anysite-competitor-intelligence/references/ANALYSIS_PATTERNS.md
+++ b/content/anysite/skills/anysite-competitor-intelligence/references/ANALYSIS_PATTERNS.md
@@ -1,0 +1,97 @@
+# Competitive Analysis Patterns
+
+Frameworks and templates for analyzing competitors using anysite MCP data.
+
+## SWOT Analysis Framework
+
+### Data Collection for SWOT
+
+**Strengths**:
+```
+LinkedIn:
+- get_linkedin_company -> Company size, growth
+- get_linkedin_company_posts -> Messaging, brand strength
+- search_linkedin_users -> Leadership quality
+
+Y Combinator:
+- get_yc_company -> Funding, pedigree
+
+Social:
+- Follower counts, engagement rates
+- Content quality and frequency
+```
+
+**Weaknesses**:
+```
+Reddit:
+- search_reddit_posts(competitor) -> Customer complaints
+- Product gaps, feature requests
+
+LinkedIn:
+- Employee turnover (departures)
+- Job re-postings (hiring challenges)
+
+Web:
+- Website quality, user experience
+- Missing features vs. competitors
+```
+
+**Opportunities**:
+```
+Market gaps identified through:
+- Competitor job postings (expansion areas)
+- Customer requests in forums
+- Underserved geographies
+- Unaddressed use cases
+```
+
+**Threats**:
+```
+Competitive threats:
+- YC batch analysis (new entrants)
+- Hiring velocity (aggressive growth)
+- New product launches
+- Pricing changes
+```
+
+## Competitive Positioning Matrix
+
+**Dimensions to Track**:
+1. Market Focus (Enterprise vs. SMB)
+2. Product Complexity (Simple vs. Feature-Rich)
+3. Pricing Strategy (Premium vs. Value)
+4. Customer Type (Technical vs. Business Users)
+
+**Data Sources**:
+- Website messaging
+- LinkedIn company description
+- Pricing pages
+- Job postings (customer success vs. enterprise support)
+
+## Porter's Five Forces Analysis
+
+**Threat of New Entrants**:
+- Monitor YC batches for new competitors
+- Track LinkedIn company formations in space
+- Watch for well-funded startups
+
+**Competitive Rivalry**:
+- Employee count growth rates
+- Content output and engagement
+- Product launch frequency
+- Market share signals
+
+**Supplier Power**:
+- Identify common technology partners
+- Track integrations and partnerships
+- Monitor platform dependencies
+
+**Buyer Power**:
+- Analyze customer segments (from job postings)
+- Track pricing transparency
+- Monitor customer communities
+
+**Threat of Substitutes**:
+- Identify adjacent solutions
+- Track feature overlap
+- Monitor market positioning shifts

--- a/content/anysite/skills/anysite-content-analytics/SKILL.md
+++ b/content/anysite/skills/anysite-content-analytics/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: anysite-content-analytics
+description: "Measure content performance, engagement metrics, and posting strategy effectiveness"
+metadata:
+  revision: 1
+  updated-on: "2026-03-16"
+  source: community
+  tags: "engagement,roi,viral,posting-strategy,benchmarking"
+---
+
+# anysite Content Analytics
+
+Measure and optimize content performance across social platforms using anysite MCP. Track engagement, identify top performers, and refine your content strategy.
+
+## Overview
+
+- **Track post performance** across Instagram, YouTube, LinkedIn, Twitter/X
+- **Analyze engagement metrics** (likes, comments, shares, views)
+- **Identify top content** and viral patterns
+- **Benchmark against competitors** for strategy insights
+- **Optimize posting strategy** based on data
+
+**Coverage**: 80% - Strong for Instagram, YouTube, LinkedIn, Twitter, Reddit
+
+## Supported Platforms
+
+- Instagram: Posts, Reels, likes, comments, engagement rates
+- YouTube: Videos, views, likes, comments, watch time indicators
+- LinkedIn: Posts, articles, reactions, comments, shares
+- Twitter/X: Tweets, retweets, likes, replies
+- Reddit: Posts, upvotes, comments, awards
+
+## Quick Start
+
+**Step 1: Collect Content Data**
+
+Platform-specific:
+- Instagram: `get_instagram_user_posts(username, count=50)`
+- LinkedIn: `get_linkedin_user_posts(urn, count=50)`
+- Twitter: `get_twitter_user_posts(user, count=100)`
+- YouTube: `get_youtube_channel_videos(channel, count=30)`
+
+**Step 2: Analyze Engagement**
+
+Calculate metrics:
+- Engagement rate: (likes + comments + shares) / followers
+- Best performing content: Top 10% by engagement
+- Content types: Video vs. image vs. text
+- Posting frequency: Posts per week
+
+**Step 3: Identify Patterns**
+
+Look for:
+- Best posting times (day of week, time)
+- Top-performing topics/themes
+- Optimal content length
+- High-engagement formats
+
+**Step 4: Optimize Strategy**
+
+Based on findings:
+- Double down on top content types
+- Post more during peak engagement times
+- Replicate successful topics
+- Adjust content mix
+
+## Common Workflows
+
+### Workflow 1: Instagram Content Audit
+
+1. Get all posts: `get_instagram_user_posts(username, count=100)`
+2. Calculate metrics: engagement rate, content type breakdown
+3. Identify top performers: sort by engagement, analyze common patterns
+4. Analyze content mix: Reels vs. carousels vs. single images
+5. Benchmark against competitors
+
+### Workflow 2: LinkedIn Content Strategy Analysis
+
+1. Collect post history: `get_linkedin_user_posts(urn, count=100)`
+2. Categorize content: text-only, image, video, article, poll
+3. Analyze engagement by type: reactions, comments, shares per category
+4. Topic analysis: extract themes from top posts
+5. Posting timing analysis: group by day/time, calculate average engagement
+
+### Workflow 3: YouTube Channel Performance Analysis
+
+1. Get channel videos: `get_youtube_channel_videos(channel, count=50)`
+2. Analyze each video: views, likes, comments, view velocity
+3. Identify patterns in top 20%: length, titles, topics, timing
+4. Engagement analysis from comments
+5. Content mix optimization: long-form vs short, tutorial vs entertainment
+
+## MCP Tools Reference
+
+### Instagram
+- `get_instagram_user_posts(user, count)` - Get posts with engagement
+- `get_instagram_post(post_id)` - Get detailed post metrics
+- `get_instagram_post_likes(post, count)` - Analyze likers
+- `get_instagram_post_comments(post, count)` - Get comments
+
+### LinkedIn
+- `get_linkedin_user_posts(urn, count)` - Get post history
+- `get_linkedin_company_posts(urn, count)` - Company page posts
+
+### Twitter/X
+- `get_twitter_user_posts(user, count)` - Get tweets
+- `search_twitter_posts(query, count)` - Find trending tweets
+
+### YouTube
+- `get_youtube_channel_videos(channel, count)` - All videos
+- `get_youtube_video(video)` - Video details and metrics
+- `get_youtube_video_comments(video, count)` - Comments
+
+### Reddit
+- `reddit_user_posts(username, count)` - User's posts
+- `search_reddit_posts(query, count)` - Find popular posts
+
+## Key Metrics
+
+**Engagement Rate**:
+- Formula: (Likes + Comments + Shares) / Followers x 100
+- Instagram benchmark: 3-6%
+- LinkedIn benchmark: 2-5% of connections
+- Twitter benchmark: 0.5-1%
+
+**Content Performance Score**:
+```
+Score = (Engagement Rate x 40) +
+        (Comments/Likes Ratio x 30) +
+        (Share Rate x 30)
+```
+
+**Viral Potential Indicators**:
+- Engagement rate >2x average
+- High share rate (>5% of engagement)
+- Rapid engagement velocity (50% within 24h)
+- Quality comments (questions, discussions)
+
+## Output Formats
+
+**Chat Summary**: Top 5 performing posts, key insights, optimization recommendations
+**CSV Export**: Post URL, date, type, likes, comments, shares, engagement rate, rank
+**JSON Export**: Full post data with metadata, time-series engagement, historical trends
+
+## Reference Documentation
+
+- **[METRICS_GUIDE.md](references/METRICS_GUIDE.md)** - Detailed metrics definitions, calculation formulas, and benchmarks

--- a/content/anysite/skills/anysite-content-analytics/references/METRICS_GUIDE.md
+++ b/content/anysite/skills/anysite-content-analytics/references/METRICS_GUIDE.md
@@ -1,0 +1,63 @@
+# Content Analytics Metrics Guide
+
+## Core Metrics
+
+**Engagement Rate**:
+```
+(Likes + Comments + Shares) / Followers x 100
+
+Benchmarks:
+- Instagram: 3-6% (good), 7%+ (excellent)
+- LinkedIn: 2-5% (good), 6%+ (excellent)
+- Twitter: 0.5-1% (good), 2%+ (excellent)
+```
+
+**Engagement Velocity**:
+```
+Engagement in first 24h / Total engagement x 100
+
+Good: 50-60%
+Excellent: 70%+
+```
+
+**Comment-to-Like Ratio**:
+```
+Comments / Likes x 100
+
+Indicates engagement quality
+Good: 5-10%
+Excellent: 15%+
+```
+
+## Platform-Specific Metrics
+
+**Instagram**:
+- Saves (if available): Indicates value
+- Shares: Viral potential
+- Profile visits: Discovery effectiveness
+
+**LinkedIn**:
+- Click-through rate on links
+- Follower growth from posts
+- Comment quality (length, depth)
+
+**YouTube**:
+- View duration: Watch time percentage
+- Subscriber conversion: Subs from video
+- Click-through rate on thumbnails
+
+## Content Type Benchmarks
+
+**Instagram**:
+- Reels: 5-10% engagement
+- Carousels: 4-7% engagement
+- Single images: 3-5% engagement
+
+**LinkedIn**:
+- Native video: Highest engagement
+- Text + image: Good engagement
+- Link posts: Lower engagement
+
+**YouTube**:
+- 10-15 min: Optimal length for most niches
+- First 30 sec: Critical for retention

--- a/content/anysite/skills/anysite-influencer-discovery/SKILL.md
+++ b/content/anysite/skills/anysite-influencer-discovery/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: anysite-influencer-discovery
+description: "Find and evaluate influencers by niche, engagement rate, and audience quality"
+metadata:
+  revision: 1
+  updated-on: "2026-03-16"
+  source: community
+  tags: "creators,ambassador,micro-influencer,partnership,kol"
+---
+
+# anysite Influencer Discovery
+
+Find and analyze influencers across social platforms using anysite MCP. Discover content creators, evaluate their reach and engagement, and identify partnership opportunities.
+
+## Overview
+
+- **Discover influencers** across Instagram, Twitter, LinkedIn, YouTube
+- **Analyze engagement** and audience quality
+- **Track activity** and content patterns
+- **Evaluate partnership fit** based on niche and metrics
+- **Build influencer lists** with contact information
+
+**Coverage**: 85% - Excellent for Instagram, Twitter, LinkedIn, YouTube influencers.
+
+## Supported Platforms
+
+- Instagram: Profile stats, posts, followers, engagement, Reels
+- Twitter/X: User search, followers, tweets, engagement
+- LinkedIn: B2B influencers, thought leaders, professional content
+- YouTube: Channel search, subscribers, views, video performance
+- Reddit: Community influencers, karma, post quality
+
+## Quick Start
+
+**Step 1: Search for Influencers**
+
+By platform:
+- Instagram: `search_instagram_posts` with niche keywords + hashtags
+- Twitter: `search_twitter_users` with niche keywords
+- LinkedIn: `search_linkedin_users` with industry + "thought leader"
+- YouTube: `search_youtube_videos` with niche, then analyze channels
+
+**Step 2: Analyze Profiles**
+
+Get detailed metrics:
+- Instagram: `get_instagram_user` -> followers, posts, engagement rate
+- Twitter: `get_twitter_user` -> followers, tweet frequency
+- YouTube: `get_youtube_channel_videos` -> subscribers, views, growth
+- LinkedIn: `get_linkedin_profile` -> connections, post engagement
+
+**Step 3: Evaluate Engagement**
+
+Check engagement quality:
+- Post likes, comments, shares
+- Engagement rate (engagement / followers)
+- Audience authenticity (comment quality)
+- Content consistency (posts per week)
+
+**Step 4: Build Influencer List**
+
+Export with:
+- Name, handle, platform
+- Follower count, engagement rate
+- Niche/topics, content type
+- Contact info (if available)
+- Partnership fit score
+
+## Common Workflows
+
+### Workflow 1: Instagram Influencer Discovery
+
+**Scenario**: Find Instagram influencers in sustainable fashion (10k-100k followers)
+
+1. Search by hashtag/keywords: `search_instagram_posts(query="sustainable fashion", count=100)`
+2. Analyze each creator: `get_instagram_user(username)` -> filter by follower range
+3. Evaluate content: `get_instagram_user_posts(username, count=30)` -> engagement rate, quality
+4. Check audience quality: `get_instagram_post_likes` + `get_instagram_post_comments` -> real engagement
+5. Get contact information from bios and LinkedIn
+
+### Workflow 2: LinkedIn Thought Leader Identification
+
+**Scenario**: Find B2B thought leaders in SaaS/sales
+
+1. Search for active posters: `search_linkedin_users(keywords="SaaS sales thought leader", count=100)`
+2. Analyze post activity: `get_linkedin_user_posts(urn, count=50)` -> filter by frequency and engagement
+3. Evaluate influence: average reactions, comment quality, share count
+4. Assess content quality: expertise demonstration, original insights
+
+### Workflow 3: YouTube Creator Research
+
+**Scenario**: Find YouTube creators in tech reviews
+
+1. Search for niche content: `search_youtube_videos(query="tech review 2026", count=100)`
+2. Analyze channels: `get_youtube_channel_videos(channel, count=30)` -> metrics
+3. Evaluate video performance: views, likes, comments per video
+4. Analyze audience engagement from comments
+
+## MCP Tools Reference
+
+### Instagram
+- `search_instagram_posts` - Find posts by keywords/hashtags
+- `get_instagram_user` - Get profile with followers, bio
+- `get_instagram_user_posts` - Get recent posts with engagement
+- `get_instagram_post_likes` - Check audience authenticity
+- `get_instagram_post_comments` - Analyze engagement quality
+- `get_instagram_user_friendships` - Get followers list
+
+### Twitter/X
+- `search_twitter_users` - Find users by keywords/bio
+- `get_twitter_user` - Get profile with followers, tweets
+- `get_twitter_user_posts` - Get recent tweets with engagement
+- `search_twitter_posts` - Find influential tweets in niche
+
+### LinkedIn
+- `search_linkedin_users` - Find professionals by keywords/title
+- `get_linkedin_profile` - Get complete profile
+- `get_linkedin_user_posts` - Get post history and engagement
+- `get_linkedin_user_skills` - Verify expertise
+
+### YouTube
+- `search_youtube_videos` - Find videos by keywords
+- `get_youtube_channel_videos` - Get all videos from channel
+- `get_youtube_video` - Get video metrics (views, likes)
+- `get_youtube_video_comments` - Analyze audience engagement
+
+### Reddit
+- `search_reddit_posts` - Find influential posts in subreddits
+- `reddit_user_posts` - Get user's post history
+- `reddit_user_comments` - Analyze community engagement
+
+## Influencer Evaluation Framework
+
+### Reach Metrics
+- **Followers**: Total audience size
+- **Views**: Average content views
+- **Growth**: Follower growth rate
+
+### Engagement Metrics
+- **Rate**: Engagement / Followers
+- **Quality**: Comment depth and relevance
+- **Consistency**: Regular engagement patterns
+
+### Authenticity Indicators
+- **Audience Quality**: Real vs. fake followers
+- **Comment Quality**: Meaningful discussions
+- **Growth Pattern**: Organic vs. purchased
+- **Engagement Distribution**: Consistent vs. spiky
+
+### Content Quality
+- **Production Value**: Visual/audio quality
+- **Originality**: Unique vs. repurposed
+- **Consistency**: Regular posting schedule
+- **Niche Alignment**: On-brand content
+
+### Partnership Fit
+- **Audience Overlap**: Match with target market
+- **Brand Alignment**: Values and messaging
+- **Professionalism**: Past partnerships, disclosure
+- **Availability**: Contact information, responsiveness
+
+## Advanced Features
+
+### Micro-Influencer Strategy
+
+Focus on 10k-50k followers for higher engagement:
+- Higher engagement rates (5-10% vs. 1-3%)
+- More authentic audience connections
+- Lower partnership costs
+- Niche expertise
+
+### Multi-Platform Presence Analysis
+
+Identify influencers active across platforms:
+1. Find on Instagram/Twitter
+2. Search LinkedIn for professional presence
+3. Check for YouTube channel
+4. Look for website/blog (parse_webpage)
+
+## Output Formats
+
+**Chat Summary**: Top 10 influencers with key metrics, engagement comparison, partnership recommendations
+**CSV Export**: Name, handle, platform, followers, engagement rate, niche, email, fit score
+**JSON Export**: Complete profile data, all posts with engagement, audience demographics
+
+## Reference Documentation
+
+- **[DISCOVERY_CRITERIA.md](references/DISCOVERY_CRITERIA.md)** - Influencer evaluation criteria, scoring frameworks, and niche identification strategies

--- a/content/anysite/skills/anysite-influencer-discovery/references/DISCOVERY_CRITERIA.md
+++ b/content/anysite/skills/anysite-influencer-discovery/references/DISCOVERY_CRITERIA.md
@@ -1,0 +1,50 @@
+# Influencer Discovery Criteria
+
+## Influencer Scoring Framework (0-100 points)
+
+### Reach (25 points)
+- 100k+ followers: 25 points
+- 50k-100k: 20 points
+- 10k-50k: 15 points
+- 1k-10k: 10 points
+- <1k: 5 points
+
+### Engagement Rate (30 points)
+- >10%: 30 points
+- 7-10%: 25 points
+- 4-7%: 20 points
+- 2-4%: 15 points
+- <2%: 5 points
+
+###Authenticity (25 points)
+- Organic growth pattern: 10 points
+- Quality comments: 8 points
+- Consistent engagement: 7 points
+
+### Niche Alignment (20 points)
+- Perfect fit: 20 points
+- Strong fit: 15 points
+- Moderate fit: 10 points
+- Weak fit: 5 points
+
+## Platform-Specific Benchmarks
+
+**Instagram**:
+- Engagement rate: 3-6% (good), 7%+ (excellent)
+- Posts per week: 3-5 (ideal)
+- Story engagement: 5-10% of followers
+
+**Twitter/X**:
+- Engagement rate: 1-3% (good), 4%+ (excellent)
+- Tweets per day: 2-5 (ideal)
+- Retweet ratio: 20-30%
+
+**LinkedIn**:
+- Engagement rate: 2-5% of connections (good)
+- Posts per week: 2-3 (ideal)
+- Comment quality: High
+
+**YouTube**:
+- View/subscriber ratio: 10-20% (good)
+- Upload frequency: Weekly (ideal)
+- Average watch time: >50%

--- a/content/anysite/skills/anysite-lead-generation/SKILL.md
+++ b/content/anysite/skills/anysite-lead-generation/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: anysite-lead-generation
+description: "LinkedIn prospect discovery, email finding, company research, and contact enrichment for sales"
+metadata:
+  revision: 1
+  updated-on: "2026-03-16"
+  source: community
+  tags: "prospecting,outreach,email-finder,contacts,b2b,crm"
+---
+
+# anysite Lead Generation
+
+Professional lead generation and prospecting using the anysite MCP server. Find prospects on LinkedIn, discover verified emails, extract contacts from websites, and build comprehensive lead lists for sales, recruiting, and business development.
+
+## Overview
+
+- **Find qualified prospects** on LinkedIn using advanced search filters
+- **Enrich profiles** with work history, education, and skills
+- **Discover email addresses** through LinkedIn email finding
+- **Extract contact information** from company websites
+- **Research companies** to identify target accounts
+- **Build prospect lists** formatted for CRM import
+
+## Supported Platforms
+
+- **LinkedIn** (Primary): People search, profile enrichment, email discovery, company research, employee listings
+- **Web Scraping**: Contact extraction from websites, sitemap parsing, general web data
+- **Instagram**: Business account discovery and profile analysis (supplementary)
+- **Y Combinator**: Startup company and founder research (supplementary)
+
+## Quick Start
+
+### Step 1: Identify Your Lead Source
+
+| Goal | Primary Tool | Use Case |
+|------|-------------|----------|
+| Find prospects by title/company | `search_linkedin_users` | B2B prospecting, targeted outreach |
+| Enrich existing leads | `get_linkedin_profile` | Add work history, education, skills |
+| Find verified emails | `find_linkedin_user_email` | Email outreach campaigns |
+| Extract website contacts | `parse_webpage` | Get emails/phones from contact pages |
+| Research target companies | `search_linkedin_companies` | Account-based marketing (ABM) |
+| Find company employees | `search_linkedin_users` + company filter | Multi-threading into accounts |
+
+### Step 2: Execute Data Collection
+
+**Find Sales VPs in San Francisco**
+```
+Tool: mcp__anysite__search_linkedin_users
+Parameters:
+- title: "VP Sales"
+- location: "San Francisco Bay Area"
+- count: 25
+```
+
+**Enrich a LinkedIn Profile**
+```
+Tool: mcp__anysite__get_linkedin_profile
+Parameters:
+- user: "linkedin.com/in/johndoe" or "johndoe"
+- with_experience: true
+- with_education: true
+- with_skills: true
+```
+
+**Find Email Address**
+```
+Tool: mcp__anysite__find_linkedin_user_email
+Parameters:
+- email: "john@company.com" (for reverse lookup)
+- count: 5
+```
+
+**Extract Contacts from Website**
+```
+Tool: mcp__anysite__parse_webpage
+Parameters:
+- url: "https://company.com/contact"
+- extract_contacts: true
+- strip_all_tags: true
+```
+
+### Step 3: Process and Analyze Results
+
+Review the returned data for:
+- **Profile completeness**: Work history, education, skills presence
+- **Contact quality**: Email deliverability, phone format
+- **Relevance scoring**: Title match, company fit, location alignment
+- **Enrichment opportunities**: Missing data that can be filled
+
+### Step 4: Format Output
+
+**CSV Export**: Full prospect list with all fields, ready for CRM import (Salesforce, HubSpot)
+**JSON Export**: Structured data for custom integration and automation
+**Chat Summary**: Top prospects with key details and actionable next steps
+
+## Common Workflows
+
+### Workflow 1: LinkedIn B2B Prospecting
+
+**Scenario**: Find 50 qualified prospects at SaaS companies
+
+1. **Search for prospects**: `search_linkedin_users` with title, location, company keywords, count=50
+2. **Enrich top prospects** (10-20): `get_linkedin_profile` with experience and education
+3. **Find email addresses**: `find_linkedin_user_email` + `get_linkedin_user_email_db`
+4. **Export to CRM**: CSV with Full Name, Title, Company, Location, Email, LinkedIn URL
+
+### Workflow 2: Account-Based Marketing (ABM)
+
+**Scenario**: Find decision-makers at specific target companies
+
+1. **Research target companies**: `search_linkedin_companies` with ICP criteria
+2. **Get company details**: `get_linkedin_company` for each target
+3. **Find employees**: `search_linkedin_users` with company filter + title filter
+4. **Enrich decision-makers**: `get_linkedin_profile` + `find_linkedin_user_email`
+5. **Create ABM campaign**: Group by company, identify multi-threading opportunities
+
+### Workflow 3: Website Contact Extraction
+
+**Scenario**: Extract contacts from company websites
+
+1. **Get company websites** from LinkedIn or existing list
+2. **Parse contact pages**: `parse_webpage` with `extract_contacts=true` on /contact, /about/team
+3. **Get sitemap**: `get_sitemap` for comprehensive page discovery
+4. **Deduplicate and validate** extracted contacts
+
+## Multi-Platform Lead Enrichment
+
+Combine LinkedIn data with other platforms:
+
+**Pattern**: LinkedIn -> Company Website -> Instagram (for B2C)
+
+1. Find prospect on LinkedIn
+2. Get company website from LinkedIn company profile
+3. Extract additional contacts from website
+4. Check Instagram for business account (B2C companies)
+5. Analyze social presence and engagement
+
+## Boolean Search Patterns
+
+**Title Combinations**:
+- `"VP Sales" OR "Head of Sales" OR "Director Sales"` - Multiple title variations
+- `"Software Engineer" AND "Python"` - Title + required skill
+- `"Marketing" NOT "Intern"` - Exclude junior levels
+
+**Company Patterns**:
+- `"Google OR Meta OR Amazon"` - Multiple target companies
+- `"SaaS" AND "B2B"` - Industry qualifiers
+
+**Location Strategies**:
+- `"San Francisco Bay Area"` - Metropolitan areas
+- `"United States"` - Country-level
+
+## Rate Limits and Best Practices
+
+**Strategies for Large Datasets**:
+1. **Batch Processing**: Use `count` parameter to limit results per call (25-50 at a time)
+2. **Increase Timeout**: Use `request_timeout` parameter for complex queries (400-600 seconds)
+3. **Parallel Processing**: Search multiple locations simultaneously
+
+**Data Freshness**:
+- LinkedIn data is real-time through anysite MCP
+- Email database (`get_linkedin_user_email_db`) may have stale entries
+- Use `find_linkedin_user_email` for current discovery, fall back to database
+
+**Privacy and Compliance**:
+- Respect LinkedIn's usage policies
+- Comply with GDPR/CCPA requirements
+- Only collect publicly available emails
+- Provide opt-out mechanisms and maintain suppression lists
+
+## Reference Documentation
+
+- **[LINKEDIN_STRATEGIES.md](references/LINKEDIN_STRATEGIES.md)** - Advanced LinkedIn search patterns, Boolean operators, and targeting strategies
+- **[WEB_SCRAPING.md](references/WEB_SCRAPING.md)** - Website contact extraction patterns, common page structures, and parsing techniques
+- **[WORKFLOWS.md](references/WORKFLOWS.md)** - Detailed workflow examples, MCP tool parameters, lead scoring framework, and troubleshooting

--- a/content/anysite/skills/anysite-lead-generation/references/LINKEDIN_STRATEGIES.md
+++ b/content/anysite/skills/anysite-lead-generation/references/LINKEDIN_STRATEGIES.md
@@ -1,0 +1,460 @@
+# LinkedIn Lead Generation Strategies
+
+Advanced strategies and best practices for LinkedIn prospecting using anysite MCP.
+
+## Boolean Search Operators
+
+### Basic Operators
+
+**AND** - Both terms must be present
+```
+title:"Software Engineer" AND "Python"
+```
+
+**OR** - Either term must be present
+```
+title:"VP Sales" OR "Head of Sales" OR "Director Sales"
+```
+
+**NOT** - Exclude terms
+```
+title:"Marketing" NOT "Intern" NOT "Coordinator"
+```
+
+**Quotes** - Exact phrase match
+```
+title:"Chief Technology Officer"
+```
+
+**Parentheses** - Group logic
+```
+title:("VP" OR "Director") AND ("Sales" OR "Business Development")
+```
+
+### Advanced Search Patterns
+
+#### Title Targeting
+
+**Executive Level**:
+```
+title:(VP OR "Vice President" OR SVP OR EVP OR C-level OR Chief OR President)
+```
+
+**Management Level**:
+```
+title:(Director OR "Head of" OR Manager OR Lead) NOT (Assistant OR Associate)
+```
+
+**Individual Contributor**:
+```
+title:("Software Engineer" OR Developer OR Analyst) NOT (Manager OR Director OR Lead)
+```
+
+**Seniority Filters**:
+```
+title:(Senior OR Staff OR Principal OR Lead OR Architect)
+```
+
+#### Industry-Specific Patterns
+
+**SaaS/Technology**:
+```
+company_keywords:(SaaS OR "Cloud Software" OR "Enterprise Software" OR B2B)
+```
+
+**Finance**:
+```
+company_keywords:("Investment Bank" OR "Private Equity" OR "Venture Capital" OR Fintech)
+```
+
+**Healthcare**:
+```
+company_keywords:(Healthcare OR "Health Tech" OR Medical OR Pharma OR Biotech)
+```
+
+**E-commerce/Retail**:
+```
+company_keywords:(E-commerce OR Retail OR "Consumer Products" OR DTC)
+```
+
+#### Location Strategies
+
+**Metropolitan Areas**:
+```
+location:"San Francisco Bay Area"
+location:"New York City Metropolitan Area"
+location:"Greater Boston"
+```
+
+**Remote Work**:
+```
+location:(Remote OR "Work from Home" OR Distributed)
+```
+
+**Multi-Location Search**:
+```
+location:("San Francisco" OR "New York" OR "Austin" OR "Seattle")
+```
+
+**Country-Level**:
+```
+location:"United States"
+location:"United Kingdom"
+```
+
+## ICP-Based Search Strategies
+
+### Enterprise B2B SaaS
+
+**Target Profile**: Decision-makers at mid-market to enterprise SaaS companies
+
+**Search Strategy**:
+```
+Step 1: Find Companies
+- keywords: "B2B SaaS" OR "Enterprise Software"
+- employee_count: ["201-500", "501-1000", "1001-5000"]
+- industry: "Computer Software"
+
+Step 2: Find Decision-Makers
+- company_keywords: <from step 1>
+- title: "VP" OR "SVP" OR "Chief" OR "Head of"
+- keywords: "Sales" OR "Revenue" OR "GTM" OR "Business Development"
+```
+
+**Refinement**:
+- Filter for companies with recent funding (check YC or Crunchbase)
+- Prioritize companies with 100+ LinkedIn followers
+- Target specific verticals (HR Tech, Sales Tech, Marketing Tech)
+
+### Startup Ecosystem
+
+**Target Profile**: Founders and early employees at seed/Series A startups
+
+**Search Strategy**:
+```
+Step 1: Find Startups (Y Combinator)
+- search_yc_companies
+- batches: Recent batches (W24, S23, W23)
+- industries: <your target verticals>
+
+Step 2: Find Founders
+- get_yc_company -> Extract founder LinkedIn profiles
+- title: "Founder" OR "Co-Founder" OR "CEO"
+
+Step 3: Find Early Team
+- company_keywords: <startup names from step 1>
+- title: "Head of" OR "VP" OR "Lead"
+- Filter for <50 total employees
+```
+
+**Refinement**:
+- Target companies that recently raised funding
+- Focus on specific YC batches or industries
+- Look for hiring signals (job postings, team growth)
+
+### Agency/Services
+
+**Target Profile**: Agency owners and service providers
+
+**Search Strategy**:
+```
+Step 1: Find Agencies
+- keywords: "Agency" OR "Services" OR "Consulting"
+- employee_count: ["11-50", "51-200"]
+- industry: <specific agency type>
+
+Step 2: Find Owners/Principals
+- title: "Owner" OR "Founder" OR "Principal" OR "Managing Director"
+- company_keywords: <agency names>
+```
+
+**Refinement**:
+- Target specific agency types (Marketing, Design, Development)
+- Filter by client focus (B2B vs B2C)
+- Look for agencies with strong LinkedIn presence
+
+## Search Workflow Optimization
+
+### Funnel Approach
+
+**Stage 1: Broad Search** (500+ prospects)
+- Cast wide net with general criteria
+- Focus on title and location only
+- Identify target companies
+
+**Stage 2: Company Filtering** (200-300 prospects)
+- Research target companies
+- Filter by company size, industry, funding
+- Remove obviously poor fits
+
+**Stage 3: Title Refinement** (100-150 prospects)
+- Narrow to specific decision-maker titles
+- Filter by seniority level
+- Prioritize by title match
+
+**Stage 4: Profile Enrichment** (50-75 prospects)
+- Get full LinkedIn profiles
+- Review work history and education
+- Score based on qualification criteria
+
+**Stage 5: Email Discovery** (25-40 prospects)
+- Find verified emails
+- Extract website contacts
+- Validate email addresses
+
+**Stage 6: Final Qualification** (15-25 prospects)
+- Deep research on top prospects
+- Personalization research
+- Ready for outreach
+
+### Batch Processing Strategy
+
+**Batch Size Guidelines**:
+- **Initial Search**: 50-100 prospects per batch
+- **Profile Enrichment**: 10-20 profiles per batch
+- **Email Finding**: 5-10 lookups per batch
+- **Website Scraping**: 5-10 websites per batch
+
+**Timing Between Batches**:
+- Wait 30-60 seconds between large searches
+- Process enrichment results before next batch
+- Review quality before scaling up
+
+**Parallel Processing**:
+- Search multiple locations simultaneously
+- Enrich different cohorts in parallel
+- Extract contacts from multiple websites at once
+
+Example:
+```
+Parallel Batch 1:
+- search_linkedin_users(location="San Francisco", count=50)
+- search_linkedin_users(location="New York", count=50)
+- search_linkedin_users(location="Austin", count=50)
+
+After review, Parallel Batch 2:
+- Enrich top 10 from San Francisco
+- Enrich top 10 from New York
+- Enrich top 10 from Austin
+```
+
+## Qualification Frameworks
+
+### BANT Framework (Budget, Authority, Need, Timeline)
+
+**Budget** - Company size and funding
+```
+Check:
+- Employee count (proxy for budget)
+- Recent funding rounds (via YC or company posts)
+- Company description for "Enterprise" or "SMB"
+```
+
+**Authority** - Decision-making power
+```
+Target titles:
+- C-level: Final decision maker
+- VP/SVP: Budget authority
+- Director: Influencer/user
+- Manager: User/champion
+```
+
+**Need** - Problem awareness
+```
+Research:
+- LinkedIn posts about challenges
+- Job postings for relevant roles
+- Company growth signals
+- Industry trends
+```
+
+**Timeline** - Buying readiness
+```
+Indicators:
+- Recently joined company (new priorities)
+- Job posting for related role
+- Company expansion news
+- Fiscal calendar alignment
+```
+
+### Lead Scoring Model
+
+**Profile Score (40 points)**:
+- Exact title match: 20 points
+- Similar title: 15 points
+- Right department: 10 points
+- Related role: 5 points
+
+**Company Score (30 points)**:
+- Ideal company size: 15 points
+- Right industry: 10 points
+- Growth signals: 5 points
+
+**Engagement Score (20 points)**:
+- Active on LinkedIn: 10 points
+- Recent posts: 5 points
+- Profile completeness: 5 points
+
+**Contact Score (10 points)**:
+- Email found: 10 points
+- Phone found: 5 points
+- No contact: 0 points
+
+**Total**: 0-100 points
+- **80-100**: Immediate outreach
+- **60-79**: High priority
+- **40-59**: Qualified
+- **<40**: Nurture or discard
+
+## Personalization Research
+
+### Profile Intelligence
+
+**Work History**:
+```
+get_linkedin_profile + with_experience: true
+
+Extract:
+- Career progression (promotions, moves)
+- Company tenure (job hopper vs. stable)
+- Industry experience
+- Skill development path
+```
+
+**Education**:
+```
+get_linkedin_profile + with_education: true
+
+Look for:
+- Alma mater (school connections)
+- Degree relevance to your solution
+- Certifications (continuous learning)
+- Shared education background
+```
+
+### Company Intelligence
+
+**Company Profile**:
+```
+get_linkedin_company
+
+Analyze:
+- Company description (positioning)
+- Industry and specialties
+- Employee count trend
+- Headquarters location
+```
+
+**Recent Activity**:
+```
+get_linkedin_company_posts
+
+Review:
+- Announcement posts (expansion, funding, hiring)
+- Thought leadership topics
+- Engagement levels
+- Company culture signals
+```
+
+## Email Discovery Strategies
+
+### LinkedIn Email Methods
+
+**Method 1**: Direct Email Finding
+```
+find_linkedin_user_email(email="prospect@company.com")
+```
+
+**Method 2**: Database Lookup
+```
+get_linkedin_user_email_db(profile="linkedin.com/in/prospect")
+```
+
+**Method 3**: Contact Info Section
+```
+get_linkedin_profile(user, with_experience=true)
+-> Check profile for contact info section
+-> May include email, phone, website
+```
+
+### Website Email Extraction
+
+**Contact Page Pattern**:
+```
+parse_webpage(
+  url="https://company.com/contact",
+  extract_contacts=true
+)
+
+Common contact pages:
+- /contact
+- /contact-us
+- /about/contact
+- /get-in-touch
+- /reach-us
+```
+
+### Email Pattern Guessing
+
+**Common Patterns**:
+```
+first.last@company.com (most common)
+first@company.com
+flast@company.com
+firstl@company.com
+first_last@company.com
+```
+
+## CRM Integration Patterns
+
+### Salesforce Import Format
+
+**Required Fields**:
+```csv
+First Name,Last Name,Email,Company,Title,Phone,LinkedIn URL
+Jane,Smith,jane@tech.com,TechCorp,VP Sales,415-555-1234,linkedin.com/in/janesmith
+```
+
+### HubSpot Import Format
+
+**Contact Properties**:
+```csv
+Email,First Name,Last Name,Job Title,Company Name,LinkedIn Profile URL,Lead Score,Lifecycle Stage
+jane@tech.com,Jane,Smith,VP Sales,TechCorp,linkedin.com/in/janesmith,85,Sales Qualified Lead
+```
+
+## Compliance & Best Practices
+
+### GDPR Compliance
+
+- Only collect publicly available information
+- Document lawful basis for processing
+- Provide data subject rights (access, deletion)
+- Maintain data processing records
+- Encrypt data at rest and in transit
+
+### CAN-SPAM Compliance
+
+- Accurate "From" name and email
+- Truthful subject lines
+- Include physical mailing address
+- Provide clear opt-out mechanism
+- Honor opt-outs within 10 business days
+
+### LinkedIn Usage Policies
+
+**Do's**:
+- Respect connection limits (100-200/week max)
+- Personalize connection requests
+- Engage authentically with content
+- Use data for legitimate business purposes
+
+**Don'ts**:
+- Don't automate connection requests
+- Don't send mass generic messages
+- Don't scrape private profile information
+- Don't circumvent LinkedIn's limits
+
+---
+
+**Next Steps**: Apply these strategies to your lead generation workflows, and refer to [WEB_SCRAPING.md](WEB_SCRAPING.md) for website contact extraction techniques.

--- a/content/anysite/skills/anysite-lead-generation/references/WEB_SCRAPING.md
+++ b/content/anysite/skills/anysite-lead-generation/references/WEB_SCRAPING.md
@@ -1,0 +1,146 @@
+# Web Scraping for Contact Extraction
+
+Strategies and techniques for extracting contact information from company websites using anysite MCP.
+
+## Overview
+
+Web scraping complements LinkedIn lead generation by:
+- Finding contacts not active on LinkedIn
+- Discovering phone numbers and addresses
+- Verifying email addresses
+- Accessing information from company directories
+- Getting regional office contacts
+
+## Contact Extraction Tools
+
+### parse_webpage
+
+Primary tool for extracting contacts from web pages.
+
+**Basic Usage**:
+```
+Tool: mcp__anysite__parse_webpage
+Parameters:
+- url: "https://company.com/contact"
+- extract_contacts: true
+- strip_all_tags: true
+- only_main_content: true
+```
+
+**Returns**:
+- Emails: All email addresses found
+- Phones: Phone numbers in various formats
+- Social links: LinkedIn, Twitter, Facebook, Instagram
+- Content: Page text for additional parsing
+
+### get_sitemap
+
+Discover all pages on a website to find contact information.
+
+**Basic Usage**:
+```
+Tool: mcp__anysite__get_sitemap
+Parameters:
+- url: "https://company.com"
+- count: 100
+```
+
+## Common Page Patterns
+
+### Contact Pages
+Standard URLs: `/contact`, `/contact-us`, `/get-in-touch`, `/reach-us`
+
+### About Pages
+Standard URLs: `/about`, `/about-us`, `/who-we-are`, `/company`
+
+### Team/People Pages
+Standard URLs: `/team`, `/our-team`, `/people`, `/leadership`, `/about/team`
+
+### Locations/Offices Pages
+Standard URLs: `/locations`, `/offices`, `/contact/locations`
+
+## Email Pattern Recognition
+
+### Common Email Formats
+```
+first.last@company.com          (Most common)
+first@company.com               (Small companies)
+flast@company.com               (Medium companies)
+firstl@company.com              (Larger companies)
+first_last@company.com          (Underscore variant)
+```
+
+### Department Emails
+```
+sales@company.com
+info@company.com
+contact@company.com
+support@company.com
+careers@company.com
+```
+
+## Multi-Page Scraping Workflows
+
+### Workflow 1: Comprehensive Company Contact Extraction
+
+1. Get sitemap: `get_sitemap("https://company.com", count=100)`
+2. Filter for relevant pages (contact, team, about, leadership)
+3. Parse each relevant page with `extract_contacts=true`
+4. Consolidate and deduplicate
+5. Enrich with LinkedIn
+
+### Workflow 2: Team Directory Scraping
+
+1. Find team page (try common patterns or use sitemap)
+2. Extract team members with `parse_webpage`
+3. Parse individual profiles if available
+4. Match to LinkedIn
+5. Construct email addresses from detected patterns
+
+### Workflow 3: Multi-Location Contact Extraction
+
+1. Find locations page
+2. Extract location information (addresses, phones, emails)
+3. Parse location-specific pages
+4. Find office leaders via LinkedIn
+5. Build location contact sheet
+
+## Integration with LinkedIn Data
+
+### LinkedIn -> Web Enrichment
+1. Find prospects on LinkedIn
+2. Get company websites from LinkedIn company profiles
+3. Extract company contacts from websites
+4. Match web contacts to LinkedIn prospects
+5. Build enriched prospect list
+
+### Web -> LinkedIn Validation
+1. Extract team from website
+2. Search LinkedIn for each person
+3. Validate and enrich with LinkedIn data
+4. Cross-reference for accuracy
+5. Build validated contact list
+
+## Best Practices
+
+### Efficiency
+1. Start with sitemap to identify all relevant pages
+2. Parse in batches of 5-10 websites at a time
+3. Prioritize high-value pages (team, leadership) over generic contact pages
+4. Use LinkedIn first for individual contacts, web scraping for company-level contacts
+
+### Quality
+1. Validate all contact data before using
+2. Match emails to people when possible (vs. generic info@)
+3. Check data freshness (recent LinkedIn activity = current employee)
+4. Verify company domain matches website being scraped
+
+### Compliance
+1. Respect robots.txt and website terms of service
+2. Rate limit requests to avoid overloading servers
+3. Only collect publicly available contact information
+4. Provide opt-out mechanism in all communications
+
+---
+
+**Next Steps**: Combine web scraping with LinkedIn strategies from [LINKEDIN_STRATEGIES.md](LINKEDIN_STRATEGIES.md) for comprehensive lead generation.

--- a/content/anysite/skills/anysite-lead-generation/references/WORKFLOWS.md
+++ b/content/anysite/skills/anysite-lead-generation/references/WORKFLOWS.md
@@ -1,0 +1,190 @@
+# Lead Generation Workflows & Tool Reference
+
+## Workflow: Recruiter Candidate Sourcing
+
+**Scenario**: Find qualified candidates for open positions
+
+**Steps**:
+
+1. **Define candidate profile**: Required skills, titles, experience level, location
+
+2. **Search for candidates**
+```
+Tool: mcp__anysite__search_linkedin_users
+Parameters:
+- keywords: <technical skills, e.g., "Python React AWS">
+- title: <relevant titles, e.g., "Software Engineer, Senior Engineer">
+- location: <location or "Remote">
+- count: 100
+```
+
+3. **Enrich candidate profiles**
+```
+For promising candidates:
+Tool: mcp__anysite__get_linkedin_profile
+Tool: mcp__anysite__get_linkedin_user_experience
+Tool: mcp__anysite__get_linkedin_user_skills
+Tool: mcp__anysite__get_linkedin_user_education
+```
+
+4. **Find contact information**
+```
+Tool: mcp__anysite__find_linkedin_user_email
+Tool: mcp__anysite__get_linkedin_user_email_db
+```
+
+5. **Build candidate pipeline**: Score candidates on skills match, prioritize by experience, create outreach sequence
+
+## MCP Tools Reference
+
+### LinkedIn People Search
+**Tool**: `mcp__anysite__search_linkedin_users`
+
+**Parameters**:
+- `keywords` (optional): General keywords for search
+- `title` (optional): Job title keywords (e.g., "VP Sales", "Software Engineer")
+- `company_keywords` (optional): Company name keywords
+- `location` (optional): Location (city, state, country)
+- `school_keywords` (optional): School/university keywords
+- `first_name` (optional): First name
+- `last_name` (optional): Last name
+- `count` (default: 10): Number of results to return
+
+**Returns**: List of user profiles with name, title, location, profile URL, and URN
+
+### LinkedIn Profile Details
+**Tool**: `mcp__anysite__get_linkedin_profile`
+
+**Parameters**:
+- `user` (required): LinkedIn username or full profile URL
+- `with_education` (default: true): Include education history
+- `with_experience` (default: true): Include work experience
+- `with_skills` (default: true): Include skills
+
+**Returns**: Complete profile with work history, education, skills, certifications
+
+### Email Finding
+**Tool**: `mcp__anysite__find_linkedin_user_email`
+
+**Parameters**:
+- `email` (required): Email address for reverse lookup
+- `count` (default: 5): Number of results
+- `request_timeout` (default: 300): Timeout in seconds
+
+### Email Database Lookup
+**Tool**: `mcp__anysite__get_linkedin_user_email_db`
+
+**Parameters**:
+- `profile` (required): LinkedIn profile URL
+- `request_timeout` (default: 300): Timeout in seconds
+
+### Company Search
+**Tool**: `mcp__anysite__search_linkedin_companies`
+
+**Parameters**:
+- `keywords` (optional): Company name or description keywords
+- `location` (optional): Company location
+- `industry` (optional): Industry type
+- `employee_count` (optional): Array of employee count ranges (e.g., ["51-200", "201-500"])
+- `count` (required): Number of results to return
+
+### Company Details
+**Tool**: `mcp__anysite__get_linkedin_company`
+
+**Parameters**:
+- `company` (required): Company identifier or LinkedIn URL
+
+### Company Employee Stats
+**Tool**: `mcp__anysite__get_linkedin_company_employee_stats`
+
+**Parameters**:
+- `urn` (required): Company URN from company lookup
+
+### Web Contact Extraction
+**Tool**: `mcp__anysite__parse_webpage`
+
+**Parameters**:
+- `url` (required): Webpage URL
+- `extract_contacts` (default: false): Extract emails, phones, social links
+- `strip_all_tags` (default: true): Remove HTML tags
+- `only_main_content` (default: true): Extract only main content area
+
+### LinkedIn User Experience
+**Tool**: `mcp__anysite__get_linkedin_user_experience`
+
+**Parameters**:
+- `urn` (required): User URN from search or profile
+- `count` (default: 10): Number of experience entries
+
+### LinkedIn User Skills
+**Tool**: `mcp__anysite__get_linkedin_user_skills`
+
+**Parameters**:
+- `urn` (required): User URN
+- `count` (default: 10): Number of skills to return
+
+## Lead Scoring Framework
+
+Score prospects based on multiple criteria:
+
+**Profile Completeness** (0-20 points): Has email (+10), complete work history (+5), education (+3), skills (+2)
+**Title Match** (0-30 points): Exact match (+30), similar (+20), related (+10)
+**Company Fit** (0-25 points): Ideal size (+25), acceptable (+15), too small/large (+5)
+**Experience Level** (0-15 points): 5-10 years (+15), 3-5 years (+10), 10+ years (+10), <3 years (+5)
+**Location** (0-10 points): Target location (+10), acceptable (+5), remote (+8)
+
+**Total Score**: 0-100 points
+- **90-100**: Hot lead - Contact immediately
+- **70-89**: Warm lead - High priority follow-up
+- **50-69**: Qualified - Standard outreach
+- **<50**: Unqualified - Nurture or discard
+
+## Automated Prospect Enrichment
+
+Systematic enrichment workflow for large lists:
+
+1. **Initial Search**: Get 100-500 prospects from LinkedIn search
+2. **First Filter**: Remove obviously unqualified (wrong title, location, etc.)
+3. **Batch Enrichment**: Enrich top 50 prospects with full profiles
+4. **Email Discovery**: Find emails for top 25 prospects
+5. **Web Research**: Extract company contacts for remaining prospects
+6. **Final Scoring**: Apply lead scoring framework
+7. **Export**: Generate CSV for top-scored leads only
+
+## Troubleshooting
+
+### No Results from LinkedIn Search
+- Broaden search criteria (remove some filters)
+- Try location variations: "San Francisco", "San Francisco Bay Area", "SF"
+- Use partial titles: "Sales" instead of "Vice President of Sales"
+- Verify company names with `search_linkedin_companies` first
+
+### Email Not Found
+1. Try `get_linkedin_user_email_db` as alternative
+2. Extract email from company website instead
+3. Use email pattern guessing (firstname.lastname@company.com)
+4. Check for email in LinkedIn profile "Contact Info" section
+
+### Timeout Errors
+- Reduce `count` parameter (try 25-50 instead of 100+)
+- Increase `request_timeout` to 400-600 seconds
+- Break large searches into multiple smaller searches
+
+### Incomplete Profile Data
+- Set `with_experience=true`, `with_education=true` explicitly
+- Try getting detailed experience with `get_linkedin_user_experience`
+- Accept incomplete data and supplement with web research
+
+## Example Use Cases
+
+### Enterprise SaaS Sales
+1. Define ICP: VP/Director level, Enterprise Software, 500-5000 employees
+2. Search LinkedIn with company and title filters
+3. Filter by company size, enrich top 30 prospects
+4. Find emails for top 20, export CSV for Salesforce
+
+### Partnership Outreach
+1. Search companies: `keywords="marketing automation" employee_count=["51-200"]`
+2. Identify decision-makers: `title="VP Product OR Head of Partnerships"`
+3. Research company details and recent posts
+4. Multi-channel outreach: LinkedIn + email

--- a/content/anysite/skills/anysite-market-research/SKILL.md
+++ b/content/anysite/skills/anysite-market-research/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: anysite-market-research
+description: "Analyze tech markets, startup ecosystems, public companies, and industry dynamics"
+metadata:
+  revision: 1
+  updated-on: "2026-03-16"
+  source: community
+  tags: "industry,opportunity,tam,landscape,investment,due-diligence"
+---
+
+# anysite Market Research
+
+Comprehensive market research using Y Combinator, SEC, social media, and web data through anysite MCP. Analyze tech markets, research startups, and study competitive landscapes.
+
+## Overview
+
+- **Research startup ecosystems** via Y Combinator data
+- **Analyze public companies** through SEC filings
+- **Gather market intelligence** from social platforms
+- **Study industry trends** across communities
+- **Identify market opportunities** through data analysis
+
+**Coverage**: 70% - Excellent for tech/startup markets; pivoted from local business to tech focus
+
+## Supported Platforms
+
+- Y Combinator: Startup research, batch analysis, founder discovery, funding data
+- SEC: Public company filings, financial data, disclosures
+- Reddit: Market sentiment, community insights, product discussions
+- LinkedIn: Industry trends, company intelligence, professional discussions
+- Twitter/X: Market pulse, news, influencer opinions
+- Web Scraping: Company websites, industry reports, market data
+
+## Quick Start
+
+**Step 1: Define Research Scope**
+
+Choose focus:
+- Startup ecosystem: `search_yc_companies`
+- Public companies: `sec_search_companies`
+- Industry sentiment: `search_reddit_posts`, `search_twitter_posts`
+- Company intelligence: `search_linkedin_companies`
+
+**Step 2: Gather Data**
+
+Execute searches:
+```
+# Startup research
+search_yc_companies(industries=["fintech"], batches=["W24", "S23"])
+
+# Public company research
+sec_search_companies(entity_name="tech company", forms=["10-K"])
+
+# Market sentiment
+search_reddit_posts(query="fintech trends", count=100)
+```
+
+**Step 3: Analyze Results**
+
+Extract insights:
+- Market size indicators
+- Competitive landscape
+- Technology trends
+- Consumer sentiment
+- Funding patterns
+
+**Step 4: Synthesize Findings**
+
+Deliver:
+- Market opportunity assessment
+- Competitive analysis
+- Trend identification
+- Strategic recommendations
+
+## Common Workflows
+
+### Workflow 1: Startup Ecosystem Analysis
+
+**Scenario**: Analyze fintech startup landscape
+
+**Steps**:
+
+1. **Find Startups**
+```
+search_yc_companies(
+  industries=["fintech"],
+  batches=["W24", "S23", "W23", "S22"],
+  count=100
+)
+```
+
+2. **Categorize by Focus**
+```
+For each startup:
+  get_yc_company(company)
+
+Group by:
+- Payments
+- Lending
+- Investment/Trading
+- Banking
+- Insurance
+- B2B fintech tools
+```
+
+3. **Analyze Patterns**
+```
+Identify:
+- Hot subcategories (most startups)
+- Team size distribution
+- Geographic concentration
+- Common tech stacks (from job postings)
+```
+
+4. **Research Traction**
+```
+For promising startups:
+  search_linkedin_companies(keywords=startup_name)
+  search_twitter_posts(query=startup_name)
+  parse_webpage(startup_website)
+```
+
+5. **Identify White Spaces**
+```
+Compare:
+- Overcrowded categories
+- Underserved segments
+- Emerging opportunities
+- Geographic gaps
+```
+
+### Workflow 2: Public Company Competitive Analysis
+
+**Scenario**: Research public competitors in cloud infrastructure
+
+1. Find companies via `sec_search_companies`
+2. Get financial data from SEC documents
+3. Analyze strategy from 10-K filings
+4. Track year-over-year changes
+5. Supplement with LinkedIn and social intel
+
+### Workflow 3: Industry Trend Analysis
+
+**Scenario**: Understand AI/ML market evolution
+
+1. YC startup trends by batch
+2. Public market signals from SEC
+3. Community sentiment from Reddit
+4. Professional discussion on LinkedIn
+5. Web intelligence from company blogs
+
+## MCP Tools Reference
+
+### Y Combinator Research
+- `search_yc_companies` - Find startups by industry, batch, filters
+- `get_yc_company` - Get detailed company profile
+- `search_yc_founders` - Research founders
+
+### SEC Research
+- `sec_search_companies` - Find public companies and filings
+- `sec_document` - Get full document content
+
+### Social Intelligence
+- `search_reddit_posts` - Community insights and sentiment
+- `search_twitter_posts` - Real-time market pulse
+- `search_linkedin_posts` - Professional trends
+
+### Company Intelligence
+- `search_linkedin_companies` - Find companies
+- `get_linkedin_company` - Company details
+- `parse_webpage` - Extract website data
+
+### Market Discovery
+- `duckduckgo_search` - General web research
+- `get_sitemap` - Comprehensive website analysis
+
+## Market Analysis Frameworks
+
+**TAM/SAM/SOM Analysis**:
+```
+Total Addressable Market (TAM):
+- Count YC companies in category x avg market size
+- SEC filing market size mentions
+- Industry reports (web scraping)
+
+Serviceable Addressable Market (SAM):
+- Filter by geography, segment
+- LinkedIn company search by ICP
+- YC companies by batch/stage
+
+Serviceable Obtainable Market (SOM):
+- Realistic capture based on competition
+- Competitive analysis via LinkedIn/social
+- Market share indicators
+```
+
+**Porter's Five Forces**:
+```
+Using anysite data:
+
+1. Competitive Rivalry:
+   - YC startups in space
+   - LinkedIn company counts
+   - Social mention volume
+
+2. Threat of New Entrants:
+   - Recent YC batches
+   - Funding announcements
+   - Talent movement (LinkedIn)
+
+3. Supplier Power:
+   - Technology dependencies
+   - Integration partners
+
+4. Buyer Power:
+   - Customer reviews (Reddit)
+   - Pricing transparency
+   - Switching costs mentioned
+
+5. Threat of Substitutes:
+   - Alternative solutions
+   - Adjacent markets
+```
+
+## Output Formats
+
+**Chat Summary**: Key market insights, competitive landscape, opportunities, recommendations
+**CSV Export**: Company list with metrics, market segmentation, trend indicators
+**JSON Export**: Complete research data, time-series analysis, cross-platform correlations
+
+## Reference Documentation
+
+- **[RESEARCH_METHODS.md](references/RESEARCH_METHODS.md)** - Market research methodologies, analysis frameworks, and data synthesis techniques

--- a/content/anysite/skills/anysite-market-research/references/RESEARCH_METHODS.md
+++ b/content/anysite/skills/anysite-market-research/references/RESEARCH_METHODS.md
@@ -1,0 +1,65 @@
+# Market Research Methodologies
+
+## Primary Research via Social Listening
+
+**Reddit Market Research**:
+```
+Value: Unfiltered customer opinions
+Approach: Search product categories, pain points
+Analysis: Sentiment, feature requests, complaints
+```
+
+**LinkedIn Professional Insights**:
+```
+Value: B2B market signals
+Approach: Industry discussions, job postings
+Analysis: Hiring trends, strategic priorities
+```
+
+## Secondary Research via Public Data
+
+**SEC Filings Analysis**:
+```
+10-K: Annual reports, full business overview
+10-Q: Quarterly updates, recent changes
+8-K: Material events, acquisitions
+```
+
+**Y Combinator Database**:
+```
+Batch trends: Focus areas over time
+Funding patterns: Stage, amounts
+Team dynamics: Size, roles
+```
+
+## Market Sizing Techniques
+
+**Bottom-Up**:
+```
+YC companies x average revenue = market estimate
+LinkedIn company counts x ARPU = TAM proxy
+```
+
+**Top-Down**:
+```
+SEC filing market size mentions
+Industry reports (web scraping)
+Analyst estimates
+```
+
+## Competitive Intelligence
+
+**Direct Competitors**:
+- Same product, same market
+- YC same batch/category
+- SEC peer group analysis
+
+**Indirect Competitors**:
+- Different product, same problem
+- Adjacent categories
+- Alternative solutions
+
+**Potential Future Competitors**:
+- Well-funded adjacents
+- Technology convergence
+- Market expansion signals

--- a/content/anysite/skills/anysite-person-analyzer/SKILL.md
+++ b/content/anysite/skills/anysite-person-analyzer/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: anysite-person-analyzer
+description: "Multi-platform profile analysis: LinkedIn, Twitter, Reddit, and web presence intelligence"
+metadata:
+  revision: 1
+  updated-on: "2026-03-16"
+  source: community
+  tags: "profiling,networking,recruitment,background,osint"
+---
+
+# Person Intelligence Analyzer
+
+Comprehensive multi-platform intelligence analysis combining LinkedIn, Twitter/X, Reddit, GitHub, and web presence data to create actionable intelligence reports with cross-platform personality insights.
+
+## Analysis Workflow
+
+Execute phases sequentially, adapting depth based on available data and user requirements.
+
+### Phase 1: Initial Data Collection
+
+**Starting with LinkedIn Profile URL:**
+1. Use `get_linkedin_profile` with full parameters (education, experience, skills)
+2. Extract and save the **full URN** (format: `urn:li:fsd_profile:ACoAAABCDEF`) - critical for all subsequent API calls
+3. Also extract: company URN, current role, location, connections count
+4. Record profile completeness for confidence scoring
+
+**IMPORTANT - URN Format:**
+Always use the complete URN format `urn:li:fsd_profile:ACoAAABCDEF` from the profile response for all subsequent calls to `get_linkedin_user_posts`, `get_linkedin_user_comments`, and `get_linkedin_user_reactions`. Do not use shortened versions or profile URLs.
+
+**Starting with Name + Context:**
+1. Use `search_linkedin_users` with all available filters (name, title, company, location, school)
+2. If multiple matches: present top 3-5 candidates with distinguishing details
+3. After user confirmation, proceed with confirmed profile
+
+**Critical Data Points to Capture:**
+- Current company and role (with start date)
+- Previous roles (last 2-3 positions)
+- Education background
+- Skills and endorsements
+- Connection count, profile headline and summary
+
+### Phase 2: Activity & Engagement Analysis
+
+**Content Analysis (Posts):**
+1. Use `get_linkedin_user_posts` with the full URN
+   - Count: 20-50 depending on activity level
+   - Posted after filter: last 90 days for active users, 180 days if low activity
+2. Analyze for: topics/themes, engagement metrics, posting frequency, content style, language/tone
+
+**Engagement Analysis (Comments & Reactions):**
+1. Use `get_linkedin_user_comments` with full URN (count: 30)
+2. Use `get_linkedin_user_reactions` with full URN (count: 50)
+3. Analyze: who they engage with, topics that spark engagement, engagement style, response patterns
+
+**Output: Engagement Profile**
+- Primary content themes (ranked by frequency)
+- Engagement level: High/Medium/Low
+- Influence indicators: follower count, average engagement rate
+- Communication style: formal/casual, technical/general
+
+### Phase 3: Company Intelligence
+
+**Current Company Deep Dive:**
+1. Use `get_linkedin_company` with company URN
+2. Use `get_linkedin_company_posts` (count: 20) - analyze communication themes, strategic priorities
+3. Use `duckduckgo_search` for recent news: "[Company name] funding news", "[Company name] expansion"
+
+**Company Social Media Presence:**
+4. **Twitter/X**: Find company account via `search_twitter_users`, analyze posts for product announcements, culture signals
+5. **Reddit**: `search_reddit_posts` for company mentions - customer sentiment, industry discussions
+
+**Company Context Analysis:**
+- Business model, technology stack, market position
+- Social sentiment, community engagement
+- Growth signals, customer pain points
+
+### Phase 4: Multi-Platform Intelligence Enrichment
+
+**A. Twitter/X Analysis:**
+1. Find handle: check LinkedIn bio, or `search_twitter_users` with name + company
+2. Profile: `get_twitter_user` - follower count, bio, creation date
+3. Content: `get_twitter_user_posts` (count: 50-100) - topics, expertise, engagement rate
+4. Topic discovery: `search_twitter_posts` for key interests
+
+**B. Reddit Activity:**
+1. `search_reddit_posts` with name/company mentions
+2. Analyze: subreddit preferences, technical depth, helping behavior, community reputation
+
+**C. Instagram Presence** (optional, B2C/personal brand focus):
+- `get_instagram_user` if handle known
+- `get_instagram_user_posts` for content style analysis
+
+**D. Web Intelligence & Media Presence:**
+1. `duckduckgo_search`: "[Name] speaker conference", "[Name] interview podcast", "[Name] article blog"
+2. `duckduckgo_search`: "[Name] site:github.com" (for technical roles)
+3. `parse_webpage` for high-value sources: personal blog, interviews, conference profiles, company team pages
+
+**Platform Priority:**
+1. **Always**: LinkedIn (mandatory) + Web Search
+2. **High priority**: Twitter/X - usually most revealing for tech audience
+3. **Medium priority**: Reddit - shows technical depth and community engagement
+4. **Low priority**: Instagram - only if B2C or strong personal brand
+5. **Context-dependent**: GitHub - critical for engineering roles
+
+### Phase 5: Cross-Platform Strategic Analysis & Report Generation
+
+**Connection Strategy:**
+1. Conversation topics ranked by relevance across all platforms
+2. Platform-specific engagement approach (timing, tone, ice-breakers)
+3. Cross-platform personality synthesis
+
+**Value Assessment:**
+- **Direct Business Value**: ICP fit, decision maker level, budget authority
+- **Partnership Potential**: Technology synergies, co-marketing
+- **Network & Influence**: Network size/quality, industry influence
+- **Talent & Advisory**: Expertise match, domain knowledge
+
+**Prioritization Matrix:**
+- **Tier 1 (Hot Lead)**: Decision maker + ICP match + high engagement
+- **Tier 2 (Warm Lead)**: Mid-level + ICP match OR influencer + relevant network
+- **Tier 3 (Long-term Nurture)**: Potential future value
+- **Tier 4 (Low Priority)**: No clear fit
+
+## Error Handling & Edge Cases
+
+**Insufficient Data:** Focus more on company analysis and role-based inferences
+**Multiple Profile Matches:** Always confirm with user before deep analysis
+**Rate Limiting / API Errors:** Continue with available data, note limitations
+**Privacy Considerations:** Only analyze publicly available information, no speculation on private matters
+
+## Reference Documentation
+
+- **[REPORT_TEMPLATE.md](references/REPORT_TEMPLATE.md)** - Full output format template, customization parameters (Quick/Standard/Deep), and platform-specific focus options

--- a/content/anysite/skills/anysite-person-analyzer/references/REPORT_TEMPLATE.md
+++ b/content/anysite/skills/anysite-person-analyzer/references/REPORT_TEMPLATE.md
@@ -1,0 +1,158 @@
+# Person Intelligence Report Template
+
+## Full Output Format
+
+Generate comprehensive markdown report with these sections:
+
+```markdown
+# Person Intelligence Report: [Name]
+
+**Generated:** [Date]
+**Analysis Depth:** [Quick/Standard/Deep]
+**Confidence Score:** [0-100%] based on data availability
+
+## Executive Summary
+[2-3 sentences: who they are, what they do, why they matter]
+
+## Professional Profile
+- **Current Role:** [Title] at [Company] (since [date])
+- **Location:** [City, Country]
+- **Experience:** [X years in industry/role]
+- **Education:** [Degree, Institution]
+- **Network Size:** [LinkedIn connections count]
+- **LinkedIn Profile:** [URL]
+- **Twitter/X:** [@handle or "Not found"] ([follower count if found])
+- **Reddit:** [u/username or "Not found/searched"]
+- **GitHub:** [username or "Not found"] (if technical role)
+- **Personal Website:** [URL if found]
+
+## Key Background
+[2-3 paragraphs: career trajectory, expertise, notable achievements]
+
+## Multi-Platform Activity Analysis
+
+### LinkedIn Activity (Last 90 Days)
+
+#### Content Themes
+1. **[Theme 1]** (40% of posts) - Key topics, example post
+2. **[Theme 2]** (30% of posts) - Key topics
+3. **[Theme 3]** (20% of posts)
+
+#### Engagement Patterns
+- **Posting Frequency:** [X posts/month]
+- **Engagement Rate:** [Average likes, comments per post]
+- **Response Style:** [Description]
+
+### Twitter/X Activity (if found)
+- **Followers/Following/Tweets:** [counts]
+- **Posting Frequency:** [tweets per day/week]
+- **Content Mix:** [% original vs retweets vs replies]
+- **Primary Topics:** [top 3-5 themes]
+- **Notable Takes:** [strong opinions or viral tweets]
+
+### Reddit Activity (if found)
+- **Most Active Subreddits:** [top 3-5]
+- **Activity Type:** [asking vs answering vs discussions]
+- **Technical Depth:** [level of detail]
+
+### Cross-Platform Synthesis
+- **LinkedIn Persona:** [professional characteristics]
+- **Twitter Persona:** [casual/personal characteristics]
+- **Reddit Persona:** [technical/community characteristics]
+- **Most Active Platform:** [which has highest activity]
+- **Communication Style:** [synthesized description]
+
+## Company Intelligence: [Company Name]
+
+### Company Overview
+- **Industry/Size/Stage/Mission**
+- **Twitter/Reddit Presence**
+
+### Strategic Context
+- Recent news, growth indicators, market position
+
+### Company Social Media Presence
+- Twitter activity, Reddit community sentiment
+- Brand perception, customer insights, growth signals
+
+## External Intelligence
+- Speaking/conferences, publications/interviews
+- Blog posts/articles, media mentions
+- GitHub projects (if technical), technical writing
+
+## Connection Strategy
+
+### Recommended Conversation Topics
+1. **[Topic 1]** - [Why: specific post/tweet/comment and platform]
+2. **[Topic 2]** - [Why: company context or cross-platform theme]
+3. **[Topic 3]** - [Why: shared interest/industry trend]
+
+### Platform-Specific Engagement
+- **LinkedIn:** Best timing, approach, ice-breaker example
+- **Twitter/X:** Best timing, approach, ice-breaker example
+- **Reddit:** Best timing, approach, relevant subreddit
+- **Direct Outreach:** Best channel, timing, value proposition
+
+### Potential Pain Points
+[Inferred from role, company, posts - with evidence from platform]
+
+## Strategic Value Assessment
+
+### Primary Classification
+**[Tier 1/2/3/4]: [Customer/Partner/Influencer/Advisor/Talent]**
+
+### Value Dimensions
+- **Customer Potential:** [High/Medium/Low] - ICP fit, decision authority, buying signals
+- **Partnership Potential:** [High/Medium/Low] - Specific opportunities
+- **Network Value:** [High/Medium/Low] - Influence level, connection value
+- **Advisory/Talent Value:** [High/Medium/Low] - Specific expertise
+
+### Action Priority
+**Priority Level:** [Critical/High/Medium/Low]
+**Recommended Timeline:** [Contact within: X days/weeks]
+
+### Next Steps
+1. [Specific action item with reasoning]
+2. [Follow-up action]
+3. [Long-term nurture plan if applicable]
+
+## Analysis Metadata
+- **Platforms Analyzed:** LinkedIn, Twitter/X, Reddit, GitHub, Web
+- **Data Freshness:** [date ranges per platform]
+- **Total Data Points:** [approximate counts]
+- **Confidence Factors:** Profile completeness, activity data, cross-platform consistency
+- **Limitations:** [Any data gaps or constraints]
+```
+
+## Customization Parameters
+
+### Quick Analysis (10-15 min)
+- LinkedIn: Profile + last 10 posts + company basics
+- Twitter/X: Person profile check only
+- Web: 2-3 targeted searches
+- Reddit/GitHub: Skip unless requested
+
+### Standard Analysis (20-30 min) - DEFAULT
+- LinkedIn: Full profile + 20-50 posts + comments/reactions + company analysis
+- Company: LinkedIn + Twitter account + Reddit mentions
+- Twitter/X: Person profile + 50 recent tweets
+- Reddit: Search for person username + activity
+- Web: 5-7 strategic searches + parse 2-3 key pages
+- GitHub: Quick check (if technical role)
+
+### Deep Dive (45-60 min)
+- LinkedIn: Extended analysis (100+ posts), all activity types
+- Company: LinkedIn + Twitter (30 posts) + Reddit (comprehensive) + sentiment
+- Twitter/X: 100+ tweets, thread analysis, engagement patterns
+- Reddit: Comprehensive comment history, subreddit analysis
+- Web: 10-15 searches, parse 5-10 webpages
+- GitHub: Detailed repo analysis, contribution patterns
+- Instagram: Profile and content analysis (if relevant)
+
+### Platform-Specific Focus
+- "Focus on Twitter presence" -> Deep Twitter for person AND company
+- "Technical profile only" -> LinkedIn + GitHub + Reddit
+- "Business profile" -> LinkedIn + web presence + media
+- "Company deep dive" -> Extended company social analysis across all platforms
+
+Default to **Standard Analysis** unless specified.

--- a/content/anysite/skills/anysite-trend-analysis/SKILL.md
+++ b/content/anysite/skills/anysite-trend-analysis/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: anysite-trend-analysis
+description: "Detect emerging trends, viral content, and topic momentum across social platforms"
+metadata:
+  revision: 1
+  updated-on: "2026-03-16"
+  source: community
+  tags: "viral,hashtag,momentum,emerging,signals,zeitgeist"
+---
+
+# anysite Trend Analysis
+
+Discover emerging trends and track viral content across social platforms using anysite MCP. Identify what's gaining momentum before it peaks.
+
+## Overview
+
+- **Detect emerging trends** across multiple platforms
+- **Track viral content** and identify breakout topics
+- **Monitor hashtag performance** and trending keywords
+- **Analyze topic momentum** and growth patterns
+- **Identify market shifts** through social listening
+
+**Coverage**: 75% - Good for Twitter, Reddit, YouTube, LinkedIn, Instagram
+
+## Supported Platforms
+
+- Twitter/X: Trending topics, viral tweets, hashtag tracking
+- Reddit: Trending posts, subreddit activity, upvote velocity
+- YouTube: Trending videos, search trends, rising channels
+- LinkedIn: Professional trends, industry discussions
+- Instagram: Trending hashtags, viral content
+
+## Quick Start
+
+**Step 1: Search for Trending Content**
+
+By platform:
+- Twitter: `search_twitter_posts(query, count)` sorted by engagement
+- Reddit: `search_reddit_posts(query, count)` sorted by upvotes
+- YouTube: `search_youtube_videos(query, count)` by recent
+- LinkedIn: `search_linkedin_posts(keywords, count)`
+- Instagram: `search_instagram_posts(query, count)`
+
+**Step 2: Analyze Momentum**
+
+Check indicators:
+- Engagement velocity (growth rate)
+- Cross-platform presence
+- Comment volume and sentiment
+- Share/retweet patterns
+
+**Step 3: Track Over Time**
+
+Monitor changes:
+- Daily engagement growth
+- New platform adoption
+- Mainstream vs. niche spread
+- Peak timing prediction
+
+**Step 4: Report Insights**
+
+Deliver:
+- Trending topics list
+- Momentum indicators
+- Strategic recommendations
+- Early warnings or opportunities
+
+## Common Workflows
+
+### Workflow 1: Multi-Platform Trend Detection
+
+**Scenario**: Identify what's trending in tech/AI space
+
+1. **Search Across Platforms**
+```
+# Twitter
+search_twitter_posts(query="AI OR artificial intelligence", count=100)
+
+# Reddit
+search_reddit_posts(query="artificial intelligence", count=100)
+
+# YouTube
+search_youtube_videos(query="AI news", count=50)
+
+# LinkedIn
+search_linkedin_posts(keywords="artificial intelligence", count=50)
+```
+
+2. **Extract Common Themes**: Analyze content for recurring keywords, company mentions, events, questions
+
+3. **Calculate Trend Score**: Platform count, total engagement, growth velocity, sentiment distribution
+
+4. **Identify Breakout Trends**: Presence on 3+ platforms, engagement growing >50% daily, influencer coverage
+
+### Workflow 2: Hashtag Performance Tracking
+
+1. Search by hashtag across Instagram, Twitter, LinkedIn
+2. Calculate velocity (posts in last 24h vs. previous 24h)
+3. Analyze content evolution (early vs. recent posts)
+4. Predict peak based on growth curve
+
+### Workflow 3: Reddit Trend Mining
+
+1. Search target subreddits for top posts
+2. Analyze post momentum (upvotes per hour, comment velocity)
+3. Extract discussion themes from high-momentum posts
+4. Track cross-pollination to Twitter, LinkedIn, YouTube
+
+## MCP Tools Reference
+
+### Twitter/X
+- `search_twitter_posts(query, count)` - Find tweets, filter by engagement
+- `get_twitter_user(user)` - Check influencer adoption
+
+### Reddit
+- `search_reddit_posts(query, subreddit, count)` - Find discussions
+- `get_reddit_post(url)` - Get post details and momentum
+- `get_reddit_post_comments(url)` - Analyze discussion depth
+
+### YouTube
+- `search_youtube_videos(query, count)` - Find trending videos
+- `get_youtube_video(video)` - Track view velocity
+- `get_youtube_video_comments(video, count)` - Gauge interest
+
+### LinkedIn
+- `search_linkedin_posts(keywords, count)` - Professional trends
+- `get_linkedin_company_posts(urn, count)` - Corporate adoption
+
+### Instagram
+- `search_instagram_posts(query, count)` - Hashtag trends
+- `get_instagram_post(post_id)` - Engagement metrics
+
+## Trend Identification Framework
+
+**Trend Stages**:
+
+1. **Emergence** (0-20% awareness)
+   - Niche communities discussing
+   - Low but accelerating engagement
+   - Action: Monitor closely, prepare strategy
+
+2. **Growth** (20-50% awareness)
+   - Crossing into mainstream platforms
+   - Rapid engagement growth
+   - Action: Create content, engage actively
+
+3. **Peak** (50-80% awareness)
+   - Maximum visibility
+   - Slowing growth rate
+   - Action: Maximize presence before decline
+
+4. **Decline** (80-100% awareness)
+   - Engagement decreasing
+   - Moving to "background noise"
+   - Action: Shift focus to next trend
+
+**Momentum Indicators**:
+- **Volume**: Mentions per day
+- **Velocity**: Growth rate (% change)
+- **Reach**: Unique accounts discussing
+- **Spread**: Number of platforms
+- **Sentiment**: Positive/negative ratio
+- **Influence**: Key accounts involved
+
+## Output Formats
+
+**Chat Summary**: Top 5 trends with momentum scores, platform breakdown, strategic recommendations
+**CSV Export**: Trend name, platforms, volume, growth rate, sentiment, key influencers
+**JSON Export**: Complete trend data, time-series metrics, cross-platform correlations
+
+## Reference Documentation
+
+- **[SOCIAL_MONITORING.md](references/SOCIAL_MONITORING.md)** - Social listening techniques, monitoring strategies, and trend prediction methods

--- a/content/anysite/skills/anysite-trend-analysis/references/SOCIAL_MONITORING.md
+++ b/content/anysite/skills/anysite-trend-analysis/references/SOCIAL_MONITORING.md
@@ -1,0 +1,46 @@
+# Social Media Trend Monitoring
+
+## Trend Detection Techniques
+
+**Volume Spike Detection**:
+```
+Track mentions per hour/day
+Alert when >2x normal volume
+Indicates emerging interest
+```
+
+**Velocity Tracking**:
+```
+Calculate growth rate:
+(Today's mentions - Yesterday's mentions) / Yesterday's mentions
+
+>50% = High momentum
+>100% = Viral potential
+```
+
+**Cross-Platform Validation**:
+```
+True trends appear on multiple platforms:
+- Niche platform (Reddit) -> Mainstream (Twitter) -> Professional (LinkedIn)
+- Early signal: Reddit or specialty forums
+- Confirmation: Twitter + LinkedIn adoption
+```
+
+## Monitoring Cadence
+
+**Daily**: Hot topics, viral content
+**Weekly**: Emerging themes
+**Monthly**: Industry shifts
+**Quarterly**: Market trends
+
+## Trend Prediction Signals
+
+**Early Indicators**:
+- Sudden subreddit activity
+- Influencer experimentation
+- Technical community discussion
+
+**Confirmation Signals**:
+- Media coverage
+- Corporate adoption
+- Mainstream platform presence

--- a/content/anysite/skills/anysite-vc-analyst/SKILL.md
+++ b/content/anysite/skills/anysite-vc-analyst/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: anysite-vc-analyst
+description: "VC investor analysis, portfolio conflict detection, scoring, and personalized outreach generation"
+metadata:
+  revision: 1
+  updated-on: "2026-03-16"
+  source: community
+  tags: "fundraising,pitch,seed,series-a,angel,investor-fit"
+---
+
+# VC Investor Analyst
+
+Universal agent for startup investor research and outreach.
+
+## Onboarding Flow (REQUIRED FIRST)
+
+Before analyzing investors, gather project context. Use `AskUserQuestion` tool.
+
+### Step 1: Project Discovery
+
+Ask user to provide:
+1. **Company website** - to fetch and analyze
+2. **Pitch deck or materials** - file path or link
+3. **One-liner** - what does the company do?
+
+### Step 2: Fetch & Analyze Project
+
+1. **Website**: Use `mcp__anysite__parse_webpage(url=website)` to understand:
+   - Product/service description
+   - Target market
+   - Key features
+   - Pricing (if visible)
+
+2. **Pitch deck**: Use `Read` tool if local file, or `WebFetch` if link
+
+3. **Extract key info**:
+   - Problem & Solution
+   - Market size (TAM/SAM/SOM)
+   - Business model
+   - Traction metrics
+   - Team background
+   - Competitive landscape
+
+### Step 3: Fundraising Context
+
+Ask about:
+- Stage (Pre-Seed, Seed, Series A, Other)
+- Amount raising ($500K or less, $500K-$1M, $1M-$2M, $2M+)
+- Current traction (Pre-revenue, Early revenue, $10K-$50K MRR, $50K+ MRR)
+
+### Step 4: Investor Preferences
+
+Ask about:
+- Investor type (Angel, Micro VC, Seed VC, Strategic angels)
+- Geographic preference (US only, US + Europe, Global, Specific region)
+- Industry/theme focus (B2B SaaS, AI/ML, Developer Tools, Other)
+
+### Step 5: Build Investor Profile
+
+After gathering info, create `investor_criteria.json`:
+
+```json
+{
+  "company": {
+    "name": "...",
+    "website": "...",
+    "one_liner": "...",
+    "stage": "Pre-Seed",
+    "raising": "$1M",
+    "traction": "...",
+    "thesis_keywords": ["B2B SaaS", "AI", "..."]
+  },
+  "ideal_investor": {
+    "types": ["Angel", "Micro VC"],
+    "check_size": "$50K-$500K",
+    "stage_focus": ["Pre-Seed", "Seed"],
+    "thesis_match": ["B2B SaaS", "AI", "Developer Tools"],
+    "geography": "US + Europe"
+  },
+  "competitors": ["competitor1", "competitor2"],
+  "outreach": {
+    "pitch_deck_link": "...",
+    "calendar_link": "...",
+    "sender_name": "...",
+    "sender_title": "..."
+  }
+}
+```
+
+Save to `data/investor_criteria.json` for reference.
+
+---
+
+## Investor Analysis Workflow
+
+After onboarding, analyze investors from CSV or list.
+
+### 1. Fetch LinkedIn Profile (ALWAYS FIRST)
+
+```
+mcp__anysite__get_linkedin_profile(user="linkedin-url-or-username")
+```
+
+CSV data has ~20% error rate. Always verify actual role before scoring.
+
+### 2. Score Investor (0-100)
+
+| Factor | Weight | Check |
+|--------|--------|-------|
+| **Is Actually Investor** | GATE | Role: Partner, GP, Angel, EIR (NOT: Director, Manager, Engineer) |
+| **Stage Fit** | 25% | Matches company's raising stage |
+| **Thesis Match** | 25% | Matches company's thesis keywords |
+| **Portfolio Relevance** | 30% | Similar companies in portfolio |
+| **Activity Level** | 10% | Investments in last 12-18 months |
+| **Network Value** | 10% | Accelerator ties, fund network |
+
+**Disqualifiers (Score = 0):**
+- Corporate role at non-investment firm
+- Thesis mismatch (e.g., Crypto-only when company is SaaS)
+- Wrong person at LinkedIn URL
+- Stage too late (Series B+ fund for pre-seed company)
+
+### 3. Check Portfolio Conflicts
+
+Search for investments in company's competitors:
+```
+WebSearch("[Fund name] portfolio companies")
+WebSearch("[Investor name] investments [competitor name]")
+```
+
+**If conflict found:** -20 points + flag "PORTFOLIO CONFLICT"
+
+### 4. Generate Outreach Message
+
+For Score > 70, create personalized message using company's outreach config:
+
+```
+Hi [Name],
+
+[Hook from verified portfolio/achievement relevant to THIS company]
+
+[1-2 sentences about company - from one_liner]
+
+[Traction from company profile]
+
+[Question based on their expertise]
+
+Here's our pitch deck: [pitch_deck_link]
+
+If you'd like to chat: [calendar_link]
+If no slots work, send your availability.
+
+Best,
+[sender_name]
+[sender_title]
+```
+
+---
+
+## Output Format
+
+### Per Investor
+```json
+{
+  "investor": "Name",
+  "linkedin": "url",
+  "score": 85,
+  "current_role": "Partner @ Fund",
+  "stage_fit": "Pre-seed focus - MATCH",
+  "thesis_match": ["AI", "B2B SaaS"],
+  "portfolio_relevant": ["Company1", "Company2"],
+  "conflicts": [],
+  "risk_factors": [],
+  "outreach_hook": "Your investment in X...",
+  "message": "Full outreach text"
+}
+```
+
+### Batch Summary
+```json
+{
+  "batch": 1,
+  "total_analyzed": 20,
+  "strong_fit": 4,
+  "good_fit": 3,
+  "not_fit": 13,
+  "top_candidates": ["Name1", "Name2"]
+}
+```
+
+---
+
+## Quick Commands
+
+| Command | Action |
+|---------|--------|
+| `/vc-analyst` | Start full onboarding flow |
+| `/vc-analyst analyze [linkedin]` | Analyze single investor (requires prior onboarding) |
+| `/vc-analyst batch [csv-path]` | Analyze batch from CSV |
+| `/vc-analyst update-criteria` | Update investor criteria |
+
+## Scoring Reference
+
+See [references/scoring.md](references/scoring.md) for detailed criteria and examples.


### PR DESCRIPTION
## What

Add curated documentation for the Anysite REST API and 12 agent skills for social media intelligence workflows.

**13 API docs** (76 endpoints, Python):
- `linkedin-user` — profiles, experience, education, skills, posts (16 endpoints)
- `linkedin-company` — company profiles, employees, stats (4 endpoints)
- `linkedin-search` — search users, companies, jobs, posts (7 endpoints)
- `instagram-api` — profiles, posts, reels, comments (8 endpoints)
- `twitter-api` — profiles, tweets, search (4 endpoints)
- `reddit-api` — posts, comments, search (5 endpoints)
- `youtube-api` — videos, comments, subtitles, channels (5 endpoints)
- `crunchbase` — company profiles and search (2 endpoints)
- `yc-startups` — YC companies and founders (3 endpoints)
- `sec-filings` — SEC EDGAR filings and search (2 endpoints)
- `webparser` — web scraping, sitemaps, DuckDuckGo search (3 endpoints)
- `token-usage` — API credit monitoring (3 endpoints)

**12 agent skills** with references:
anysite-cli, lead-generation, competitor-intelligence, competitor-analyzer, market-research, person-analyzer, vc-analyst, audience-analysis, brand-reputation, content-analytics, influencer-discovery, trend-analysis

## Why

Anysite API provides unified access to social media and business data (LinkedIn, Instagram, Twitter, Reddit, YouTube, Crunchbase, YC, SEC). No curated docs exist yet — agents currently hallucinate parameter names and response fields. All params and response fields in this PR are verified against live API calls (36 endpoints tested).

## Testing

- [x] `npm test` passes (174/174)
- [x] `chub build content/ --validate-only` succeeds (1556 docs, 17 skills, 0 warnings)
- [x] Manual testing done: 36 endpoints verified with live API calls, all params and response fields match real API responses

## Notes

- Frontmatter optimized for BM25 search (short names, synonym tags, concise descriptions)
- LinkedIn split into 4 docs for better search relevance
- Skills adapted from [anysite-skills repo](https://github.com/anysiteio/agent-skills) with added Context Hub metadata
- Excluded all `ai_based` endpoints per content scope decision