### PR TITLE
docs: add Novita LLM provider content

### DIFF
--- a/cli/test/e2e.test.js
+++ b/cli/test/e2e.test.js
@@ -297,7 +297,7 @@ describe('chub CLI e2e', () => {
       // Clean up
       chub(['annotate', 'acme/widgets', '--clear']);
       chub(['annotate', 'multilang/client', '--clear']);
-    }, 10000);
+    });
 
     it('--json includes annotation in get output', () => {
       chub(['annotate', 'acme/widgets', 'JSON test note']);

--- a/cli/test/e2e.test.js
+++ b/cli/test/e2e.test.js
@@ -297,7 +297,7 @@ describe('chub CLI e2e', () => {
       // Clean up
       chub(['annotate', 'acme/widgets', '--clear']);
       chub(['annotate', 'multilang/client', '--clear']);
-    });
+    }, 10000);
 
     it('--json includes annotation in get output', () => {
       chub(['annotate', 'acme/widgets', 'JSON test note']);

--- a/content/novita/docs/llm/javascript/DOC.md
+++ b/content/novita/docs/llm/javascript/DOC.md
@@ -1,0 +1,173 @@
+---
+name: llm
+description: "Novita AI OpenAI-compatible LLM API coding guide for JavaScript and TypeScript using the official OpenAI SDK"
+metadata:
+  languages: "javascript"
+  versions: "6.31.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: maintainer
+  tags: "novita,llm,openai-compatible,javascript,typescript,ai"
+---
+
+# Novita AI JavaScript/TypeScript LLM Coding Guide
+
+You are a Novita AI coding expert. Help me write JavaScript or TypeScript code that calls Novita's LLM API correctly.
+
+Primary references:
+- https://novita.ai/docs/guides/llm-api.md
+- https://novita.ai/docs/guides/llm-batch-api.md
+- https://novita.ai/docs/guides/openai-agents-sdk.md
+
+## Golden Rule
+
+Use the official OpenAI JavaScript SDK against Novita's OpenAI-compatible base URL.
+
+- **SDK:** OpenAI Node.js SDK
+- **Package:** `openai`
+- **Base URL:** `https://api.novita.ai/openai`
+- **Auth:** `Authorization: Bearer <NOVITA_API_KEY>`
+
+For standard LLM inference, do not build raw HTTP wrappers unless you specifically need custom transport behavior.
+
+```bash
+npm install openai
+```
+
+## Initialization and API Key
+
+```typescript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "https://api.novita.ai/openai",
+  apiKey: process.env.NOVITA_API_KEY,
+});
+```
+
+Do not leave the client pointed at the default OpenAI endpoint when you mean to call Novita.
+
+## Model Naming
+
+Use Novita model IDs exactly as Novita publishes them.
+
+Examples:
+- `deepseek/deepseek-v3-0324`
+- `deepseek/deepseek-r1`
+
+Do not strip the provider prefix from model names.
+
+## Primary API Surface
+
+Default to Chat Completions for Novita LLM calls.
+
+```typescript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "https://api.novita.ai/openai",
+  apiKey: process.env.NOVITA_API_KEY,
+});
+
+const completion = await client.chat.completions.create({
+  model: "deepseek/deepseek-v3-0324",
+  messages: [
+    { role: "system", content: "You are a concise coding assistant." },
+    { role: "user", content: "Explain what a JavaScript event loop does." },
+  ],
+  max_tokens: 512,
+});
+
+console.log(completion.choices[0]?.message?.content);
+```
+
+Novita also supports legacy prompt-style completions:
+
+```typescript
+const completion = await client.completions.create({
+  model: "deepseek/deepseek-r1",
+  prompt: "Summarize the purpose of TypeScript in three bullet points.",
+  max_tokens: 256,
+});
+
+console.log(completion.choices[0]?.text);
+```
+
+## Streaming
+
+```typescript
+const stream = await client.chat.completions.create({
+  model: "deepseek/deepseek-r1",
+  messages: [
+    { role: "user", content: "Give me a debugging checklist for a failing API integration." },
+  ],
+  max_tokens: 1024,
+  stream: true,
+});
+
+for await (const chunk of stream) {
+  process.stdout.write(chunk.choices[0]?.delta?.content || "");
+}
+```
+
+## TypeScript Notes
+
+Prefer running Novita through the typed OpenAI client rather than manually building JSON payloads. This keeps request shapes close to the SDK types and reduces schema mistakes.
+
+For server-side apps, keep `NOVITA_API_KEY` in environment variables or a secrets manager. Avoid exposing it in browser bundles.
+
+## Common Parameters
+
+Common Novita LLM request parameters match the OpenAI-compatible schema:
+
+- `model`
+- `messages`
+- `prompt`
+- `max_tokens`
+- `stream`
+- `temperature`, `top_p`, `top_k`
+- `presence_penalty`, `frequency_penalty`, `repetition_penalty`
+- `stop`
+
+## OpenAI Agents SDK Compatibility
+
+Novita has explicit compatibility guidance for OpenAI Agents SDK, but the important constraint is:
+
+- use the chat-completions integration path
+- do not assume `responses` API support in that workflow
+
+See `references/openai-agents-sdk.md` for the exact setup pattern and caveat.
+
+## Batch API
+
+Use batch when you need large asynchronous LLM workloads instead of immediate responses.
+
+See `references/batch.md` for:
+- JSONL input requirements
+- file upload and batch creation
+- status polling
+- output retrieval and file retention notes
+
+## Gotchas
+
+- Set `baseURL` to `https://api.novita.ai/openai`.
+- Authenticate with a Bearer token, not a query parameter.
+- Use full Novita model IDs, including provider prefixes.
+- Batch files must be valid JSONL with unique `custom_id` values.
+- All requests in one batch file must target the same model.
+- If you copy OpenAI examples that use newer APIs, verify that Novita supports the same surface before reusing them.
+
+## When Not to Use This Entry
+
+This entry is for Novita's OpenAI-compatible LLM APIs only.
+
+Do not use it for:
+- image, audio, or video generation
+- GPU infrastructure APIs
+- Agent Sandbox operations
+
+## Additional Files
+
+For deeper workflows, use:
+- `references/batch.md`
+- `references/openai-agents-sdk.md`

--- a/content/novita/docs/llm/javascript/references/batch.md
+++ b/content/novita/docs/llm/javascript/references/batch.md
@@ -1,0 +1,102 @@
+# Novita LLM Batch API
+
+Use this reference when you need asynchronous processing for many LLM requests and do not need an immediate response.
+
+Primary source: https://novita.ai/docs/guides/llm-batch-api.md
+
+## When to Use Batch
+
+Use batch for:
+- evaluations
+- bulk classification
+- offline summarization
+- large backfills
+
+Prefer regular chat completions for interactive applications.
+
+## Input File Format
+
+Novita's batch input format is JSONL. Each line is one request payload.
+
+Rules:
+- every line must be valid JSON
+- every request must include a unique `custom_id`
+- all requests in the same file must target the same model
+- endpoint must be `/v1/chat/completions` or `/v1/completions`
+
+Example:
+
+```json
+{"custom_id":"request-1","body":{"model":"deepseek/deepseek-v3-0324","messages":[{"role":"user","content":"Hello"}],"max_tokens":400}}
+{"custom_id":"request-2","body":{"model":"deepseek/deepseek-v3-0324","messages":[{"role":"user","content":"Summarize this text"}],"max_tokens":400}}
+```
+
+## Upload the Input File
+
+Use the Files API with `purpose="batch"`.
+
+```typescript
+import OpenAI from "openai";
+import fs from "node:fs";
+
+const client = new OpenAI({
+  baseURL: "https://api.novita.ai/openai/v1",
+  apiKey: process.env.NOVITA_API_KEY,
+});
+
+const batchInputFile = await client.files.create({
+  file: fs.createReadStream("batch_input.jsonl"),
+  purpose: "batch",
+});
+```
+
+## Create the Batch
+
+```typescript
+const batch = await client.batches.create({
+  input_file_id: batchInputFile.id,
+  endpoint: "/v1/chat/completions",
+  completion_window: "48h",
+});
+```
+
+Notes:
+- `completion_window` is fixed at `48h`
+- this is an asynchronous workflow
+
+## Poll Batch Status
+
+Retrieve the batch until it reaches a terminal state.
+
+Possible statuses documented by Novita:
+- `VALIDATING`
+- `PROGRESS`
+- `COMPLETED`
+- `FAILED`
+- `EXPIRED`
+- `CANCELLING`
+- `CANCELLED`
+
+## Retrieve Results
+
+When the batch completes, read `output_file_id` and fetch the file content through the Files API.
+
+The returned content is raw file content. Keep `custom_id` stable so you can match outputs back to requests.
+
+## Limits and Retention
+
+Documented limits and lifecycle notes:
+- up to 50,000 requests per batch
+- input file size up to 100 MB
+- output files are not retained forever; Novita's official batch guide says completed output files are deleted after 30 days
+
+Download output promptly rather than treating Novita as long-term storage.
+
+## Common Failure Modes
+
+- malformed JSONL
+- missing `custom_id`
+- mixed models in one file
+- wrong endpoint value
+- invalid or expired API key
+- polling the wrong batch ID

--- a/content/novita/docs/llm/javascript/references/openai-agents-sdk.md
+++ b/content/novita/docs/llm/javascript/references/openai-agents-sdk.md
@@ -1,0 +1,53 @@
+# Novita with OpenAI Agents SDK
+
+Use this reference when integrating Novita's LLM endpoint with the OpenAI Agents SDK.
+
+Primary source: https://novita.ai/docs/guides/openai-agents-sdk.md
+
+## Compatibility Rule
+
+Novita supports the OpenAI Agents SDK through the chat-completions path.
+
+Important caveat:
+- Novita does **not** support the `responses` API for this integration pattern
+- explicitly switch the Agents SDK to `chat_completions`
+
+Novita's official guide is Python-based, but the compatibility rule matters even if your surrounding application has JavaScript or TypeScript components.
+
+## Minimal Setup
+
+```python
+import os
+from openai import AsyncOpenAI
+from agents import (
+    Agent,
+    Runner,
+    set_default_openai_api,
+    set_default_openai_client,
+    set_tracing_disabled,
+)
+
+set_default_openai_api("chat_completions")
+set_default_openai_client(
+    AsyncOpenAI(
+        base_url="https://api.novita.ai/openai",
+        api_key=os.environ["NOVITA_API_KEY"],
+    )
+)
+set_tracing_disabled(disabled=True)
+```
+
+## Common Mistakes
+
+- assuming the Agents SDK can use the Responses API unchanged
+- pointing the OpenAI client at the wrong base URL
+- using a model name without the Novita provider prefix
+
+## When to Reach for This
+
+Use this reference when:
+- you are wiring Novita into an Agents SDK workflow
+- you need handoffs, tools, or multi-agent orchestration
+- standard chat-completions usage is already working and you want to layer agents on top
+
+If your integration is entirely JavaScript, verify the agent framework and SDK combination first; Novita's official compatibility page currently documents the Python Agents SDK path.

--- a/content/novita/docs/llm/javascript/references/openai-agents-sdk.md
+++ b/content/novita/docs/llm/javascript/references/openai-agents-sdk.md
@@ -14,28 +14,15 @@ Important caveat:
 
 Novita's official guide is Python-based, but the compatibility rule matters even if your surrounding application has JavaScript or TypeScript components.
 
-## Minimal Setup
+## Integration Guidance
 
-```python
-import os
-from openai import AsyncOpenAI
-from agents import (
-    Agent,
-    Runner,
-    set_default_openai_api,
-    set_default_openai_client,
-    set_tracing_disabled,
-)
+Novita's official compatibility guide for OpenAI Agents SDK is Python-based. For JavaScript/TypeScript teams, the important takeaway is not a separate Novita JavaScript agents client, but the protocol constraint:
 
-set_default_openai_api("chat_completions")
-set_default_openai_client(
-    AsyncOpenAI(
-        base_url="https://api.novita.ai/openai",
-        api_key=os.environ["NOVITA_API_KEY"],
-    )
-)
-set_tracing_disabled(disabled=True)
-```
+- use Novita through an OpenAI-compatible client pointed at `https://api.novita.ai/openai`
+- force the agent framework onto the chat-completions path
+- do not assume a Responses API-based integration will work unchanged
+
+If your stack includes a JavaScript application layer and a Python-based agent runtime, apply Novita configuration at the agent runtime boundary rather than trying to translate the official example into a different API mode.
 
 ## Common Mistakes
 

--- a/content/novita/docs/llm/python/DOC.md
+++ b/content/novita/docs/llm/python/DOC.md
@@ -1,0 +1,200 @@
+---
+name: llm
+description: "Novita AI OpenAI-compatible LLM API coding guide for Python applications using the official OpenAI SDK"
+metadata:
+  languages: "python"
+  versions: "2.28.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: maintainer
+  tags: "novita,llm,openai-compatible,python,ai"
+---
+
+# Novita AI Python LLM Coding Guide
+
+You are a Novita AI coding expert. Help me write Python code that calls Novita's LLM API correctly.
+
+Primary references:
+- https://novita.ai/docs/guides/llm-api.md
+- https://novita.ai/docs/guides/llm-batch-api.md
+- https://novita.ai/docs/guides/openai-agents-sdk.md
+
+## Golden Rule
+
+Use the official OpenAI Python SDK against Novita's OpenAI-compatible base URL.
+
+- **SDK:** OpenAI Python SDK
+- **Package:** `openai`
+- **Base URL:** `https://api.novita.ai/openai`
+- **Auth:** `Authorization: Bearer <NOVITA_API_KEY>`
+
+Novita does not require a Novita-specific Python client for basic LLM inference. Use `OpenAI` or `AsyncOpenAI` and override `base_url`.
+
+```bash
+pip install openai
+```
+
+## Initialization and API Key
+
+Set `NOVITA_API_KEY` in the environment and create an OpenAI client with Novita's base URL.
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://api.novita.ai/openai",
+    api_key=os.environ["NOVITA_API_KEY"],
+)
+```
+
+Do not use the default OpenAI base URL when targeting Novita.
+
+## Model Naming
+
+Use Novita model IDs exactly as published by Novita. They are typically provider-prefixed.
+
+Examples:
+- `deepseek/deepseek-v3-0324`
+- `deepseek/deepseek-r1`
+
+Do not shorten model names to `deepseek-v3-0324` or similar aliases unless Novita's model list explicitly shows that exact ID.
+
+## Primary API Surface
+
+For LLM work, default to Chat Completions.
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://api.novita.ai/openai",
+    api_key=os.environ["NOVITA_API_KEY"],
+)
+
+completion = client.chat.completions.create(
+    model="deepseek/deepseek-v3-0324",
+    messages=[
+        {"role": "system", "content": "You are a concise coding assistant."},
+        {"role": "user", "content": "Explain what a Python context manager does."},
+    ],
+    max_tokens=512,
+)
+
+print(completion.choices[0].message.content)
+```
+
+Novita also supports the legacy Completions endpoint for prompt-style requests:
+
+```python
+completion = client.completions.create(
+    model="deepseek/deepseek-r1",
+    prompt="Write a three-line summary of rate limiting.",
+    max_tokens=256,
+)
+
+print(completion.choices[0].text)
+```
+
+## Streaming
+
+Use streaming for interactive output and long responses.
+
+```python
+stream = client.chat.completions.create(
+    model="deepseek/deepseek-r1",
+    messages=[
+        {"role": "user", "content": "Give me a step-by-step debugging checklist."},
+    ],
+    max_tokens=1024,
+    stream=True,
+)
+
+for chunk in stream:
+    delta = chunk.choices[0].delta.content or ""
+    print(delta, end="", flush=True)
+```
+
+## Async Usage
+
+```python
+import asyncio
+import os
+from openai import AsyncOpenAI
+
+client = AsyncOpenAI(
+    base_url="https://api.novita.ai/openai",
+    api_key=os.environ["NOVITA_API_KEY"],
+)
+
+async def main():
+    completion = await client.chat.completions.create(
+        model="deepseek/deepseek-v3-0324",
+        messages=[{"role": "user", "content": "List three Python testing tips."}],
+        max_tokens=256,
+    )
+    print(completion.choices[0].message.content)
+
+asyncio.run(main())
+```
+
+## Common Parameters
+
+Common Novita LLM request parameters match the OpenAI-compatible schema:
+
+- `model`: required model ID
+- `messages`: required for chat completions
+- `prompt`: required for legacy completions
+- `max_tokens`: output cap
+- `stream`: enable token streaming
+- `temperature`, `top_p`, `top_k`: generation controls
+- `presence_penalty`, `frequency_penalty`, `repetition_penalty`: repetition controls
+- `stop`: stop sequences
+
+Prefer changing `temperature` or `top_p`, not both at once, unless you have a specific reason.
+
+## OpenAI Agents SDK Compatibility
+
+Novita works with OpenAI Agents SDK in compatibility mode, but there is one important caveat:
+
+- Novita does **not** support the OpenAI `responses` API for that integration path
+- configure the Agents SDK to use `chat_completions`
+
+See `references/openai-agents-sdk.md` for the exact setup pattern.
+
+## Batch API
+
+Use the Batch API when you need asynchronous processing for many requests and can wait up to 48 hours for results.
+
+See `references/batch.md` for:
+- JSONL request format
+- file upload flow
+- batch creation and polling
+- output retrieval and retention rules
+
+## Gotchas
+
+- Always set `base_url="https://api.novita.ai/openai"`.
+- Always send auth as a Bearer token.
+- Use Novita model IDs exactly as listed by Novita.
+- Batch input files must use JSONL, with one request per line and a unique `custom_id`.
+- All requests in one batch file must target the same model.
+- Batch output files should be downloaded promptly after completion; official docs say output files are not retained indefinitely.
+- If an integration example assumes OpenAI Responses API, verify Novita compatibility before copying it.
+
+## When Not to Use This Entry
+
+This entry is for Novita's OpenAI-compatible LLM APIs only.
+
+Do not use it for:
+- image, audio, or video generation
+- serverless GPU endpoints
+- GPU instance lifecycle management
+- Agent Sandbox runtime operations
+
+## Additional Files
+
+For deeper workflows, use:
+- `references/batch.md`
+- `references/openai-agents-sdk.md`

--- a/content/novita/docs/llm/python/references/batch.md
+++ b/content/novita/docs/llm/python/references/batch.md
@@ -1,0 +1,101 @@
+# Novita LLM Batch API
+
+Use this reference when you need asynchronous processing for many LLM requests and do not need an immediate response.
+
+Primary source: https://novita.ai/docs/guides/llm-batch-api.md
+
+## When to Use Batch
+
+Use batch for:
+- evaluations
+- bulk classification
+- offline summarization
+- large backfills
+
+Prefer regular chat completions for interactive applications.
+
+## Input File Format
+
+Novita's batch input format is JSONL. Each line is one request payload.
+
+Rules:
+- every line must be valid JSON
+- every request must include a unique `custom_id`
+- all requests in the same file must target the same model
+- endpoint must be `/v1/chat/completions` or `/v1/completions`
+
+Example:
+
+```json
+{"custom_id":"request-1","body":{"model":"deepseek/deepseek-v3-0324","messages":[{"role":"user","content":"Hello"}],"max_tokens":400}}
+{"custom_id":"request-2","body":{"model":"deepseek/deepseek-v3-0324","messages":[{"role":"user","content":"Summarize this text"}],"max_tokens":400}}
+```
+
+## Upload the Input File
+
+Use the Files API with `purpose="batch"`.
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://api.novita.ai/openai/v1",
+    api_key="...",
+)
+
+batch_input_file = client.files.create(
+    file=open("batch_input.jsonl", "rb"),
+    purpose="batch",
+)
+```
+
+## Create the Batch
+
+```python
+batch = client.batches.create(
+    input_file_id=batch_input_file.id,
+    endpoint="/v1/chat/completions",
+    completion_window="48h",
+)
+```
+
+Notes:
+- `completion_window` is fixed at `48h`
+- this is an asynchronous workflow
+
+## Poll Batch Status
+
+Retrieve the batch until it reaches a terminal state.
+
+Possible statuses documented by Novita:
+- `VALIDATING`
+- `PROGRESS`
+- `COMPLETED`
+- `FAILED`
+- `EXPIRED`
+- `CANCELLING`
+- `CANCELLED`
+
+## Retrieve Results
+
+When the batch completes, read `output_file_id` and fetch the file content through the Files API.
+
+The returned content is raw file content. Keep `custom_id` stable so you can match outputs back to requests.
+
+## Limits and Retention
+
+Documented limits and lifecycle notes:
+- up to 50,000 requests per batch
+- input file size up to 100 MB
+- output files are not retained forever; Novita's official batch guide says completed output files are deleted after 30 days
+
+Download output promptly rather than treating Novita as long-term storage.
+
+## Common Failure Modes
+
+- malformed JSONL
+- missing `custom_id`
+- mixed models in one file
+- wrong endpoint value
+- invalid or expired API key
+- polling the wrong batch ID

--- a/content/novita/docs/llm/python/references/openai-agents-sdk.md
+++ b/content/novita/docs/llm/python/references/openai-agents-sdk.md
@@ -1,0 +1,66 @@
+# Novita with OpenAI Agents SDK
+
+Use this reference when integrating Novita's LLM endpoint with the OpenAI Agents SDK.
+
+Primary source: https://novita.ai/docs/guides/openai-agents-sdk.md
+
+## Compatibility Rule
+
+Novita supports the OpenAI Agents SDK through the chat-completions path.
+
+Important caveat:
+- Novita does **not** support the `responses` API for this integration pattern
+- explicitly switch the Agents SDK to `chat_completions`
+
+## Minimal Setup
+
+```python
+import os
+from openai import AsyncOpenAI
+from agents import (
+    Agent,
+    Runner,
+    set_default_openai_api,
+    set_default_openai_client,
+    set_tracing_disabled,
+)
+
+set_default_openai_api("chat_completions")
+set_default_openai_client(
+    AsyncOpenAI(
+        base_url="https://api.novita.ai/openai",
+        api_key=os.environ["NOVITA_API_KEY"],
+    )
+)
+set_tracing_disabled(disabled=True)
+
+agent = Agent(
+    name="Assistant",
+    instructions="You are a helpful assistant.",
+    model=os.environ["MODEL_NAME"],
+)
+
+result = Runner.run_sync(agent, "Write a haiku about recursion.")
+print(result.final_output)
+```
+
+## Required Environment Variables
+
+- `NOVITA_API_KEY`
+- `MODEL_NAME`
+
+Use a real Novita model ID such as `deepseek/deepseek-v3-0324`.
+
+## Common Mistakes
+
+- forgetting to set `set_default_openai_api("chat_completions")`
+- leaving the client pointed at OpenAI instead of Novita
+- using a model name that omits the provider prefix
+- assuming every OpenAI Agents SDK example works unchanged against Novita
+
+## When to Reach for This
+
+Use this reference when:
+- you are wiring Novita into an existing Agents SDK app
+- you need handoffs, tools, or multi-agent orchestration
+- standard chat-completions usage is already working and you want to layer agents on top


### PR DESCRIPTION
## What

Adds initial Novita AI LLM provider content under `content/novita/docs/llm/` with:

- JavaScript/TypeScript variant
- Python variant
- language-specific reference files for Batch API usage
- language-specific reference files for OpenAI Agents SDK compatibility

## Why

Novita's public docs currently provide broad platform-level guidance, but Context Hub works best when provider content is organized around a narrow integration surface that an agent can apply directly.

This PR focuses on Novita's OpenAI-compatible LLM API because it is the clearest first entry point for coding agents and the most aligned with existing provider docs in this repo.

The new docs give agents the specific context they are likely to get wrong today:

- use the official OpenAI SDKs against `https://api.novita.ai/openai`
- authenticate with Bearer tokens
- use full provider-prefixed Novita model IDs
- default to Chat Completions for Novita LLM usage
- handle Batch API as a separate asynchronous workflow
- treat OpenAI Agents SDK as a compatibility path that must use `chat_completions`, not the Responses API

## Coverage

**Main docs**

- `content/novita/docs/llm/javascript/DOC.md`
- `content/novita/docs/llm/python/DOC.md`

These cover:

- SDK selection
- initialization and auth
- base URL setup
- model naming
- chat completions
- legacy completions
- streaming
- async usage for Python
- Novita-specific gotchas

**Reference files**

- `content/novita/docs/llm/javascript/references/batch.md`
- `content/novita/docs/llm/javascript/references/openai-agents-sdk.md`
- `content/novita/docs/llm/python/references/batch.md`
- `content/novita/docs/llm/python/references/openai-agents-sdk.md`

These cover:

- Batch JSONL shape, upload flow, polling, limits, and retention
- OpenAI Agents SDK compatibility setup and the `chat_completions` constraint

## Testing

- [x] `node cli/bin/chub build content/ --validate-only`
- [x] `node cli/bin/chub build content/ -o /tmp/context-hub-dist`
- [x] Verified built registry includes `novita/llm` with both language variants and their `references/...` files

## Notes

- This PR intentionally does **not** cover Novita Sandbox, media generation APIs, GPU instances, or serverless GPU workflows. Those are better handled as follow-up entries.
- I initially placed shared reference files at `content/novita/docs/llm/references/`, but the build only exposes files that live alongside each language variant. The final structure duplicates the references under each language directory so they are discoverable via `chub get`.
- SDK versions in frontmatter are based on current OpenAI package releases at the time of writing: Python `openai` `2.28.0`, Node `openai` `6.31.0`.