### PR TITLE
fix: update CONTRIBUTING.md sample-content/ references (closes #47)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ npm install
 
 ```bash
 node cli/bin/chub --help
-node cli/bin/chub build sample-content/ --validate-only
+node cli/bin/chub build content/ --validate-only
 ```
 
 ### Running Tests
@@ -41,7 +41,7 @@ npm run test:coverage # with coverage
 2. Make your changes
 3. Add or update tests as needed
 4. Ensure all tests pass: `cd cli && npm test`
-5. Validate the build: `node cli/bin/chub build sample-content/ --validate-only`
+5. Validate the build: `node cli/bin/chub build content/ --validate-only`
 6. Submit a pull request
 
 ### Code Style
@@ -61,7 +61,7 @@ cli/
     commands/           # Command implementations
     lib/                # Core utilities
   tests/                # Vitest tests
-sample-content/         # Test fixtures
+cli/test/fixtures/  # Test fixtures
 docs/                   # Design docs
 ```
 


### PR DESCRIPTION
## Summary

The `sample-content/` directory was removed but CONTRIBUTING.md still referenced it in two places.

## Changes
- Line 24/44: `node cli/bin/chub build sample-content/ --validate-only` → `node cli/bin/chub build content/ --validate-only`
- Line 64: Updated project structure comment to point to `cli/test/fixtures/` for test fixtures

Closes #47