### PR TITLE
added an example github custom agent to use chub

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aisuite/chub",
-  "version": "0.1.3",
+  "version": "0.1.2",
   "description": "CLI for Context Hub - search and retrieve LLM-optimized docs and skills",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What

An example guthub agent is added to show how chub skill can be effectively used

## Why

This agent covers below
 - 1 liner section on how to ask custom agents to use chub
 - `Known Doc IDs` section to skip expensive chub search for documents fetched repeatedly

## Testing

- [ ] `npm test` passes
- [ ] `chub build sample-content/ --validate-only` succeeds
- [ ] Manual testing done (describe below)

## Notes

Any additional context for reviewers.
