### PR TITLE
Update AG2 docs and references

### DIFF
--- a/content/autogen/docs/package/python/DOC.md
+++ b/content/autogen/docs/package/python/DOC.md
@@ -3,9 +3,9 @@ name: package
 description: "AG2 / AutoGen Python package for building LLM agents, multi-agent chats, tools, and code-executing workflows"
 metadata:
   languages: "python"
-  versions: "0.11.2"
-  revision: 1
-  updated-on: "2026-03-12"
+  versions: "0.11.3"
+  revision: 2
+  updated-on: "2026-03-17"
   source: maintainer
   tags: "autogen,ag2,agents,llm,multi-agent,openai,tool-use"
 ---
@@ -21,14 +21,14 @@ Treat `autogen` on PyPI as the AG2 project. The package name in your lockfile ma
 Pin the package version your project expects:
 
 ```bash
-python -m pip install "autogen[openai]==0.11.2"
+python -m pip install "autogen[openai]==0.11.3"
 ```
 
 Equivalent commands:
 
 ```bash
-uv add "autogen[openai]==0.11.2"
-poetry add "autogen[openai]==0.11.2"
+uv add "autogen[openai]==0.11.3"
+poetry add "autogen[openai]==0.11.3"
 ```
 
 Notes:
@@ -39,78 +39,51 @@ Notes:
 
 ## Authentication And Model Setup
 
-For OpenAI-backed agents, set credentials in the environment:
-
-```bash
-export OPENAI_API_KEY="your-api-key"
-```
-
-Minimal model configuration:
+`LLMConfig` takes a dict with provider-specific fields. AG2 supports multiple providers — install the matching extra for each (e.g., `autogen[openai]`, `autogen[google]`, `autogen[anthropic]`).
 
 ```python
-from autogen import AssistantAgent
 from autogen.llm_config import LLMConfig
 
-llm_config = LLMConfig(
-    api_type="openai",
-    model="gpt-4.1-mini",
-    api_key="your-api-key",
-)
+# OpenAI
+llm_config = LLMConfig({"api_type": "openai", "model": "gpt-4.1-mini", "api_key": "your-api-key"})
 
-assistant = AssistantAgent(
-    name="assistant",
-    llm_config=llm_config,
-)
+# Google
+llm_config = LLMConfig({"api_type": "google", "model": "gemini-3.1-flash-lite-preview"})
+
+# Anthropic
+llm_config = LLMConfig({"api_type": "anthropic", "model": "claude-sonnet-4-20250514"})
 ```
 
 If credentials already live in the environment, keep secrets out of source files:
 
 ```python
 import os
-
-from autogen import AssistantAgent
 from autogen.llm_config import LLMConfig
 
-llm_config = LLMConfig(
-    api_type="openai",
-    model="gpt-4.1-mini",
-    api_key=os.environ["OPENAI_API_KEY"],
-)
-
-assistant = AssistantAgent(name="assistant", llm_config=llm_config)
+llm_config = LLMConfig({"api_type": "openai", "model": "gpt-4.1-mini", "api_key": os.environ["OPENAI_API_KEY"]})
 ```
 
-AG2 also supports loading a config list from JSON or an environment variable:
-
-```python
-from autogen.llm_config import LLMConfig
-
-llm_config = LLMConfig.from_json(
-    path="OAI_CONFIG_LIST",
-    file_location=".",
-    filter_dict={"model": ["gpt-4.1-mini"]},
-)
-```
-
-Use that pattern when a project already stores multi-model credentials in `OAI_CONFIG_LIST`.
+See `references/agents.md` for the full `LLMConfig` reference including `from_json` loading.
 
 ## Core Usage
+
+AG2 has two main entry points:
+- **`run()`** — for single-agent and two-agent conversations (see `references/agents.md`)
+- **`run_group_chat()`** — for orchestrating 3+ agents (see `references/group-chat.md`)
+
+Both return a `RunResponse`. Call `.process()` to execute, then access `.summary`, `.cost`, `.last_speaker`, and `.context_variables`.
 
 ### Quick start with a single assistant
 
 `run()` prepares the chat and `process()` executes it:
 
 ```python
-from autogen import AssistantAgent
+from autogen import ConversableAgent
 from autogen.llm_config import LLMConfig
 
-assistant = AssistantAgent(
+assistant = ConversableAgent(
     name="assistant",
-    llm_config=LLMConfig(
-        api_type="openai",
-        model="gpt-4.1-mini",
-        api_key="your-api-key",
-    ),
+    llm_config=LLMConfig({"api_type": "google", "model": "gemini-3.1-flash-lite-preview"}),
     system_message="You are a concise Python coding assistant.",
 )
 
@@ -127,28 +100,24 @@ print(chat_result.summary)
 Use `UserProxyAgent` when a workflow needs a human checkpoint, tool execution, or code execution policy:
 
 ```python
-from autogen import AssistantAgent, UserProxyAgent
+from autogen import ConversableAgent, UserProxyAgent
 from autogen.llm_config import LLMConfig
 
-assistant = AssistantAgent(
+assistant = ConversableAgent(
     name="assistant",
-    llm_config=LLMConfig(
-        api_type="openai",
-        model="gpt-4.1-mini",
-        api_key="your-api-key",
-    ),
+    llm_config=LLMConfig({"api_type": "openai", "model": "gpt-4.1-mini", "api_key": "your-api-key"}),
 )
 
 user_proxy = UserProxyAgent(
     name="user_proxy",
-    human_input_mode="NEVER",
     code_execution_config=False,
 )
 
-result = user_proxy.initiate_chat(
-    assistant,
+result = user_proxy.run(
+    recipient=assistant,
     message="Summarize the advantages of asyncio for IO-bound work.",
 )
+result.process()
 
 print(result.summary)
 ```
@@ -158,62 +127,84 @@ print(result.summary)
 AG2 is built around agent-to-agent conversations. A minimal planning-and-review flow looks like this:
 
 ```python
-from autogen import AssistantAgent
+from autogen import ConversableAgent
+from autogen.agentchat import run_group_chat
 from autogen.agentchat.group.patterns import AutoPattern
 from autogen.llm_config import LLMConfig
 
-llm_config = LLMConfig(
-    api_type="openai",
-    model="gpt-4.1-mini",
-    api_key="your-api-key",
-)
+llm_config = LLMConfig({"api_type": "google", "model": "gemini-3.1-flash-lite-preview"})
 
-planner = AssistantAgent(name="planner", llm_config=llm_config)
-reviewer = AssistantAgent(name="reviewer", llm_config=llm_config)
+planner = ConversableAgent(name="planner", llm_config=llm_config,
+    description="Plans implementation steps and breaks down tasks.")
+coder = ConversableAgent(name="coder", llm_config=llm_config,
+    description="Writes Python code based on the plan.")
+reviewer = ConversableAgent(name="reviewer", llm_config=llm_config,
+    description="Reviews code and plans for correctness.")
 
-groupchat = AutoPattern(
+pattern = AutoPattern(
     initial_agent=planner,
-    agents=[planner, reviewer],
+    agents=[planner, coder, reviewer],
+    group_manager_args={"llm_config": llm_config},
 )
 
-result = groupchat.run(
-    message="Plan a Python CLI that syncs local markdown files to S3."
+result = run_group_chat(
+    pattern=pattern,
+    messages="Plan a Python CLI that syncs local markdown files to S3.",
 )
 result.process()
 ```
 
-Use specialized system prompts and smaller agent sets first. Group chats become noisy quickly when every agent has the same role.
+Use specialized system prompts and smaller agent sets first. Group chats become noisy quickly when every agent has the same role. Set `description` on each agent — the group manager uses descriptions to select the next speaker.
+
+### Tools
+
+Register tool functions on agents via the `functions` parameter. In group chat, tool execution is automatic. In two-agent `run()`, split registration between LLM and execution agents:
+
+```python
+from typing import Annotated
+
+def search_web(query: Annotated[str, "The search query"]) -> str:
+    """Search the web and return results."""
+    return do_search(query)
+
+# Group chat: just pass functions, execution is automatic
+agent = ConversableAgent(name="researcher", llm_config=llm_config, functions=[search_web])
+
+# Two-agent: split registration (see references/agents.md for details)
+@user_proxy.register_for_execution()
+@assistant.register_for_llm(description="Look up a stock price")
+def get_stock_price(symbol: Annotated[str, "The ticker symbol"]) -> str:
+    return fetch_price(symbol)
+```
+
+See `references/agents.md` for full tool registration patterns and `references/group-chat.md` for `ReplyResult` (controlling routing from within tools).
 
 ## Code Execution
 
 AG2 can execute code through a configured executor. Keep execution disabled unless you explicitly need it:
 
 ```python
-from autogen import AssistantAgent, UserProxyAgent
+from autogen import ConversableAgent, UserProxyAgent
 from autogen.coding import LocalCommandLineCodeExecutor
 from autogen.llm_config import LLMConfig
 
 executor = LocalCommandLineCodeExecutor(work_dir="coding")
 
-assistant = AssistantAgent(
+assistant = ConversableAgent(
     name="assistant",
-    llm_config=LLMConfig(
-        api_type="openai",
-        model="gpt-4.1-mini",
-        api_key="your-api-key",
-    ),
+    llm_config=LLMConfig({"api_type": "openai", "model": "gpt-4.1-mini", "api_key": "your-api-key"}),
 )
 
 user_proxy = UserProxyAgent(
     name="user_proxy",
-    human_input_mode="NEVER",
     code_execution_config={"executor": executor},
 )
 
-user_proxy.initiate_chat(
-    assistant,
+result = user_proxy.run(
+    recipient=assistant,
     message="Write and run Python code that prints the first 10 Fibonacci numbers.",
 )
+result.process()
 ```
 
 Notes:
@@ -227,18 +218,18 @@ Notes:
 - The package slug and the project branding differ. `autogen` on PyPI is AG2, and the docs frequently use `ag2` in install commands.
 - The import path does not change just because the install command uses `ag2`; current examples still import from `autogen`.
 - Missing extras are a common failure mode. Install `[openai]` or the provider extra that matches your model backend.
-- `LLMConfig` needs provider-specific fields. Do not assume a raw `model=` string is enough when the backend also needs `api_type`, `base_url`, or credentials.
-- `run()` and `initiate_chat()` return chat results; call `process()` when you want the conversation to execute and finalize under the newer workflow shown in current docs.
+- `LLMConfig` takes a dict — do not pass keyword arguments. Use `LLMConfig({"api_type": "openai", "model": "gpt-4.1-mini"})`, not `LLMConfig(api_type="openai", model="gpt-4.1-mini")`.
+- `run()` and `run_group_chat()` return a `RunResponse`; call `.process()` to execute the conversation. Access `.summary`, `.cost`, `.last_speaker` after processing.
 - Code execution is opt-in. `code_execution_config=False` is safer than silently allowing local execution.
 - Older examples on blogs and issue threads may still use pre-0.9 group-chat or Swarm terminology. Prefer the current AG2 docs for orchestration patterns.
 
 ## Version-Sensitive Notes
 
-- The version used here `0.11.2` matches the current PyPI release as of March 12, 2026.
+- The version used here `0.11.3` matches the current PyPI release as of March 12, 2026.
 - The docs URL points to the GitHub repo. The canonical maintainer docs for daily use are on `docs.ag2.ai`; use the repo mainly for source, examples, and release history.
 - AG2 `0.8` made provider integrations optional extras, which is why current install commands explicitly include `[openai]`.
 - AG2 `0.9` merged the older Swarm and Group Chat concepts into a unified Group Chat pattern model. If you see Swarm-only examples, treat them as older guidance unless the target codebase is already built around them.
-- The docs root used here is `https://docs.ag2.ai/latest/`, not a version-pinned `0.11.2` snapshot. If an example disagrees with your installed package, check the repo tag or release notes for `v0.11.2` before copying newer APIs.
+- The docs root used here is `https://docs.ag2.ai/latest/`, not a version-pinned `0.11.3` snapshot. If an example disagrees with your installed package, check the repo tag or release notes for `v0.11.3` before copying newer APIs.
 
 ## Official Sources Used
 
@@ -250,3 +241,8 @@ Notes:
 - AG2 OpenAI model guide: `https://docs.ag2.ai/latest/docs/user-guide/models/openai/`
 - AG2 code execution guide: `https://docs.ag2.ai/latest/docs/user-guide/advanced-concepts/code-execution/`
 - AG2 repository: `https://github.com/ag2ai/ag2`
+
+## Available References
+
+- `references/agents.md` — Agent classes, `run()`, `run_iter()`, tool registration
+- `references/group-chat.md` — `run_group_chat()`, patterns, handoffs, targets, `ReplyResult`, context variables

--- a/content/autogen/docs/package/python/references/agents.md
+++ b/content/autogen/docs/package/python/references/agents.md
@@ -1,0 +1,336 @@
+# AG2 Agent API Reference
+
+## LLMConfig
+
+Wraps model configuration for any supported provider. Always pass a dict:
+
+```python
+from autogen.llm_config import LLMConfig
+
+# OpenAI
+llm_config = LLMConfig({"api_type": "openai", "model": "gpt-4.1-mini", "api_key": "your-api-key"})
+
+# Google
+llm_config = LLMConfig({"api_type": "google", "model": "gemini-3.1-flash-lite-preview"})
+
+# Anthropic
+llm_config = LLMConfig({"api_type": "anthropic", "model": "claude-sonnet-4-20250514"})
+```
+
+| Key | Required | Description |
+|---|---|---|
+| `api_type` | Yes | Provider identifier: `"openai"`, `"google"`, `"anthropic"`, etc. |
+| `model` | Yes | Model name as the provider expects it |
+| `api_key` | No | API key; omit if set in environment variables |
+| `base_url` | No | Custom endpoint URL (for proxies or self-hosted models) |
+| `temperature` | No | Sampling temperature |
+| `max_tokens` | No | Maximum tokens in response |
+
+### Loading from JSON file
+
+```python
+llm_config = LLMConfig.from_json(
+    path="OAI_CONFIG_LIST",
+    file_location=".",
+    filter_dict={"model": ["gpt-4.1-mini"]},
+)
+```
+
+Use when a project stores multi-model credentials in an `OAI_CONFIG_LIST` file.
+
+### Using as context manager
+
+```python
+with LLMConfig({"api_type": "openai", "model": "gpt-4.1-mini"}) as config:
+    agent = ConversableAgent(name="assistant", llm_config=config)
+```
+
+Note: Each provider requires its corresponding extra to be installed (e.g., `autogen[openai]`, `autogen[google]`, `autogen[anthropic]`). Without the extra, model calls will fail at runtime.
+
+## ConversableAgent
+
+The base class for all AG2 agents. Every agent is a `ConversableAgent` or extends one.
+
+### Constructor
+
+```python
+from autogen import ConversableAgent
+
+agent = ConversableAgent(
+    name="my_agent",
+    system_message="You are a helpful assistant.",
+    llm_config=llm_config,
+    human_input_mode="NEVER",
+    code_execution_config=False,
+    functions=[my_tool_fn],
+)
+```
+
+| Param | Type | Default | Description |
+|---|---|---|---|
+| `name` | `str` | required | Unique agent identifier |
+| `system_message` | `str \| None` | `""` | Role/personality prompt sent to the LLM |
+| `llm_config` | `LLMConfig \| dict \| False \| None` | `None` | LLM configuration; `False` disables LLM |
+| `human_input_mode` | `"ALWAYS" \| "NEVER" \| "TERMINATE"` | `"TERMINATE"` | When to solicit human input |
+| `code_execution_config` | `dict \| False` | `False` | Code executor settings; `False` disables |
+| `functions` | `list[Callable]` | `None` | Tool functions the agent can call |
+| `is_termination_msg` | `Callable[[dict], bool] \| None` | `None` | Predicate to end the conversation |
+| `max_consecutive_auto_reply` | `int \| None` | `None` | Auto-reply limit before requesting human input |
+| `description` | `str \| None` | `None` | Description used by group chat manager for speaker selection |
+
+## UserProxyAgent
+
+Pre-configured to represent a human or execute code on their behalf. Extends `ConversableAgent`.
+
+```python
+from autogen import UserProxyAgent
+
+user_proxy = UserProxyAgent(
+    name="user_proxy",
+    code_execution_config={"executor": executor},
+)
+```
+
+Key defaults that differ from `ConversableAgent`:
+- `human_input_mode="ALWAYS"` — prompts for human input by default
+- `llm_config=False` — no LLM backing
+- `code_execution_config={}` — code execution enabled by default
+
+Use when: you need a human-in-the-loop checkpoint, tool execution relay, or code execution sandbox.
+
+## run()
+
+The primary method for single-agent and two-agent conversations. For 3+ agents, use `run_group_chat()` (see `references/group-chat.md`). Non-blocking — runs the chat in a background thread and returns a `RunResponse` immediately.
+
+```python
+result = assistant.run(
+    message="Write a function that groups strings by first letter.",
+    max_turns=3,
+)
+result.process()  # execute and stream output to console
+
+print(result.summary)
+```
+
+| Param | Type | Default | Description |
+|---|---|---|---|
+| `message` | `str \| dict \| Callable \| None` | `None` | Initial message to start the chat |
+| `recipient` | `ConversableAgent \| None` | `None` | Target agent; `None` enables single-agent mode |
+| `max_turns` | `int \| None` | `None` | Maximum conversation turns |
+| `user_input` | `bool \| None` | `False` | Whether to allow user input during execution |
+| `tools` | `Tool \| Iterable[Tool] \| None` | `None` | Tools available (single-agent mode only) |
+| `clear_history` | `bool` | `True` | Clear chat history before starting |
+| `silent` | `bool \| None` | `False` | Suppress console output |
+| `summary_method` | `str \| Callable \| None` | `"last_msg"` | How to generate the summary (`"last_msg"`, `"reflection_with_llm"`, or callable) |
+| `msg_to` | `str \| None` | `"agent"` | Direction of initial message: `"agent"` or `"user"` |
+
+### Single-agent mode
+
+When `recipient=None`, `run()` creates a temporary executor agent automatically:
+
+```python
+result = assistant.run(
+    message="Explain Python decorators.",
+    max_turns=1,
+)
+result.process()
+```
+
+### Two-agent mode
+
+Pass a `recipient` to create a direct conversation between two agents:
+
+```python
+result = user_proxy.run(
+    recipient=assistant,
+    message="Summarize the advantages of asyncio.",
+    max_turns=4,
+)
+result.process()
+```
+
+### RunResponse
+
+`run()` returns a `RunResponse`. Call `.process()` to execute, then access results:
+
+```python
+result = assistant.run(message="Explain decorators.", max_turns=2)
+result.process()
+
+print(result.summary)        # conversation summary
+print(result.cost)           # token usage and cost breakdown
+print(result.last_speaker)   # name of the last agent that spoke
+```
+
+| Property | Type | Description |
+|---|---|---|
+| `.summary` | `str \| None` | Conversation summary (controlled by `summary_method`) |
+| `.cost` | `Cost \| None` | Token usage and cost; `.cost.usage_including_cached_inference` and `.cost.usage_excluding_cached_inference` each have `.total_cost` |
+| `.last_speaker` | `str \| None` | Name of the last agent that spoke |
+| `.context_variables` | `ContextVariables \| None` | Shared context state |
+| `.events` | `Iterable[BaseEvent]` | Stream of conversation events |
+| `.messages` | `Iterable[Message]` | Chat messages exchanged |
+
+Pass a custom `EventProcessorProtocol` to `.process(processor)` for custom event handling.
+
+## run_iter()
+
+Stepped execution — the background thread pauses after each event until you advance. Use for event-driven UIs, custom logging, or streaming integrations.
+
+```python
+from autogen.events import TextEvent, TerminationEvent
+
+for event in assistant.run_iter(
+    message="Write a haiku about Python.",
+    yield_on=[TextEvent, TerminationEvent],
+):
+    if isinstance(event, TextEvent):
+        print(f"[{event.source}]: {event.content}")
+    elif isinstance(event, TerminationEvent):
+        print("Done.")
+```
+
+| Param | Type | Default | Description |
+|---|---|---|---|
+| `yield_on` | `Sequence[type[BaseEvent]] \| None` | `None` | Event types to yield; `None` yields all |
+
+All other params match `run()`. Common event types:
+
+| Event | Description |
+|---|---|
+| `TextEvent` | Agent produced text output |
+| `ToolCallEvent` | Agent invoked a tool |
+| `TerminationEvent` | Conversation ended |
+| `InputRequestEvent` | Agent is requesting user input |
+
+## Tool Registration
+
+Tool execution works differently depending on whether you use group chat or two-agent chat.
+
+### Group chat: automatic tool execution
+
+In `run_group_chat()`, tool execution is automatic. Register tools on the agent via `functions` and AG2 handles execution internally through a built-in `_Group_Tool_Executor` agent:
+
+```python
+from typing import Annotated
+
+def search_web(query: Annotated[str, "The search query"]) -> str:
+    """Search the web and return results."""
+    return do_search(query)
+
+researcher = ConversableAgent(
+    name="researcher",
+    llm_config=llm_config,
+    functions=[search_web],
+    description="Researches topics using web search.",
+)
+writer = ConversableAgent(name="writer", llm_config=llm_config,
+    description="Writes content based on research.")
+editor = ConversableAgent(name="editor", llm_config=llm_config,
+    description="Edits and polishes written content.")
+
+# In group chat, tool calls are executed automatically
+result = run_group_chat(
+    pattern=AutoPattern(
+        initial_agent=researcher,
+        agents=[researcher, writer, editor],
+        group_manager_args={"llm_config": llm_config},
+    ),
+    messages="Research and write about AG2 documentation.",
+)
+result.process()
+```
+
+### Two-agent chat: split registration
+
+With `run()` and two agents, you must explicitly split tool registration — one agent proposes the tool call (LLM), and the other executes it:
+
+```python
+from typing import Annotated
+from autogen import ConversableAgent, UserProxyAgent
+
+assistant = ConversableAgent(name="assistant", llm_config=llm_config)
+user_proxy = UserProxyAgent(name="user_proxy", code_execution_config=False)
+
+@user_proxy.register_for_execution()
+@assistant.register_for_llm(description="Search the web")
+def search_web(query: Annotated[str, "The search query"]) -> str:
+    return do_search(query)
+
+result = user_proxy.run(
+    recipient=assistant,
+    message="Search for AG2 documentation.",
+)
+result.process()
+```
+
+| Decorator | Purpose |
+|---|---|
+| `@agent.register_for_llm(description=...)` | Makes the tool available in the agent's LLM tool list (agent proposes the call) |
+| `@agent.register_for_execution(name=...)` | Registers the function for actual execution by that agent (agent runs it) |
+
+The LLM agent decides when to call the tool; the execution agent runs it and returns the result.
+
+### Single-agent mode: inline tools
+
+When using `run()` without a recipient, pass tools directly:
+
+```python
+from typing import Annotated
+
+def search_web(query: Annotated[str, "The search query"]) -> str:
+    """Search the web and return results."""
+    return do_search(query)
+
+assistant = ConversableAgent(name="assistant", llm_config=llm_config)
+
+result = assistant.run(
+    message="Search for AG2 documentation.",
+    tools=[search_web],
+)
+result.process()
+```
+
+### Defining tool functions
+
+Use `Annotated` types with descriptions on every parameter. The function docstring becomes the tool description the LLM sees:
+
+```python
+from typing import Annotated, Any
+
+def check_payment(
+    vendor: Annotated[str, "The vendor name"],
+    amount: Annotated[float, "The transaction amount"],
+) -> dict[str, Any]:
+    """Check if a payment has been processed."""
+    return {"status": "processed", "vendor": vendor}
+```
+
+### Tools with context variables
+
+Name a parameter `context_variables: ContextVariables` and AG2 injects the shared context automatically:
+
+```python
+from autogen.agentchat.group.context_variables import ContextVariables
+
+def get_user_name(context_variables: ContextVariables) -> str:
+    """Get the current user's name from context."""
+    return context_variables.get("user_name", "Unknown")
+```
+
+## initiate_chat() (legacy)
+
+Blocking two-agent chat. Suitable for simple synchronous scripts:
+
+```python
+result = user_proxy.initiate_chat(
+    assistant,
+    message="Explain list comprehensions.",
+    max_turns=3,
+)
+print(result.summary)
+```
+
+Returns a `ChatResult` with `.chat_history`, `.summary`, `.cost`, `.human_input`.
+
+Note: Prefer `run()` + `.process()` for new code. `run()` supports single-agent mode, event streaming, and the `RunResponse` interface. `initiate_chat()` is retained for backward compatibility.

--- a/content/autogen/docs/package/python/references/group-chat.md
+++ b/content/autogen/docs/package/python/references/group-chat.md
@@ -1,0 +1,585 @@
+# AG2 Group Chat API Reference
+
+## run_group_chat()
+
+The primary function for orchestrating 3+ agents. For single-agent or two-agent conversations, use `run()` (see `references/agents.md`). Non-blocking — runs in a background thread and returns a `RunResponse` immediately.
+
+```python
+from autogen import ConversableAgent
+from autogen.agentchat import run_group_chat
+from autogen.agentchat.group.patterns import AutoPattern
+from autogen.llm_config import LLMConfig
+
+llm_config = LLMConfig({"api_type": "google", "model": "gemini-3.1-flash-lite-preview"})
+
+planner = ConversableAgent(name="planner", llm_config=llm_config,
+    description="Plans implementation steps and breaks down tasks.")
+reviewer = ConversableAgent(name="reviewer", llm_config=llm_config,
+    description="Reviews work for correctness and quality.")
+coder = ConversableAgent(name="coder", llm_config=llm_config,
+    description="Writes Python code based on the plan.")
+
+pattern = AutoPattern(
+    initial_agent=planner,
+    agents=[planner, reviewer, coder],
+    group_manager_args={"llm_config": llm_config},
+)
+
+result = run_group_chat(
+    pattern=pattern,
+    messages="Design a REST API for a todo app.",
+    max_rounds=10,
+)
+result.process()
+
+print(result.summary)
+```
+
+| Param | Type | Default | Description |
+|---|---|---|---|
+| `pattern` | `Pattern` | required | Orchestration pattern controlling agent selection |
+| `messages` | `str \| list[dict]` | required | Initial message(s) to start the group chat |
+| `max_rounds` | `int` | `20` | Maximum conversation rounds before termination |
+
+### RunResponse
+
+`run_group_chat()` returns a `RunResponse`. Call `.process()` to execute, then access results:
+
+```python
+result = run_group_chat(pattern=pattern, messages="Design an API.")
+result.process()
+
+print(result.summary)                          # conversation summary
+print(result.cost)                             # token usage and cost breakdown
+print(result.last_speaker)                     # name of the last agent that spoke
+print(result.context_variables.to_dict())      # final shared state
+```
+
+| Property | Type | Description |
+|---|---|---|
+| `.summary` | `str \| None` | Conversation summary (controlled by `summary_method`) |
+| `.cost` | `Cost \| None` | Token usage and cost; `.cost.usage_including_cached_inference` and `.cost.usage_excluding_cached_inference` each have `.total_cost` |
+| `.last_speaker` | `str \| None` | Name of the last agent that spoke |
+| `.context_variables` | `ContextVariables \| None` | Final shared state after the conversation |
+| `.events` | `Iterable[BaseEvent]` | Stream of all conversation events |
+| `.messages` | `Iterable[Message]` | Chat messages exchanged |
+
+`run()` returns the same `RunResponse` — see `references/agents.md` for details.
+
+## run_group_chat_iter()
+
+Stepped iteration over group chat events. Use for streaming UIs or custom event processing.
+
+```python
+from autogen.agentchat import run_group_chat_iter
+from autogen.events import TextEvent, TerminationEvent
+
+for event in run_group_chat_iter(
+    pattern=pattern,
+    messages="Plan a deployment strategy.",
+    max_rounds=15,
+    yield_on=[TextEvent, TerminationEvent],
+):
+    if isinstance(event, TextEvent):
+        print(f"[{event.source}]: {event.content}")
+```
+
+| Param | Type | Default | Description |
+|---|---|---|---|
+| `yield_on` | `Sequence[type[BaseEvent]] \| None` | `None` | Event types to yield; `None` yields all |
+
+All other params match `run_group_chat()`. Common event types:
+
+| Event | Description |
+|---|---|
+| `TextEvent` | Agent produced text output |
+| `ToolCallEvent` | Agent invoked a tool |
+| `GroupChatRunChatEvent` | Group chat round completed |
+| `TerminationEvent` | Conversation ended |
+
+## Tool Execution in Group Chat
+
+In group chat, tool execution is automatic. Register tools on an agent via `functions` and AG2 handles execution internally — no need for a separate executor agent or split registration:
+
+```python
+from typing import Annotated
+
+def lookup_order(order_id: Annotated[str, "The order ID"]) -> str:
+    """Look up an order by ID."""
+    return f"Order {order_id}: shipped"
+
+agent = ConversableAgent(
+    name="support",
+    llm_config=llm_config,
+    functions=[lookup_order],
+)
+```
+
+This differs from two-agent `run()` where you must split registration between an LLM agent and an execution agent. See `references/agents.md` for the two-agent pattern.
+
+## Patterns
+
+Patterns control how agents take turns in a group chat. All patterns share a common base:
+
+| Param | Type | Default | Description |
+|---|---|---|---|
+| `initial_agent` | `ConversableAgent` | required | Agent that speaks first |
+| `agents` | `list[ConversableAgent]` | required | All participating agents |
+| `user_agent` | `ConversableAgent \| None` | `None` | Human-in-the-loop agent |
+| `group_manager_args` | `dict \| None` | `None` | Config for the internal group manager (e.g., `llm_config`, `is_termination_msg`) |
+| `context_variables` | `ContextVariables \| None` | `None` | Shared state across agents |
+| `group_after_work` | `TransitionTarget \| None` | `TerminateTarget()` | Default action when no handoff triggers |
+| `summary_method` | `str \| Callable \| None` | `"last_msg"` | How to generate the conversation summary |
+
+### AutoPattern
+
+LLM-based agent selection. The group manager uses its LLM to choose the next speaker based on conversation context. Easiest to start with.
+
+Important: Set `description` on each agent — the group manager uses agent descriptions to decide who speaks next. Without descriptions, it uses the system_message which can be too verbose.
+
+```python
+from autogen.agentchat.group.patterns import AutoPattern
+
+planner = ConversableAgent(name="planner", llm_config=llm_config,
+    description="Plans implementation steps and breaks down tasks.")
+coder = ConversableAgent(name="coder", llm_config=llm_config,
+    description="Writes Python code based on the plan.")
+reviewer = ConversableAgent(name="reviewer", llm_config=llm_config,
+    description="Reviews code and plans for correctness and quality.")
+
+pattern = AutoPattern(
+    initial_agent=planner,
+    agents=[planner, coder, reviewer],
+    group_manager_args={"llm_config": llm_config},
+)
+```
+
+`group_after_work` is always `GroupManagerTarget` (LLM picks the next agent). Requires an LLM config on the group manager.
+
+Use when: you want the LLM to dynamically route between agents without explicit handoff rules.
+
+### DefaultPattern
+
+Explicit handoff-driven routing. Agents must configure their own transitions via `agent.handoffs`. No automatic next-speaker selection.
+
+```python
+from autogen.agentchat.group.patterns import DefaultPattern
+from autogen.agentchat.group import OnCondition, AfterWork
+
+planner.handoffs.add_llm_condition(
+    OnCondition(target=coder, condition="The plan is ready to implement.")
+)
+coder.handoffs.add_llm_condition(
+    OnCondition(target=reviewer, condition="Code is ready for review.")
+)
+reviewer.handoffs.set_after_work(AfterWork(target=planner))
+
+pattern = DefaultPattern(
+    initial_agent=planner,
+    agents=[planner, coder, reviewer],
+)
+```
+
+Use when: you need deterministic control over agent transitions.
+
+### RoundRobinPattern
+
+Agents speak in list order, cycling back to the first. No LLM-based selection.
+
+```python
+from autogen.agentchat.group.patterns import RoundRobinPattern
+
+pattern = RoundRobinPattern(
+    initial_agent=agent_a,
+    agents=[agent_a, agent_b, agent_c],
+)
+```
+
+Use when: every agent must contribute each round in a fixed order.
+
+### RandomPattern
+
+Each turn, a random agent is selected. No LLM-based selection.
+
+```python
+from autogen.agentchat.group.patterns import RandomPattern
+
+pattern = RandomPattern(
+    initial_agent=agent_a,
+    agents=[agent_a, agent_b, agent_c],
+)
+```
+
+Use when: you want diverse perspectives without ordering bias.
+
+### ManualPattern
+
+Prompts the user to select the next agent each turn.
+
+```python
+from autogen.agentchat.group.patterns import ManualPattern
+
+pattern = ManualPattern(
+    initial_agent=agent_a,
+    agents=[agent_a, agent_b, agent_c],
+    user_agent=human,
+)
+```
+
+Use when: a human operator needs full control over the conversation flow.
+
+## Handoffs
+
+Handoffs control how agents transition to each other in `DefaultPattern` (or when adding custom transitions in any pattern).
+
+### OnCondition
+
+LLM-evaluated transition. The condition is translated into a tool the LLM can call to trigger the handoff.
+
+```python
+from autogen.agentchat.group import OnCondition
+
+planner.handoffs.add_llm_condition(
+    OnCondition(
+        target=reviewer,
+        condition="The plan is complete and ready for review.",
+    )
+)
+```
+
+| Param | Type | Description |
+|---|---|---|
+| `target` | `TransitionTarget` | Agent or target to hand off to |
+| `condition` | `str` | Natural language condition evaluated by the LLM |
+
+### OnContextCondition
+
+Context variable-based transition. Evaluated without an LLM call — checked before `OnCondition`.
+
+```python
+from autogen.agentchat.group import OnContextCondition
+
+planner.handoffs.add_context_condition(
+    OnContextCondition(
+        target=reviewer,
+        condition=lambda ctx: ctx.get("plan_ready", False),
+    )
+)
+```
+
+### AfterWork
+
+Fallback target when no `OnCondition` or `OnContextCondition` triggers.
+
+```python
+from autogen.agentchat.group import AfterWork
+
+reviewer.handoffs.set_after_work(AfterWork(target=planner))
+```
+
+### Transition Targets
+
+Targets control where the conversation goes next. Used in `OnCondition`, `AfterWork`, and `ReplyResult`.
+
+| Target | Description |
+|---|---|
+| `AgentTarget(agent)` | Hand off to a specific agent instance |
+| `AgentNameTarget("name")` | Hand off to an agent by name (string) |
+| `RevertToUserTarget()` | Return control to the user agent |
+| `StayTarget()` | Current agent continues speaking |
+| `TerminateTarget()` | End the group chat |
+| `GroupManagerTarget()` | Let the group manager LLM pick the next agent |
+| `RandomAgentTarget(agents)` | Randomly select from a list of agents |
+| `FunctionTarget(fn)` | Call a function to determine the next target dynamically |
+
+All targets import from `autogen.agentchat.group`.
+
+#### AgentTarget
+
+The most common target — routes to a specific agent:
+
+```python
+from autogen.agentchat.group import AgentTarget, OnCondition
+
+planner.handoffs.add_llm_condition(
+    OnCondition(target=AgentTarget(coder), condition="Plan is ready to implement.")
+)
+```
+
+You can also pass an agent instance directly to `target=` in `OnCondition` or `AfterWork` — AG2 wraps it in `AgentTarget` automatically.
+
+#### FunctionTarget
+
+Calls a function at transition time to dynamically decide where to go. The function receives the last message and context variables, and must return a `FunctionTargetResult`:
+
+```python
+from autogen.agentchat.group import FunctionTarget, OnCondition
+from autogen.agentchat.group.targets.function_target import FunctionTargetResult
+
+def route_next(output: str, context_variables: ContextVariables) -> FunctionTargetResult:
+    if context_variables.get("needs_review", False):
+        return FunctionTargetResult(target=AgentTarget(reviewer))
+    return FunctionTargetResult(target=AgentTarget(coder))
+
+planner.handoffs.set_after_work(
+    AfterWork(target=FunctionTarget(route_next))
+)
+```
+
+| `FunctionTargetResult` field | Type | Description |
+|---|---|---|
+| `target` | `TransitionTarget` | Required — the next target to transition to |
+| `messages` | `list \| str \| None` | Optional messages to broadcast to specific agents |
+| `context_variables` | `ContextVariables \| None` | Optional context updates to merge |
+
+Use when: the next agent depends on runtime state that can't be expressed as a static condition.
+
+### Handoffs API
+
+All methods return `self` for chaining:
+
+```python
+agent.handoffs \
+    .add_llm_condition(OnCondition(target=other, condition="Ready.")) \
+    .set_after_work(AfterWork(target=TerminateTarget()))
+```
+
+| Method | Description |
+|---|---|
+| `.add_llm_condition(condition)` | Add an LLM-evaluated transition |
+| `.add_context_condition(condition)` | Add a context variable-based transition |
+| `.set_after_work(target)` | Set unconditional fallback (replaces existing) |
+| `.add_after_work(condition)` | Add conditional fallback |
+| `.add(condition)` | Type-dispatched — adds any condition type |
+| `.add_many(conditions)` | Add multiple conditions at once |
+| `.clear()` | Remove all handoffs |
+
+## ReplyResult
+
+Tool functions can return a `ReplyResult` to control both the response message and which agent speaks next. This is the primary way tools influence routing in group chats.
+
+```python
+from autogen.agentchat.group.reply_result import ReplyResult
+from autogen.agentchat.group import AgentTarget
+
+def process_order(order_id: Annotated[str, "The order ID"],
+                  context_variables: ContextVariables) -> ReplyResult:
+    """Process an order and route to the appropriate agent."""
+    result = do_processing(order_id)
+    context_variables.set("order_status", result["status"])
+
+    if result["status"] == "needs_review":
+        return ReplyResult(
+            message=f"Order {order_id} needs manual review.",
+            target=AgentTarget(reviewer),
+            context_variables=context_variables,
+        )
+    return ReplyResult(
+        message=f"Order {order_id} processed successfully.",
+        target=AgentTarget(shipping_agent),
+    )
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `message` | `str` | required | The tool's response text (what the LLM sees) |
+| `target` | `TransitionTarget \| None` | `None` | Which agent to hand off to next |
+| `context_variables` | `ContextVariables \| None` | `None` | Context updates to merge into the group's shared state |
+
+A `ReplyResult` without a `target` lets the normal handoff/pattern logic decide the next speaker while still updating context variables:
+
+```python
+def fetch_data(query: Annotated[str, "The query"]) -> ReplyResult:
+    """Fetch data without influencing routing."""
+    result = do_fetch(query)
+    return ReplyResult(message=result)
+```
+
+When `target` is set, `ReplyResult` overrides the normal routing. Without `ReplyResult` at all, a tool returns a plain string and the pattern decides the next speaker.
+
+Note: Only the `message` field is visible to the LLM in conversation history. The `target` and `context_variables` are consumed by the orchestration layer silently.
+
+## ContextVariables
+
+Dict-like shared state accessible by all agents and tool functions in a group chat.
+
+```python
+from autogen.agentchat.group.context_variables import ContextVariables
+
+ctx = ContextVariables({"user_name": "Alice", "step": 1})
+
+# Dict-like access
+ctx["step"] = 2
+name = ctx.get("user_name", "Unknown")
+del ctx["step"]
+```
+
+| Method | Description |
+|---|---|
+| `.get(key, default)` | Get value with fallback |
+| `.set(key, value)` | Set a value |
+| `.remove(key)` | Remove a key, returns `bool` |
+| `.update(dict)` | Merge another dict |
+| `.contains(key)` | Check existence |
+| `.to_dict()` | Export as plain dict |
+
+### Injecting into tool functions
+
+Name a parameter `context_variables: ContextVariables` and AG2 provides it automatically:
+
+```python
+def update_step(context_variables: ContextVariables) -> str:
+    """Advance to the next workflow step."""
+    step = context_variables.get("step", 0) + 1
+    context_variables.set("step", step)
+    return f"Advanced to step {step}"
+```
+
+### Passing to a pattern
+
+```python
+ctx = ContextVariables({"project": "my-app"})
+
+pattern = DefaultPattern(
+    initial_agent=planner,
+    agents=[planner, coder, reviewer],
+    context_variables=ctx,
+)
+
+result = run_group_chat(pattern=pattern, messages="Start the project.")
+result.process()
+
+# Access final context state
+print(result.context_variables.to_dict())
+```
+
+## Termination
+
+### is_termination_msg
+
+Pass a predicate to `group_manager_args` to stop the chat when a condition is met:
+
+```python
+def should_terminate(msg: dict) -> bool:
+    content = msg.get("content", "") or ""
+    return "DONE" in content
+
+pattern = AutoPattern(
+    initial_agent=planner,
+    agents=[planner, reviewer, coder],  # ensure each agent has a description set
+    group_manager_args={
+        "llm_config": llm_config,
+        "is_termination_msg": should_terminate,
+    },
+)
+```
+
+### max_rounds
+
+Set `max_rounds` in `run_group_chat()` to cap the number of turns:
+
+```python
+result = run_group_chat(pattern=pattern, messages="Go.", max_rounds=5)
+```
+
+### Agent-level termination
+
+Use `TerminateTarget()` in handoffs to end the group chat from a specific agent:
+
+```python
+from autogen.agentchat.group import AfterWork, TerminateTarget
+
+reviewer.handoffs.set_after_work(AfterWork(target=TerminateTarget()))
+```
+
+## initiate_group_chat() (legacy)
+
+Blocking group chat. Returns a tuple instead of `RunResponse`:
+
+```python
+from autogen.agentchat import initiate_group_chat
+
+result, context_variables, last_agent = initiate_group_chat(
+    pattern=pattern,
+    messages="Start planning.",
+    max_rounds=10,
+)
+print(result.summary)
+```
+
+Returns `(ChatResult, ContextVariables, Agent)`.
+
+Note: Prefer `run_group_chat()` + `.process()` for new code. It returns a unified `RunResponse` with event streaming support. `initiate_group_chat()` is retained for backward compatibility.
+
+## Common Patterns
+
+### Planning and review loop
+
+```python
+planner = ConversableAgent(name="planner", llm_config=llm_config,
+    system_message="Create detailed implementation plans.",
+    description="Plans implementation steps and breaks down tasks.")
+coder = ConversableAgent(name="coder", llm_config=llm_config,
+    system_message="Implement the plan in Python.",
+    description="Writes Python code based on the plan.")
+reviewer = ConversableAgent(name="reviewer", llm_config=llm_config,
+    system_message="Review plans and code. Say APPROVED when satisfied.",
+    description="Reviews code and plans for correctness.")
+
+def is_approved(msg):
+    return "APPROVED" in (msg.get("content", "") or "")
+
+pattern = AutoPattern(
+    initial_agent=planner,
+    agents=[planner, coder, reviewer],
+    group_manager_args={"llm_config": llm_config, "is_termination_msg": is_approved},
+)
+
+result = run_group_chat(pattern=pattern, messages="Plan a user auth system.")
+result.process()
+```
+
+### Explicit handoff chain
+
+```python
+from autogen.agentchat.group import OnCondition, AfterWork, TerminateTarget
+from autogen.agentchat.group.patterns import DefaultPattern
+
+researcher = ConversableAgent(name="researcher", llm_config=llm_config)
+writer = ConversableAgent(name="writer", llm_config=llm_config)
+editor = ConversableAgent(name="editor", llm_config=llm_config)
+
+researcher.handoffs.add_llm_condition(
+    OnCondition(target=writer, condition="Research is complete.")
+)
+writer.handoffs.add_llm_condition(
+    OnCondition(target=editor, condition="Draft is written.")
+)
+editor.handoffs.set_after_work(AfterWork(target=TerminateTarget()))
+
+pattern = DefaultPattern(
+    initial_agent=researcher,
+    agents=[researcher, writer, editor],
+)
+
+result = run_group_chat(pattern=pattern, messages="Write about async Python.")
+result.process()
+```
+
+### Human-in-the-loop
+
+```python
+from autogen import UserProxyAgent
+
+human = UserProxyAgent(name="human")
+
+pattern = AutoPattern(
+    initial_agent=planner,
+    agents=[planner, coder, reviewer],  # ensure each agent has a description set
+    user_agent=human,
+    group_manager_args={"llm_config": llm_config},
+)
+
+result = run_group_chat(pattern=pattern, messages="Build a CLI tool.")
+result.process()
+```


### PR DESCRIPTION
## What
                            
Add two API reference files for the AG2/AutoGen Python package and modernize the existing `DOC.md` to align with the current AG2 API surface.

New files:
- `references/agents.md` — LLMConfig, ConversableAgent, UserProxyAgent, run(), run_iter(), RunResponse, and tool registration patterns (group chat automatic execution vs two-agent split registration vs single-agent inline)
- `references/group-chat.md` — run_group_chat(), run_group_chat_iter(), orchestration patterns (Auto, Default, RoundRobin, Random, Manual), handoffs (OnCondition, OnContextCondition, AfterWork), transition targets (AgentTarget, FunctionTarget, TerminateTarget, etc.), ReplyResult, ContextVariables, and termination strategies

Updated `DOC.md`:
- Bump version to 0.11.3, revision 1 → 2
- Replace all initiate_chat() / initiate_group_chat() examples with run() + .process() and
run_group_chat() + .process()
- Switch LLMConfig from keyword args to dict syntax
- Add multi-provider examples (OpenAI, Google, Anthropic)
- Add tools overview section
- Add references footer linking to the new files

## Why

The existing DOC.md was a usage guide covering install, auth, and basic patterns but lacked API reference depth for agents and group chat orchestration. AI agents using Context Hub had no way to look up method signatures, tool registration patterns, or handoff/routing APIs without falling back to source code.

The examples also used initiate_chat() and keyword-based LLMConfig — both outdated patterns. The modern AG2 API uses run() / run_group_chat() with dict-based LLMConfig, and the docs now reflect that.

## Testing

- npm test — 174 tests pass
- chub build content/ --validate-only — 1544 docs, 5 skills, 0 warnings
- chub get autogen/package --lang python returns updated DOC.md
- chub get autogen/package --lang python --file references/agents.md returns agents reference
- chub get autogen/package --lang python --file references/group-chat.md returns group-chat reference
- chub get autogen/package --lang python --full returns all three files

## Notes

- The last four test items require a local source config pointing at the built `content/dist/` directory since the default remote CDN won't have these changes yet.
- As an AG2 maintainer, the content is marked source: maintainer.
- AssistantAgent references were intentionally removed — ConversableAgent is the base class and all examples use it directly to avoid confusion.