### PR TITLE
Add 100 REST API docs for AI agents and cross-border automation

### DIFF
--- a/content/adyen/docs/rest-api/python/DOC.md
+++ b/content/adyen/docs/rest-api/python/DOC.md
@@ -1,0 +1,294 @@
+---
+name: rest-api
+description: "Adyen - Global payment platform, checkout, payouts, and recurring payments"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "adyen,payments,checkout,global,europe,psp,api"
+---
+
+# Adyen REST API - Python (`httpx`)
+
+## Golden Rule
+
+Always use the `X-API-Key` header for authentication -- never Basic Auth for Checkout API. Live URLs are merchant-specific with a unique prefix (not the same as test URLs). Version your endpoints explicitly (e.g., `/v71/`). All amounts are in **minor units** (cents): EUR 10.00 = 1000. Never log full card numbers or API keys.
+
+## Installation
+
+```bash
+pip install httpx python-dotenv
+```
+
+## Base URL
+
+| Environment | API | URL |
+|-------------|-----|-----|
+| Test | Checkout | `https://checkout-test.adyen.com/v71` |
+| Live | Checkout | `https://{PREFIX}-checkout-live.adyenpayments.com/checkout/v71` |
+| Test | Payouts | `https://pal-test.adyen.com/pal/servlet/Payout/v68` |
+| Test | Management | `https://management-test.adyen.com/v3` |
+
+The `{PREFIX}` for live is found in Customer Area under Developers > API URLs.
+
+```python
+import os
+
+# Test environment
+BASE_URL = os.environ.get("ADYEN_BASE_URL", "https://checkout-test.adyen.com/v71")
+```
+
+## Authentication
+
+Adyen uses an API key passed in the `X-API-Key` header. Generate keys from the Customer Area under Developers > API credentials.
+
+```python
+import httpx
+import os
+
+API_KEY = os.environ["ADYEN_API_KEY"]
+MERCHANT_ACCOUNT = os.environ["ADYEN_MERCHANT_ACCOUNT"]
+
+headers = {
+    "X-API-Key": API_KEY,
+    "Content-Type": "application/json",
+}
+```
+
+After generating a new API key, the previous key remains active for 24 hours to allow seamless rotation.
+
+## Rate Limiting
+
+Adyen enforces rate limits and returns HTTP 429 when exceeded. Implement backoff:
+
+```python
+import asyncio
+
+async def adyen_request(
+    client: httpx.AsyncClient, method: str, url: str, **kwargs
+) -> dict:
+    for attempt in range(5):
+        resp = await client.request(method, url, headers=headers, **kwargs)
+        if resp.status_code == 429:
+            await asyncio.sleep(2 ** attempt)
+            continue
+        resp.raise_for_status()
+        return resp.json()
+    raise Exception("Rate limit exceeded after retries")
+```
+
+## Methods
+
+### Create Payment Session (Checkout)
+
+Start a payment transaction. This is the primary endpoint for accepting payments.
+
+```python
+async def create_payment(
+    client: httpx.AsyncClient,
+    amount_minor_units: int,
+    currency: str,
+    reference: str,
+    return_url: str,
+    payment_method: dict,
+    shopper_reference: str | None = None,
+) -> dict:
+    payload = {
+        "merchantAccount": MERCHANT_ACCOUNT,
+        "amount": {"value": amount_minor_units, "currency": currency},
+        "reference": reference,
+        "returnUrl": return_url,
+        "paymentMethod": payment_method,
+    }
+    if shopper_reference:
+        payload["shopperReference"] = shopper_reference
+
+    resp = await client.post(
+        f"{BASE_URL}/payments", headers=headers, json=payload
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Submit Payment Details (3D Secure)
+
+Handle additional authentication details (e.g., 3DS redirect).
+
+```python
+async def submit_payment_details(
+    client: httpx.AsyncClient, details: dict, payment_data: str | None = None
+) -> dict:
+    payload = {"details": details}
+    if payment_data:
+        payload["paymentData"] = payment_data
+
+    resp = await client.post(
+        f"{BASE_URL}/payments/details", headers=headers, json=payload
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Create Payment Session (Drop-in)
+
+Create a session for Adyen Drop-in/Components (recommended flow).
+
+```python
+async def create_session(
+    client: httpx.AsyncClient,
+    amount_minor_units: int,
+    currency: str,
+    reference: str,
+    return_url: str,
+    shopper_reference: str | None = None,
+) -> dict:
+    payload = {
+        "merchantAccount": MERCHANT_ACCOUNT,
+        "amount": {"value": amount_minor_units, "currency": currency},
+        "reference": reference,
+        "returnUrl": return_url,
+    }
+    if shopper_reference:
+        payload["shopperReference"] = shopper_reference
+
+    resp = await client.post(
+        f"{BASE_URL}/sessions", headers=headers, json=payload
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Capture Payment
+
+Capture a previously authorized payment.
+
+```python
+async def capture_payment(
+    client: httpx.AsyncClient,
+    payment_psp_reference: str,
+    amount_minor_units: int,
+    currency: str,
+) -> dict:
+    payload = {
+        "merchantAccount": MERCHANT_ACCOUNT,
+        "amount": {"value": amount_minor_units, "currency": currency},
+    }
+    resp = await client.post(
+        f"{BASE_URL}/payments/{payment_psp_reference}/captures",
+        headers=headers,
+        json=payload,
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Refund Payment
+
+```python
+async def refund_payment(
+    client: httpx.AsyncClient,
+    payment_psp_reference: str,
+    amount_minor_units: int,
+    currency: str,
+    reference: str,
+) -> dict:
+    payload = {
+        "merchantAccount": MERCHANT_ACCOUNT,
+        "amount": {"value": amount_minor_units, "currency": currency},
+        "reference": reference,
+    }
+    resp = await client.post(
+        f"{BASE_URL}/payments/{payment_psp_reference}/refunds",
+        headers=headers,
+        json=payload,
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Cancel Payment
+
+```python
+async def cancel_payment(
+    client: httpx.AsyncClient, payment_psp_reference: str
+) -> dict:
+    payload = {"merchantAccount": MERCHANT_ACCOUNT}
+    resp = await client.post(
+        f"{BASE_URL}/payments/{payment_psp_reference}/cancels",
+        headers=headers,
+        json=payload,
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### List Payment Methods
+
+Retrieve available payment methods for a given context.
+
+```python
+async def get_payment_methods(
+    client: httpx.AsyncClient,
+    country_code: str,
+    currency: str,
+    amount_minor_units: int,
+) -> dict:
+    payload = {
+        "merchantAccount": MERCHANT_ACCOUNT,
+        "countryCode": country_code,
+        "amount": {"value": amount_minor_units, "currency": currency},
+    }
+    resp = await client.post(
+        f"{BASE_URL}/paymentMethods", headers=headers, json=payload
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+## Error Handling
+
+Adyen errors include a `status`, `errorCode`, `message`, and `errorType`:
+
+```json
+{
+  "status": 422,
+  "errorCode": "14_006",
+  "message": "Required field 'merchantAccount' is not provided.",
+  "errorType": "validation"
+}
+```
+
+```python
+class AdyenAPIError(Exception):
+    def __init__(self, status: int, body: dict):
+        self.status = status
+        self.error_code = body.get("errorCode", "unknown")
+        self.error_type = body.get("errorType", "unknown")
+        self.message = body.get("message", str(body))
+        super().__init__(
+            f"HTTP {status} [{self.error_code}] ({self.error_type}): {self.message}"
+        )
+
+
+async def adyen_request_safe(
+    client: httpx.AsyncClient, method: str, url: str, **kwargs
+) -> dict:
+    resp = await client.request(method, url, headers=headers, **kwargs)
+    if resp.status_code >= 400:
+        raise AdyenAPIError(resp.status_code, resp.json())
+    return resp.json()
+```
+
+Common error types: `validation` (bad input), `security` (auth issues), `configuration` (account setup), `internal` (Adyen server error).
+
+## Common Pitfalls
+
+1. **Minor units for amounts** -- EUR 10.00 must be sent as `1000`. JPY 500 is sent as `500` (no decimals). Always check currency exponent.
+2. **Live URL prefix** -- The live Checkout URL is merchant-specific (`{PREFIX}-checkout-live.adyenpayments.com`). Test and live URLs are completely different domains.
+3. **merchantAccount required** -- Nearly every request needs the `merchantAccount` field. Forgetting it is the most common validation error.
+4. **Idempotency** -- Use the `Idempotency-Key` header for payment requests to avoid duplicate charges.
+5. **Webhook verification** -- Adyen sends payment result notifications via webhooks. Always verify the HMAC signature on incoming webhooks.
+6. **3DS handling** -- Many European payments require 3D Secure. Check the `resultCode` for `RedirectShopper` or `ChallengeShopper` and handle the redirect flow.
+7. **API versioning** -- Adyen increments API versions frequently. Pin your integration to a specific version and test before upgrading.

--- a/content/alpaca/docs/rest-api/python/DOC.md
+++ b/content/alpaca/docs/rest-api/python/DOC.md
@@ -1,0 +1,421 @@
+---
+name: rest-api
+description: "Alpaca Trading & Market Data REST API Python coding guidelines using httpx async"
+metadata:
+  languages: "python"
+  versions: "3.12.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "alpaca,trading,stocks,crypto,market-data,commission-free,usa,api"
+---
+
+# Alpaca REST API Python Coding Guidelines
+
+You are an Alpaca API coding expert. Help me with writing code that calls the Alpaca Trading and Market Data REST APIs using httpx async in Python.
+
+Official documentation: https://docs.alpaca.markets/
+
+## Golden Rule: Use httpx Async for All REST Calls
+
+Always use `httpx.AsyncClient` for all Alpaca REST API interactions. Do not use the `alpaca-py` SDK or `requests`. All code must be async-first using `httpx`.
+
+- **HTTP Library:** httpx (async)
+- **Correct:** `async with httpx.AsyncClient() as client:`
+- **Incorrect:** Using `requests`, `alpaca-py`, `alpaca-trade-api`, or synchronous httpx
+
+## Installation
+
+```bash
+pip install httpx python-dotenv
+```
+
+**Environment Variables:**
+
+```bash
+export ALPACA_API_KEY='your_api_key_here'
+export ALPACA_API_SECRET='your_api_secret_here'
+```
+
+Or create a `.env` file:
+
+```bash
+ALPACA_API_KEY=your_api_key_here
+ALPACA_API_SECRET=your_api_secret_here
+```
+
+Load in Python:
+
+```python
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+api_key = os.getenv("ALPACA_API_KEY")
+api_secret = os.getenv("ALPACA_API_SECRET")
+```
+
+## Base URLs
+
+| Environment      | Trading API                           | Market Data API                  |
+|------------------|---------------------------------------|----------------------------------|
+| **Live**         | `https://api.alpaca.markets`          | `https://data.alpaca.markets`    |
+| **Paper**        | `https://paper-api.alpaca.markets`    | `https://data.alpaca.markets`    |
+
+Paper trading uses the same market data endpoint as live. Only the trading base URL differs.
+
+## Authentication
+
+Alpaca uses two custom headers for API key + secret authentication:
+
+| Header                  | Value            |
+|-------------------------|------------------|
+| `APCA-API-KEY-ID`       | Your API key ID  |
+| `APCA-API-SECRET-KEY`   | Your secret key  |
+
+Alternatively, HTTP Basic Auth is supported (key ID as username, secret as password).
+
+```python
+import httpx
+
+TRADING_BASE = "https://paper-api.alpaca.markets"
+DATA_BASE = "https://data.alpaca.markets"
+
+HEADERS = {
+    "APCA-API-KEY-ID": api_key,
+    "APCA-API-SECRET-KEY": api_secret,
+}
+
+async def get_account():
+    async with httpx.AsyncClient(base_url=TRADING_BASE, headers=HEADERS) as client:
+        resp = await client.get("/v2/account")
+        resp.raise_for_status()
+        return resp.json()
+```
+
+## Rate Limiting
+
+- **Default:** 200 requests per minute per API key
+- **Paid data plans:** Up to 1,000 requests per minute
+- Exceeding the limit returns HTTP `429 Too Many Requests`
+- Implement exponential backoff on 429 responses
+
+```python
+import asyncio
+import httpx
+
+async def request_with_retry(client: httpx.AsyncClient, method: str, url: str, **kwargs):
+    for attempt in range(5):
+        resp = await client.request(method, url, **kwargs)
+        if resp.status_code == 429:
+            wait = 2 ** attempt
+            await asyncio.sleep(wait)
+            continue
+        resp.raise_for_status()
+        return resp.json()
+    raise Exception("Rate limit exceeded after retries")
+```
+
+## Methods
+
+### Account
+
+```python
+async def get_account():
+    """GET /v2/account - Get account info (buying power, equity, status)."""
+    async with httpx.AsyncClient(base_url=TRADING_BASE, headers=HEADERS) as client:
+        resp = await client.get("/v2/account")
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Orders
+
+```python
+async def create_order(symbol: str, qty: float, side: str, order_type: str, time_in_force: str = "day", limit_price: float | None = None):
+    """POST /v2/orders - Submit a new order."""
+    payload = {
+        "symbol": symbol,
+        "qty": str(qty),
+        "side": side,           # "buy" or "sell"
+        "type": order_type,     # "market", "limit", "stop", "stop_limit", "trailing_stop"
+        "time_in_force": time_in_force,  # "day", "gtc", "opg", "cls", "ioc", "fok"
+    }
+    if limit_price is not None:
+        payload["limit_price"] = str(limit_price)
+    async with httpx.AsyncClient(base_url=TRADING_BASE, headers=HEADERS) as client:
+        resp = await client.post("/v2/orders", json=payload)
+        resp.raise_for_status()
+        return resp.json()
+
+async def list_orders(status: str = "open", limit: int = 50):
+    """GET /v2/orders - List orders filtered by status."""
+    async with httpx.AsyncClient(base_url=TRADING_BASE, headers=HEADERS) as client:
+        resp = await client.get("/v2/orders", params={"status": status, "limit": limit})
+        resp.raise_for_status()
+        return resp.json()
+
+async def get_order(order_id: str):
+    """GET /v2/orders/{order_id} - Get a specific order."""
+    async with httpx.AsyncClient(base_url=TRADING_BASE, headers=HEADERS) as client:
+        resp = await client.get(f"/v2/orders/{order_id}")
+        resp.raise_for_status()
+        return resp.json()
+
+async def cancel_order(order_id: str):
+    """DELETE /v2/orders/{order_id} - Cancel an order."""
+    async with httpx.AsyncClient(base_url=TRADING_BASE, headers=HEADERS) as client:
+        resp = await client.delete(f"/v2/orders/{order_id}")
+        resp.raise_for_status()
+
+async def cancel_all_orders():
+    """DELETE /v2/orders - Cancel all open orders."""
+    async with httpx.AsyncClient(base_url=TRADING_BASE, headers=HEADERS) as client:
+        resp = await client.delete("/v2/orders")
+        resp.raise_for_status()
+        return resp.json()
+
+async def replace_order(order_id: str, qty: float | None = None, limit_price: float | None = None):
+    """PATCH /v2/orders/{order_id} - Replace/modify an existing order."""
+    payload = {}
+    if qty is not None:
+        payload["qty"] = str(qty)
+    if limit_price is not None:
+        payload["limit_price"] = str(limit_price)
+    async with httpx.AsyncClient(base_url=TRADING_BASE, headers=HEADERS) as client:
+        resp = await client.patch(f"/v2/orders/{order_id}", json=payload)
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Positions
+
+```python
+async def list_positions():
+    """GET /v2/positions - List all open positions."""
+    async with httpx.AsyncClient(base_url=TRADING_BASE, headers=HEADERS) as client:
+        resp = await client.get("/v2/positions")
+        resp.raise_for_status()
+        return resp.json()
+
+async def get_position(symbol: str):
+    """GET /v2/positions/{symbol} - Get position for a symbol."""
+    async with httpx.AsyncClient(base_url=TRADING_BASE, headers=HEADERS) as client:
+        resp = await client.get(f"/v2/positions/{symbol}")
+        resp.raise_for_status()
+        return resp.json()
+
+async def close_position(symbol: str):
+    """DELETE /v2/positions/{symbol} - Close a position."""
+    async with httpx.AsyncClient(base_url=TRADING_BASE, headers=HEADERS) as client:
+        resp = await client.delete(f"/v2/positions/{symbol}")
+        resp.raise_for_status()
+        return resp.json()
+
+async def close_all_positions():
+    """DELETE /v2/positions - Close all positions."""
+    async with httpx.AsyncClient(base_url=TRADING_BASE, headers=HEADERS) as client:
+        resp = await client.delete("/v2/positions")
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Assets
+
+```python
+async def list_assets(status: str = "active", asset_class: str = "us_equity"):
+    """GET /v2/assets - List tradeable assets."""
+    async with httpx.AsyncClient(base_url=TRADING_BASE, headers=HEADERS) as client:
+        resp = await client.get("/v2/assets", params={"status": status, "asset_class": asset_class})
+        resp.raise_for_status()
+        return resp.json()
+
+async def get_asset(symbol: str):
+    """GET /v2/assets/{symbol} - Get asset details."""
+    async with httpx.AsyncClient(base_url=TRADING_BASE, headers=HEADERS) as client:
+        resp = await client.get(f"/v2/assets/{symbol}")
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Market Clock and Calendar
+
+```python
+async def get_clock():
+    """GET /v2/clock - Get market open/close status."""
+    async with httpx.AsyncClient(base_url=TRADING_BASE, headers=HEADERS) as client:
+        resp = await client.get("/v2/clock")
+        resp.raise_for_status()
+        return resp.json()
+
+async def get_calendar(start: str, end: str):
+    """GET /v2/calendar - Get market calendar. Dates in YYYY-MM-DD format."""
+    async with httpx.AsyncClient(base_url=TRADING_BASE, headers=HEADERS) as client:
+        resp = await client.get("/v2/calendar", params={"start": start, "end": end})
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Portfolio History
+
+```python
+async def get_portfolio_history(period: str = "1M", timeframe: str = "1D"):
+    """GET /v2/account/portfolio/history - Get portfolio value over time."""
+    async with httpx.AsyncClient(base_url=TRADING_BASE, headers=HEADERS) as client:
+        resp = await client.get("/v2/account/portfolio/history", params={
+            "period": period,        # "1D", "1W", "1M", "3M", "1A", "all"
+            "timeframe": timeframe,  # "1Min", "5Min", "15Min", "1H", "1D"
+        })
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Market Data - Stock Bars (OHLCV)
+
+```python
+async def get_stock_bars(symbol: str, timeframe: str = "1Day", start: str | None = None, end: str | None = None, limit: int = 100):
+    """GET /v2/stocks/{symbol}/bars - Get historical OHLCV bars."""
+    params = {"timeframe": timeframe, "limit": limit}
+    if start:
+        params["start"] = start  # RFC3339 format: "2024-01-01T00:00:00Z"
+    if end:
+        params["end"] = end
+    async with httpx.AsyncClient(base_url=DATA_BASE, headers=HEADERS) as client:
+        resp = await client.get(f"/v2/stocks/{symbol}/bars", params=params)
+        resp.raise_for_status()
+        return resp.json()
+
+async def get_multi_stock_bars(symbols: list[str], timeframe: str = "1Day", start: str | None = None, limit: int = 100):
+    """GET /v2/stocks/bars - Get bars for multiple symbols."""
+    params = {"symbols": ",".join(symbols), "timeframe": timeframe, "limit": limit}
+    if start:
+        params["start"] = start
+    async with httpx.AsyncClient(base_url=DATA_BASE, headers=HEADERS) as client:
+        resp = await client.get("/v2/stocks/bars", params=params)
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Market Data - Latest Quotes and Trades
+
+```python
+async def get_latest_quote(symbol: str):
+    """GET /v2/stocks/{symbol}/quotes/latest - Get latest NBBO quote."""
+    async with httpx.AsyncClient(base_url=DATA_BASE, headers=HEADERS) as client:
+        resp = await client.get(f"/v2/stocks/{symbol}/quotes/latest")
+        resp.raise_for_status()
+        return resp.json()
+
+async def get_latest_trade(symbol: str):
+    """GET /v2/stocks/{symbol}/trades/latest - Get latest trade."""
+    async with httpx.AsyncClient(base_url=DATA_BASE, headers=HEADERS) as client:
+        resp = await client.get(f"/v2/stocks/{symbol}/trades/latest")
+        resp.raise_for_status()
+        return resp.json()
+
+async def get_snapshot(symbol: str):
+    """GET /v2/stocks/{symbol}/snapshot - Get full snapshot (latest trade, quote, bar)."""
+    async with httpx.AsyncClient(base_url=DATA_BASE, headers=HEADERS) as client:
+        resp = await client.get(f"/v2/stocks/{symbol}/snapshot")
+        resp.raise_for_status()
+        return resp.json()
+
+async def get_snapshots(symbols: list[str]):
+    """GET /v2/stocks/snapshots - Get snapshots for multiple symbols."""
+    async with httpx.AsyncClient(base_url=DATA_BASE, headers=HEADERS) as client:
+        resp = await client.get("/v2/stocks/snapshots", params={"symbols": ",".join(symbols)})
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Market Data - Crypto
+
+```python
+async def get_crypto_bars(symbol: str, timeframe: str = "1Day", start: str | None = None, limit: int = 100):
+    """GET /v1beta3/crypto/us/bars - Get crypto OHLCV bars. Symbol format: BTC/USD."""
+    params = {"symbols": symbol, "timeframe": timeframe, "limit": limit}
+    if start:
+        params["start"] = start
+    async with httpx.AsyncClient(base_url=DATA_BASE, headers=HEADERS) as client:
+        resp = await client.get("/v1beta3/crypto/us/bars", params=params)
+        resp.raise_for_status()
+        return resp.json()
+
+async def get_crypto_latest_quote(symbol: str):
+    """GET /v1beta3/crypto/us/latest/quotes - Get latest crypto quote."""
+    async with httpx.AsyncClient(base_url=DATA_BASE, headers=HEADERS) as client:
+        resp = await client.get("/v1beta3/crypto/us/latest/quotes", params={"symbols": symbol})
+        resp.raise_for_status()
+        return resp.json()
+```
+
+## Error Handling
+
+Alpaca returns standard HTTP status codes. Errors include a JSON body with a `message` field.
+
+| Status | Meaning                                      |
+|--------|----------------------------------------------|
+| 200    | Success                                      |
+| 207    | Multi-status (partial success for batch ops)  |
+| 400    | Bad request / validation error               |
+| 401    | Unauthorized (invalid API key)               |
+| 403    | Forbidden (insufficient permissions)         |
+| 404    | Resource not found                           |
+| 422    | Unprocessable entity (order rejected)        |
+| 429    | Rate limit exceeded                          |
+| 500    | Internal server error                        |
+
+```python
+import httpx
+
+async def safe_request(client: httpx.AsyncClient, method: str, url: str, **kwargs):
+    try:
+        resp = await client.request(method, url, **kwargs)
+        resp.raise_for_status()
+        return resp.json()
+    except httpx.HTTPStatusError as e:
+        error_body = e.response.json() if e.response.headers.get("content-type", "").startswith("application/json") else {}
+        msg = error_body.get("message", e.response.text)
+        if e.response.status_code == 429:
+            raise Exception(f"Rate limited: {msg}")
+        elif e.response.status_code == 422:
+            raise Exception(f"Order rejected: {msg}")
+        elif e.response.status_code == 401:
+            raise Exception(f"Unauthorized: check APCA-API-KEY-ID and APCA-API-SECRET-KEY headers")
+        else:
+            raise Exception(f"Alpaca API error {e.response.status_code}: {msg}")
+    except httpx.RequestError as e:
+        raise Exception(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+1. **Wrong base URL for paper vs live.** Paper trading uses `paper-api.alpaca.markets`. Market data always uses `data.alpaca.markets` for both paper and live.
+
+2. **Header names are custom.** Use `APCA-API-KEY-ID` and `APCA-API-SECRET-KEY`, not `Authorization: Bearer`. These are non-standard header names unique to Alpaca.
+
+3. **Quantity must be a string.** When submitting orders, `qty` and `limit_price` must be strings, not floats or ints.
+
+4. **Market data timeframe format.** Use values like `"1Min"`, `"5Min"`, `"1Hour"`, `"1Day"`, `"1Week"`, `"1Month"` -- not `"1m"` or `"1d"`.
+
+5. **Crypto symbol format.** Crypto pairs use slash notation: `"BTC/USD"`, `"ETH/USD"` -- not `"BTCUSD"`.
+
+6. **Timestamps are RFC3339.** Market data start/end params require RFC3339 format: `"2024-01-01T00:00:00Z"`.
+
+7. **Rate limits are per API key, not per IP.** Sharing keys across services will share the rate limit.
+
+8. **Paper trading orders are not real.** Paper trades execute against simulated fills. Market data is real, but fills are synthetic.
+
+9. **Market hours matter.** Equity orders outside market hours (9:30 AM - 4:00 PM ET) require `extended_hours: true` for limit orders. Market orders will be queued.
+
+10. **Pagination.** List endpoints use `next_page_token` in the response. Pass it as a query param to get the next page.
+
+## Useful Links
+
+- Official Documentation: https://docs.alpaca.markets/
+- Trading API Reference: https://docs.alpaca.markets/reference/
+- Market Data API: https://docs.alpaca.markets/docs/about-market-data-api
+- Authentication: https://docs.alpaca.markets/docs/authentication
+- Paper Trading: https://docs.alpaca.markets/docs/paper-trading
+- API Dashboard: https://app.alpaca.markets/

--- a/content/amadeus/docs/rest-api/python/DOC.md
+++ b/content/amadeus/docs/rest-api/python/DOC.md
@@ -1,0 +1,320 @@
+---
+name: rest-api
+description: "Amadeus - Flight Search, Hotel Search & Travel Intelligence REST API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "amadeus,travel,flights,hotels,booking,airline,api"
+---
+
+# Amadeus Self-Service REST API (Python / httpx)
+
+## Golden Rule
+
+Always use the **test environment** (`test.api.amadeus.com`) during development. OAuth tokens expire after **30 minutes** -- cache and refresh them. Every booking flow is three steps: **Search -> Price -> Book**. Never skip the Price confirmation step before booking.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+The official `amadeus` Python SDK exists (`pip install amadeus`), but this guide uses raw `httpx` async calls for full control.
+
+## Base URL
+
+| Environment | Base URL                          |
+|-------------|-----------------------------------|
+| Test        | `https://test.api.amadeus.com`    |
+| Production  | `https://api.amadeus.com`         |
+
+## Authentication
+
+OAuth 2.0 **client_credentials** grant. Obtain `client_id` and `client_secret` by creating a free account at <https://developers.amadeus.com/register>.
+
+### Token Request
+
+```python
+import httpx
+from datetime import datetime, timedelta
+
+class AmadeusAuth:
+    def __init__(self, client_id: str, client_secret: str, *, test: bool = True):
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.base = "https://test.api.amadeus.com" if test else "https://api.amadeus.com"
+        self._token: str | None = None
+        self._expires_at: datetime = datetime.min
+
+    async def get_token(self, client: httpx.AsyncClient) -> str:
+        if self._token and datetime.now() < self._expires_at:
+            return self._token
+        resp = await client.post(
+            f"{self.base}/v1/security/oauth2/token",
+            data={
+                "grant_type": "client_credentials",
+                "client_id": self.client_id,
+                "client_secret": self.client_secret,
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        resp.raise_for_status()
+        body = resp.json()
+        self._token = body["access_token"]
+        self._expires_at = datetime.now() + timedelta(seconds=body["expires_in"] - 60)
+        return self._token
+
+    async def auth_headers(self, client: httpx.AsyncClient) -> dict[str, str]:
+        token = await self.get_token(client)
+        return {"Authorization": f"Bearer {token}"}
+```
+
+## Rate Limiting
+
+| Environment | Limit                       |
+|-------------|-----------------------------|
+| Test        | 10 requests/sec per user    |
+| Production  | 40 requests/sec per user    |
+| AI/Partner  | 20 requests/sec per user    |
+
+No more than 1 request every 100 ms (50 ms for AI/Partner APIs). Test environment also has a monthly free-tier call quota. Exceeding limits returns HTTP **429**.
+
+## Methods
+
+### Flight Offers Search
+
+```python
+async def search_flights(
+    auth: AmadeusAuth,
+    origin: str,
+    destination: str,
+    departure_date: str,
+    adults: int = 1,
+    *,
+    return_date: str | None = None,
+    max_results: int = 10,
+) -> dict:
+    async with httpx.AsyncClient() as client:
+        headers = await auth.auth_headers(client)
+        params = {
+            "originLocationCode": origin,
+            "destinationLocationCode": destination,
+            "departureDate": departure_date,
+            "adults": adults,
+            "max": max_results,
+        }
+        if return_date:
+            params["returnDate"] = return_date
+        resp = await client.get(
+            f"{auth.base}/v2/shopping/flight-offers",
+            headers=headers,
+            params=params,
+        )
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Flight Price Confirmation
+
+```python
+async def confirm_price(auth: AmadeusAuth, flight_offer: dict) -> dict:
+    async with httpx.AsyncClient() as client:
+        headers = await auth.auth_headers(client)
+        headers["Content-Type"] = "application/json"
+        resp = await client.post(
+            f"{auth.base}/v1/shopping/flight-offers/pricing",
+            headers=headers,
+            json={"data": {"type": "flight-offers-pricing", "flightOffers": [flight_offer]}},
+        )
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Flight Order (Booking)
+
+```python
+async def book_flight(
+    auth: AmadeusAuth,
+    flight_offer: dict,
+    travelers: list[dict],
+) -> dict:
+    async with httpx.AsyncClient() as client:
+        headers = await auth.auth_headers(client)
+        headers["Content-Type"] = "application/json"
+        resp = await client.post(
+            f"{auth.base}/v1/booking/flight-orders",
+            headers=headers,
+            json={
+                "data": {
+                    "type": "flight-order",
+                    "flightOffers": [flight_offer],
+                    "travelers": travelers,
+                }
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Hotel Search by City
+
+```python
+async def search_hotels_by_city(
+    auth: AmadeusAuth,
+    city_code: str,
+    radius: int = 5,
+    radius_unit: str = "KM",
+) -> dict:
+    async with httpx.AsyncClient() as client:
+        headers = await auth.auth_headers(client)
+        resp = await client.get(
+            f"{auth.base}/v1/reference-data/locations/hotels/by-city",
+            headers=headers,
+            params={
+                "cityCode": city_code,
+                "radius": radius,
+                "radiusUnit": radius_unit,
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Hotel Offers (Pricing/Availability)
+
+```python
+async def get_hotel_offers(
+    auth: AmadeusAuth,
+    hotel_ids: list[str],
+    check_in: str,
+    check_out: str,
+    adults: int = 1,
+) -> dict:
+    async with httpx.AsyncClient() as client:
+        headers = await auth.auth_headers(client)
+        resp = await client.get(
+            f"{auth.base}/v3/shopping/hotel-offers",
+            headers=headers,
+            params={
+                "hotelIds": ",".join(hotel_ids),
+                "checkInDate": check_in,
+                "checkOutDate": check_out,
+                "adults": adults,
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Airport/City Autocomplete
+
+```python
+async def location_search(
+    auth: AmadeusAuth,
+    keyword: str,
+    sub_type: str = "CITY,AIRPORT",
+) -> dict:
+    async with httpx.AsyncClient() as client:
+        headers = await auth.auth_headers(client)
+        resp = await client.get(
+            f"{auth.base}/v1/reference-data/locations",
+            headers=headers,
+            params={"keyword": keyword, "subType": sub_type},
+        )
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Key Endpoint Reference
+
+| Category        | Endpoint                                                  | Method |
+|-----------------|-----------------------------------------------------------|--------|
+| Flight Search   | `/v2/shopping/flight-offers`                              | GET    |
+| Flight Pricing  | `/v1/shopping/flight-offers/pricing`                      | POST   |
+| Flight Booking  | `/v1/booking/flight-orders`                               | POST   |
+| Flight Order    | `/v1/booking/flight-orders/{orderId}`                     | GET    |
+| Seat Maps       | `/v1/shopping/seatmaps`                                   | GET/POST |
+| Cheapest Dates  | `/v1/shopping/flight-dates`                               | GET    |
+| Inspiration     | `/v1/shopping/flight-destinations`                        | GET    |
+| Hotels by City  | `/v1/reference-data/locations/hotels/by-city`             | GET    |
+| Hotels by Geo   | `/v1/reference-data/locations/hotels/by-geocode`          | GET    |
+| Hotel Offers    | `/v3/shopping/hotel-offers`                               | GET    |
+| Hotel Booking   | `/v2/booking/hotel-orders`                                | POST   |
+| Hotel Ratings   | `/v2/e-reputation/hotel-sentiments`                       | GET    |
+| Location Search | `/v1/reference-data/locations`                            | GET    |
+| Airlines        | `/v1/reference-data/airlines`                             | GET    |
+| Check-in Links  | `/v2/reference-data/urls/checkin-links`                   | GET    |
+| Activities      | `/v1/shopping/activities`                                 | GET    |
+| Transfers       | `/v1/shopping/transfer-offers`                            | POST   |
+| Trip Purpose    | `/v1/travel/predictions/trip-purpose`                     | GET    |
+| Flight Delay    | `/v1/travel/predictions/flight-delay`                     | GET    |
+| Air Traffic     | `/v1/travel/analytics/air-traffic/booked`                 | GET    |
+
+## Error Handling
+
+```python
+import httpx
+
+async def safe_amadeus_request(auth: AmadeusAuth, method: str, path: str, **kwargs) -> dict:
+    async with httpx.AsyncClient() as client:
+        headers = await auth.auth_headers(client)
+        headers.update(kwargs.pop("headers", {}))
+        resp = await getattr(client, method)(
+            f"{auth.base}{path}", headers=headers, **kwargs
+        )
+        if resp.status_code == 401:
+            # Token expired -- force refresh and retry once
+            auth._token = None
+            headers = await auth.auth_headers(client)
+            headers.update(kwargs.pop("headers", {}))
+            resp = await getattr(client, method)(
+                f"{auth.base}{path}", headers=headers, **kwargs
+            )
+        if resp.status_code == 429:
+            raise RuntimeError("Rate limit exceeded -- back off and retry")
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### HTTP Status Code Reference
+
+| Status | Amadeus Code | Meaning                        |
+|--------|--------------|--------------------------------|
+| 400    | 477          | Invalid format (bad IATA code) |
+| 401    | 38190        | Invalid/expired access token   |
+| 401    | 38192        | Access token expired           |
+| 403    | 38197        | HTTPS required or forbidden    |
+| 404    | 38196        | Resource/endpoint not found    |
+| 429    | 38194        | Rate limit exceeded            |
+| 429    | 38195        | Monthly quota exceeded         |
+| 500    | 38189        | Internal server error          |
+
+Error response body format:
+
+```json
+{
+  "errors": [
+    {
+      "status": 400,
+      "code": 477,
+      "title": "INVALID FORMAT",
+      "detail": "invalid city/airport code",
+      "source": { "parameter": "originLocationCode" }
+    }
+  ]
+}
+```
+
+## Common Pitfalls
+
+1. **Tokens expire after 30 minutes.** Always cache the token and check expiry before each request. Do not request a new token on every call.
+2. **Test environment has a monthly free-tier quota.** Exceeding it returns 429 until the next month. Monitor usage in the developer dashboard.
+3. **IATA codes are required**, not city names. Use the Location Search endpoint to resolve city names to IATA codes first.
+4. **The booking flow is three steps.** Search returns offers, but prices are not guaranteed until you call the Pricing endpoint. Only then call the Booking endpoint.
+5. **Dates must be ISO 8601 format** (`YYYY-MM-DD`). Past dates return error code 4926.
+6. **Hotel IDs must be obtained first** from the hotel-list endpoints (by-city, by-geocode, by-hotels) before querying offers.
+7. **Production requires a separate key.** Test keys do not work on `api.amadeus.com`. You must request production access through the developer portal.
+8. **All requests must use HTTPS.** HTTP requests return 403.

--- a/content/apollo-io/docs/rest-api/python/DOC.md
+++ b/content/apollo-io/docs/rest-api/python/DOC.md
@@ -1,0 +1,247 @@
+---
+name: rest-api
+description: "Apollo.io B2B Contact & Company Enrichment API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-13"
+  source: community
+  tags: "apollo,b2b,enrichment,contacts,companies,leads,sales,api,integration"
+---
+
+# Apollo.io API
+
+> **Golden Rule:** Apollo.io has no official Python SDK. Use `httpx` (async) or `requests` (sync) for direct REST API access. People search is free (no credits); enrichment consumes credits. Always handle rate limits and error responses explicitly.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+`https://api.apollo.io/api/v1`
+
+Note: Organization enrichment (single) uses `https://api.apollo.io/v1/` (no `/api/` prefix).
+
+## Authentication
+
+**Type:** API Key
+
+```python
+import httpx
+
+API_KEY = "your-apollo-api-key"
+BASE_URL = "https://api.apollo.io/api/v1"
+
+headers = {"x-api-key": API_KEY, "Content-Type": "application/json"}
+client = httpx.AsyncClient(headers=headers)
+```
+
+## Rate Limiting
+
+| Plan | Per Minute | Daily |
+|---|---|---|
+| Free | 50 | 600 |
+| Basic/Pro | 200 | 2,000 |
+
+Bulk endpoints are capped at 50% of single-endpoint per-minute rates. Check `POST /usage_stats/api_usage_stats` (requires master API key) to monitor consumption.
+
+## Methods
+
+### `search_people`
+
+**Endpoint:** `POST /mixed_people/api_search`
+
+Search for people matching criteria. **Free -- does not consume credits.** Does NOT return emails/phone numbers (use enrichment for that).
+
+| Parameter | Type | Default |
+|---|---|---|
+| `first_name` | `str` | `None` |
+| `last_name` | `str` | `None` |
+| `organization_name` | `str` | `None` |
+| `domain` | `str` | `None` |
+| `linkedin_url` | `str` | `None` |
+| `page` | `int` | `1` |
+
+**Returns:** JSON with `people` array and `pagination` object (100 per page, max 500 pages)
+
+```python
+payload = {
+    "organization_name": "Anthropic",
+    "page": 1
+}
+response = await client.post(f"{BASE_URL}/mixed_people/api_search", json=payload)
+response.raise_for_status()
+data = response.json()
+people = data.get("people", [])
+```
+
+### `enrich_person`
+
+**Endpoint:** `POST /people/match`
+
+Enrich a single person record. **Consumes credits.** Returns emails and phone numbers.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `first_name` | `str` | `None` |
+| `last_name` | `str` | `None` |
+| `email` | `str` | `None` |
+| `domain` | `str` | `None` |
+| `organization_name` | `str` | `None` |
+| `linkedin_url` | `str` | `None` |
+| `id` | `str` | `None` |
+| `reveal_personal_emails` | `bool` | `False` |
+| `reveal_phone_number` | `bool` | `False` |
+
+**Returns:** JSON with `person` and `organization` objects
+
+```python
+payload = {
+    "first_name": "Jane",
+    "last_name": "Doe",
+    "domain": "anthropic.com",
+    "reveal_personal_emails": True
+}
+response = await client.post(f"{BASE_URL}/people/match", json=payload)
+response.raise_for_status()
+data = response.json()
+person = data.get("person", {})
+email = person.get("email")
+```
+
+### `bulk_enrich_people`
+
+**Endpoint:** `POST /people/bulk_match`
+
+Enrich up to 10 people per request. **Consumes credits.**
+
+| Parameter | Type | Default |
+|---|---|---|
+| `details` | `list` | **required** |
+| `reveal_personal_emails` | `bool` | `False` |
+| `reveal_phone_number` | `bool` | `False` |
+
+**Returns:** JSON with `matches` array, `credits_consumed`, `missing_records`
+
+```python
+payload = {
+    "details": [
+        {"first_name": "Jane", "last_name": "Doe", "domain": "anthropic.com"},
+        {"email": "john@example.com"}
+    ],
+    "reveal_personal_emails": True
+}
+response = await client.post(f"{BASE_URL}/people/bulk_match", json=payload)
+response.raise_for_status()
+data = response.json()
+matches = data.get("matches", [])
+```
+
+### `enrich_organization`
+
+**Endpoint:** `GET https://api.apollo.io/v1/organizations/enrich`
+
+Enrich a single company by domain. **Consumes credits.** Note: uses `/v1/` base (no `/api/` prefix).
+
+| Parameter | Type | Default |
+|---|---|---|
+| `domain` | `str` | `None` |
+| `organization_name` | `str` | `None` |
+
+**Returns:** JSON with organization data (industry, employee count, funding, technologies, etc.)
+
+```python
+ORG_URL = "https://api.apollo.io/v1/organizations/enrich"
+params = {"domain": "anthropic.com"}
+response = await client.get(ORG_URL, params=params)
+response.raise_for_status()
+data = response.json()
+org = data.get("organization", {})
+```
+
+### `create_contact`
+
+**Endpoint:** `POST /contacts`
+
+Save an enriched lead to Apollo CRM. Does not consume credits.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `first_name` | `str` | **required** |
+| `last_name` | `str` | **required** |
+| `email` | `str` | `None` |
+| `organization_name` | `str` | `None` |
+| `title` | `str` | `None` |
+
+**Returns:** JSON with full contact object
+
+```python
+payload = {
+    "first_name": "Jane",
+    "last_name": "Doe",
+    "email": "jane@anthropic.com",
+    "organization_name": "Anthropic",
+    "title": "Engineer"
+}
+response = await client.post(f"{BASE_URL}/contacts", json=payload)
+response.raise_for_status()
+contact = response.json()
+```
+
+### `search_organizations`
+
+**Endpoint:** `POST /mixed_companies/search`
+
+Search for companies matching criteria.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `page` | `int` | `1` |
+
+**Returns:** JSON with companies array and pagination
+
+```python
+payload = {
+    "page": 1
+}
+response = await client.post(f"{BASE_URL}/mixed_companies/search", json=payload)
+response.raise_for_status()
+data = response.json()
+```
+
+## Error Handling
+
+```python
+import httpx
+
+try:
+    response = await client.post(f"{BASE_URL}/people/match", json=payload)
+    response.raise_for_status()
+    data = response.json()
+except httpx.HTTPStatusError as e:
+    if e.response.status_code == 401:
+        print("Authentication failed -- check your API key")
+    elif e.response.status_code == 429:
+        print("Rate limited -- back off and retry")
+    elif e.response.status_code == 403:
+        print("Forbidden -- this endpoint may require a master API key")
+    else:
+        print(f"Apollo API error {e.response.status_code}: {e.response.text}")
+except httpx.RequestError as e:
+    print(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+- People search (`/mixed_people/api_search`) is free but does NOT return emails/phones -- you must enrich separately
+- Use `domain` (not full URL) for organization enrichment -- strip `www.` and `https://`
+- Provide as many identifying fields as possible to increase enrichment match accuracy
+- Bulk endpoints accept max 10 records per request and are rate-limited at 50% of single endpoints
+- Organization enrichment (single) uses a different base URL: `https://api.apollo.io/v1/` (no `/api/`)
+- Pagination caps at 500 pages (50,000 records) -- use filters to narrow results
+- Always call `response.raise_for_status()` to catch HTTP errors
+- Set a reasonable timeout: `httpx.AsyncClient(timeout=30.0)`

--- a/content/aviationstack/docs/rest-api/python/DOC.md
+++ b/content/aviationstack/docs/rest-api/python/DOC.md
@@ -1,0 +1,377 @@
+---
+name: rest-api
+description: "AviationStack - Real-time Flight Tracking and Aviation Data"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "aviationstack,flights,aviation,tracking,airports,airlines,api"
+---
+
+# AviationStack API - Python Reference (httpx)
+
+## Golden Rule
+
+Authentication uses an `access_key` **query parameter** on every request -- not a header. The free tier is HTTP only (no HTTPS) and limited to real-time flights. Historical data, future schedules, and HTTPS require a paid plan. Always check your plan's capabilities before building features that depend on paid endpoints.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+All examples use `httpx` with async/await. For scripts that need a synchronous entrypoint:
+
+```python
+import asyncio
+import httpx
+
+async def main():
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{BASE_URL}/flights",
+            params={"access_key": ACCESS_KEY},
+        )
+        print(resp.json())
+
+asyncio.run(main())
+```
+
+## Base URL
+
+```
+http://api.aviationstack.com/v1
+```
+
+**HTTPS** (paid plans only):
+
+```
+https://api.aviationstack.com/v1
+```
+
+```python
+import os
+
+ACCESS_KEY = os.environ["AVIATIONSTACK_ACCESS_KEY"]
+# Use http for free tier, https for paid plans
+BASE_URL = "http://api.aviationstack.com/v1"
+```
+
+## Authentication
+
+AviationStack uses **API key as a query parameter** on every request:
+
+```
+http://api.aviationstack.com/v1/flights?access_key=YOUR_ACCESS_KEY
+```
+
+There are no authorization headers. The key is passed as the `access_key` parameter.
+
+```python
+def auth_params(**kwargs) -> dict:
+    """Build params dict with access_key included."""
+    return {"access_key": ACCESS_KEY, **kwargs}
+```
+
+## Rate Limiting
+
+| Plan | Monthly Requests |
+|---|---|
+| Free | 100 requests/month |
+| Basic | 500 requests/month |
+| Professional | 5,000 requests/month |
+| Business | 50,000 requests/month |
+| Enterprise | Custom |
+
+When you exceed your monthly quota, the API returns an error in the JSON response body (not via HTTP status code). Always check the response for an `error` key.
+
+## Methods
+
+### Real-time Flights
+
+Get real-time flight status data. This is the primary endpoint.
+
+**Optional parameters:**
+- `flight_iata` (str) -- IATA flight number (e.g., `AA100`)
+- `flight_icao` (str) -- ICAO flight number
+- `dep_iata` (str) -- Departure airport IATA code (e.g., `JFK`)
+- `arr_iata` (str) -- Arrival airport IATA code
+- `airline_iata` (str) -- Airline IATA code (e.g., `AA`)
+- `airline_icao` (str) -- Airline ICAO code
+- `flight_status` (str) -- Filter by status: `scheduled`, `active`, `landed`, `cancelled`, `incident`, `diverted`
+- `limit` (int) -- Results per page (default: 100)
+- `offset` (int) -- Pagination offset
+
+```python
+async def get_flights(
+    client: httpx.AsyncClient,
+    flight_iata: str = None,
+    dep_iata: str = None,
+    arr_iata: str = None,
+    airline_iata: str = None,
+    flight_status: str = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> dict:
+    params = auth_params(limit=limit, offset=offset)
+    if flight_iata:
+        params["flight_iata"] = flight_iata
+    if dep_iata:
+        params["dep_iata"] = dep_iata
+    if arr_iata:
+        params["arr_iata"] = arr_iata
+    if airline_iata:
+        params["airline_iata"] = airline_iata
+    if flight_status:
+        params["flight_status"] = flight_status
+    resp = await client.get(f"{BASE_URL}/flights", params=params)
+    resp.raise_for_status()
+    return resp.json()
+
+# Usage -- look up a specific flight
+data = await get_flights(client, flight_iata="AA100")
+for flight in data["data"]:
+    print(f"{flight['flight']['iata']}: {flight['flight_status']}")
+```
+
+### Historical Flights (Paid)
+
+Get historical flight data for a specific date.
+
+**Additional parameters:**
+- `flight_date` (str) -- Date in `YYYY-MM-DD` format
+
+```python
+async def get_historical_flights(
+    client: httpx.AsyncClient,
+    flight_date: str,
+    dep_iata: str = None,
+    arr_iata: str = None,
+) -> dict:
+    params = auth_params(flight_date=flight_date)
+    if dep_iata:
+        params["dep_iata"] = dep_iata
+    if arr_iata:
+        params["arr_iata"] = arr_iata
+    resp = await client.get(f"{BASE_URL}/flights", params=params)
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Future Flight Schedules (Paid)
+
+Look up scheduled future flights.
+
+```python
+async def get_future_flights(
+    client: httpx.AsyncClient,
+    iata_code: str,
+    flight_type: str = "departure",
+    date: str = None,
+) -> dict:
+    params = auth_params(iataCode=iata_code, type=flight_type)
+    if date:
+        params["date"] = date
+    resp = await client.get(f"{BASE_URL}/flightsFuture", params=params)
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Airports
+
+Look up airport data.
+
+**Optional parameters:**
+- `search` (str) -- Search by airport name
+- `iata_code` (str) -- Filter by IATA code
+- `country_iso2` (str) -- Filter by country ISO2 code
+
+```python
+async def get_airports(
+    client: httpx.AsyncClient,
+    search: str = None,
+    iata_code: str = None,
+    country_iso2: str = None,
+) -> dict:
+    params = auth_params()
+    if search:
+        params["search"] = search
+    if iata_code:
+        params["iata_code"] = iata_code
+    if country_iso2:
+        params["country_iso2"] = country_iso2
+    resp = await client.get(f"{BASE_URL}/airports", params=params)
+    resp.raise_for_status()
+    return resp.json()
+
+# Usage -- find airports in Japan
+airports = await get_airports(client, country_iso2="JP")
+```
+
+### Airlines
+
+Look up airline data.
+
+```python
+async def get_airlines(
+    client: httpx.AsyncClient,
+    search: str = None,
+    iata_code: str = None,
+) -> dict:
+    params = auth_params()
+    if search:
+        params["search"] = search
+    if iata_code:
+        params["iata_code"] = iata_code
+    resp = await client.get(f"{BASE_URL}/airlines", params=params)
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Routes
+
+Look up airline route information.
+
+```python
+async def get_routes(
+    client: httpx.AsyncClient,
+    dep_iata: str = None,
+    arr_iata: str = None,
+    airline_iata: str = None,
+) -> dict:
+    params = auth_params()
+    if dep_iata:
+        params["dep_iata"] = dep_iata
+    if arr_iata:
+        params["arr_iata"] = arr_iata
+    if airline_iata:
+        params["airline_iata"] = airline_iata
+    resp = await client.get(f"{BASE_URL}/routes", params=params)
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Aircraft Types and Airplanes
+
+Look up aircraft information.
+
+```python
+async def get_aircraft_types(client: httpx.AsyncClient) -> dict:
+    resp = await client.get(f"{BASE_URL}/aircraft_types", params=auth_params())
+    resp.raise_for_status()
+    return resp.json()
+
+async def get_airplanes(client: httpx.AsyncClient, airline_iata: str = None) -> dict:
+    params = auth_params()
+    if airline_iata:
+        params["airline_iata"] = airline_iata
+    resp = await client.get(f"{BASE_URL}/airplanes", params=params)
+    resp.raise_for_status()
+    return resp.json()
+```
+
+## Error Handling
+
+Successful responses return HTTP 200 with a JSON body containing `pagination` and `data` fields:
+
+```json
+{
+    "pagination": {"limit": 100, "offset": 0, "count": 100, "total": 15432},
+    "data": [...]
+}
+```
+
+On failure, the response includes an `error` object:
+
+```json
+{
+    "error": {
+        "code": "usage_limit_reached",
+        "message": "Your monthly API request volume has been reached. Please upgrade your plan."
+    }
+}
+```
+
+**Common error codes:**
+
+| Error Code | Meaning |
+|---|---|
+| `missing_access_key` | No `access_key` parameter provided |
+| `invalid_access_key` | The access key is not valid |
+| `inactive_user` | Account is inactive |
+| `usage_limit_reached` | Monthly request quota exceeded |
+| `function_access_restricted` | Endpoint not available on your plan (e.g., historical on free tier) |
+| `https_access_restricted` | HTTPS not available on free plan |
+| `404_not_found` | Invalid endpoint path |
+
+**Robust error handling pattern:**
+
+```python
+import asyncio
+import httpx
+import logging
+
+logger = logging.getLogger(__name__)
+
+class AviationStackError(Exception):
+    def __init__(self, code: str, message: str):
+        self.code = code
+        self.message = message
+        super().__init__(f"[{code}] {message}")
+
+async def aviation_request(
+    client: httpx.AsyncClient,
+    endpoint: str,
+    params: dict = None,
+    max_retries: int = 3,
+) -> dict:
+    url = f"{BASE_URL}/{endpoint}"
+    request_params = auth_params(**(params or {}))
+
+    for attempt in range(max_retries):
+        try:
+            resp = await client.get(url, params=request_params)
+        except httpx.RequestError as e:
+            logger.warning(f"Network error on {endpoint} (attempt {attempt+1}): {e}")
+            await asyncio.sleep(2 ** attempt)
+            continue
+
+        data = resp.json()
+
+        # AviationStack returns errors in the JSON body, not always via HTTP status
+        if "error" in data:
+            error = data["error"]
+            code = error.get("code", "unknown")
+            message = error.get("message", "Unknown error")
+            if code == "usage_limit_reached":
+                raise AviationStackError(code, message)  # No point retrying
+            raise AviationStackError(code, message)
+
+        return data
+
+    raise AviationStackError("network_error", f"Max retries exceeded for {endpoint}")
+```
+
+## Common Pitfalls
+
+1. **Free tier is HTTP only.** The free plan does not support HTTPS. If you use `https://` in the base URL on a free plan, you get a `https_access_restricted` error. Use `http://` or upgrade.
+
+2. **Free tier is limited to 100 requests/month.** That is roughly 3 per day. Cache results aggressively. Consider storing flight data in a local database.
+
+3. **Historical and future schedules require paid plans.** The free tier only supports real-time flight data. Passing `flight_date` on a free plan returns `function_access_restricted`.
+
+4. **Errors are in the JSON body, not HTTP status codes.** The API often returns HTTP 200 even for errors. Always check for an `error` key in the response JSON before processing `data`.
+
+5. **Pagination is essential for large result sets.** The default limit is 100. Use `offset` to page through results. The `pagination.total` field tells you the total count.
+
+6. **API key is in the URL.** Since `access_key` is a query parameter, it appears in server logs, browser history, and network traces. Never expose this in client-side code.
+
+7. **Flight IATA codes are not unique per day.** The same flight number can appear multiple times (codeshares, connecting flights). Filter by departure/arrival airport to narrow results.
+
+8. **Timezone handling.** Departure and arrival times include timezone information. Parse them carefully -- do not assume all times are UTC.
+
+9. **Rate limits are monthly, not per-second.** There is no burst rate limit, but hitting your monthly cap locks you out until the next billing cycle.
+
+10. **The `search` parameter on lookup endpoints is a text search.** Searching for "New" on the airports endpoint returns New York, New Delhi, Newark, etc. Use specific IATA codes when you know the exact airport.

--- a/content/bhashini/docs/rest-api/python/DOC.md
+++ b/content/bhashini/docs/rest-api/python/DOC.md
@@ -1,0 +1,273 @@
+---
+name: rest-api
+description: "Bhashini - Indian Government Indic Language Platform (ASR, Translation, TTS)"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-13"
+  source: community
+  tags: "bhashini,indian-languages,indic,speech-to-text,translation,text-to-speech,asr,nmt,tts,government,meity,api,integration"
+---
+
+# Bhashini API
+
+> **Golden Rule:** Bhashini is the Indian government's language technology platform (MeitY). It has no official Python SDK. Use `httpx` for direct REST access. The ULCA/Dhruva Pipeline API is **free** but requires a 2-phase auth flow: first get config (returns dynamic auth + service IDs), then call compute. Supports 22 Indian languages.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URLs
+
+| Step | URL |
+|---|---|
+| Pipeline Config | `https://meity-auth.ulcacontrib.org/ulca/apis/v0/model/getModelsPipeline` |
+| Pipeline Compute | `https://dhruva-api.bhashini.gov.in/services/inference/pipeline` |
+
+**Important:** The compute URL is returned dynamically in the config response as `callbackUrl`. Always use the returned URL.
+
+## Authentication
+
+**Type:** Two-phase (ULCA credentials → dynamic auth token)
+
+```python
+import httpx
+
+USER_ID = "your-ulca-user-id"      # From bhashini.gov.in/ulca/profile
+ULCA_API_KEY = "your-ulca-api-key"  # Generate at profile page (max 5 keys)
+
+CONFIG_URL = "https://meity-auth.ulcacontrib.org/ulca/apis/v0/model/getModelsPipeline"
+
+# Phase 1: Config call uses ULCA credentials
+config_headers = {
+    "userID": USER_ID,
+    "ulcaApiKey": ULCA_API_KEY,
+    "Content-Type": "application/json"
+}
+
+client = httpx.AsyncClient(timeout=60.0)
+```
+
+Register free at: https://bhashini.gov.in/ulca/user/register
+
+## Supported Languages
+
+All 22 scheduled languages of India plus English. Common codes:
+
+| Language | Code | Language | Code |
+|---|---|---|---|
+| Hindi | `hi` | Tamil | `ta` |
+| Bengali | `bn` | Telugu | `te` |
+| Gujarati | `gu` | Kannada | `kn` |
+| Marathi | `mr` | Malayalam | `ml` |
+| Punjabi | `pa` | Odia | `or` |
+| Urdu | `ur` | Assamese | `as` |
+| English | `en` | Nepali | `ne` |
+
+Also: Bodo (`brx`), Dogri (`doi`), Maithili (`mai`), Manipuri (`mni`), Santali (`sat`), Sanskrit (`sa`), Sindhi (`sd`), Kashmiri (`ks`), Konkani (`gom`)
+
+## Methods
+
+### `get_pipeline_config` (Step 1 — Required)
+
+**Endpoint:** `POST https://meity-auth.ulcacontrib.org/ulca/apis/v0/model/getModelsPipeline`
+
+Get available models and dynamic auth credentials for pipeline tasks. Must be called before any compute request.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `pipelineTasks` | `list` | **required** (task types: `asr`, `translation`, `tts`) |
+| `pipelineRequestConfig.pipelineId` | `str` | **required** (`64392f96daac500b55c543cd` for MeitY) |
+
+**Returns:** JSON with available models, service IDs, and `pipelineInferenceAPIEndPoint` (contains `callbackUrl` and `inferenceApiKey`)
+
+```python
+config_payload = {
+    "pipelineTasks": [
+        {"taskType": "translation", "config": {
+            "language": {"sourceLanguage": "hi", "targetLanguage": "en"}
+        }}
+    ],
+    "pipelineRequestConfig": {
+        "pipelineId": "64392f96daac500b55c543cd"
+    }
+}
+
+response = await client.post(CONFIG_URL, json=config_payload, headers=config_headers)
+response.raise_for_status()
+config = response.json()
+
+# Extract dynamic auth and compute URL
+endpoint = config["pipelineInferenceAPIEndPoint"]
+compute_url = endpoint["callbackUrl"]
+auth_key = endpoint["inferenceApiKey"]
+compute_headers = {
+    auth_key["name"]: auth_key["value"],  # "Authorization": "<dynamic-token>"
+    "Content-Type": "application/json"
+}
+
+# Extract service ID for translation
+service_id = config["pipelineResponseConfig"][0]["config"][0]["serviceId"]
+```
+
+### `translate` (Step 2 — Compute)
+
+**Endpoint:** `POST {callbackUrl}` (from config response)
+
+Translate text between Indian languages.
+
+```python
+payload = {
+    "pipelineTasks": [{
+        "taskType": "translation",
+        "config": {
+            "language": {"sourceLanguage": "hi", "targetLanguage": "en"},
+            "serviceId": service_id
+        }
+    }],
+    "inputData": {
+        "input": [{"source": "नमस्ते, आप कैसे हैं?"}],
+        "audio": [{"audioContent": None}]
+    }
+}
+response = await client.post(compute_url, json=payload, headers=compute_headers)
+response.raise_for_status()
+result = response.json()
+translated = result["pipelineResponse"][0]["output"][0]["target"]
+# "Hello, how are you?"
+```
+
+### `speech_to_text` (ASR Compute)
+
+**Endpoint:** `POST {callbackUrl}`
+
+Transcribe audio in any supported Indian language.
+
+```python
+import base64
+
+with open("audio.wav", "rb") as f:
+    audio_b64 = base64.b64encode(f.read()).decode()
+
+payload = {
+    "pipelineTasks": [{
+        "taskType": "asr",
+        "config": {
+            "language": {"sourceLanguage": "hi"},
+            "serviceId": asr_service_id,
+            "audioFormat": "wav",
+            "samplingRate": 16000
+        }
+    }],
+    "inputData": {
+        "input": [{"source": None}],
+        "audio": [{"audioContent": audio_b64}]
+    }
+}
+response = await client.post(compute_url, json=payload, headers=compute_headers)
+response.raise_for_status()
+result = response.json()
+transcript = result["pipelineResponse"][0]["output"][0]["source"]
+```
+
+### `text_to_speech` (TTS Compute)
+
+**Endpoint:** `POST {callbackUrl}`
+
+Generate speech audio from text.
+
+```python
+payload = {
+    "pipelineTasks": [{
+        "taskType": "tts",
+        "config": {
+            "language": {"sourceLanguage": "ta"},
+            "serviceId": tts_service_id,
+            "gender": "female"
+        }
+    }],
+    "inputData": {
+        "input": [{"source": "வணக்கம், எப்படி இருக்கிறீர்கள்?"}],
+        "audio": [{"audioContent": None}]
+    }
+}
+response = await client.post(compute_url, json=payload, headers=compute_headers)
+response.raise_for_status()
+result = response.json()
+audio_b64 = result["pipelineResponse"][0]["audio"][0]["audioContent"]
+audio_bytes = base64.b64decode(audio_b64)
+with open("output.wav", "wb") as f:
+    f.write(audio_bytes)
+```
+
+### Full Pipeline (ASR → Translation → TTS)
+
+Chain multiple tasks in a single compute call:
+
+```python
+# First get config for all 3 tasks
+config_payload = {
+    "pipelineTasks": [
+        {"taskType": "asr", "config": {"language": {"sourceLanguage": "hi"}}},
+        {"taskType": "translation", "config": {"language": {"sourceLanguage": "hi", "targetLanguage": "ta"}}},
+        {"taskType": "tts", "config": {"language": {"sourceLanguage": "ta"}}}
+    ],
+    "pipelineRequestConfig": {"pipelineId": "64392f96daac500b55c543cd"}
+}
+# ... get config, extract service IDs ...
+
+# Then compute full pipeline
+payload = {
+    "pipelineTasks": [
+        {"taskType": "asr", "config": {"language": {"sourceLanguage": "hi"}, "serviceId": asr_sid, "audioFormat": "wav", "samplingRate": 16000}},
+        {"taskType": "translation", "config": {"language": {"sourceLanguage": "hi", "targetLanguage": "ta"}, "serviceId": nmt_sid}},
+        {"taskType": "tts", "config": {"language": {"sourceLanguage": "ta"}, "serviceId": tts_sid, "gender": "female"}}
+    ],
+    "inputData": {
+        "input": [{"source": None}],
+        "audio": [{"audioContent": audio_b64}]
+    }
+}
+response = await client.post(compute_url, json=payload, headers=compute_headers)
+response.raise_for_status()
+# Result contains all 3 pipeline outputs
+```
+
+## Error Handling
+
+```python
+import httpx
+
+try:
+    response = await client.post(compute_url, json=payload, headers=compute_headers)
+    response.raise_for_status()
+    data = response.json()
+except httpx.HTTPStatusError as e:
+    if e.response.status_code == 401:
+        print("Auth failed -- re-fetch config to get fresh credentials")
+    elif e.response.status_code == 429:
+        print("Rate limited -- back off and retry")
+    elif e.response.status_code == 400:
+        print(f"Bad request: {e.response.text}")
+    else:
+        print(f"Bhashini API error {e.response.status_code}: {e.response.text}")
+except httpx.RequestError as e:
+    print(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+- **Two API calls required**: You MUST call config first to get dynamic auth credentials and service IDs before compute
+- **Do NOT hardcode service IDs** -- they are dynamic and returned by the config endpoint
+- **Auth tokens are temporary** -- if compute returns 401, re-fetch config for fresh credentials
+- Audio is **base64-encoded** in both request (ASR input) and response (TTS output)
+- ASR supports `wav` and `flac` formats at 16000 Hz sampling rate
+- TTS gender options: `"male"` or `"female"`
+- Language codes use ISO 639 format: `hi` (Hindi), `ta` (Tamil), `bn` (Bengali) -- NOT BCP-47 (`hi-IN`)
+- Pipeline ID `64392f96daac500b55c543cd` (MeitY) or `643930aa521a4b1ba0f4c41d` (AI4Bharat)
+- The ULCA platform is described as "for PoC" -- contact Bhashini for production access
+- Set `timeout=60.0` -- speech processing can be slow
+- Registration is free at https://bhashini.gov.in/ulca/user/register (max 5 API keys per account)

--- a/content/browserless/docs/rest-api/python/DOC.md
+++ b/content/browserless/docs/rest-api/python/DOC.md
@@ -1,0 +1,467 @@
+---
+name: rest-api
+description: "Browserless - Headless Browser Automation REST API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-13"
+  source: community
+  tags: "browserless,headless,browser,scraping,screenshot,pdf,puppeteer,playwright,automation,api"
+---
+
+# Browserless API
+
+> **Golden Rule:** Every REST API call is stateless -- each request launches a browser, performs one task, and closes the session. Cookies and state do NOT persist between calls. Send either `url` or `html` in the JSON body, never both. Always include your API token as a query parameter.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+```
+https://production-sfo.browserless.io
+```
+
+Your account may use a different region. Check your Browserless dashboard for the exact base URL.
+
+## Authentication
+
+All requests require an API token passed as a query parameter `?token=YOUR_API_TOKEN_HERE`. Obtain your token from the Browserless account dashboard at https://cloud.browserless.io.
+
+```python
+import httpx
+
+BASE_URL = "https://production-sfo.browserless.io"
+TOKEN = "YOUR_API_TOKEN_HERE"
+
+def browserless_url(endpoint: str) -> str:
+    """Build a full Browserless API URL with token."""
+    return f"{BASE_URL}{endpoint}?token={TOKEN}"
+```
+
+## Rate Limiting
+
+Rate limits depend on your plan tier. Limits are based on concurrent sessions (how many browsers can run simultaneously) and total units per month. Check your dashboard for current usage and limits. The API returns HTTP 429 when limits are exceeded.
+
+## Methods
+
+### POST /content
+
+Fetch fully rendered HTML from a page, including JavaScript-rendered content.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `url` | string | yes* | URL to fetch |
+| `html` | string | yes* | Raw HTML to render (instead of url) |
+| `gotoOptions` | object | no | Navigation options (`waitUntil`, `timeout`) |
+| `waitForSelector` | object | no | Wait for CSS selector (`selector`, `visible`, `hidden`, `timeout`) |
+| `waitForTimeout` | number | no | Wait N milliseconds before returning |
+| `bestAttempt` | boolean | no | Continue even if async operations fail |
+| `rejectResourceTypes` | array | no | Block resource types (e.g. `["image", "stylesheet"]`) |
+
+*Provide either `url` or `html`, not both.
+
+**Response:** `text/html` -- the fully rendered HTML string.
+
+```python
+import httpx
+
+resp = httpx.post(
+    browserless_url("/content"),
+    json={
+        "url": "https://example.com/",
+        "gotoOptions": {"waitUntil": "networkidle2"},
+    },
+    timeout=30.0,
+)
+resp.raise_for_status()
+html_content = resp.text
+```
+
+---
+
+### POST /scrape
+
+Extract structured data from a page using CSS selectors. Uses `document.querySelectorAll` under the hood.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `url` | string | yes | URL to scrape |
+| `elements` | array | yes | Array of `{"selector": "css-selector"}` objects |
+| `gotoOptions` | object | no | Navigation options |
+| `waitForSelector` | object | no | Wait for CSS selector before scraping |
+| `waitForTimeout` | number | no | Wait N milliseconds |
+| `bestAttempt` | boolean | no | Continue on async failures |
+
+**Response:** `application/json`
+
+```json
+{
+  "data": [
+    {
+      "selector": "h1",
+      "results": [
+        {
+          "text": "Page Title",
+          "html": "<h1>Page Title</h1>",
+          "attributes": [{"name": "class", "value": "title"}],
+          "height": 120,
+          "width": 736,
+          "top": 196,
+          "left": 32
+        }
+      ]
+    }
+  ]
+}
+```
+
+```python
+import httpx
+
+resp = httpx.post(
+    browserless_url("/scrape"),
+    json={
+        "url": "https://example.com/",
+        "elements": [
+            {"selector": "h1"},
+            {"selector": "meta[name='description']"},
+        ],
+    },
+    timeout=30.0,
+)
+resp.raise_for_status()
+data = resp.json()
+for element in data["data"]:
+    print(f"Selector: {element['selector']}")
+    for result in element["results"]:
+        print(f"  Text: {result['text']}")
+```
+
+---
+
+### POST /screenshot
+
+Capture a screenshot of a page or rendered HTML.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `url` | string | yes* | URL to capture |
+| `html` | string | yes* | Raw HTML to render (instead of url) |
+| `options` | object | no | Screenshot options (see below) |
+| `addScriptTag` | array | no | Inject scripts before capture |
+| `addStyleTag` | array | no | Inject styles before capture |
+| `gotoOptions` | object | no | Navigation options |
+| `waitForSelector` | object | no | Wait for CSS selector |
+| `waitForTimeout` | number | no | Wait N milliseconds |
+
+**options object:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `type` | string | `"png"` | Image format: `png`, `jpeg`, or `webp` |
+| `fullPage` | boolean | `false` | Capture entire scrollable page |
+| `quality` | number | - | Image quality 0-100 (jpeg/webp only) |
+
+*Provide either `url` or `html`, not both.
+
+**Response:** Binary image data with `Content-Type: image/png` (or jpeg/webp).
+
+```python
+import httpx
+
+resp = httpx.post(
+    browserless_url("/screenshot"),
+    json={
+        "url": "https://example.com/",
+        "options": {
+            "fullPage": True,
+            "type": "png",
+        },
+    },
+    timeout=30.0,
+)
+resp.raise_for_status()
+with open("screenshot.png", "wb") as f:
+    f.write(resp.content)
+```
+
+---
+
+### POST /pdf
+
+Generate a PDF from a page or rendered HTML.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `url` | string | yes* | URL to convert |
+| `html` | string | yes* | Raw HTML to render (instead of url) |
+| `options` | object | no | PDF options (see below) |
+| `addScriptTag` | array | no | Inject scripts before generation |
+| `addStyleTag` | array | no | Inject styles before generation |
+| `gotoOptions` | object | no | Navigation options |
+| `waitForSelector` | object | no | Wait for CSS selector |
+| `waitForTimeout` | number | no | Wait N milliseconds |
+
+**options object:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `format` | string | `"Letter"` | Page format: `A0`-`A5`, `Letter`, `Legal`, `Tabloid` |
+| `printBackground` | boolean | `false` | Include background colors/images |
+| `displayHeaderFooter` | boolean | `false` | Show header and footer |
+| `landscape` | boolean | `false` | Landscape orientation |
+| `margin` | object | - | Margins: `{top, bottom, left, right}` as CSS strings |
+
+*Provide either `url` or `html`, not both.
+
+**Response:** Binary PDF data with `Content-Type: application/pdf`.
+
+```python
+import httpx
+
+resp = httpx.post(
+    browserless_url("/pdf"),
+    json={
+        "url": "https://example.com/",
+        "options": {
+            "format": "A4",
+            "printBackground": True,
+            "margin": {
+                "top": "1cm",
+                "bottom": "1cm",
+                "left": "1cm",
+                "right": "1cm",
+            },
+        },
+    },
+    timeout=30.0,
+)
+resp.raise_for_status()
+with open("output.pdf", "wb") as f:
+    f.write(resp.content)
+```
+
+---
+
+### POST /function
+
+Run custom Puppeteer code server-side. Accepts either `application/javascript` or `application/json`.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `code` | string | yes | Async JavaScript function (JSON mode) |
+| `context` | object | no | Variables passed into the function (JSON mode) |
+
+The function receives `{ page, context }` and must return `{ data, type }`.
+
+**Response:** Varies based on the `type` returned by your function.
+
+```python
+import httpx
+
+code = """
+export default async ({ page, context }) => {
+  await page.goto(context.url);
+  const title = await page.title();
+  return {
+    data: { title: title, url: context.url },
+    type: "application/json",
+  };
+};
+"""
+
+resp = httpx.post(
+    browserless_url("/function"),
+    json={
+        "code": code,
+        "context": {"url": "https://example.com/"},
+    },
+    timeout=60.0,
+)
+resp.raise_for_status()
+result = resp.json()
+print(result["title"])
+```
+
+---
+
+### POST /unblock
+
+Bypass CAPTCHAs and bot detection. Returns only the data you request via boolean flags.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `url` | string | yes | Target URL to unblock |
+| `content` | boolean | no | Return full HTML content |
+| `cookies` | boolean | no | Return cookies set by the site |
+| `screenshot` | boolean | no | Return base64-encoded screenshot |
+| `browserWSEndpoint` | boolean | no | Return WebSocket endpoint for further automation |
+| `ttl` | number | no | Time-to-live in ms for browser session (with `browserWSEndpoint`) |
+
+**Note:** Append `&proxy=residential` to the query string for residential proxy support.
+
+**Response:** `application/json` with requested fields (unrequested fields are `null`).
+
+```python
+import httpx
+
+resp = httpx.post(
+    browserless_url("/unblock"),
+    json={
+        "url": "https://example.com/",
+        "content": True,
+        "cookies": True,
+    },
+    timeout=60.0,
+)
+resp.raise_for_status()
+data = resp.json()
+html = data.get("content")
+cookies = data.get("cookies")
+```
+
+---
+
+### POST /performance
+
+Run a Lighthouse audit for SEO, accessibility, and performance metrics.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `url` | string | yes | URL to audit |
+| `config` | object | no | Lighthouse configuration |
+
+**config object:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `extends` | string | Base config, typically `"lighthouse:default"` |
+| `settings` | object | Settings like `onlyCategories: ["performance", "accessibility"]` |
+
+**Response:** `application/json` with Lighthouse audit results.
+
+```python
+import httpx
+
+resp = httpx.post(
+    browserless_url("/performance"),
+    json={
+        "url": "https://example.com/",
+        "config": {
+            "extends": "lighthouse:default",
+            "settings": {
+                "onlyCategories": ["performance", "seo"],
+            },
+        },
+    },
+    timeout=120.0,
+)
+resp.raise_for_status()
+audits = resp.json()["data"]["audits"]
+for name, audit in audits.items():
+    if audit.get("score") is not None:
+        print(f"{audit['title']}: {audit['score']}")
+```
+
+---
+
+### POST /download
+
+Retrieve files that Chrome downloads during script execution.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| (body) | string | yes | JavaScript code (sent as `application/javascript`) |
+
+**Response:** Binary file data matching the downloaded file type.
+
+```python
+import httpx
+
+code = """
+export default async ({ page }) => {
+  await page.goto("https://example.com/download-page");
+  await page.click("#download-button");
+};
+"""
+
+resp = httpx.post(
+    browserless_url("/download"),
+    content=code.encode(),
+    headers={"Content-Type": "application/javascript"},
+    timeout=60.0,
+)
+resp.raise_for_status()
+with open("downloaded_file", "wb") as f:
+    f.write(resp.content)
+```
+
+## Shared Request Configuration
+
+These options work across `/content`, `/scrape`, `/screenshot`, and `/pdf` endpoints:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `gotoOptions` | object | `{"waitUntil": "networkidle2", "timeout": 30000}` |
+| `waitForSelector` | object | `{"selector": ".loaded", "visible": true, "timeout": 5000}` |
+| `waitForTimeout` | number | Milliseconds to wait before proceeding |
+| `waitForFunction` | object | `{"fn": "() => document.readyState === 'complete'", "timeout": 5000}` |
+| `waitForEvent` | object | `{"event": "myCustomEvent", "timeout": 5000}` |
+| `bestAttempt` | boolean | Continue processing even when async operations fail |
+| `rejectResourceTypes` | array | Block resource types: `["image", "stylesheet", "font", "media"]` |
+| `rejectRequestPattern` | array | Block requests matching regex patterns |
+
+### gotoOptions.waitUntil values
+
+| Value | Description |
+|-------|-------------|
+| `"load"` | Wait for the `load` event |
+| `"domcontentloaded"` | Wait for `DOMContentLoaded` event |
+| `"networkidle0"` | Wait until 0 network connections for 500ms |
+| `"networkidle2"` | Wait until 2 or fewer network connections for 500ms |
+
+## Error Handling
+
+```python
+import httpx
+
+def browserless_request(endpoint: str, payload: dict, timeout: float = 30.0) -> httpx.Response:
+    """Make a Browserless API request with error handling."""
+    try:
+        resp = httpx.post(
+            browserless_url(endpoint),
+            json=payload,
+            timeout=timeout,
+        )
+        resp.raise_for_status()
+        return resp
+    except httpx.TimeoutException:
+        raise RuntimeError(f"Browserless request to {endpoint} timed out after {timeout}s")
+    except httpx.HTTPStatusError as e:
+        status = e.response.status_code
+        if status == 401:
+            raise RuntimeError("Invalid or missing API token")
+        elif status == 429:
+            raise RuntimeError("Rate limit exceeded -- reduce concurrency or upgrade plan")
+        elif status == 500:
+            raise RuntimeError(f"Browserless server error: {e.response.text}")
+        else:
+            raise RuntimeError(f"Browserless API error {status}: {e.response.text}")
+```
+
+## Common Pitfalls
+
+- **Stateless sessions:** Each API call starts a fresh browser. Cookies, localStorage, and auth state do not persist between requests. Use `/unblock` with `cookies: true` to capture cookies, then pass them in subsequent requests.
+- **url vs html:** Never send both `url` and `html` in the same request -- pick one. The API will error or behave unexpectedly.
+- **Timeouts:** Default httpx timeout (5s) is too short for most browser operations. Set `timeout=30.0` or higher. For `/performance`, use `timeout=120.0`.
+- **Content-Type matters:** `/function` and `/download` can accept `application/javascript` (raw code) or `application/json` (with code + context). Make sure headers match.
+- **Bot detection:** If `/content` returns empty or incomplete HTML, switch to `/unblock` which handles CAPTCHAs and bot detection.
+- **Resource blocking:** Use `rejectResourceTypes: ["image", "stylesheet", "font"]` to speed up scraping when you only need text content.
+- **waitUntil:** Default `gotoOptions.waitUntil` may not wait for JS-rendered content. Use `"networkidle2"` or `waitForSelector` to ensure dynamic content has loaded.
+- **Binary responses:** `/screenshot`, `/pdf`, and `/download` return binary data. Use `resp.content` (not `resp.text`) and write in binary mode (`"wb"`).
+- **Token exposure:** The API token is in the URL query string. Never log full request URLs in production. Consider using environment variables: `TOKEN = os.environ["BROWSERLESS_TOKEN"]`.

--- a/content/calendly/docs/rest-api/python/DOC.md
+++ b/content/calendly/docs/rest-api/python/DOC.md
@@ -1,0 +1,276 @@
+---
+name: rest-api
+description: "Calendly - Scheduling & Availability API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-13"
+  source: community
+  tags: "calendly,scheduling,calendar,meetings,availability,events,invitees,webhooks,booking,api,integration"
+---
+
+# Calendly API v2
+
+> **Golden Rule:** Calendly has no official Python SDK. Use `httpx` for direct REST access. Auth uses Bearer token (Personal Access Token or OAuth 2.0). Resources are referenced by **full URIs** (not just UUIDs) in filter parameters. First call should always be `GET /users/me` to obtain your user URI and organization URI. Cursor-based pagination with `page_token`/`count` params.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+```
+https://api.calendly.com
+```
+
+## Authentication
+
+**Type:** Bearer Token (Personal Access Token or OAuth 2.0)
+
+```python
+import httpx
+
+TOKEN = "your-calendly-personal-access-token"
+BASE_URL = "https://api.calendly.com"
+
+headers = {
+    "Authorization": f"Bearer {TOKEN}",
+    "Content-Type": "application/json"
+}
+client = httpx.AsyncClient(headers=headers, timeout=30.0)
+```
+
+**Important:** Generate Personal Access Tokens from Calendly > Integrations > API & Webhooks. Use OAuth 2.0 for multi-user public apps.
+
+## Rate Limiting
+
+Not publicly documented with specific numbers. Monitor for HTTP 429 and respect `Retry-After` headers. Implement exponential backoff.
+
+## Methods
+
+### `get_current_user`
+
+**Endpoint:** `GET /users/me`
+
+Get the authenticated user's info. **Call this first** to obtain your user URI and organization URI needed for all other endpoints.
+
+**Returns:** JSON with `resource` containing `uri`, `name`, `email`, `timezone`, `current_organization`
+
+```python
+response = await client.get(f"{BASE_URL}/users/me")
+response.raise_for_status()
+user = response.json()["resource"]
+user_uri = user["uri"]  # "https://api.calendly.com/users/ABCDEF123"
+org_uri = user["current_organization"]  # needed for other endpoints
+```
+
+### `list_event_types`
+
+**Endpoint:** `GET /event_types`
+
+List event type configurations (e.g., "30 Minute Meeting"). These are templates, not scheduled bookings.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `user` | `str` | filter by user URI |
+| `organization` | `str` | filter by org URI |
+| `active` | `bool` | `None` (`true` or `false`) |
+| `count` | `int` | `20` (max 100) |
+| `page_token` | `str` | `None` |
+
+```python
+params = {"user": user_uri, "active": "true"}
+response = await client.get(f"{BASE_URL}/event_types", params=params)
+response.raise_for_status()
+data = response.json()
+event_types = data["collection"]
+```
+
+### `list_scheduled_events`
+
+**Endpoint:** `GET /scheduled_events`
+
+List actual scheduled events (bookings) with optional date range filters.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `user` | `str` | filter by user URI |
+| `organization` | `str` | filter by org URI |
+| `min_start_time` | `str` | `None` (ISO 8601) |
+| `max_start_time` | `str` | `None` (ISO 8601) |
+| `status` | `str` | `None` (`active` or `canceled`) |
+| `invitee_email` | `str` | `None` |
+| `sort` | `str` | `None` (e.g., `start_time:asc`) |
+| `count` | `int` | `20` (max 100) |
+| `page_token` | `str` | `None` |
+
+```python
+params = {
+    "user": user_uri,
+    "min_start_time": "2026-03-01T00:00:00Z",
+    "max_start_time": "2026-03-31T23:59:59Z",
+    "status": "active",
+    "sort": "start_time:asc"
+}
+response = await client.get(f"{BASE_URL}/scheduled_events", params=params)
+response.raise_for_status()
+data = response.json()
+events = data["collection"]
+
+# Paginate
+next_token = data["pagination"].get("next_page_token")
+while next_token:
+    params["page_token"] = next_token
+    response = await client.get(f"{BASE_URL}/scheduled_events", params=params)
+    response.raise_for_status()
+    data = response.json()
+    events.extend(data["collection"])
+    next_token = data["pagination"].get("next_page_token")
+```
+
+### `get_event_invitees`
+
+**Endpoint:** `GET /scheduled_events/{event_uuid}/invitees`
+
+List invitees for a specific scheduled event.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `status` | `str` | `None` (`active` or `canceled`) |
+| `email` | `str` | `None` |
+| `count` | `int` | `20` (max 100) |
+
+**Returns:** JSON collection with invitee `name`, `email`, `timezone`, `status`, `questions_and_answers`
+
+```python
+event_uuid = "EVT_UUID"
+response = await client.get(f"{BASE_URL}/scheduled_events/{event_uuid}/invitees")
+response.raise_for_status()
+invitees = response.json()["collection"]
+for invitee in invitees:
+    print(f"{invitee['name']} - {invitee['email']}")
+```
+
+### `cancel_event`
+
+**Endpoint:** `POST /scheduled_events/{event_uuid}/cancellation`
+
+Cancel a scheduled event.
+
+```python
+event_uuid = "EVT_UUID"
+payload = {"reason": "Schedule conflict"}
+response = await client.post(
+    f"{BASE_URL}/scheduled_events/{event_uuid}/cancellation",
+    json=payload
+)
+response.raise_for_status()
+```
+
+### `get_available_times`
+
+**Endpoint:** `GET /event_type_available_times`
+
+Get available time slots for an event type within a date range (max 1 month).
+
+| Parameter | Type | Default |
+|---|---|---|
+| `event_type` | `str` | **required** (event type URI) |
+| `start_time` | `str` | **required** (ISO 8601) |
+| `end_time` | `str` | **required** (ISO 8601, max 1 month from start) |
+
+```python
+params = {
+    "event_type": "https://api.calendly.com/event_types/EVTYPE_UUID",
+    "start_time": "2026-03-13T00:00:00Z",
+    "end_time": "2026-03-20T23:59:59Z"
+}
+response = await client.get(f"{BASE_URL}/event_type_available_times", params=params)
+response.raise_for_status()
+slots = response.json()["collection"]
+```
+
+### `get_busy_times`
+
+**Endpoint:** `GET /user_busy_times`
+
+Get a user's busy time blocks.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `user` | `str` | **required** (user URI) |
+| `start_time` | `str` | **required** (ISO 8601) |
+| `end_time` | `str` | **required** (ISO 8601) |
+
+```python
+params = {
+    "user": user_uri,
+    "start_time": "2026-03-13T00:00:00Z",
+    "end_time": "2026-03-20T23:59:59Z"
+}
+response = await client.get(f"{BASE_URL}/user_busy_times", params=params)
+response.raise_for_status()
+busy = response.json()["collection"]
+```
+
+### `create_webhook`
+
+**Endpoint:** `POST /webhook_subscriptions`
+
+Subscribe to event notifications. Requires Professional plan or above.
+
+```python
+payload = {
+    "url": "https://your-endpoint.com/webhook",
+    "events": ["invitee.created", "invitee.canceled"],
+    "scope": "user",
+    "organization": org_uri,
+    "user": user_uri
+}
+response = await client.post(f"{BASE_URL}/webhook_subscriptions", json=payload)
+response.raise_for_status()
+webhook = response.json()["resource"]
+```
+
+## Error Handling
+
+```python
+import httpx
+
+try:
+    response = await client.get(f"{BASE_URL}/scheduled_events", params=params)
+    response.raise_for_status()
+    data = response.json()
+except httpx.HTTPStatusError as e:
+    if e.response.status_code == 401:
+        print("Auth failed -- check Bearer token or refresh OAuth token")
+    elif e.response.status_code == 403:
+        print("Forbidden -- insufficient permissions or plan upgrade needed")
+    elif e.response.status_code == 422:
+        error = e.response.json()
+        print(f"Validation error: {error.get('message')} - {error.get('details')}")
+    elif e.response.status_code == 429:
+        print("Rate limited -- implement exponential backoff")
+    else:
+        print(f"Calendly error {e.response.status_code}: {e.response.text}")
+except httpx.RequestError as e:
+    print(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+- **Call `GET /users/me` first** -- you need the user URI and org URI for almost all other endpoints
+- Filter parameters expect **full resource URIs** (e.g., `https://api.calendly.com/users/UUID`), not just UUIDs
+- **Event types vs scheduled events**: Event types are templates ("30 min meeting"); scheduled events are actual bookings
+- Availability date range cannot exceed **1 month**
+- Maximum **100 results** per page; paginate with `page_token`
+- Timestamps must be **ISO 8601 in UTC** (e.g., `2026-03-13T10:00:00Z`)
+- Timezones use **IANA format** (e.g., `America/New_York`)
+- Reschedules trigger **two webhook events**: `invitee.canceled` (old) + `invitee.created` (new)
+- Webhooks require **Professional plan** or above
+- Webhook endpoint must respond with **2xx within 10 seconds**; 25 retries over 24 hours before auto-disable
+- Maximum **10 additional guests** per event
+- API v1 was deprecated August 27, 2025 -- use v2 only

--- a/content/canvas-lms/docs/rest-api/python/DOC.md
+++ b/content/canvas-lms/docs/rest-api/python/DOC.md
@@ -1,0 +1,405 @@
+---
+name: rest-api
+description: "Canvas LMS REST API - Learning management system for courses, assignments, grades, and enrollments"
+metadata:
+  languages: "python"
+  versions: "v1"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "canvas,lms,education,courses,assignments,grades,students,api"
+---
+
+# Canvas LMS REST API - Python Reference (httpx)
+
+## Golden Rule
+
+Canvas API requests go to **your institution's Canvas domain** (e.g., `https://yourschool.instructure.com`). Authentication uses an OAuth2 Bearer token in the `Authorization` header. All responses are JSON. Pagination uses `Link` headers with `rel="next"` -- always follow these rather than constructing page URLs manually. Default page size is 10 items; use `per_page` (max varies by endpoint) to increase.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+All examples use `httpx` with async/await. For scripts that need a synchronous entrypoint:
+
+```python
+import asyncio
+import httpx
+
+async def main():
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{BASE_URL}/api/v1/courses",
+            headers=HEADERS,
+            params={"per_page": 50},
+        )
+        print(resp.json())
+
+asyncio.run(main())
+```
+
+## Base URL
+
+```
+https://{your-canvas-domain}/api/v1
+```
+
+Examples:
+- `https://yourschool.instructure.com/api/v1`
+- `https://canvas.instructure.com/api/v1` (free-for-teacher accounts)
+
+```python
+import os
+
+ACCESS_TOKEN = os.environ["CANVAS_ACCESS_TOKEN"]
+BASE_URL = os.environ.get("CANVAS_BASE_URL", "https://yourschool.instructure.com")
+API_URL = f"{BASE_URL}/api/v1"
+HEADERS = {"Authorization": f"Bearer {ACCESS_TOKEN}"}
+```
+
+## Authentication
+
+Canvas uses **OAuth2 Bearer tokens**. Include the token in the `Authorization` header on every request:
+
+```
+Authorization: Bearer <ACCESS-TOKEN>
+```
+
+Tokens can be:
+- **Personal access tokens** -- generated in Canvas under Account > Settings > Approved Integrations
+- **OAuth2 tokens** -- obtained via the OAuth2 flow for third-party apps
+
+Never pass tokens as query parameters in production (supported but insecure).
+
+## Rate Limiting
+
+Canvas uses a token-bucket rate limiter. Each account gets a bucket of requests that refills over time. The response headers indicate your current quota:
+
+| Header | Meaning |
+|---|---|
+| `X-Rate-Limit-Remaining` | Requests remaining in the current bucket |
+| `X-Request-Cost` | Cost of the current request |
+
+When the bucket is empty, Canvas returns HTTP `403` with a `Retry-After` header.
+
+```python
+import asyncio
+
+async def canvas_request(
+    client: httpx.AsyncClient,
+    method: str,
+    path: str,
+    params: dict = None,
+    json_data: dict = None,
+    max_retries: int = 3,
+) -> httpx.Response:
+    for attempt in range(max_retries):
+        resp = await client.request(
+            method,
+            f"{API_URL}{path}",
+            headers=HEADERS,
+            params=params,
+            json=json_data,
+        )
+        if resp.status_code == 403 and "Rate Limit" in resp.text:
+            wait = float(resp.headers.get("Retry-After", 2 ** attempt))
+            await asyncio.sleep(wait)
+            continue
+        resp.raise_for_status()
+        return resp
+    raise Exception("Max retries exceeded due to rate limiting")
+```
+
+## Pagination
+
+Canvas uses **Link header pagination**. Responses include a `Link` header with URLs for `current`, `next`, `prev`, `first`, and `last` pages.
+
+```python
+import re
+
+async def paginate(client: httpx.AsyncClient, path: str, params: dict = None) -> list:
+    all_items = []
+    url = f"{API_URL}{path}"
+    request_params = {**(params or {}), "per_page": 100}
+
+    while url:
+        resp = await client.get(url, headers=HEADERS, params=request_params)
+        resp.raise_for_status()
+        all_items.extend(resp.json())
+
+        # After first request, params are encoded in the Link URL
+        request_params = None
+
+        # Parse Link header for next page
+        link_header = resp.headers.get("Link", "")
+        match = re.search(r'<([^>]+)>;\s*rel="next"', link_header)
+        url = match.group(1) if match else None
+
+    return all_items
+```
+
+## Methods
+
+### List Courses
+
+List courses for the authenticated user.
+
+**Parameters:**
+- `enrollment_type` (str) -- Filter by role: `teacher`, `student`, `ta`, `observer`, `designer`
+- `enrollment_state` (str) -- Filter by state: `active`, `invited_or_pending`, `completed`
+- `state[]` (str) -- Course state: `unpublished`, `available`, `completed`, `deleted`
+- `include[]` (str) -- Extra data: `total_students`, `teachers`, `term`, `course_image`
+- `per_page` (int) -- Results per page (default 10)
+
+```python
+async def list_courses(
+    client: httpx.AsyncClient,
+    enrollment_type: str = None,
+    enrollment_state: str = "active",
+    include: list[str] = None,
+) -> list:
+    params = {"enrollment_state": enrollment_state}
+    if enrollment_type:
+        params["enrollment_type"] = enrollment_type
+    if include:
+        params["include[]"] = include
+    return await paginate(client, "/courses", params)
+
+# Usage
+courses = await list_courses(client, enrollment_type="teacher", include=["total_students", "term"])
+for c in courses:
+    print(f"{c['id']}: {c['name']} ({c.get('total_students', '?')} students)")
+```
+
+### Get a Single Course
+
+```python
+async def get_course(client: httpx.AsyncClient, course_id: int, include: list[str] = None) -> dict:
+    params = {}
+    if include:
+        params["include[]"] = include
+    resp = await canvas_request(client, "GET", f"/courses/{course_id}", params=params)
+    return resp.json()
+```
+
+### List Assignments
+
+**Parameters:**
+- `search_term` (str) -- Partial match on assignment name
+- `bucket` (str) -- Filter by: `past`, `overdue`, `undated`, `ungraded`, `unsubmitted`, `upcoming`, `future`
+- `order_by` (str) -- `position`, `name`, `due_at`
+- `include[]` (str) -- `submission`, `assignment_visibility`, `all_dates`, `overrides`, `score_statistics`
+
+```python
+async def list_assignments(
+    client: httpx.AsyncClient,
+    course_id: int,
+    bucket: str = None,
+    search_term: str = None,
+    include: list[str] = None,
+) -> list:
+    params = {}
+    if bucket:
+        params["bucket"] = bucket
+    if search_term:
+        params["search_term"] = search_term
+    if include:
+        params["include[]"] = include
+    return await paginate(client, f"/courses/{course_id}/assignments", params)
+
+# Usage -- get upcoming assignments with submission status
+assignments = await list_assignments(client, 12345, bucket="upcoming", include=["submission"])
+for a in assignments:
+    print(f"{a['name']} -- due: {a.get('due_at', 'no date')}")
+```
+
+### Create an Assignment
+
+```python
+async def create_assignment(
+    client: httpx.AsyncClient,
+    course_id: int,
+    name: str,
+    points_possible: float = 0,
+    due_at: str = None,
+    submission_types: list[str] = None,
+    description: str = "",
+) -> dict:
+    payload = {
+        "assignment": {
+            "name": name,
+            "points_possible": points_possible,
+            "description": description,
+            "submission_types": submission_types or ["online_text_entry"],
+        }
+    }
+    if due_at:
+        payload["assignment"]["due_at"] = due_at  # ISO 8601 format
+    resp = await canvas_request(client, "POST", f"/courses/{course_id}/assignments", json_data=payload)
+    return resp.json()
+
+# Usage
+new_assignment = await create_assignment(
+    client, 12345,
+    name="Week 5 Essay",
+    points_possible=100,
+    due_at="2026-04-01T23:59:00Z",
+    submission_types=["online_upload", "online_text_entry"],
+)
+```
+
+### List Enrollments
+
+```python
+async def list_enrollments(
+    client: httpx.AsyncClient,
+    course_id: int,
+    enrollment_type: str = None,
+    state: str = "active",
+) -> list:
+    params = {"state[]": state}
+    if enrollment_type:
+        params["type[]"] = enrollment_type  # e.g., "StudentEnrollment", "TeacherEnrollment"
+    return await paginate(client, f"/courses/{course_id}/enrollments", params)
+
+# Usage -- list all active students
+students = await list_enrollments(client, 12345, enrollment_type="StudentEnrollment")
+for s in students:
+    print(f"{s['user']['name']} -- grade: {s.get('grades', {}).get('current_score', 'N/A')}")
+```
+
+### List Submissions for an Assignment
+
+```python
+async def list_submissions(
+    client: httpx.AsyncClient,
+    course_id: int,
+    assignment_id: int,
+    include: list[str] = None,
+) -> list:
+    params = {}
+    if include:
+        params["include[]"] = include  # e.g., ["user", "submission_comments"]
+    return await paginate(client, f"/courses/{course_id}/assignments/{assignment_id}/submissions", params)
+```
+
+### Update a Grade
+
+```python
+async def update_grade(
+    client: httpx.AsyncClient,
+    course_id: int,
+    assignment_id: int,
+    user_id: int,
+    grade: str,
+    comment: str = None,
+) -> dict:
+    payload = {"submission": {"posted_grade": grade}}
+    if comment:
+        payload["comment"] = {"text_comment": comment}
+    resp = await canvas_request(
+        client, "PUT",
+        f"/courses/{course_id}/assignments/{assignment_id}/submissions/{user_id}",
+        json_data=payload,
+    )
+    return resp.json()
+
+# Usage
+await update_grade(client, 12345, 67890, 11111, "85", comment="Good work!")
+```
+
+### List Users in a Course
+
+```python
+async def list_users(
+    client: httpx.AsyncClient,
+    course_id: int,
+    enrollment_type: str = None,
+    search_term: str = None,
+    include: list[str] = None,
+) -> list:
+    params = {}
+    if enrollment_type:
+        params["enrollment_type[]"] = enrollment_type
+    if search_term:
+        params["search_term"] = search_term
+    if include:
+        params["include[]"] = include  # e.g., ["email", "enrollments", "avatar_url"]
+    return await paginate(client, f"/courses/{course_id}/users", params)
+```
+
+### List Modules
+
+```python
+async def list_modules(client: httpx.AsyncClient, course_id: int) -> list:
+    return await paginate(client, f"/courses/{course_id}/modules")
+
+async def list_module_items(client: httpx.AsyncClient, course_id: int, module_id: int) -> list:
+    return await paginate(client, f"/courses/{course_id}/modules/{module_id}/items")
+```
+
+## Error Handling
+
+Canvas returns standard HTTP status codes with JSON error bodies.
+
+| Code | Meaning |
+|---|---|
+| 200 | Success |
+| 201 | Created |
+| 400 | Bad Request -- invalid parameters |
+| 401 | Unauthorized -- invalid or expired token |
+| 403 | Forbidden -- rate limited or insufficient permissions |
+| 404 | Not Found -- resource does not exist or user lacks access |
+| 422 | Unprocessable Entity -- validation error |
+| 500 | Internal Server Error |
+
+```python
+import httpx
+import logging
+
+logger = logging.getLogger(__name__)
+
+class CanvasAPIError(Exception):
+    def __init__(self, status_code: int, errors: list):
+        self.status_code = status_code
+        self.errors = errors
+        super().__init__(f"[{status_code}] {errors}")
+
+async def safe_canvas_request(
+    client: httpx.AsyncClient,
+    method: str,
+    path: str,
+    **kwargs,
+) -> dict:
+    try:
+        resp = await canvas_request(client, method, path, **kwargs)
+        return resp.json()
+    except httpx.HTTPStatusError as e:
+        body = e.response.json() if e.response.content else {}
+        errors = body.get("errors", [body.get("message", "Unknown error")])
+        raise CanvasAPIError(e.response.status_code, errors) from e
+```
+
+## Common Pitfalls
+
+1. **Pagination is mandatory.** Default page size is 10. If you do not follow `Link` headers, you will silently miss data. Always use a pagination helper.
+
+2. **Timestamps are UTC ISO 8601.** Canvas returns and expects `YYYY-MM-DDTHH:MM:SSZ`. Do not send local times without timezone info.
+
+3. **`include[]` parameters are arrays.** Pass them as repeated query parameters (`include[]=submission&include[]=user`) or as a list in httpx params.
+
+4. **Token scopes matter.** Personal tokens have full user permissions, but OAuth tokens are limited to requested scopes. A 401 may mean a scope issue, not an invalid token.
+
+5. **`per_page` has an unpublished maximum.** Instructure can change the max at any time. Request 100 and follow pagination rather than trying to get all results in one call.
+
+6. **SIS IDs require prefixes.** When using SIS IDs instead of Canvas IDs, prefix them: `sis_course_id:MATH101`, `sis_user_id:student42`.
+
+7. **Assignment `submission_types` is required for creation.** Omitting it causes a 422. Valid values include: `online_text_entry`, `online_url`, `online_upload`, `media_recording`, `none`.
+
+8. **Grades are strings.** The `posted_grade` field accepts strings like `"85"`, `"A-"`, `"pass"`, or `"incomplete"`.
+
+9. **Deleted items may still appear.** Use `state[]` filters or check the `workflow_state` field to exclude deleted or unpublished items.
+
+10. **Rate limit cost varies by endpoint.** Listing operations cost more than single-resource GETs. Monitor `X-Request-Cost` headers and batch wisely.

--- a/content/cashfree/docs/rest-api/python/DOC.md
+++ b/content/cashfree/docs/rest-api/python/DOC.md
@@ -1,0 +1,247 @@
+---
+name: rest-api
+description: "Cashfree Payments - Indian Payment Gateway & Payouts API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-13"
+  source: community
+  tags: "cashfree,payments,india,upi,payment-gateway,payouts,refunds,orders,api,integration"
+---
+
+# Cashfree Payments API
+
+> **Golden Rule:** Cashfree has an official Python SDK (`cashfree-pg` on PyPI), but you can also use `httpx` for direct REST API access. Auth uses `x-client-id` and `x-client-secret` headers. The `x-api-version` header is required on every request. PG and Payouts use separate credentials.
+
+## Installation
+
+```bash
+pip install httpx
+# Or use the official SDK: pip install cashfree-pg
+```
+
+## Base URL
+
+| Environment | Payment Gateway | Payouts |
+|---|---|---|
+| Production | `https://api.cashfree.com/pg` | `https://payout-api.cashfree.com/payout` |
+| Sandbox | `https://sandbox.cashfree.com/pg` | `https://payout-gamma.cashfree.com/payout` |
+
+## Authentication
+
+**Type:** Client ID + Secret (custom headers)
+
+```python
+import httpx
+
+CLIENT_ID = "your-cashfree-app-id"
+CLIENT_SECRET = "your-cashfree-secret-key"
+BASE_URL = "https://sandbox.cashfree.com/pg"  # Use sandbox for testing
+
+headers = {
+    "x-client-id": CLIENT_ID,
+    "x-client-secret": CLIENT_SECRET,
+    "x-api-version": "2025-01-01",
+    "Content-Type": "application/json"
+}
+client = httpx.AsyncClient(headers=headers)
+```
+
+**Important:** Never expose `x-client-secret` in client-side code. Server-to-server only.
+
+## Rate Limiting
+
+Per-account, per-IP, per-minute limits (viewable in dashboard). Response headers: `x-ratelimit-limit`, `x-ratelimit-remaining`. HTTP 429 blocks requests for up to one minute.
+
+## Methods
+
+### `create_order`
+
+**Endpoint:** `POST /orders`
+
+Create a payment order. Returns a `payment_session_id` for client-side payment flow.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `order_amount` | `float` | **required** |
+| `order_currency` | `str` | **required** (`INR`) |
+| `customer_details.customer_id` | `str` | **required** |
+| `customer_details.customer_phone` | `str` | **required** |
+| `customer_details.customer_email` | `str` | `None` |
+| `order_meta.return_url` | `str` | `None` |
+
+**Returns:** JSON with `cf_order_id`, `order_id`, `order_status`, `payment_session_id`
+
+```python
+payload = {
+    "order_amount": 100.00,
+    "order_currency": "INR",
+    "customer_details": {
+        "customer_id": "cust_123",
+        "customer_phone": "9876543210",
+        "customer_email": "customer@example.com"
+    },
+    "order_meta": {
+        "return_url": "https://yoursite.com/return?order_id={order_id}"
+    }
+}
+response = await client.post(f"{BASE_URL}/orders", json=payload)
+response.raise_for_status()
+order = response.json()
+session_id = order["payment_session_id"]
+```
+
+### `get_order`
+
+**Endpoint:** `GET /orders/{order_id}`
+
+Retrieve order details and status.
+
+**Returns:** JSON with order details. Statuses: `ACTIVE`, `PAID`, `EXPIRED`, `TERMINATED`
+
+```python
+order_id = "order_123"
+response = await client.get(f"{BASE_URL}/orders/{order_id}")
+response.raise_for_status()
+order = response.json()
+status = order["order_status"]
+```
+
+### `get_payments_for_order`
+
+**Endpoint:** `GET /orders/{order_id}/payments`
+
+List all payment attempts for an order.
+
+```python
+response = await client.get(f"{BASE_URL}/orders/{order_id}/payments")
+response.raise_for_status()
+payments = response.json()
+```
+
+### `create_refund`
+
+**Endpoint:** `POST /orders/{order_id}/refunds`
+
+Initiate a refund for a paid order.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `refund_amount` | `float` | **required** |
+| `refund_id` | `str` | **required** (3-40 alphanumeric chars) |
+| `refund_note` | `str` | `None` |
+| `refund_speed` | `str` | `STANDARD` (or `INSTANT`) |
+
+**Returns:** JSON with `cf_refund_id`, `refund_status`. Statuses: `SUCCESS`, `PENDING`, `CANCELLED`, `FAILED`
+
+```python
+payload = {
+    "refund_amount": 50.00,
+    "refund_id": "refund_abc123",
+    "refund_note": "Customer requested refund",
+    "refund_speed": "STANDARD"
+}
+response = await client.post(f"{BASE_URL}/orders/{order_id}/refunds", json=payload)
+response.raise_for_status()
+refund = response.json()
+```
+
+### `create_payment_link`
+
+**Endpoint:** `POST /links`
+
+Generate a shareable payment link.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `link_amount` | `float` | **required** |
+| `link_currency` | `str` | **required** (`INR`) |
+| `link_purpose` | `str` | **required** |
+| `customer_details.customer_phone` | `str` | **required** |
+| `link_expiry_time` | `str` | `None` (ISO 8601 with timezone) |
+
+**Returns:** JSON with `link_url`, `cf_link_id`, `link_status`
+
+```python
+payload = {
+    "link_amount": 500.00,
+    "link_currency": "INR",
+    "link_purpose": "Monthly subscription",
+    "customer_details": {
+        "customer_phone": "9876543210",
+        "customer_name": "Jane Doe"
+    },
+    "link_expiry_time": "2024-12-31T23:59:59+05:30"
+}
+response = await client.post(f"{BASE_URL}/links", json=payload)
+response.raise_for_status()
+link = response.json()
+payment_url = link["link_url"]
+```
+
+### `create_payout`
+
+**Endpoint:** `POST /v2/transfers` (on Payouts base URL)
+
+Transfer funds to bank account, UPI, or card. Uses separate Payouts credentials.
+
+```python
+PAYOUT_URL = "https://payout-api.cashfree.com/payout"
+payout_headers = {
+    "x-client-id": "your-payout-app-id",
+    "x-client-secret": "your-payout-secret",
+    "x-api-version": "2025-01-01",
+    "Content-Type": "application/json"
+}
+payload = {
+    "transfer_id": "txn_001",
+    "transfer_amount": 1000.00,
+    "transfer_currency": "INR",
+    "beneficiary_details": {
+        "beneficiary_id": "ben_123",
+        "transfer_mode": "upi",
+        "beneficiary_vpa": "user@upi"
+    }
+}
+response = await client.post(
+    f"{PAYOUT_URL}/v2/transfers", json=payload, headers=payout_headers
+)
+response.raise_for_status()
+```
+
+## Error Handling
+
+```python
+import httpx
+
+try:
+    response = await client.post(f"{BASE_URL}/orders", json=payload)
+    response.raise_for_status()
+    data = response.json()
+except httpx.HTTPStatusError as e:
+    if e.response.status_code == 401:
+        print("Auth failed -- check x-client-id and x-client-secret")
+    elif e.response.status_code == 429:
+        print("Rate limited -- blocked for up to 1 minute")
+    elif e.response.status_code == 409:
+        print("Duplicate operation -- use x-idempotency-key header")
+    else:
+        error = e.response.json()
+        print(f"Cashfree error: {error.get('message')} ({error.get('code')})")
+except httpx.RequestError as e:
+    print(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+- `x-api-version` header is **required** on every request (current: `2025-01-01`)
+- PG and Payouts use **different** API credentials -- don't mix them
+- Never expose `x-client-secret` in client-side/frontend code
+- Use `x-idempotency-key` header on create operations to prevent duplicates on retries
+- Use sandbox URLs for testing -- no real money is moved
+- Order amounts are in INR by default; use `order_currency` for international
+- `return_url` supports `{order_id}` placeholder which Cashfree replaces automatically
+- Check `x-ratelimit-remaining` response header to avoid hitting rate limits
+- Refund `refund_id` must be 3-40 alphanumeric characters
+- Set a reasonable timeout: `httpx.AsyncClient(timeout=30.0)`

--- a/content/cerebras/docs/rest-api/python/DOC.md
+++ b/content/cerebras/docs/rest-api/python/DOC.md
@@ -1,0 +1,382 @@
+---
+name: rest-api
+description: "Cerebras - Ultra-Fast LLM Inference API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "cerebras,inference,llm,fast-inference,chat,completions,ai,api"
+---
+
+# Cerebras Inference REST API (Python / httpx)
+
+## Golden Rule
+
+Cerebras provides an **OpenAI-compatible** REST API running on custom Wafer-Scale Engine hardware, delivering inference speeds of 2,000-3,000+ tokens/sec. The API surface mirrors OpenAI's Chat Completions format, so if you know the OpenAI API, you already know this one. Use `httpx` (async) for all HTTP calls. Always stream responses for the best latency experience. Never hardcode your API key; use environment variables.
+
+---
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+No Cerebras SDK is required. The REST API is fully accessible with any HTTP client. We use `httpx` for its native async/streaming support.
+
+---
+
+## Base URL
+
+```
+https://api.cerebras.ai/v1
+```
+
+All endpoints are relative to this base.
+
+---
+
+## Authentication
+
+Cerebras uses Bearer token authentication via an API key.
+
+1. Sign up at [https://cloud.cerebras.ai](https://cloud.cerebras.ai)
+2. Navigate to **API Keys** and create a new key
+3. Export it as an environment variable:
+
+```bash
+export CEREBRAS_API_KEY="csk-your-key-here"
+```
+
+Every request must include the header:
+
+```
+Authorization: Bearer <CEREBRAS_API_KEY>
+```
+
+---
+
+## Available Models
+
+| Model | Speed | Input Price | Output Price | Notes |
+|---|---|---|---|---|
+| `llama3.1-8b` | ~2,200 tok/s | $0.10/M | $0.10/M | Fast, lightweight |
+| `gpt-oss-120b` | ~3,000 tok/s | $0.35/M | $0.75/M | Strong general-purpose |
+| `qwen-3-235b-a22b-instruct-2507` | ~1,400 tok/s | $0.60/M | $1.20/M | Preview |
+| `zai-glm-4.7` | ~1,000 tok/s | $2.25/M | $2.75/M | Preview, reasoning support |
+
+Use the `/v1/models` endpoint to fetch the current list programmatically.
+
+---
+
+## Rate Limiting
+
+Rate limits are applied at the **organization level** (not per-user) using a **token bucket algorithm** that continuously replenishes quota.
+
+### Free Tier
+
+| Model | TPM | RPM | TPH | RPH | TPD | RPD |
+|---|---|---|---|---|---|---|
+| `gpt-oss-120b` | 64K | 30 | 1M | 900 | 1M | 14.4K |
+| `llama3.1-8b` | 60K | 30 | 1M | 900 | 1M | 14.4K |
+| `qwen-3-235b-a22b-instruct-2507` | 60K | 30 | 1M | 900 | 1M | 14.4K |
+| `zai-glm-4.7` | 60K | 10 | 1M | 100 | 1M | 100 |
+
+### PayGo (Developer) Tier
+
+| Model | TPM | RPM |
+|---|---|---|
+| `gpt-oss-120b` | 1M | 1K |
+| `llama3.1-8b` | 2M | 2K |
+| `qwen-3-235b-a22b-instruct-2507` | 250K | 250 |
+| `zai-glm-4.7` | 500K | 500 |
+
+When a rate limit is hit, the API returns HTTP `429`. Requests are pre-rejected if the estimated token consumption exceeds available quota. Response headers provide real-time usage visibility.
+
+---
+
+## Methods
+
+### Chat Completions (Non-Streaming)
+
+**POST** `/v1/chat/completions`
+
+```python
+import httpx
+import os
+
+CEREBRAS_API_KEY = os.environ["CEREBRAS_API_KEY"]
+BASE_URL = "https://api.cerebras.ai/v1"
+
+async def chat_completion():
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{BASE_URL}/chat/completions",
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {CEREBRAS_API_KEY}",
+            },
+            json={
+                "model": "llama3.1-8b",
+                "messages": [
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": "Explain quantum computing in two sentences."},
+                ],
+                "temperature": 0.7,
+                "max_completion_tokens": 256,
+                "top_p": 1.0,
+            },
+            timeout=60.0,
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        content = data["choices"][0]["message"]["content"]
+        usage = data["usage"]
+        time_info = data["time_info"]
+
+        print(f"Response: {content}")
+        print(f"Tokens: {usage['prompt_tokens']} in, {usage['completion_tokens']} out")
+        print(f"Total time: {time_info['total_time']:.3f}s")
+        return data
+```
+
+#### Response Shape
+
+```json
+{
+  "id": "chatcmpl-...",
+  "object": "chat.completion",
+  "created": 1710000000,
+  "model": "llama3.1-8b",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "..."
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 25,
+    "completion_tokens": 48,
+    "total_tokens": 73
+  },
+  "time_info": {
+    "queue_time": 0.001,
+    "prompt_time": 0.005,
+    "completion_time": 0.018,
+    "total_time": 0.024,
+    "created": 1710000000
+  }
+}
+```
+
+#### Request Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `model` | string | Yes | Model ID (e.g., `llama3.1-8b`, `gpt-oss-120b`) |
+| `messages` | array | Yes | Conversation messages (`role` + `content`) |
+| `temperature` | float | No | Randomness 0-1.5 (default model-dependent) |
+| `top_p` | float | No | Nucleus sampling (alternative to temperature) |
+| `max_completion_tokens` | int | No | Max tokens in the response |
+| `stream` | bool | No | Enable streaming (default `false`) |
+| `seed` | int | No | For deterministic output attempts |
+| `stop` | array | No | Up to 4 stop sequences |
+| `response_format` | object | No | `text` (default), `json_schema`, or `json_object` |
+| `tools` | array | No | Function/tool definitions |
+| `tool_choice` | string/object | No | `none`, `auto`, `required`, or specific function |
+| `reasoning_effort` | string | No | `low`, `medium`, `high` (`gpt-oss-120b` only) |
+| `logprobs` | bool | No | Return token log probabilities |
+| `top_logprobs` | int | No | 0-20 most likely tokens per position |
+| `user` | string | No | End-user identifier for abuse monitoring |
+
+---
+
+### Chat Completions (Streaming)
+
+Set `"stream": true` to receive Server-Sent Events (SSE). The `usage` and `time_info` fields are included only in the **final chunk**.
+
+```python
+import httpx
+import os
+import json
+
+CEREBRAS_API_KEY = os.environ["CEREBRAS_API_KEY"]
+BASE_URL = "https://api.cerebras.ai/v1"
+
+async def chat_completion_stream():
+    async with httpx.AsyncClient() as client:
+        async with client.stream(
+            "POST",
+            f"{BASE_URL}/chat/completions",
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {CEREBRAS_API_KEY}",
+            },
+            json={
+                "model": "llama3.1-8b",
+                "messages": [
+                    {"role": "user", "content": "Write a haiku about fast inference."},
+                ],
+                "stream": True,
+                "temperature": 0.7,
+                "max_completion_tokens": 128,
+            },
+            timeout=60.0,
+        ) as response:
+            response.raise_for_status()
+            async for line in response.aiter_lines():
+                if not line or not line.startswith("data: "):
+                    continue
+                payload = line.removeprefix("data: ")
+                if payload.strip() == "[DONE]":
+                    break
+                chunk = json.loads(payload)
+                delta = chunk["choices"][0].get("delta", {})
+                content = delta.get("content", "")
+                if content:
+                    print(content, end="", flush=True)
+            print()  # newline at end
+```
+
+---
+
+### List Models
+
+**GET** `/v1/models`
+
+```python
+import httpx
+import os
+
+CEREBRAS_API_KEY = os.environ["CEREBRAS_API_KEY"]
+BASE_URL = "https://api.cerebras.ai/v1"
+
+async def list_models():
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{BASE_URL}/models",
+            headers={"Authorization": f"Bearer {CEREBRAS_API_KEY}"},
+            timeout=30.0,
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        for model in data["data"]:
+            print(f"{model['id']} (owned by {model['owned_by']})")
+        return data
+```
+
+#### Response Shape
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "llama3.1-8b",
+      "object": "model",
+      "created": 1721692800,
+      "owned_by": "Meta"
+    }
+  ]
+}
+```
+
+---
+
+## Error Handling
+
+The API returns standard HTTP status codes. Implement retry logic with exponential backoff for transient errors.
+
+| HTTP Status | Error Type | Description |
+|---|---|---|
+| 400 | BadRequestError | Malformed request or invalid parameters |
+| 401 | AuthenticationError | Missing or invalid API key |
+| 402 | PaymentRequired | Billing issue on your account |
+| 403 | PermissionDeniedError | Insufficient permissions |
+| 404 | NotFoundError | Invalid endpoint or model not found |
+| 422 | UnprocessableEntityError | Valid JSON but semantically invalid |
+| 429 | RateLimitError | Rate limit exceeded; back off and retry |
+| 500 | InternalServerError | Server-side issue; retry with backoff |
+| 503 | ServiceUnavailable | Temporary overload; retry with backoff |
+
+### Retry-Eligible Errors
+
+Automatically retry these with exponential backoff: `408`, `429`, `500+`, and connection errors.
+
+```python
+import httpx
+import os
+import json
+import asyncio
+
+CEREBRAS_API_KEY = os.environ["CEREBRAS_API_KEY"]
+BASE_URL = "https://api.cerebras.ai/v1"
+
+async def chat_with_retries(messages: list, max_retries: int = 3):
+    """Chat completion with exponential backoff retry."""
+    async with httpx.AsyncClient() as client:
+        for attempt in range(max_retries + 1):
+            try:
+                response = await client.post(
+                    f"{BASE_URL}/chat/completions",
+                    headers={
+                        "Content-Type": "application/json",
+                        "Authorization": f"Bearer {CEREBRAS_API_KEY}",
+                    },
+                    json={
+                        "model": "llama3.1-8b",
+                        "messages": messages,
+                        "temperature": 0,
+                    },
+                    timeout=60.0,
+                )
+                response.raise_for_status()
+                return response.json()
+
+            except httpx.HTTPStatusError as e:
+                status = e.response.status_code
+                if status in (429, 500, 502, 503) and attempt < max_retries:
+                    wait = 2 ** attempt  # 1s, 2s, 4s
+                    print(f"HTTP {status}, retrying in {wait}s...")
+                    await asyncio.sleep(wait)
+                    continue
+                raise
+            except httpx.ConnectError:
+                if attempt < max_retries:
+                    wait = 2 ** attempt
+                    await asyncio.sleep(wait)
+                    continue
+                raise
+```
+
+---
+
+## Common Pitfalls
+
+1. **Using `requests` instead of `httpx`** -- The `requests` library has no native async or streaming support. Always use `httpx` with `AsyncClient` for non-blocking I/O and `client.stream()` for SSE consumption.
+
+2. **Not streaming by default** -- Cerebras delivers tokens at 2,000-3,000+ tok/s. If you wait for the full response, you add unnecessary latency. Always set `"stream": true` for user-facing applications.
+
+3. **Ignoring `time_info`** -- Unlike OpenAI, Cerebras returns a `time_info` object with `queue_time`, `prompt_time`, `completion_time`, and `total_time`. Use these to monitor performance and detect queue congestion.
+
+4. **Hardcoding the API key** -- Never embed `csk-...` keys in source code. Use `os.environ["CEREBRAS_API_KEY"]` or a secrets manager.
+
+5. **Not handling SSE `[DONE]` sentinel** -- The stream terminates with `data: [DONE]`. If you try to JSON-parse this, you will get an error. Always check for it before parsing.
+
+6. **Assuming OpenAI parity for all features** -- While the API is OpenAI-compatible, not all OpenAI features are supported (e.g., vision, embeddings, fine-tuning endpoints). Check the models endpoint for current capabilities.
+
+7. **Confusing `max_tokens` with `max_completion_tokens`** -- Cerebras uses `max_completion_tokens` (matching newer OpenAI convention). Using the old `max_tokens` parameter may not work as expected.
+
+8. **Ignoring organization-level rate limits** -- Rate limits are per-organization, not per-key. Multiple services sharing one org will share the same token and request budgets.
+
+9. **Not setting timeouts** -- The default `httpx` timeout may be too short or too long. Set explicit `timeout=60.0` to match the API's default behavior and avoid hanging requests.
+
+10. **Free tier `zai-glm-4.7` limits** -- This model has significantly lower free-tier RPM/RPH/RPD limits (10/100/100) compared to other models. Plan your usage accordingly.

--- a/content/chargebee/docs/rest-api/python/DOC.md
+++ b/content/chargebee/docs/rest-api/python/DOC.md
@@ -1,0 +1,298 @@
+---
+name: rest-api
+description: "Chargebee - Subscription Billing & Revenue Management REST API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "chargebee,billing,subscriptions,invoicing,revenue,saas,api"
+---
+
+# Chargebee REST API - Python (httpx) Coding Guidelines
+
+You are a Chargebee REST API coding expert. Help me interact with the Chargebee subscription billing platform using direct HTTP calls via `httpx` (async). Chargebee manages subscriptions, customers, invoices, payment sources, and hosted checkout pages for SaaS and recurring billing businesses.
+
+Official API reference: https://apidocs.chargebee.com/docs/api
+
+## Golden Rule: Use httpx for All HTTP Calls
+
+Always use the `httpx` async client for direct REST API interactions with Chargebee. Do NOT use `requests` or the `chargebee` Python SDK.
+
+**Library:** `httpx`
+**Installation:** `pip install httpx`
+
+## API Fundamentals
+
+- **Base URL:** `https://{site}.chargebee.com/api/v2` (replace `{site}` with your Chargebee site name)
+- **Authentication:** HTTP Basic Auth with your API key as the username and an empty password
+- **Request Format:** Form-encoded (`application/x-www-form-urlencoded`) for write operations
+- **Response Format:** JSON
+- **HTTP Methods:** GET for reads, POST for writes (create, update, delete actions)
+- **Pagination:** Cursor-based using `offset` returned in responses; pass as query param for next page
+- **List Limits:** Use `limit` param (default 10, max 100)
+- **Timestamps:** Unix epoch seconds
+- **Amounts:** In the smallest currency unit (cents for USD, pence for GBP)
+
+### Important: Form-Encoded Requests
+
+Chargebee uses form-encoded request bodies (not JSON). For nested objects, use bracket notation:
+- `customer[first_name]=John`
+- `subscription_items[item_price_id][0]=premium-monthly`
+
+## Authentication and Client Setup
+
+```python
+import httpx, os
+from contextlib import asynccontextmanager
+
+@asynccontextmanager
+async def chargebee_client():
+    site = os.environ["CHARGEBEE_SITE"]
+    async with httpx.AsyncClient(
+        base_url=f"https://{site}.chargebee.com/api/v2",
+        auth=(os.environ["CHARGEBEE_API_KEY"], ""),
+        timeout=30.0,
+    ) as client:
+        yield client
+```
+
+## Subscriptions API
+
+Subscriptions are the core billing entity in Chargebee.
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/subscriptions/create_with_items` | Create with item-based model |
+| GET | `/subscriptions/{sub_id}` | Retrieve a subscription |
+| GET | `/subscriptions` | List subscriptions |
+| POST | `/subscriptions/{sub_id}/cancel_for_items` | Cancel item-based subscription |
+| POST | `/subscriptions/{sub_id}/pause` | Pause a subscription |
+| POST | `/subscriptions/{sub_id}/resume` | Resume a paused subscription |
+
+Statuses: `future`, `in_trial`, `active`, `non_renewing`, `paused`, `cancelled`, `transferred`
+
+### Create Subscription (Item-Based Model)
+
+```python
+async def create_subscription(customer_id: str, item_price_id: str, quantity: int = 1) -> dict:
+    data = {
+        "customer_id": customer_id,
+        "subscription_items[item_price_id][0]": item_price_id,
+        "subscription_items[quantity][0]": str(quantity),
+    }
+    async with chargebee_client() as client:
+        resp = await client.post("/subscriptions/create_with_items", data=data)
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### List Subscriptions with Filtering
+
+```python
+async def list_subscriptions(status: str | None = None, limit: int = 10, offset: str | None = None) -> dict:
+    params: dict = {"limit": limit}
+    if status:
+        params["status[is]"] = status
+    if offset:
+        params["offset"] = offset
+    async with chargebee_client() as client:
+        resp = await client.get("/subscriptions", params=params)
+        resp.raise_for_status()
+        return resp.json()
+# Response: {"list": [{"subscription": {...}, "customer": {...}}, ...], "next_offset": "..."}
+```
+
+### Cancel Subscription
+
+```python
+async def cancel_subscription(subscription_id: str, end_of_term: bool = True) -> dict:
+    data = {"end_of_term": str(end_of_term).lower()}
+    async with chargebee_client() as client:
+        resp = await client.post(f"/subscriptions/{subscription_id}/cancel_for_items", data=data)
+        resp.raise_for_status()
+        return resp.json()
+```
+
+## Customers API
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/customers` | Create a customer |
+| GET | `/customers/{cust_id}` | Retrieve a customer |
+| GET | `/customers` | List customers |
+| POST | `/customers/{cust_id}` | Update a customer |
+| POST | `/customers/{cust_id}/delete` | Delete a customer |
+
+Key attributes: `id`, `first_name`, `last_name`, `email`, `phone`, `company`, `auto_collection` (on/off), `net_term_days`, `taxability`, `meta_data` (custom JSON).
+
+### Create Customer
+
+```python
+async def create_customer(first_name: str, last_name: str, email: str, **extra) -> dict:
+    import json
+    data = {"first_name": first_name, "last_name": last_name, "email": email}
+    if "meta_data" in extra:
+        extra["meta_data"] = json.dumps(extra["meta_data"])
+    data.update({k: str(v) for k, v in extra.items()})
+    async with chargebee_client() as client:
+        resp = await client.post("/customers", data=data)
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### List Customers
+
+```python
+async def list_customers(email: str | None = None, limit: int = 10, offset: str | None = None) -> dict:
+    params: dict = {"limit": limit}
+    if email:
+        params["email[is]"] = email
+    if offset:
+        params["offset"] = offset
+    async with chargebee_client() as client:
+        resp = await client.get("/customers", params=params)
+        resp.raise_for_status()
+        return resp.json()
+```
+
+## Invoices API
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/invoices` | Create an invoice |
+| GET | `/invoices/{inv_id}` | Retrieve an invoice |
+| GET | `/invoices` | List invoices |
+| POST | `/invoices/{inv_id}/collect_payment` | Collect payment |
+| POST | `/invoices/{inv_id}/void` | Void an invoice |
+
+Statuses: `pending`, `paid`, `posted`, `payment_due`, `not_paid`, `voided`
+
+### Create One-Time Invoice
+
+```python
+async def create_invoice(customer_id: str, charges: list[dict], currency_code: str = "USD") -> dict:
+    data: dict = {"customer_id": customer_id, "currency_code": currency_code}
+    for i, charge in enumerate(charges):
+        data[f"charges[amount][{i}]"] = str(charge["amount"])
+        data[f"charges[description][{i}]"] = charge["description"]
+    async with chargebee_client() as client:
+        resp = await client.post("/invoices", data=data)
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### List Invoices
+
+```python
+async def list_invoices(customer_id: str | None = None, status: str | None = None, limit: int = 10, offset: str | None = None) -> dict:
+    params: dict = {"limit": limit}
+    if customer_id:
+        params["customer_id[is]"] = customer_id
+    if status:
+        params["status[is]"] = status
+    if offset:
+        params["offset"] = offset
+    async with chargebee_client() as client:
+        resp = await client.get("/invoices", params=params)
+        resp.raise_for_status()
+        return resp.json()
+```
+
+## Error Handling
+
+| Status | Meaning |
+|--------|---------|
+| 200 | Success |
+| 400 | Bad request / validation error |
+| 401 | Authentication failure |
+| 404 | Resource not found |
+| 409 | Conflict (duplicate ID, concurrent update) |
+| 429 | Rate limited |
+| 500 | Internal server error |
+
+Error response: `{"message": "...", "type": "invalid_request", "api_error_code": "resource_not_found", "param": "subscription_id", "http_status_code": 404}`
+
+```python
+import asyncio
+
+class ChargebeeAPIError(Exception):
+    def __init__(self, status_code: int, error_type: str, api_error_code: str, message: str, param: str | None = None):
+        self.status_code = status_code
+        self.error_type = error_type
+        self.api_error_code = api_error_code
+        self.param = param
+        super().__init__(f"[{status_code}] {api_error_code}: {message}")
+
+async def chargebee_request(method: str, endpoint: str, data: dict | None = None, params: dict | None = None, max_retries: int = 3) -> dict:
+    """Make an authenticated Chargebee API request with error handling and retry."""
+    async with chargebee_client() as client:
+        for attempt in range(max_retries):
+            try:
+                resp = await client.request(method, endpoint, data=data, params=params)
+                resp.raise_for_status()
+                return resp.json()
+            except httpx.HTTPStatusError as e:
+                body = e.response.json() if e.response.content else {}
+                if e.response.status_code == 429 and attempt < max_retries - 1:
+                    await asyncio.sleep(2 ** attempt)
+                    continue
+                if e.response.status_code >= 500 and attempt < max_retries - 1:
+                    await asyncio.sleep(1)
+                    continue
+                raise ChargebeeAPIError(
+                    status_code=e.response.status_code,
+                    error_type=body.get("type", "unknown"),
+                    api_error_code=body.get("api_error_code", "unknown"),
+                    message=body.get("message", str(e)),
+                    param=body.get("param"),
+                ) from e
+    raise RuntimeError("Max retries exceeded")
+```
+
+## Pagination Helper
+
+```python
+async def paginate_chargebee(endpoint: str, params: dict | None = None, max_pages: int = 10) -> list[dict]:
+    """Auto-paginate through Chargebee list endpoints."""
+    all_items = []
+    current_params = dict(params or {})
+    current_params.setdefault("limit", 100)
+    for _ in range(max_pages):
+        result = await chargebee_request("GET", endpoint, params=current_params)
+        items = result.get("list", [])
+        all_items.extend(items)
+        next_offset = result.get("next_offset")
+        if not next_offset or not items:
+            break
+        current_params["offset"] = next_offset
+    return all_items
+```
+
+## Filter Operators
+
+Chargebee supports rich filtering on list endpoints using bracket notation:
+
+| Operator | Syntax | Example |
+|----------|--------|---------|
+| is | `field[is]=value` | `status[is]=active` |
+| is_not | `field[is_not]=value` | `status[is_not]=cancelled` |
+| in | `field[in]=[val1,val2]` | `status[in]=["active","in_trial"]` |
+| starts_with | `field[starts_with]=prefix` | `email[starts_with]=john` |
+| between | `field[between]=[start,end]` | `created_at[between]=[1704067200,1706745600]` |
+| after / before | `field[after]=value` | `created_at[after]=1704067200` |
+
+## Common Pitfalls
+
+1. **Form-encoded, not JSON.** POST requests use `application/x-www-form-urlencoded`, not JSON. Use `data=` not `json=` in httpx.
+2. **Bracket notation for nested params.** Use `subscription_items[item_price_id][0]` for array/nested fields.
+3. **Amounts in smallest unit.** 50000 cents = $500.00 USD.
+4. **Timestamps are Unix seconds.** Not milliseconds.
+5. **Cursor pagination.** Use `offset` from previous response, not page numbers.
+
+## Useful Links
+
+- **API Reference:** https://apidocs.chargebee.com/docs/api
+- **Webhook Events:** https://apidocs.chargebee.com/docs/api/events
+- **Test Environment:** Use your test site at `{site}-test.chargebee.com`

--- a/content/charity-navigator/docs/rest-api/python/DOC.md
+++ b/content/charity-navigator/docs/rest-api/python/DOC.md
@@ -1,0 +1,388 @@
+---
+name: rest-api
+description: "Charity Navigator - US charity ratings, research data, and nonprofit organization profiles API."
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "charity-navigator,charity,ratings,nonprofit,usa,api"
+---
+
+# Charity Navigator REST API v2 - Python Reference (httpx)
+
+## Golden Rule
+
+Authentication uses **two query parameters** on every request: `app_id` and `app_key`, obtained from the developer portal at https://developer.charitynavigator.org/. All responses are JSON. Pagination defaults to 100 results per page (max 1,000) with a hard limit of 10,000 total results per query. Organizations are identified by their IRS **EIN** (Employer Identification Number). Charity Navigator also offers a GraphQL API, but this document covers the REST API v2.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+All examples use `httpx` with async/await. For scripts that need a synchronous entrypoint:
+
+```python
+import asyncio
+import httpx
+
+async def main():
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{BASE_URL}/Organizations",
+            params={"app_id": APP_ID, "app_key": APP_KEY, "search": "red cross"},
+        )
+        print(resp.json())
+
+asyncio.run(main())
+```
+
+## Base URL
+
+```
+https://api.data.charitynavigator.org/v2
+```
+
+```python
+import os
+
+APP_ID = os.environ["CHARITY_NAV_APP_ID"]
+APP_KEY = os.environ["CHARITY_NAV_APP_KEY"]
+BASE_URL = "https://api.data.charitynavigator.org/v2"
+```
+
+## Authentication
+
+Charity Navigator uses **app_id + app_key as query parameters** on every request:
+
+```
+https://api.data.charitynavigator.org/v2/Organizations?app_id=YOUR_APP_ID&app_key=YOUR_APP_KEY
+```
+
+Register at https://developer.charitynavigator.org/ to obtain credentials.
+
+```python
+def auth_params(**extra) -> dict:
+    return {"app_id": APP_ID, "app_key": APP_KEY, **extra}
+```
+
+## Rate Limiting
+
+Charity Navigator does not publicly document specific rate limits. Implement reasonable throttling for batch operations.
+
+```python
+import asyncio
+
+async def cn_request(
+    client: httpx.AsyncClient,
+    path: str,
+    params: dict = None,
+    max_retries: int = 3,
+) -> dict | list:
+    request_params = auth_params(**(params or {}))
+    url = f"{BASE_URL}{path}"
+
+    for attempt in range(max_retries):
+        try:
+            resp = await client.get(url, params=request_params)
+        except httpx.RequestError:
+            await asyncio.sleep(2 ** attempt)
+            continue
+
+        if resp.status_code == 200:
+            return resp.json()
+
+        if resp.status_code == 429:
+            await asyncio.sleep(min(2 ** attempt, 30))
+            continue
+
+        resp.raise_for_status()
+
+    raise Exception("Max retries exceeded")
+```
+
+## Methods
+
+### Search Organizations
+
+Search for charitable organizations with filtering and sorting.
+
+**Parameters:**
+- `search` (str) -- Search term
+- `searchType` (str) -- `DEFAULT` or `NAME_ONLY`
+- `rated` (str) -- `TRUE` (rated only) or `FALSE` (unrated only)
+- `categoryID` (int) -- Filter by category
+- `causeID` (int) -- Filter by cause
+- `state` (str) -- US state abbreviation (e.g., `NY`)
+- `city` (str) -- City name
+- `zip` (str) -- ZIP code
+- `minRating` (int) -- Minimum overall rating (0-4)
+- `maxRating` (int) -- Maximum overall rating (0-4)
+- `sizeRange` (int) -- Organization size: 1 (small), 2 (mid), 3 (large)
+- `sort` (str) -- `NAME:ASC`, `RATING:DESC`, or `RELEVANCE:DESC`
+- `pageSize` (int) -- Results per page (default: 100, max: 1,000)
+- `pageNum` (int) -- Page number (default: 1)
+
+```python
+async def search_organizations(
+    client: httpx.AsyncClient,
+    search: str = None,
+    state: str = None,
+    rated: str = None,
+    min_rating: int = None,
+    sort: str = "RELEVANCE:DESC",
+    page_size: int = 100,
+    page_num: int = 1,
+) -> list:
+    params = {"pageSize": page_size, "pageNum": page_num, "sort": sort}
+    if search:
+        params["search"] = search
+    if state:
+        params["state"] = state
+    if rated:
+        params["rated"] = rated
+    if min_rating is not None:
+        params["minRating"] = min_rating
+    return await cn_request(client, "/Organizations", params)
+
+# Usage
+orgs = await search_organizations(client, search="habitat for humanity", state="NY")
+for org in orgs:
+    print(f"{org['ein']}: {org['charityName']} - Rating: {org.get('currentRating', {}).get('rating')}")
+```
+
+### Get Organization
+
+Retrieve full details for a single organization by EIN.
+
+```python
+async def get_organization(client: httpx.AsyncClient, ein: str) -> dict:
+    return await cn_request(client, f"/Organizations/{ein}")
+
+# Usage
+org = await get_organization(client, "13-1788491")
+print(f"{org['charityName']}")
+print(f"Rating: {org['currentRating']['rating']}")
+print(f"Category: {org['category']['categoryName']}")
+print(f"Cause: {org['cause']['causeName']}")
+```
+
+### Get Organization Ratings
+
+Retrieve all ratings for an organization (historical).
+
+**Parameters:**
+- `pageSize` (int) -- Results per page
+- `pageNum` (int) -- Page number
+
+```python
+async def get_ratings(
+    client: httpx.AsyncClient,
+    ein: str,
+    page_size: int = 100,
+    page_num: int = 1,
+) -> list:
+    return await cn_request(
+        client, f"/Organizations/{ein}/Ratings",
+        {"pageSize": page_size, "pageNum": page_num},
+    )
+
+# Usage
+ratings = await get_ratings(client, "13-1788491")
+for r in ratings:
+    print(f"Rating: {r['rating']} (Score: {r['score']}) - {r['ratingDate']}")
+```
+
+### Get Specific Rating
+
+Retrieve a single rating by organization EIN and rating ID.
+
+```python
+async def get_rating(client: httpx.AsyncClient, ein: str, rating_id: int) -> dict:
+    return await cn_request(client, f"/Organizations/{ein}/Ratings/{rating_id}")
+```
+
+### Get Organization Advisories
+
+Retrieve advisories (cautionary communications) for an organization.
+
+**Parameters:**
+- `status` (str) -- `ALL`, `ACTIVE`, or `REMOVED` (default: `ALL`)
+
+```python
+async def get_advisories(
+    client: httpx.AsyncClient,
+    ein: str,
+    status: str = "ALL",
+) -> list:
+    return await cn_request(
+        client, f"/Organizations/{ein}/Advisories",
+        {"status": status},
+    )
+
+# Usage
+advisories = await get_advisories(client, "13-1788491", status="ACTIVE")
+for adv in advisories:
+    print(f"{adv['advisoryDate']}: {adv['description']}")
+```
+
+### Get Specific Advisory
+
+Retrieve a single advisory by ID.
+
+```python
+async def get_advisory(client: httpx.AsyncClient, ein: str, advisory_id: int) -> dict:
+    return await cn_request(client, f"/Organizations/{ein}/Advisories/{advisory_id}")
+```
+
+### Get All Active Advisories
+
+Retrieve all organizations that currently have active advisories.
+
+```python
+async def get_all_active_advisories(
+    client: httpx.AsyncClient,
+    page_size: int = 100,
+    page_num: int = 1,
+) -> list:
+    return await cn_request(
+        client, "/Advisory",
+        {"pageSize": page_size, "pageNum": page_num},
+    )
+
+# Usage
+active = await get_all_active_advisories(client)
+for entry in active:
+    print(f"{entry['organization']['charityName']}: {entry['description']}")
+```
+
+### Get Lists
+
+Retrieve curated or generated lists of organizations published by Charity Navigator.
+
+```python
+async def get_lists(
+    client: httpx.AsyncClient,
+    page_size: int = 100,
+    page_num: int = 1,
+) -> list:
+    return await cn_request(
+        client, "/Lists",
+        {"pageSize": page_size, "pageNum": page_num},
+    )
+
+# Usage
+lists = await get_lists(client)
+for lst in lists:
+    print(f"{lst['listID']}: {lst['title']}")
+```
+
+### Get Specific List
+
+Retrieve details for a single curated list.
+
+```python
+async def get_list(client: httpx.AsyncClient, list_id: int) -> dict:
+    return await cn_request(client, f"/Lists/{list_id}")
+
+# Usage
+charity_list = await get_list(client, 1)
+print(charity_list["title"])
+for org in charity_list.get("organizations", []):
+    print(f"  {org['charityName']}")
+```
+
+### Get Categories
+
+Retrieve all charity classification categories.
+
+```python
+async def get_categories(client: httpx.AsyncClient) -> list:
+    return await cn_request(client, "/Categories")
+
+# Usage
+categories = await get_categories(client)
+for cat in categories:
+    print(f"{cat['categoryID']}: {cat['categoryName']}")
+    for cause in cat.get("causes", []):
+        print(f"  {cause['causeID']}: {cause['causeName']}")
+```
+
+## Error Handling
+
+Successful responses return HTTP 200 with a JSON body (array or object).
+
+**Common status codes:**
+
+| Code | Meaning |
+|---|---|
+| 200 | Success |
+| 400 | Bad Request -- invalid parameter values or missing required parameters |
+| 404 | Not Found -- EIN not found, or page number exceeds available data |
+| 500 | Internal Server Error |
+
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+
+class CharityNavError(Exception):
+    def __init__(self, status_code: int, message: str):
+        self.status_code = status_code
+        self.message = message
+        super().__init__(f"[{status_code}] {message}")
+
+async def cn_request_safe(
+    client: httpx.AsyncClient,
+    path: str,
+    params: dict = None,
+    max_retries: int = 3,
+) -> dict | list:
+    request_params = auth_params(**(params or {}))
+    url = f"{BASE_URL}{path}"
+
+    for attempt in range(max_retries):
+        try:
+            resp = await client.get(url, params=request_params)
+        except httpx.RequestError as e:
+            logger.warning(f"Network error (attempt {attempt+1}): {e}")
+            await asyncio.sleep(2 ** attempt)
+            continue
+
+        if resp.status_code == 200:
+            return resp.json()
+
+        if resp.status_code == 429:
+            wait = min(2 ** attempt, 30)
+            logger.warning(f"Rate limited, retrying in {wait}s")
+            await asyncio.sleep(wait)
+            continue
+
+        raise CharityNavError(resp.status_code, resp.text)
+
+    raise CharityNavError(429, "Max retries exceeded")
+```
+
+## Common Pitfalls
+
+1. **Two credentials required.** Unlike most APIs, Charity Navigator requires both `app_id` and `app_key` on every request. Missing either returns an error.
+
+2. **EIN format includes a hyphen.** EINs are formatted as `XX-XXXXXXX` (e.g., `13-1788491`). Some endpoints accept with or without the hyphen, but always include it for consistency.
+
+3. **Pagination maxes out at 10,000 results.** Even with multiple pages, the total accessible results cap at 10,000. Use more specific filters to narrow results.
+
+4. **Default page size is 100.** If you need fewer results, set `pageSize` explicitly to reduce response size and improve performance.
+
+5. **Rating scale is 0-4 stars.** Charity Navigator uses a 0-4 star rating system, not 0-5. Filter parameters `minRating` and `maxRating` use this range.
+
+6. **Not all organizations are rated.** Use `rated=TRUE` to filter to only rated organizations. Unrated organizations have no `currentRating` field.
+
+7. **The `sort` parameter uses a colon format.** Sort values are `NAME:ASC`, `RATING:DESC`, or `RELEVANCE:DESC` -- not separate sort/direction parameters.
+
+8. **Advisories are cautionary, not ratings.** Advisories flag unusual events (governance issues, fraud alerts). They are separate from the star rating system.
+
+9. **Categories have a two-level hierarchy.** Each category contains multiple causes. Filter by `categoryID` for broad filtering or `causeID` for specific targeting.
+
+10. **The API returns arrays for collection endpoints.** Unlike many APIs that wrap results in an object, collection endpoints return a plain JSON array. Check the return type annotation.

--- a/content/clevertap/docs/rest-api/python/DOC.md
+++ b/content/clevertap/docs/rest-api/python/DOC.md
@@ -1,0 +1,224 @@
+---
+name: rest-api
+description: "CleverTap Customer Engagement & Analytics API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-13"
+  source: community
+  tags: "clevertap,customer-engagement,analytics,campaigns,push-notifications,events,profiles,api,integration"
+---
+
+# CleverTap API
+
+> **Golden Rule:** CleverTap has no official Python SDK on PyPI. Use `httpx` (async) or `requests` (sync) for direct REST API access. Auth uses two custom headers: `X-CleverTap-Account-Id` and `X-CleverTap-Passcode`. Base URL is region-specific. Rate limits are concurrent (not time-based).
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+Region-specific (check your CleverTap dashboard):
+
+| Region | URL |
+|---|---|
+| Europe (Default) | `https://api.clevertap.com` |
+| India | `https://in1.api.clevertap.com` |
+| Singapore | `https://sg1.api.clevertap.com` |
+| US | `https://us1.api.clevertap.com` |
+| Indonesia | `https://aps3.api.clevertap.com` |
+| UAE | `https://mec1.api.clevertap.com` |
+
+## Authentication
+
+**Type:** Custom Headers (Account ID + Passcode)
+
+```python
+import httpx
+
+ACCOUNT_ID = "your-clevertap-account-id"
+PASSCODE = "your-clevertap-passcode"
+BASE_URL = "https://in1.api.clevertap.com"  # Use your region
+
+headers = {
+    "X-CleverTap-Account-Id": ACCOUNT_ID,
+    "X-CleverTap-Passcode": PASSCODE,
+    "Content-Type": "application/json; charset=utf-8"
+}
+client = httpx.AsyncClient(headers=headers)
+```
+
+## Rate Limiting
+
+CleverTap uses **concurrent request limits** (not per-minute):
+
+| API Category | Max Concurrent |
+|---|---|
+| Upload (profiles/events) | 15 |
+| All other endpoints | 3 |
+
+Returns HTTP 429 when exceeded.
+
+## Methods
+
+### `upload_profiles`
+
+**Endpoint:** `POST /1/upload`
+
+Create or update user profiles. Max 1000 records per call.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `d` | `list` | **required** (array of profile objects) |
+
+**Returns:** JSON with `status`, `processed`, `unprocessed`
+
+```python
+payload = {
+    "d": [{
+        "type": "profile",
+        "identity": "user@example.com",
+        "profileData": {
+            "Name": "Jane Doe",
+            "Email": "user@example.com",
+            "Phone": "+919876543210",
+            "Plan": "Premium"
+        }
+    }]
+}
+response = await client.post(f"{BASE_URL}/1/upload", json=payload)
+response.raise_for_status()
+data = response.json()
+# {"status": "success", "processed": 1, "unprocessed": []}
+```
+
+### `upload_events`
+
+**Endpoint:** `POST /1/upload`
+
+Track user events. Same endpoint as profiles; differentiated by `type: "event"`.
+
+```python
+payload = {
+    "d": [{
+        "identity": "user@example.com",
+        "type": "event",
+        "evtName": "Product Viewed",
+        "evtData": {
+            "Product name": "Wireless Headphones",
+            "Category": "Electronics",
+            "Price": 79.99
+        }
+    }]
+}
+response = await client.post(f"{BASE_URL}/1/upload", json=payload)
+response.raise_for_status()
+```
+
+### `query_profiles`
+
+**Endpoint:** `POST /1/profiles.json` → `GET /1/profiles.json?cursor={cursor}`
+
+Query user profiles with cursor-based pagination.
+
+```python
+# Step 1: Initial query
+query = {"event_name": "App Launched", "from": 20240101, "to": 20240131}
+response = await client.post(f"{BASE_URL}/1/profiles.json", json=query)
+response.raise_for_status()
+data = response.json()
+profiles = data.get("records", [])
+cursor = data.get("cursor")
+
+# Step 2: Paginate with cursor
+while cursor:
+    response = await client.get(f"{BASE_URL}/1/profiles.json", params={"cursor": cursor})
+    response.raise_for_status()
+    data = response.json()
+    profiles.extend(data.get("records", []))
+    cursor = data.get("cursor")
+```
+
+### `query_events`
+
+**Endpoint:** `POST /1/events.json` → `GET /1/events.json?cursor={cursor}`
+
+Query events by name and date range.
+
+```python
+query = {"event_name": "Product Viewed", "from": 20240101, "to": 20240131}
+response = await client.post(f"{BASE_URL}/1/events.json", json=query)
+response.raise_for_status()
+data = response.json()
+events = data.get("records", [])
+```
+
+### `create_campaign`
+
+**Endpoint:** `POST /1/targets/create.json`
+
+Create push, email, SMS, or web push campaigns.
+
+```python
+payload = {
+    "name": "Welcome Email",
+    "target_mode": "email",
+    "where": {"event_name": "App Launched", "from": 20240101, "to": 20240131},
+    "content": {"subject": "Welcome!", "body": "<html>Welcome aboard!</html>"},
+    "when": "now"
+}
+response = await client.post(f"{BASE_URL}/1/targets/create.json", json=payload)
+response.raise_for_status()
+```
+
+### `get_realtime_counts`
+
+**Endpoint:** `POST /1/now.json`
+
+Get real-time user/event counts.
+
+```python
+payload = {"event_name": "App Launched"}
+response = await client.post(f"{BASE_URL}/1/now.json", json=payload)
+response.raise_for_status()
+counts = response.json()
+```
+
+## Error Handling
+
+```python
+import httpx
+
+try:
+    response = await client.post(f"{BASE_URL}/1/upload", json=payload)
+    response.raise_for_status()
+    data = response.json()
+    if data.get("unprocessed"):
+        print(f"Partial failure: {len(data['unprocessed'])} records failed")
+except httpx.HTTPStatusError as e:
+    if e.response.status_code == 401:
+        print("Auth failed -- check Account ID and Passcode")
+    elif e.response.status_code == 429:
+        print("Too many concurrent requests -- reduce parallelism")
+    else:
+        print(f"CleverTap API error {e.response.status_code}: {e.response.text}")
+except httpx.RequestError as e:
+    print(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+- Auth uses TWO custom headers (`X-CleverTap-Account-Id` + `X-CleverTap-Passcode`), not Bearer
+- Base URL is region-specific -- using wrong region causes auth failures
+- Profiles and events share the same `/1/upload` endpoint -- the `type` field differentiates them
+- Max 1000 records per upload call
+- Rate limits are **concurrent** (not per-minute) -- 15 for uploads, 3 for queries
+- Query APIs use cursor-based pagination: POST to start, GET with `cursor` param to paginate
+- Check `unprocessed` array in response -- HTTP 200 doesn't mean all records succeeded
+- Add `?dryRun=1` to upload URLs to validate without persisting
+- Date format in queries: `YYYYMMDD` as integer (e.g., `20240101`)
+- Set `Content-Type: application/json; charset=utf-8` (charset matters)

--- a/content/coinbase/docs/rest-api/python/DOC.md
+++ b/content/coinbase/docs/rest-api/python/DOC.md
@@ -1,0 +1,394 @@
+---
+name: rest-api
+description: "Coinbase Advanced Trade REST API Python coding guidelines using httpx async"
+metadata:
+  languages: "python"
+  versions: "3.12.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "coinbase,crypto,trading,bitcoin,ethereum,exchange,api"
+---
+
+# Coinbase Advanced Trade REST API Python Coding Guidelines
+
+You are a Coinbase Advanced Trade API coding expert. Help me with writing code using the Coinbase Advanced Trade REST API with httpx async in Python.
+
+You can find the official documentation here:
+https://docs.cdp.coinbase.com/advanced-trade/reference
+
+## Golden Rule: Use httpx Async with JWT Authentication
+
+Always use `httpx` with async/await for all Coinbase Advanced Trade API interactions. Authenticate using JWT (JSON Web Token) generated from your CDP API key and secret. Never send your API secret directly in requests. Never use deprecated API key authentication methods.
+
+## Installation
+
+```bash
+pip install httpx PyJWT cryptography
+```
+
+**Environment Variables:**
+
+```bash
+export COINBASE_API_KEY='organizations/{org_id}/apiKeys/{key_id}'
+export COINBASE_API_SECRET='-----BEGIN EC PRIVATE KEY-----\n...\n-----END EC PRIVATE KEY-----'
+```
+
+Load environment variables in Python:
+
+```python
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+api_key = os.getenv("COINBASE_API_KEY")
+api_secret = os.getenv("COINBASE_API_SECRET").replace("\\n", "\n")
+```
+
+## Base URL
+
+```
+https://api.coinbase.com
+```
+
+All Advanced Trade endpoints are prefixed with `/api/v3/brokerage/`.
+
+## Authentication
+
+Coinbase Advanced Trade uses JWT (JSON Web Token) authentication signed with ES256 (ECDSA).
+
+```python
+import time
+import secrets
+import jwt
+
+
+def generate_jwt(api_key: str, api_secret: str, request_method: str = "", request_path: str = "") -> str:
+    """Generate a JWT for Coinbase Advanced Trade API."""
+    uri = ""
+    if request_method and request_path:
+        uri = f"{request_method} {request_path}"
+
+    payload = {
+        "sub": api_key,
+        "iss": "cdp",
+        "aud": ["cdp_service"],
+        "nbf": int(time.time()),
+        "exp": int(time.time()) + 120,
+        "uris": [uri] if uri else [],
+    }
+    headers = {
+        "kid": api_key,
+        "nonce": secrets.token_hex(16),
+        "typ": "JWT",
+    }
+    return jwt.encode(payload, api_secret, algorithm="ES256", headers=headers)
+```
+
+### Authenticated Client Helper
+
+```python
+import httpx
+
+
+class CoinbaseClient:
+    BASE_URL = "https://api.coinbase.com"
+
+    def __init__(self, api_key: str, api_secret: str):
+        self.api_key = api_key
+        self.api_secret = api_secret
+
+    def _headers(self, method: str, path: str) -> dict:
+        token = generate_jwt(self.api_key, self.api_secret, method, path)
+        return {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+
+    async def _request(self, method: str, path: str, **kwargs) -> dict:
+        url = f"{self.BASE_URL}{path}"
+        headers = self._headers(method.upper(), path.split("?")[0])
+        async with httpx.AsyncClient() as client:
+            resp = await client.request(method, url, headers=headers, **kwargs)
+            resp.raise_for_status()
+            return resp.json()
+
+    async def get(self, path: str, params: dict | None = None) -> dict:
+        return await self._request("GET", path, params=params)
+
+    async def post(self, path: str, json_data: dict | None = None) -> dict:
+        return await self._request("POST", path, json=json_data)
+```
+
+## Rate Limiting
+
+| Endpoint Type | Limit |
+|---|---|
+| Private endpoints | 30 requests/second per user |
+| Public endpoints | 10 requests/second per IP |
+
+Implement rate limiting:
+
+```python
+import asyncio
+
+semaphore = asyncio.Semaphore(25)  # Stay under 30/s limit
+
+async def rate_limited_request(client: CoinbaseClient, path: str) -> dict:
+    async with semaphore:
+        result = await client.get(path)
+        await asyncio.sleep(0.04)  # ~25 req/s pacing
+        return result
+```
+
+## Methods
+
+### List Accounts
+
+```python
+async def list_accounts(client: CoinbaseClient, limit: int = 49, cursor: str = "") -> dict:
+    """List trading accounts."""
+    params = {"limit": limit}
+    if cursor:
+        params["cursor"] = cursor
+    return await client.get("/api/v3/brokerage/accounts", params=params)
+
+# Usage
+import asyncio
+
+async def main():
+    cb = CoinbaseClient(api_key, api_secret)
+    accounts = await list_accounts(cb)
+    for acct in accounts.get("accounts", []):
+        print(f"{acct['currency']}: {acct['available_balance']['value']}")
+
+asyncio.run(main())
+```
+
+### Get Account
+
+```python
+async def get_account(client: CoinbaseClient, account_uuid: str) -> dict:
+    """Get a specific account by UUID."""
+    return await client.get(f"/api/v3/brokerage/accounts/{account_uuid}")
+```
+
+### Create Order
+
+```python
+import uuid
+
+async def create_order(
+    client: CoinbaseClient,
+    product_id: str,
+    side: str,
+    order_type: str = "market",
+    base_size: str | None = None,
+    quote_size: str | None = None,
+    limit_price: str | None = None,
+) -> dict:
+    """Create a new order."""
+    client_order_id = str(uuid.uuid4())
+    order_config = {}
+
+    if order_type == "market":
+        if side == "BUY":
+            order_config = {"market_market_ioc": {"quote_size": quote_size}}
+        else:
+            order_config = {"market_market_ioc": {"base_size": base_size}}
+    elif order_type == "limit":
+        order_config = {
+            "limit_limit_gtc": {
+                "base_size": base_size,
+                "limit_price": limit_price,
+            }
+        }
+
+    payload = {
+        "client_order_id": client_order_id,
+        "product_id": product_id,
+        "side": side,
+        "order_configuration": order_config,
+    }
+    return await client.post("/api/v3/brokerage/orders", json_data=payload)
+
+# Market buy $100 of BTC
+# await create_order(cb, "BTC-USD", "BUY", "market", quote_size="100")
+
+# Limit sell 0.01 BTC at $70,000
+# await create_order(cb, "BTC-USD", "SELL", "limit", base_size="0.01", limit_price="70000")
+```
+
+### List Orders
+
+```python
+async def list_orders(
+    client: CoinbaseClient,
+    product_id: str = "",
+    order_status: list[str] | None = None,
+    limit: int = 100,
+) -> dict:
+    """List orders with optional filters."""
+    params = {"limit": limit}
+    if product_id:
+        params["product_id"] = product_id
+    if order_status:
+        params["order_status"] = order_status
+    return await client.get("/api/v3/brokerage/orders/historical/batch", params=params)
+```
+
+### Get Order
+
+```python
+async def get_order(client: CoinbaseClient, order_id: str) -> dict:
+    """Get a specific order by ID."""
+    return await client.get(f"/api/v3/brokerage/orders/historical/{order_id}")
+```
+
+### Cancel Orders
+
+```python
+async def cancel_orders(client: CoinbaseClient, order_ids: list[str]) -> dict:
+    """Cancel one or more orders."""
+    return await client.post(
+        "/api/v3/brokerage/orders/batch_cancel",
+        json_data={"order_ids": order_ids},
+    )
+```
+
+### List Products
+
+```python
+async def list_products(
+    client: CoinbaseClient,
+    product_type: str = "SPOT",
+    limit: int = 100,
+) -> dict:
+    """List available trading products."""
+    params = {"product_type": product_type, "limit": limit}
+    return await client.get("/api/v3/brokerage/products", params=params)
+```
+
+### Get Product
+
+```python
+async def get_product(client: CoinbaseClient, product_id: str) -> dict:
+    """Get details for a specific product (e.g., BTC-USD)."""
+    return await client.get(f"/api/v3/brokerage/products/{product_id}")
+```
+
+### Get Product Candles
+
+```python
+async def get_candles(
+    client: CoinbaseClient,
+    product_id: str,
+    start: str,
+    end: str,
+    granularity: str = "ONE_HOUR",
+) -> dict:
+    """Get candle (OHLCV) data for a product.
+
+    Granularity options: ONE_MINUTE, FIVE_MINUTE, FIFTEEN_MINUTE,
+    THIRTY_MINUTE, ONE_HOUR, TWO_HOUR, SIX_HOUR, ONE_DAY.
+    start/end are Unix timestamps as strings.
+    """
+    params = {
+        "start": start,
+        "end": end,
+        "granularity": granularity,
+    }
+    return await client.get(f"/api/v3/brokerage/products/{product_id}/candles", params=params)
+```
+
+### Get Market Ticker
+
+```python
+async def get_ticker(client: CoinbaseClient, product_id: str, limit: int = 100) -> dict:
+    """Get recent trades (ticker) for a product."""
+    params = {"limit": limit}
+    return await client.get(f"/api/v3/brokerage/products/{product_id}/ticker", params=params)
+```
+
+### Get Best Bid/Ask
+
+```python
+async def get_best_bid_ask(client: CoinbaseClient, product_ids: list[str] | None = None) -> dict:
+    """Get best bid/ask for products."""
+    params = {}
+    if product_ids:
+        params["product_ids"] = product_ids
+    return await client.get("/api/v3/brokerage/best_bid_ask", params=params)
+```
+
+## Error Handling
+
+```python
+import httpx
+
+async def safe_request(client: CoinbaseClient, path: str) -> dict | None:
+    """Make a request with error handling."""
+    try:
+        return await client.get(path)
+    except httpx.HTTPStatusError as e:
+        status = e.response.status_code
+        body = e.response.json() if e.response.headers.get("content-type", "").startswith("application/json") else {}
+        error_msg = body.get("error", "")
+        error_detail = body.get("message", "")
+
+        if status == 401:
+            print(f"Authentication failed: {error_detail}")
+        elif status == 403:
+            print(f"Forbidden - check API key permissions: {error_detail}")
+        elif status == 404:
+            print(f"Resource not found: {error_detail}")
+        elif status == 429:
+            print("Rate limited - backing off")
+            await asyncio.sleep(1)
+        elif status >= 500:
+            print(f"Server error ({status}): {error_detail}")
+        else:
+            print(f"HTTP {status}: {error_msg} - {error_detail}")
+        return None
+    except httpx.RequestError as e:
+        print(f"Network error: {e}")
+        return None
+```
+
+### Common Error Responses
+
+| HTTP Status | Error | Description |
+|---|---|---|
+| 400 | INVALID_ARGUMENT | Bad request parameters |
+| 401 | UNAUTHENTICATED | Invalid or expired JWT |
+| 403 | PERMISSION_DENIED | API key lacks required permission |
+| 404 | NOT_FOUND | Resource does not exist |
+| 429 | RESOURCE_EXHAUSTED | Rate limit exceeded |
+| 500 | INTERNAL | Server-side error |
+
+## Common Pitfalls
+
+1. **JWT Expiration** - JWTs expire after 2 minutes. Generate a fresh JWT for each request. Do not cache tokens for longer than ~90 seconds.
+
+2. **API Secret Format** - The API secret is a PEM-encoded EC private key. Ensure newline characters (`\n`) are properly preserved when loading from environment variables. Use `.replace("\\n", "\n")`.
+
+3. **Product ID Format** - Coinbase uses hyphenated pairs like `BTC-USD`, not `BTCUSD` or `BTC_USD`.
+
+4. **Order Configuration Nesting** - Order parameters are nested inside `order_configuration` with a key specific to the order type (e.g., `market_market_ioc`, `limit_limit_gtc`). This is a common source of 400 errors.
+
+5. **Client Order ID** - Every order requires a unique `client_order_id`. Use `uuid.uuid4()` to generate one per order.
+
+6. **String Amounts** - All monetary amounts (`base_size`, `quote_size`, `limit_price`) must be strings, not floats or integers.
+
+7. **Pagination** - List endpoints use cursor-based pagination. Check for a `cursor` field in the response and pass it in subsequent requests.
+
+8. **URI in JWT** - The JWT `uris` claim must match the request method and path exactly. A mismatch causes 401 errors.
+
+## Useful Links
+
+- Official Documentation: https://docs.cdp.coinbase.com/advanced-trade/reference
+- Authentication Guide: https://docs.cdp.coinbase.com/advanced-trade/docs/rest-api-auth
+- Python SDK (alternative): https://github.com/coinbase/coinbase-advanced-py
+- Rate Limits: https://docs.cloud.coinbase.com/advanced-trade/docs/rest-api-rate-limits
+- API Key Management: https://www.coinbase.com/settings/api

--- a/content/coingecko/docs/rest-api/python/DOC.md
+++ b/content/coingecko/docs/rest-api/python/DOC.md
@@ -1,0 +1,404 @@
+---
+name: rest-api
+description: "CoinGecko REST API Python coding guidelines using httpx async"
+metadata:
+  languages: "python"
+  versions: "3.12.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "coingecko,crypto,market-data,prices,coins,defi,nft,api"
+---
+
+# CoinGecko REST API Python Coding Guidelines
+
+You are a CoinGecko API coding expert. Help me with writing code using the CoinGecko REST API with httpx async in Python.
+
+You can find the official documentation here:
+https://docs.coingecko.com/reference/introduction
+
+## Golden Rule: Use httpx Async with API Key Authentication
+
+Always use `httpx` with async/await for all CoinGecko API interactions. Use the Pro API base URL with an API key for production. The free (demo) tier is available for testing but has strict rate limits. Never hardcode API keys in source code.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+**Environment Variables:**
+
+```bash
+# For Pro API (paid plans)
+export COINGECKO_API_KEY='your_pro_api_key_here'
+
+# For Demo/Free API
+export COINGECKO_DEMO_API_KEY='your_demo_api_key_here'
+```
+
+Load environment variables in Python:
+
+```python
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+api_key = os.getenv("COINGECKO_API_KEY")
+```
+
+## Base URL
+
+| Tier | Base URL | Auth Header |
+|---|---|---|
+| Pro (paid) | `https://pro-api.coingecko.com/api/v3` | `x-cg-pro-api-key` |
+| Demo (free) | `https://api.coingecko.com/api/v3` | `x-cg-demo-api-key` |
+
+## Authentication
+
+CoinGecko uses API key authentication via a custom header or query parameter.
+
+```python
+import httpx
+
+
+class CoinGeckoClient:
+    def __init__(self, api_key: str, pro: bool = True):
+        if pro:
+            self.base_url = "https://pro-api.coingecko.com/api/v3"
+            self.headers = {"x-cg-pro-api-key": api_key, "accept": "application/json"}
+        else:
+            self.base_url = "https://api.coingecko.com/api/v3"
+            self.headers = {"x-cg-demo-api-key": api_key, "accept": "application/json"}
+
+    async def get(self, path: str, params: dict | None = None) -> dict | list:
+        url = f"{self.base_url}{path}"
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(url, headers=self.headers, params=params or {})
+            resp.raise_for_status()
+            return resp.json()
+```
+
+## Rate Limiting
+
+| Plan | Rate Limit | Cache/Update Frequency |
+|---|---|---|
+| Demo (free) | ~10-30 calls/min | 30-60 seconds |
+| Analyst | 500 calls/min | 20 seconds |
+| Lite | 500 calls/min | 20 seconds |
+| Pro | 1000 calls/min | 20 seconds |
+| Enterprise | Custom | 20 seconds |
+
+```python
+import asyncio
+import time
+
+
+class RateLimiter:
+    def __init__(self, calls_per_minute: int = 25):
+        self.interval = 60.0 / calls_per_minute
+        self.last_call = 0.0
+        self._lock = asyncio.Lock()
+
+    async def acquire(self):
+        async with self._lock:
+            now = time.time()
+            wait = self.interval - (now - self.last_call)
+            if wait > 0:
+                await asyncio.sleep(wait)
+            self.last_call = time.time()
+```
+
+## Methods
+
+### Ping (Check API Status)
+
+```python
+async def ping(client: CoinGeckoClient) -> dict:
+    """Check API server status."""
+    return await client.get("/ping")
+
+# Usage
+import asyncio
+
+async def main():
+    cg = CoinGeckoClient(api_key, pro=True)
+    result = await ping(cg)
+    print(result)  # {"gecko_says": "(V3) To the Moon!"}
+
+asyncio.run(main())
+```
+
+### Simple Price
+
+```python
+async def get_simple_price(
+    client: CoinGeckoClient,
+    ids: str,
+    vs_currencies: str = "usd",
+    include_market_cap: bool = False,
+    include_24hr_vol: bool = False,
+    include_24hr_change: bool = False,
+    include_last_updated_at: bool = False,
+    precision: str | None = None,
+) -> dict:
+    """Get current price of coins.
+
+    Args:
+        ids: Comma-separated coin IDs (e.g., "bitcoin,ethereum").
+        vs_currencies: Comma-separated target currencies (e.g., "usd,eur").
+        precision: Decimal places - "full" or 0-18.
+    """
+    params = {
+        "ids": ids,
+        "vs_currencies": vs_currencies,
+        "include_market_cap": str(include_market_cap).lower(),
+        "include_24hr_vol": str(include_24hr_vol).lower(),
+        "include_24hr_change": str(include_24hr_change).lower(),
+        "include_last_updated_at": str(include_last_updated_at).lower(),
+    }
+    if precision:
+        params["precision"] = precision
+    return await client.get("/simple/price", params=params)
+
+# Get BTC and ETH prices in USD with market cap
+# result = await get_simple_price(cg, "bitcoin,ethereum", "usd", include_market_cap=True)
+# print(result["bitcoin"]["usd"])
+```
+
+### Coins List
+
+```python
+async def get_coins_list(
+    client: CoinGeckoClient, include_platform: bool = False
+) -> list:
+    """Get list of all supported coins with id, name, and symbol.
+
+    Note: No pagination needed. Returns full list.
+    """
+    params = {"include_platform": str(include_platform).lower()}
+    return await client.get("/coins/list", params=params)
+```
+
+### Coins Markets
+
+```python
+async def get_coins_markets(
+    client: CoinGeckoClient,
+    vs_currency: str = "usd",
+    ids: str | None = None,
+    category: str | None = None,
+    order: str = "market_cap_desc",
+    per_page: int = 100,
+    page: int = 1,
+    sparkline: bool = False,
+    price_change_percentage: str | None = None,
+) -> list:
+    """Get coin market data (price, market cap, volume) with pagination.
+
+    Args:
+        order: Sort by - market_cap_desc, market_cap_asc, volume_desc, volume_asc, id_asc, id_desc.
+        price_change_percentage: Comma-separated intervals - "1h,24h,7d,14d,30d,200d,1y".
+    """
+    params = {
+        "vs_currency": vs_currency,
+        "order": order,
+        "per_page": per_page,
+        "page": page,
+        "sparkline": str(sparkline).lower(),
+    }
+    if ids:
+        params["ids"] = ids
+    if category:
+        params["category"] = category
+    if price_change_percentage:
+        params["price_change_percentage"] = price_change_percentage
+    return await client.get("/coins/markets", params=params)
+
+# Top 10 coins by market cap with 24h change
+# result = await get_coins_markets(cg, per_page=10, price_change_percentage="24h")
+```
+
+### Coin by ID
+
+```python
+async def get_coin(
+    client: CoinGeckoClient,
+    coin_id: str,
+    localization: bool = False,
+    tickers: bool = False,
+    market_data: bool = True,
+    community_data: bool = False,
+    developer_data: bool = False,
+    sparkline: bool = False,
+) -> dict:
+    """Get detailed data for a specific coin.
+
+    Args:
+        coin_id: Coin ID from /coins/list (e.g., "bitcoin").
+    """
+    params = {
+        "localization": str(localization).lower(),
+        "tickers": str(tickers).lower(),
+        "market_data": str(market_data).lower(),
+        "community_data": str(community_data).lower(),
+        "developer_data": str(developer_data).lower(),
+        "sparkline": str(sparkline).lower(),
+    }
+    return await client.get(f"/coins/{coin_id}", params=params)
+```
+
+### Coin Historical Data
+
+```python
+async def get_coin_history(
+    client: CoinGeckoClient, coin_id: str, date: str, localization: bool = False
+) -> dict:
+    """Get historical data for a coin on a specific date.
+
+    Args:
+        coin_id: Coin ID (e.g., "bitcoin").
+        date: Date in dd-mm-yyyy format (e.g., "30-12-2025").
+    """
+    params = {"date": date, "localization": str(localization).lower()}
+    return await client.get(f"/coins/{coin_id}/history", params=params)
+```
+
+### Coin Market Chart
+
+```python
+async def get_coin_market_chart(
+    client: CoinGeckoClient,
+    coin_id: str,
+    vs_currency: str = "usd",
+    days: str = "30",
+    interval: str | None = None,
+    precision: str | None = None,
+) -> dict:
+    """Get historical market data (price, market cap, volume) over time.
+
+    Args:
+        days: Number of days (1, 7, 14, 30, 90, 180, 365, "max").
+        interval: Data interval - "daily", "hourly", or auto.
+    """
+    params = {"vs_currency": vs_currency, "days": days}
+    if interval:
+        params["interval"] = interval
+    if precision:
+        params["precision"] = precision
+    return await client.get(f"/coins/{coin_id}/market_chart", params=params)
+```
+
+### Trending Coins
+
+```python
+async def get_trending(client: CoinGeckoClient) -> dict:
+    """Get trending search coins, NFTs, and categories."""
+    return await client.get("/search/trending")
+```
+
+### Search
+
+```python
+async def search(client: CoinGeckoClient, query: str) -> dict:
+    """Search for coins, categories, and exchanges.
+
+    Args:
+        query: Search string (e.g., "bitcoin", "defi").
+    """
+    return await client.get("/search", params={"query": query})
+```
+
+### Global Data
+
+```python
+async def get_global(client: CoinGeckoClient) -> dict:
+    """Get cryptocurrency global data (total market cap, volume, dominance)."""
+    return await client.get("/global")
+```
+
+### Exchange List
+
+```python
+async def get_exchanges(
+    client: CoinGeckoClient, per_page: int = 100, page: int = 1
+) -> list:
+    """Get list of exchanges ranked by trading volume."""
+    return await client.get("/exchanges", params={"per_page": per_page, "page": page})
+```
+
+### Categories
+
+```python
+async def get_categories(client: CoinGeckoClient, order: str = "market_cap_desc") -> list:
+    """Get list of coin categories with market data."""
+    return await client.get("/coins/categories", params={"order": order})
+```
+
+## Error Handling
+
+```python
+async def safe_request(client: CoinGeckoClient, path: str, params: dict | None = None) -> dict | list | None:
+    """Make a request with error handling."""
+    try:
+        return await client.get(path, params=params)
+    except httpx.HTTPStatusError as e:
+        status = e.response.status_code
+        if status == 401:
+            print("Invalid API key")
+        elif status == 429:
+            retry_after = e.response.headers.get("retry-after", "60")
+            print(f"Rate limited - retry after {retry_after}s")
+            await asyncio.sleep(int(retry_after))
+        elif status == 403:
+            print("Access forbidden - check your plan tier")
+        elif status == 404:
+            print("Endpoint or resource not found")
+        elif status >= 500:
+            print(f"CoinGecko server error ({status})")
+        else:
+            print(f"HTTP {status}: {e.response.text}")
+        return None
+    except httpx.RequestError as e:
+        print(f"Network error: {e}")
+        return None
+```
+
+### Common HTTP Error Codes
+
+| Status | Description |
+|---|---|
+| 400 | Bad request - invalid parameters |
+| 401 | Unauthorized - invalid or missing API key |
+| 403 | Forbidden - endpoint not available on your plan |
+| 404 | Not found - invalid coin ID or endpoint |
+| 429 | Too many requests - rate limit exceeded |
+| 500 | Internal server error |
+| 503 | Service unavailable |
+
+## Common Pitfalls
+
+1. **Coin IDs vs Symbols** - CoinGecko uses unique string IDs (e.g., `"bitcoin"`, `"ethereum"`), not ticker symbols. Use `/coins/list` to find the correct ID. Multiple coins can share the same symbol.
+
+2. **Free Tier Limitations** - The demo API has aggressive rate limiting (~10-30 calls/min) and slower cache updates (30-60s). Data may also be delayed compared to the Pro tier.
+
+3. **Boolean Parameters** - Pass booleans as lowercase strings (`"true"`, `"false"`) in query parameters, not Python booleans.
+
+4. **Date Format** - The `/coins/{id}/history` endpoint expects dates in `dd-mm-yyyy` format, not ISO 8601.
+
+5. **Pagination** - Market endpoints use `page` and `per_page` parameters. Max `per_page` is 250. Not all endpoints support pagination.
+
+6. **vs_currency vs vs_currencies** - The `/simple/price` endpoint uses `vs_currencies` (plural), while `/coins/markets` uses `vs_currency` (singular). Mixing them up returns empty results.
+
+7. **Rate Limit Headers** - Check `retry-after` headers when receiving 429 responses. Do not retry immediately.
+
+8. **Large Responses** - Endpoints like `/coins/{id}` return very large JSON objects. Use query parameters to disable unnecessary data sections (tickers, community_data, etc.).
+
+## Useful Links
+
+- Official Documentation: https://docs.coingecko.com/reference/introduction
+- API Status: https://status.coingecko.com/
+- Supported Coins List: https://docs.coingecko.com/reference/coins-list
+- Supported Currencies: https://docs.coingecko.com/reference/simple-supported-currencies
+- API Key Dashboard: https://www.coingecko.com/en/developers/dashboard

--- a/content/currencyapi/docs/rest-api/python/DOC.md
+++ b/content/currencyapi/docs/rest-api/python/DOC.md
@@ -1,0 +1,332 @@
+---
+name: rest-api
+description: "CurrencyAPI - Foreign Exchange Rates and Currency Conversion"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "currency,exchange-rates,forex,conversion,global,api"
+---
+
+# CurrencyAPI - Python Reference (httpx)
+
+## Golden Rule
+
+The API key goes in the `apikey` header (or as a query parameter). The free tier updates rates **daily** and has a monthly request quota. Cache responses aggressively -- exchange rates do not change every second on the free plan. Never call the API in a tight loop or on every page load.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+All examples use `httpx` with async/await. For scripts that need a synchronous entrypoint:
+
+```python
+import asyncio
+import httpx
+
+async def main():
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{BASE_URL}/latest",
+            headers=HEADERS,
+        )
+        print(resp.json())
+
+asyncio.run(main())
+```
+
+## Base URL
+
+```
+https://api.currencyapi.com/v3
+```
+
+```python
+import os
+
+API_KEY = os.environ["CURRENCYAPI_KEY"]
+BASE_URL = "https://api.currencyapi.com/v3"
+HEADERS = {"apikey": API_KEY}
+```
+
+## Authentication
+
+CurrencyAPI supports two authentication methods:
+
+1. **Header** (recommended): `apikey: YOUR-API-KEY`
+2. **Query parameter**: `?apikey=YOUR-API-KEY`
+
+```python
+# Header-based (recommended)
+resp = await client.get(f"{BASE_URL}/latest", headers={"apikey": API_KEY})
+
+# Query parameter alternative
+resp = await client.get(f"{BASE_URL}/latest", params={"apikey": API_KEY})
+```
+
+## Rate Limiting
+
+| Plan | Monthly Requests | Update Frequency |
+|---|---|---|
+| Free | 300 requests/month | Daily |
+| Paid tiers | Higher quotas | Hourly to minute-level |
+
+When you exceed your rate limit or monthly quota, the API returns HTTP `429`. The `/status` endpoint does **not** count toward your quota.
+
+```python
+async def check_status(client: httpx.AsyncClient) -> dict:
+    """Check account quota and rate limit status (free, does not count toward quota)."""
+    resp = await client.get(f"{BASE_URL}/status", headers=HEADERS)
+    resp.raise_for_status()
+    return resp.json()
+```
+
+## Methods
+
+### Latest Exchange Rates
+
+Get the most recent exchange rates for all or selected currencies.
+
+**Optional parameters:**
+- `base_currency` (str) -- Reference currency code. Default: `USD`
+- `currencies` (str) -- Comma-separated currency codes to return (e.g., `EUR,GBP,JPY`)
+- `type` (str) -- Filter by type: `fiat`, `metal`, or `crypto`
+
+```python
+async def get_latest(
+    client: httpx.AsyncClient,
+    base_currency: str = "USD",
+    currencies: str = None,
+) -> dict:
+    params = {"base_currency": base_currency}
+    if currencies:
+        params["currencies"] = currencies
+    resp = await client.get(f"{BASE_URL}/latest", headers=HEADERS, params=params)
+    resp.raise_for_status()
+    return resp.json()
+    # Returns: {"meta": {"last_updated_at": "2026-03-17..."}, "data": {"EUR": {"code": "EUR", "value": 0.923}}}
+
+# Usage
+rates = await get_latest(client, base_currency="USD", currencies="EUR,GBP,JPY")
+eur_rate = rates["data"]["EUR"]["value"]
+```
+
+### Historical Exchange Rates
+
+Get exchange rates for a specific date.
+
+**Required parameters:**
+- `date` (str) -- Date in `YYYY-MM-DD` format
+
+**Optional parameters:**
+- `base_currency` (str) -- Reference currency. Default: `USD`
+- `currencies` (str) -- Comma-separated currency codes
+
+```python
+async def get_historical(
+    client: httpx.AsyncClient,
+    date: str,
+    base_currency: str = "USD",
+    currencies: str = None,
+) -> dict:
+    params = {"date": date, "base_currency": base_currency}
+    if currencies:
+        params["currencies"] = currencies
+    resp = await client.get(f"{BASE_URL}/historical", headers=HEADERS, params=params)
+    resp.raise_for_status()
+    return resp.json()
+
+# Usage
+rates = await get_historical(client, date="2026-01-15", currencies="EUR,GBP")
+```
+
+### Range Historical Exchange Rates
+
+Get exchange rates for a date range.
+
+**Required parameters:**
+- `datetime_start` (str) -- Start datetime in ISO8601 format (e.g., `2026-01-01T00:00:00Z`)
+- `datetime_end` (str) -- End datetime in ISO8601 format
+
+```python
+async def get_range(
+    client: httpx.AsyncClient,
+    datetime_start: str,
+    datetime_end: str,
+    base_currency: str = "USD",
+    currencies: str = None,
+    accuracy: str = "day",
+) -> dict:
+    params = {
+        "datetime_start": datetime_start,
+        "datetime_end": datetime_end,
+        "base_currency": base_currency,
+        "accuracy": accuracy,
+    }
+    if currencies:
+        params["currencies"] = currencies
+    resp = await client.get(f"{BASE_URL}/range", headers=HEADERS, params=params)
+    resp.raise_for_status()
+    return resp.json()
+
+# Usage -- daily rates for January 2026
+data = await get_range(
+    client,
+    datetime_start="2026-01-01T00:00:00Z",
+    datetime_end="2026-01-31T23:59:59Z",
+    currencies="EUR",
+    accuracy="day",
+)
+```
+
+### Convert Currency
+
+Convert an amount between currencies.
+
+**Required parameters:**
+- `value` (float) -- Amount to convert
+- `base_currency` (str) -- Source currency code
+- `currencies` (str) -- Target currency code(s)
+
+```python
+async def convert(
+    client: httpx.AsyncClient,
+    value: float,
+    base_currency: str,
+    currencies: str,
+) -> dict:
+    params = {
+        "value": str(value),
+        "base_currency": base_currency,
+        "currencies": currencies,
+    }
+    resp = await client.get(f"{BASE_URL}/convert", headers=HEADERS, params=params)
+    resp.raise_for_status()
+    return resp.json()
+
+# Usage -- convert 100 USD to EUR
+result = await convert(client, value=100.0, base_currency="USD", currencies="EUR")
+converted = result["data"]["EUR"]["value"]
+```
+
+### List Currencies
+
+Get metadata for all supported currencies.
+
+**Optional parameters:**
+- `currencies` (str) -- Filter to specific currency codes
+- `type` (str) -- Filter by type: `fiat`, `metal`, or `crypto`
+
+```python
+async def list_currencies(client: httpx.AsyncClient, currency_type: str = None) -> dict:
+    params = {}
+    if currency_type:
+        params["type"] = currency_type
+    resp = await client.get(f"{BASE_URL}/currencies", headers=HEADERS, params=params)
+    resp.raise_for_status()
+    return resp.json()
+```
+
+## Error Handling
+
+Successful responses return HTTP 200 with a JSON body containing `meta` and `data` objects.
+
+On failure, the API returns an error response:
+
+```json
+{
+    "message": "Validation error",
+    "errors": {
+        "currencies": ["The selected currencies is invalid."]
+    }
+}
+```
+
+**Status codes:**
+
+| Code | Meaning |
+|---|---|
+| 200 | Success |
+| 403 | Forbidden -- plan does not include this endpoint, upgrade required |
+| 404 | Not Found -- endpoint does not exist |
+| 422 | Validation Error -- invalid parameters (bad currency code, invalid date format, etc.) |
+| 429 | Too Many Requests -- rate limit or monthly quota exceeded |
+| 500 | Internal Server Error |
+
+**Common 422 validation errors:**
+- Invalid currency code in `currencies` or `base_currency`
+- Invalid date format (must be `YYYY-MM-DD`)
+- `datetime_start` must be before or equal to `datetime_end`
+- Invalid `accuracy` value (must be `day`, `hour`, `quarter_hour`, or `minute`)
+
+**Robust error handling pattern:**
+
+```python
+import asyncio
+import httpx
+import logging
+
+logger = logging.getLogger(__name__)
+
+class CurrencyAPIError(Exception):
+    def __init__(self, status_code: int, message: str, errors: dict = None):
+        self.status_code = status_code
+        self.message = message
+        self.errors = errors or {}
+        super().__init__(f"[{status_code}] {message}")
+
+async def currency_request(
+    client: httpx.AsyncClient,
+    endpoint: str,
+    params: dict = None,
+    max_retries: int = 3,
+) -> dict:
+    url = f"{BASE_URL}/{endpoint}"
+    for attempt in range(max_retries):
+        try:
+            resp = await client.get(url, headers=HEADERS, params=params or {})
+        except httpx.RequestError as e:
+            logger.warning(f"Network error on {endpoint} (attempt {attempt+1}): {e}")
+            await asyncio.sleep(2 ** attempt)
+            continue
+
+        if resp.status_code == 200:
+            return resp.json()
+
+        if resp.status_code == 429:
+            wait = min(2 ** attempt, 60)
+            logger.warning(f"Rate limited on {endpoint}, retrying in {wait}s")
+            await asyncio.sleep(wait)
+            continue
+
+        data = resp.json() if resp.content else {}
+        raise CurrencyAPIError(
+            resp.status_code,
+            data.get("message", "Unknown error"),
+            data.get("errors", {}),
+        )
+
+    raise CurrencyAPIError(429, f"Max retries exceeded for {endpoint}")
+```
+
+## Common Pitfalls
+
+1. **Free tier is 300 requests/month.** That is roughly 10 per day. Cache results locally and avoid calling the API on every user request. Store rates in a database or in-memory cache with a TTL matching your plan's update frequency.
+
+2. **Free tier updates daily, not real-time.** If you need minute-level or hourly rates, you must upgrade. Do not assume the free tier provides live forex data.
+
+3. **Base currency defaults to USD.** If you omit `base_currency`, all rates are relative to USD. Always specify it explicitly to avoid confusion.
+
+4. **Date format is strict.** Historical dates must be `YYYY-MM-DD`. Range datetimes must be full ISO8601 with timezone (e.g., `2026-01-01T00:00:00Z`). Other formats return 422.
+
+5. **The `accuracy` parameter affects data granularity and plan access.** `minute` and `quarter_hour` accuracy require higher-tier plans. Using them on a free plan returns 403.
+
+6. **Empty `currencies` returns all currencies.** This is convenient but returns a large payload. Filter to only the currencies you need to reduce response size and processing time.
+
+7. **Metal and crypto codes differ from ISO 4217.** Gold is `XAU`, Silver is `XAG`, Bitcoin is `BTC`. Use the `/currencies` endpoint with `type=metal` or `type=crypto` to discover valid codes.
+
+8. **The status endpoint is free.** Use `/status` to check your remaining quota before making data requests. It does not count toward your monthly limit.

--- a/content/delhivery/docs/rest-api/python/DOC.md
+++ b/content/delhivery/docs/rest-api/python/DOC.md
@@ -1,0 +1,382 @@
+---
+name: rest-api
+description: "Delhivery - Indian E-commerce Logistics & Shipping API (Last-Mile Delivery)"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "delhivery,logistics,shipping,ecommerce,india,courier,tracking,delivery,cod,prepaid,warehouse,pincode,api,integration"
+---
+
+# Delhivery API
+
+> **Golden Rule:** Delhivery has no official Python SDK. Use `httpx` for direct REST access. Auth uses a static API Token passed as `Authorization: Token <your-token>`. Staging base URL is `https://staging-express.delhivery.com`; production is `https://track.delhivery.com`. The order creation endpoint requires `format=json&data=` body format. Warehouse must be pre-registered before creating shipments.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+| Environment | URL |
+|---|---|
+| Staging/Testing | `https://staging-express.delhivery.com` |
+| Production | `https://track.delhivery.com` |
+
+Documentation: https://delhivery-express-api-doc.readme.io/reference/introduction-1
+
+Developer Portal: https://one.delhivery.com/developer-portal/documents
+
+## Authentication
+
+**Type:** Static API Token
+
+```python
+import httpx
+
+API_TOKEN = "your-delhivery-api-token"  # From Delhivery One dashboard or sales SPOC
+BASE_URL = "https://staging-express.delhivery.com"  # Use track.delhivery.com for production
+
+headers = {
+    "Authorization": f"Token {API_TOKEN}",
+    "Content-Type": "application/json"
+}
+
+client = httpx.AsyncClient(
+    base_url=BASE_URL,
+    headers=headers,
+    timeout=30.0
+)
+```
+
+**Getting credentials:**
+- Staging token: Contact Delhivery sales representative
+- Production token: Login to Delhivery One account > account header > API Key
+- Staging and production tokens are different
+
+## Rate Limiting
+
+Not publicly documented. Implement reasonable rate limiting on your end. HTTP 429 returned when limits are exceeded.
+
+## Methods
+
+### `check_pincode_serviceability`
+
+**Endpoint:** `GET /c/api/pin-codes/json/`
+
+Check if Delhivery services a given pincode.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `filter_codes` | `int` | optional (specific pincode to check) |
+| `dt` | `str` | optional (date `YYYY-MM-DD`, codes activated after) |
+| `st` | `str` | optional (2-digit state code) |
+| `token` | `str` | **required** (API token) |
+
+```python
+import httpx
+
+async def check_pincode(pincode: str):
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.get(
+            f"{BASE_URL}/c/api/pin-codes/json/",
+            params={"filter_codes": pincode, "token": API_TOKEN}
+        )
+        response.raise_for_status()
+        data = response.json()
+        return data["delivery_codes"]
+```
+
+### `create_order`
+
+**Endpoint:** `POST /api/cmu/create.json`
+
+Create a new shipment order. Returns waybill (tracking number).
+
+| Parameter | Type | Default |
+|---|---|---|
+| `pickup_location.name` | `str` | **required** (must match registered warehouse, case-sensitive) |
+| `shipments[].order` | `str` | **required** (unique order ID) |
+| `shipments[].name` | `str` | **required** (consignee name) |
+| `shipments[].phone` | `str` | **required** (consignee phone) |
+| `shipments[].add` | `str` | **required** (delivery address) |
+| `shipments[].pin` | `str` | **required** (delivery pincode) |
+| `shipments[].city` | `str` | **required** |
+| `shipments[].state` | `str` | **required** |
+| `shipments[].country` | `str` | **required** |
+| `shipments[].payment_mode` | `str` | **required** (`COD`, `Prepaid`, or `Pickup`) |
+| `shipments[].products_desc` | `str` | recommended |
+| `shipments[].cod_amount` | `str` | required for COD |
+| `shipments[].total_amount` | `str` | recommended |
+| `shipments[].seller_gst_tin` | `str` | **required** (seller GST number) |
+| `shipments[].hsn_code` | `str` | **required** (product HSN code) |
+
+```python
+import httpx
+import json
+
+async def create_order():
+    payload = {
+        "pickup_location": {
+            "name": "MyWarehouse",
+            "city": "Mumbai",
+            "pin": "400001",
+            "country": "India",
+            "phone": "9876543210",
+            "add": "123 MG Road, Fort"
+        },
+        "shipments": [
+            {
+                "order": "ORD-20260317-001",
+                "name": "Rahul Sharma",
+                "phone": "9876543211",
+                "add": "456 Brigade Road",
+                "pin": "560001",
+                "city": "Bangalore",
+                "state": "Karnataka",
+                "country": "India",
+                "payment_mode": "Prepaid",
+                "products_desc": "Electronics - Headphones",
+                "total_amount": "1999",
+                "seller_gst_tin": "29ABCDE1234F1ZH",
+                "hsn_code": "8518"
+            }
+        ]
+    }
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.post(
+            f"{BASE_URL}/api/cmu/create.json",
+            headers={
+                "Authorization": f"Token {API_TOKEN}",
+                "Content-Type": "application/json"
+            },
+            content=f"format=json&data={json.dumps(payload)}"
+        )
+        response.raise_for_status()
+        data = response.json()
+        # data = {"success": true, "packages": [{"waybill": "123456789", "status": "Success", ...}]}
+        return data
+```
+
+### `track_order`
+
+**Endpoint:** `GET /api/v1/packages/json/`
+
+Track a shipment by waybill number.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `waybill` | `str` | **required** (tracking number) |
+| `token` | `str` | **required** (API token) |
+
+```python
+async def track_order(waybill: str):
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.get(
+            f"{BASE_URL}/api/v1/packages/json/",
+            params={"waybill": waybill, "token": API_TOKEN}
+        )
+        response.raise_for_status()
+        data = response.json()
+        shipment = data["ShipmentData"][0]["Shipment"]
+        print(f"Status: {shipment['Status']['Status']}")
+        print(f"Location: {shipment['Status'].get('StatusLocation', 'N/A')}")
+        return shipment
+```
+
+### `calculate_shipping_charges`
+
+**Endpoint:** `GET /api/kinko/v1/invoice/charges/.json`
+
+Get estimated shipping cost for a shipment.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `md` | `str` | **required** (`E` = Express, `S` = Surface) |
+| `cgm` | `int` | **required** (weight in grams) |
+| `o_pin` | `str` | **required** (origin pincode) |
+| `d_pin` | `str` | **required** (destination pincode) |
+| `ss` | `str` | **required** (`Delivered`, `RTO`, `DTO`) |
+| `token` | `str` | **required** |
+
+```python
+async def get_shipping_cost(origin_pin: str, dest_pin: str, weight_grams: int):
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.get(
+            f"{BASE_URL}/api/kinko/v1/invoice/charges/.json",
+            params={
+                "md": "E",
+                "cgm": weight_grams,
+                "o_pin": origin_pin,
+                "d_pin": dest_pin,
+                "ss": "Delivered",
+                "token": API_TOKEN
+            }
+        )
+        response.raise_for_status()
+        data = response.json()
+        # Contains: freight_charge, cod_charge, fuel_surcharge, total_amount, tax
+        return data
+```
+
+### `cancel_order`
+
+**Endpoint:** `POST /api/p/edit`
+
+Cancel an existing shipment.
+
+```python
+async def cancel_order(waybill: str):
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.post(
+            f"{BASE_URL}/api/p/edit",
+            headers={
+                "Authorization": f"Token {API_TOKEN}",
+                "Content-Type": "application/json"
+            },
+            json={"waybill": waybill, "cancellation": "true"}
+        )
+        response.raise_for_status()
+        return response.json()
+```
+
+### `fetch_waybills`
+
+**Endpoint:** `GET /waybill/api/bulk/json/`
+
+Get pre-generated waybill numbers for shipments.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `token` | `str` | **required** |
+| `client_name` | `str` | **required** (your Delhivery client name) |
+| `count` | `int` | **required** (number of waybills) |
+
+```python
+async def fetch_waybills(client_name: str, count: int = 10):
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.get(
+            f"{BASE_URL}/waybill/api/bulk/json/",
+            params={
+                "token": API_TOKEN,
+                "client_name": client_name,
+                "count": count
+            }
+        )
+        response.raise_for_status()
+        return response.json()
+```
+
+### `register_warehouse`
+
+**Endpoint:** `POST /api/backend/clientwarehouse/create/`
+
+Register a pickup warehouse (required before creating orders).
+
+```python
+async def register_warehouse():
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.post(
+            f"{BASE_URL}/api/backend/clientwarehouse/create/",
+            headers={
+                "Authorization": f"Token {API_TOKEN}",
+                "Content-Type": "application/json"
+            },
+            json={
+                "name": "MyWarehouse",
+                "phone": "9876543210",
+                "city": "Mumbai",
+                "pin": "400001",
+                "address": "123 MG Road, Fort, Mumbai",
+                "country": "India",
+                "email": "warehouse@example.com",
+                "registered_name": "My Company Pvt Ltd",
+                "return_address": "123 MG Road, Fort, Mumbai",
+                "return_pin": "400001",
+                "return_city": "Mumbai",
+                "return_state": "Maharashtra",
+                "return_country": "India"
+            }
+        )
+        response.raise_for_status()
+        return response.json()
+```
+
+### `schedule_pickup`
+
+**Endpoint:** `POST /fm/request/new/`
+
+Schedule a pickup from your warehouse.
+
+```python
+async def schedule_pickup(warehouse_name: str, package_count: int):
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.post(
+            f"{BASE_URL}/fm/request/new/",
+            headers={
+                "Authorization": f"Token {API_TOKEN}",
+                "Content-Type": "application/json"
+            },
+            json={
+                "pickup_date": "2026-03-18",
+                "pickup_time": "14:00:00",
+                "pickup_location": warehouse_name,
+                "expected_package_count": package_count
+            }
+        )
+        response.raise_for_status()
+        return response.json()
+```
+
+## Error Handling
+
+```python
+import httpx
+
+try:
+    response = await client.post(
+        f"{BASE_URL}/api/cmu/create.json",
+        headers=headers,
+        content=f"format=json&data={json.dumps(payload)}"
+    )
+    response.raise_for_status()
+    data = response.json()
+    # Check per-package status even on 200
+    for pkg in data.get("packages", []):
+        if pkg["status"] != "Success":
+            print(f"Package failed: {pkg.get('remarks', 'Unknown error')}")
+except httpx.HTTPStatusError as e:
+    if e.response.status_code == 401:
+        print("Authentication failed -- check API token")
+    elif e.response.status_code == 400:
+        print(f"Bad request: {e.response.text}")
+    elif e.response.status_code == 415:
+        print("Unsupported media type -- check Content-Type header")
+    elif e.response.status_code == 429:
+        print("Rate limited -- back off and retry")
+    else:
+        print(f"Delhivery API error {e.response.status_code}: {e.response.text}")
+except httpx.RequestError as e:
+    print(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+- **Order creation body format**: The POST body must be `format=json&data=<json_string>`, NOT a direct JSON body. This is a critical difference from standard REST APIs
+- **Warehouse name is case-sensitive**: The `pickup_location.name` in order creation must exactly match the registered warehouse name
+- **Staging vs Production tokens are different**: Do not use staging tokens in production or vice versa
+- **Replace `staging-express` with `track`** in the URL when switching from staging to production
+- **Special characters break orders**: Characters like `&`, `#`, `%`, `;`, `\` in address fields must be JSON-encoded
+- **E-waybill required for high-value shipments**: If shipment value exceeds INR 50,000, an e-waybill number is mandatory
+- **GST TIN and HSN code are mandatory**: `seller_gst_tin` and `hsn_code` are required for all orders
+- **COD amount vs Total amount**: For COD orders, `cod_amount` is the amount to collect; `total_amount` is the declared shipment value
+- **Check per-package status**: Even with HTTP 200, individual packages in the response can have `"status": "Failure"` with error remarks
+- **Waybill pre-generation**: For bulk operations, pre-fetch waybills via the bulk waybill API to avoid rate issues
+- **Token passed differently per endpoint**: Some endpoints use `Authorization: Token <key>` header; others accept `token` as a query parameter (e.g., tracking, pincode check)
+- **Payment mode values**: `COD` (Cash on Delivery), `Prepaid` (forward shipment), `Pickup` (reverse pickup)
+- **Bangladesh shipments**: Use `"country": "BD"` with valid BD pincode for cross-border

--- a/content/digilocker/docs/rest-api/python/DOC.md
+++ b/content/digilocker/docs/rest-api/python/DOC.md
@@ -1,0 +1,326 @@
+---
+name: rest-api
+description: "DigiLocker - India's digital document storage, sharing, and verification platform (Digital India initiative)"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "india,digilocker,kyc,documents,digital-india,government,identity,aadhaar"
+---
+
+# DigiLocker REST API
+
+## Golden Rule
+
+DigiLocker is India's official cloud-based platform for storage, sharing, and verification of documents and certificates. It is a key initiative under the Digital India program. There are **three integration roles**: Requester (fetch user documents), Issuer (push documents to users), and Authorized Partner (embed DigiLocker in your app). Access requires formal onboarding as a partner through the DigiLocker partner portal or via an aggregator like APISetu / Setu. You **cannot** call DigiLocker APIs without an approved client ID and secret. All document access requires explicit user consent via OAuth2.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+DigiLocker APIs are accessed through aggregator gateways or the direct DigiLocker partner endpoints.
+
+**Via Setu (recommended aggregator):**
+
+| Environment | Base URL |
+|-------------|----------|
+| Sandbox | `https://dg-sandbox.setu.co` |
+| Production | `https://dg.setu.co` |
+
+**Direct DigiLocker (Authorized Partner - requires formal onboarding):**
+
+| Environment | Base URL |
+|-------------|----------|
+| Production | `https://api.digitallocker.gov.in` |
+| Authorization | `https://digilocker.meripehchaan.gov.in` |
+
+**APISetu:**
+
+| Environment | Base URL |
+|-------------|----------|
+| Production | `https://apisetu.gov.in/digilocker` |
+
+## Authentication
+
+DigiLocker uses **OAuth 2.0 Authorization Code flow** for user consent. The aggregator layer (e.g., Setu) simplifies this into a redirect-based flow.
+
+### Via Setu Aggregator
+
+All requests require these headers:
+
+| Header | Description |
+|--------|-------------|
+| `x-client-id` | Your Setu client ID |
+| `x-client-secret` | Your Setu client secret |
+| `x-product-instance-id` | Your product instance ID |
+
+```python
+import httpx
+
+BASE_URL = "https://dg-sandbox.setu.co"
+HEADERS = {
+    "x-client-id": "your-client-id",
+    "x-client-secret": "your-client-secret",
+    "x-product-instance-id": "your-product-instance-id",
+    "Content-Type": "application/json",
+}
+
+
+async def create_digilocker_request(redirect_url: str) -> dict:
+    """Initiate a DigiLocker consent session. Returns a URL to redirect the user."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{BASE_URL}/api/digilocker/",
+            headers=HEADERS,
+            json={"redirectUrl": redirect_url},
+        )
+        resp.raise_for_status()
+        return resp.json()
+        # Response: { "id": "...", "status": "unauthenticated", "url": "...", "validUpto": "..." }
+```
+
+### Direct Partner OAuth2 Flow
+
+For authorized partners integrating directly:
+
+```python
+import httpx
+from urllib.parse import urlencode
+
+AUTHORIZE_URL = "https://digilocker.meripehchaan.gov.in/public/oauth2/1/authorize"
+TOKEN_URL = "https://api.digitallocker.gov.in/public/oauth2/1/token"
+CLIENT_ID = "your-app-client-id"
+CLIENT_SECRET = "your-app-client-secret"
+REDIRECT_URI = "https://your-app.com/callback"
+
+
+def get_authorization_url() -> str:
+    """Build the OAuth2 authorization URL to redirect the user."""
+    params = {
+        "response_type": "code",
+        "client_id": CLIENT_ID,
+        "redirect_uri": REDIRECT_URI,
+        "state": "random-csrf-token",
+    }
+    return f"{AUTHORIZE_URL}?{urlencode(params)}"
+
+
+async def exchange_code_for_token(authorization_code: str) -> dict:
+    """Exchange the authorization code for an access token."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            TOKEN_URL,
+            data={
+                "grant_type": "authorization_code",
+                "code": authorization_code,
+                "redirect_uri": REDIRECT_URI,
+                "client_id": CLIENT_ID,
+                "client_secret": CLIENT_SECRET,
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+```
+
+## Rate Limiting
+
+DigiLocker does not publish explicit rate limits. In practice, the Setu aggregator layer and DigiLocker impose fair-use limits. Expect throttling above ~100 requests/minute. Implement exponential backoff for 429 responses.
+
+## Methods
+
+### Create DigiLocker Request (Setu)
+
+`POST /api/digilocker/`
+
+Initiates a consent session. User must be redirected to the returned URL to authenticate and grant document access.
+
+```python
+async def create_request(redirect_url: str) -> dict:
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{BASE_URL}/api/digilocker/",
+            headers=HEADERS,
+            json={"redirectUrl": redirect_url},
+        )
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Get Request Status
+
+`GET /api/digilocker/{id}/status`
+
+Check whether the user has completed authentication and consent.
+
+```python
+async def get_request_status(request_id: str) -> dict:
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{BASE_URL}/api/digilocker/{request_id}/status",
+            headers=HEADERS,
+        )
+        resp.raise_for_status()
+        return resp.json()
+        # Response includes: id, status ("authenticated" | "unauthenticated"),
+        # digilockerUserDetails: { digilockerId, email, phoneNumber }
+```
+
+### Get Available Documents List
+
+`GET /api/digilocker/documents`
+
+Returns the catalog of document types available for fetching. Cache this locally and refresh monthly.
+
+```python
+async def list_available_documents() -> dict:
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{BASE_URL}/api/digilocker/documents",
+            headers=HEADERS,
+        )
+        resp.raise_for_status()
+        return resp.json()
+        # Each doc: { docType, orgId, orgName, description, availableFormats, parameters }
+```
+
+### Fetch a Document
+
+`POST /api/digilocker/{id}/document`
+
+Fetch a specific document for an authenticated user. Requires the request ID from an authenticated session.
+
+```python
+async def fetch_document(request_id: str, doc_type: str, org_id: str) -> dict:
+    """Fetch a document from DigiLocker for a consented user."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{BASE_URL}/api/digilocker/{request_id}/document",
+            headers=HEADERS,
+            json={
+                "docType": doc_type,       # e.g., "PANCR" for PAN card
+                "orgId": org_id,           # e.g., "002317"
+                "format": "pdf",
+                "consent": "Y",
+                "parameters": [
+                    {"name": "AC_NO", "value": "12345678"},
+                ],
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+        # Response: { "fileUrl": "https://s3-url...", "validUpto": "..." }
+```
+
+### Fetch Aadhaar Data
+
+`GET /api/digilocker/{id}/aadhaar`
+
+Retrieve Aadhaar demographic data (name, DOB, address, gender) for an authenticated user who has consented.
+
+```python
+async def fetch_aadhaar_data(request_id: str) -> dict:
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{BASE_URL}/api/digilocker/{request_id}/aadhaar",
+            headers=HEADERS,
+        )
+        resp.raise_for_status()
+        return resp.json()
+        # Returns: name, dob, address, gender, masked aadhaar, fileUrl (signed XML)
+```
+
+### Revoke Request
+
+`GET /api/digilocker/{id}/revoke`
+
+Revoke a previously authenticated session, invalidating all associated access.
+
+```python
+async def revoke_request(request_id: str) -> dict:
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{BASE_URL}/api/digilocker/{request_id}/revoke",
+            headers=HEADERS,
+        )
+        resp.raise_for_status()
+        return resp.json()
+        # Response: { "success": true }
+```
+
+## Redirect Callback Parameters
+
+After user consent, DigiLocker redirects back to your `redirectUrl` with these query params:
+
+| Parameter | Description |
+|-----------|-------------|
+| `success` | `True` or `False` |
+| `id` | The request ID |
+| `scope` | Consented document types, e.g., `ADHAR+PANCR+DRVLC` |
+| `errCode` | Error code (on failure) |
+| `errMessage` | Error message (on failure) |
+
+**Scope values:** `ADHAR` (Aadhaar), `PANCR` (PAN), `DRVLC` (Driver's License).
+
+## Error Handling
+
+```python
+import httpx
+
+
+async def safe_digilocker_call(request_id: str) -> dict | None:
+    async with httpx.AsyncClient() as client:
+        try:
+            resp = await client.get(
+                f"{BASE_URL}/api/digilocker/{request_id}/status",
+                headers=HEADERS,
+            )
+            resp.raise_for_status()
+            return resp.json()
+        except httpx.HTTPStatusError as e:
+            status = e.response.status_code
+            if status == 400:
+                print("Bad request - check parameters")
+            elif status == 401:
+                print("Unauthorized - session expired or user revoked consent")
+            elif status == 404:
+                print("Request ID not found")
+            elif status == 429:
+                print("Rate limited - implement backoff")
+            elif status == 500:
+                print("DigiLocker server error - retry later")
+            raise
+        except httpx.ConnectError:
+            print("Connection failed - DigiLocker may be down")
+            raise
+```
+
+| HTTP Code | Meaning |
+|-----------|---------|
+| 200 | Success |
+| 400 | Bad request / invalid parameters |
+| 401 | Unauthorized / consent revoked / session expired |
+| 404 | Request ID not found |
+| 429 | Rate limited |
+| 500 | DigiLocker internal server error |
+
+## Common Pitfalls
+
+1. **User's mobile must be linked to Aadhaar** - DigiLocker account creation requires an Aadhaar-linked mobile number. If the user's mobile is not linked, the consent flow will fail.
+
+2. **Document identification requires both docType AND orgId** - The same document type (e.g., driving license) may be issued by different organizations. Always use the combination of `docType` + `orgId` to uniquely identify a document.
+
+3. **Redirect URL must be publicly accessible** - The `redirectUrl` provided during session creation must be reachable from the internet. Localhost URLs will not work even in sandbox.
+
+4. **File URLs are temporary** - The `fileUrl` returned by the document fetch endpoint has an expiry (`validUpto`). Download the document promptly and store it on your side.
+
+5. **Consent scope matters** - The user may grant partial consent (e.g., only Aadhaar, not PAN). Always check the `scope` parameter in the redirect callback before attempting to fetch specific documents.
+
+6. **Setu vs Direct integration** - Using the Setu aggregator is significantly easier to onboard with (API keys via dashboard) compared to direct DigiLocker partnership which requires government approval. Start with Setu for development.
+
+7. **Document parameters vary by issuer** - Each document type requires different parameters (e.g., account number, registration number). Fetch the document catalog first and inspect the `parameters` array for each document type.

--- a/content/e2b/docs/rest-api/python/DOC.md
+++ b/content/e2b/docs/rest-api/python/DOC.md
@@ -1,0 +1,221 @@
+---
+name: rest-api
+description: "E2B - Code Execution Sandbox for AI Agents"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "e2b,sandbox,code-execution,ai-agents,cloud-sandbox,jupyter,api"
+---
+
+# E2B REST API Reference (Python / httpx)
+
+E2B provides secure, isolated cloud sandboxes for running AI-generated code. The platform
+exposes a REST API for sandbox lifecycle management and a gRPC protocol (envd) for runtime
+operations inside sandboxes (file I/O, command execution). This document covers the REST API
+surface using `httpx` as the HTTP client.
+
+> **SDK vs REST:** E2B is SDK-primary. The recommended path for Python is `pip install e2b-code-interpreter`,
+> which wraps both REST and gRPC protocols. Use the REST API directly only when you need
+> low-level control or are in an environment where the SDK cannot be installed.
+
+## Golden Rule
+
+Always clean up sandboxes when done. Each sandbox is a running VM that consumes resources
+and counts against your concurrent sandbox limit. Call `DELETE /sandboxes/{sandboxID}` or
+use the SDK's `sandbox.kill()` to terminate sandboxes you no longer need.
+
+## Installation
+
+```bash
+pip install httpx python-dotenv
+# Or for the recommended SDK path:
+pip install e2b-code-interpreter python-dotenv
+```
+
+## Base URL
+
+```
+https://api.e2b.app
+```
+
+Override via `E2B_API_URL` or `E2B_DOMAIN` environment variables for self-hosted deployments.
+
+## Authentication
+
+All REST API requests require the `X-API-Key` header. Get your key from the [E2B Dashboard](https://e2b.dev/dashboard).
+
+```python
+import os, httpx
+from dotenv import load_dotenv
+
+load_dotenv()
+
+BASE_URL = "https://api.e2b.app"
+HEADERS = {"X-API-Key": os.environ["E2B_API_KEY"], "Content-Type": "application/json"}
+```
+
+### Two-Token Model
+
+| Token | Header | Scope |
+|-------|--------|-------|
+| API Key | `X-API-Key` | REST API -- sandbox lifecycle, templates, team management |
+| envd Access Token | `X-Access-Token` | gRPC (port 49983) -- file ops, command execution inside a sandbox |
+
+The `envdAccessToken` is returned in the sandbox creation response.
+
+## Rate Limiting
+
+| Scope | Limit |
+|-------|-------|
+| Lifecycle & Management | 20,000 requests / 30 seconds |
+| Sandbox Operations | 40,000 requests / 60 seconds per IP |
+| Sandbox Creation (Hobby/Pro) | 1/sec or 5/sec |
+| Concurrent Sandboxes (Hobby/Pro) | 20 or 100-1,100 |
+
+HTTP `429 Too Many Requests` when rate-limited. Enterprise plans support custom limits.
+
+## Methods
+
+### Create Sandbox
+
+```
+POST /sandboxes
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `templateID` | string | No | Template to use (default: `base`) |
+| `timeout` | integer | No | TTL in milliseconds (max: 3,600,000 Hobby / 86,400,000 Pro) |
+| `metadata` | object | No | Key-value metadata |
+| `envs` | object | No | Environment variables injected into the sandbox |
+
+```python
+async def create_sandbox(
+    template_id: str = "base", timeout_ms: int = 300_000,
+    metadata: dict | None = None, envs: dict | None = None,
+) -> dict:
+    payload = {"templateID": template_id, "timeout": timeout_ms}
+    if metadata: payload["metadata"] = metadata
+    if envs: payload["envs"] = envs
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS, timeout=60.0) as client:
+        resp = await client.post("/sandboxes", json=payload)
+        resp.raise_for_status()
+        return resp.json()
+    # Returns: {"sandboxID": "sb-abc123", "envdAccessToken": "...", "domain": "sb-abc123.e2b.app"}
+```
+
+### List Running Sandboxes
+
+```python
+async def list_sandboxes() -> list[dict]:
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS, timeout=60.0) as client:
+        resp = await client.get("/sandboxes")
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Kill (Delete) Sandbox
+
+```python
+async def kill_sandbox(sandbox_id: str) -> None:
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS, timeout=60.0) as client:
+        resp = await client.delete(f"/sandboxes/{sandbox_id}")
+        resp.raise_for_status()
+```
+
+### Pause / Resume Sandbox
+
+```python
+async def pause_sandbox(sandbox_id: str) -> None:
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS, timeout=60.0) as client:
+        resp = await client.post(f"/sandboxes/{sandbox_id}/pause")
+        resp.raise_for_status()
+
+async def connect_sandbox(sandbox_id: str, timeout_ms: int = 300_000) -> dict:
+    """Connect to (and resume if paused) a sandbox. Returns fresh envdAccessToken."""
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS, timeout=60.0) as client:
+        resp = await client.post(f"/sandboxes/{sandbox_id}/connect", json={"timeout": timeout_ms})
+        resp.raise_for_status()
+        return resp.json()
+```
+
+Additional REST endpoints: `GET /sandboxes/{id}` (details), `POST /sandboxes/{id}/timeout` (set TTL),
+`POST /sandboxes/{id}/refreshes` (keep-alive), `POST /sandboxes/{id}/snapshots`, `GET /templates`, `GET /snapshots`.
+
+## Code Execution (SDK Recommended)
+
+Runtime operations (executing code, file I/O, shell commands) use the gRPC/envd protocol and are best accessed through the SDK.
+
+```python
+from e2b_code_interpreter import Sandbox
+
+sbx = Sandbox.create()
+execution = sbx.run_code("print('Hello from E2B!')")
+print(execution.logs)
+
+sbx.files.write("/home/user/hello.txt", "Hello, World!")
+result = sbx.commands.run("ls -la /home/user")
+print(result.stdout)
+
+sbx.kill()
+```
+
+### Async SDK Usage
+
+```python
+from e2b_code_interpreter import AsyncSandbox
+
+async def run_code_example():
+    sbx = await AsyncSandbox.create()
+    try:
+        execution = await sbx.run_code("import sys; print(sys.version)")
+        print(execution.logs)
+    finally:
+        await sbx.kill()
+```
+
+## Error Handling
+
+| Code | Meaning |
+|------|---------|
+| 200/201 | Success |
+| 204 | No Content (successful delete) |
+| 400 | Bad Request -- invalid parameters |
+| 401 | Unauthorized -- invalid or missing API key |
+| 404 | Not Found -- sandbox/template does not exist |
+| 409 | Conflict -- resource state conflict |
+| 429 | Too Many Requests -- rate limit exceeded |
+| 500 | Internal Server Error |
+
+All error responses return JSON with `code` (int) and `message` (string) fields.
+
+```python
+async def safe_create_sandbox(template_id: str = "base") -> dict | None:
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS, timeout=60.0) as client:
+        try:
+            resp = await client.post("/sandboxes", json={"templateID": template_id, "timeout": 300_000})
+            resp.raise_for_status()
+            return resp.json()
+        except httpx.HTTPStatusError as e:
+            body = e.response.json() if "application/json" in e.response.headers.get("content-type", "") else {}
+            msg = body.get("message", e.response.text)
+            raise RuntimeError(f"E2B API error {e.response.status_code}: {msg}") from e
+        except httpx.TimeoutException:
+            raise RuntimeError("Request to E2B API timed out")
+        except httpx.RequestError as e:
+            raise RuntimeError(f"Network error contacting E2B: {e}") from e
+```
+
+## Common Pitfalls
+
+1. **Forgetting to kill sandboxes.** Every sandbox is a running VM. Leaked sandboxes consume resources. Always use try/finally or context managers.
+2. **Confusing REST and gRPC scope.** The REST API handles lifecycle only (create, pause, kill, list). Code execution and file ops go through gRPC/envd on port 49983.
+3. **Using the wrong token.** `X-API-Key` authenticates REST requests. `envdAccessToken` authenticates gRPC connections. Do not mix them.
+4. **Timeout units.** The REST API expects timeouts in **milliseconds**, not seconds. 5 minutes = `300000`.
+5. **Hobby tier creation rate.** Hobby plans allow only 1 sandbox/sec. Use `asyncio.sleep(1)` between batch creation calls.
+6. **Sandbox expiration.** Max TTL is 1 hour (Hobby) or 24 hours (Pro). Use refreshes or pause to preserve state.
+7. **Not using the SDK for runtime ops.** The gRPC/envd protocol requires Protocol Buffer serialization. Use `e2b-code-interpreter` for code execution and file operations.
+8. **Missing error body parsing.** Always parse the JSON body on errors for `code` and `message` fields rather than relying only on HTTP status.

--- a/content/exa/docs/rest-api/python/DOC.md
+++ b/content/exa/docs/rest-api/python/DOC.md
@@ -1,0 +1,420 @@
+---
+name: rest-api
+description: "Exa - Neural Search API for AI Agents"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "exa,search,neural-search,semantic-search,ai-agents,web-search,rag,api"
+---
+
+# Exa Neural Search API
+
+> **Golden Rule:** Exa is a neural search engine built for AI agents. All endpoints use POST requests to `https://api.exa.ai` with JSON bodies and authenticate via the `x-api-key` header. There are four core endpoints: `/search` for web queries, `/contents` for extracting page content from URLs, `/findSimilar` for discovering related pages, and `/answer` for getting grounded LLM answers with citations. Content retrieval (text, highlights, summaries) can be requested inline with search via the `contents` parameter, or separately via the `/contents` endpoint. Search supports multiple speed/quality modes: `instant` (~200ms), `fast` (~450ms), `auto` (~1s default), and `deep` (5-60s with structured output support).
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+```
+https://api.exa.ai
+```
+
+## Authentication
+
+All requests require an API key passed in the `x-api-key` header. Obtain your key from the [Exa Dashboard](https://dashboard.exa.ai/api-keys).
+
+```python
+import httpx
+
+EXA_API_KEY = "your-api-key"
+HEADERS = {
+    "x-api-key": EXA_API_KEY,
+    "Content-Type": "application/json",
+}
+
+async def exa_request(endpoint: str, payload: dict) -> dict:
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"https://api.exa.ai{endpoint}",
+            headers=HEADERS,
+            json=payload,
+            timeout=60.0,
+        )
+        response.raise_for_status()
+        return response.json()
+```
+
+## Rate Limiting
+
+- **Free / MCP tier:** 3 requests per second, 150 requests per day.
+- **Paid tiers:** Higher limits; contact hello@exa.ai for production rate limit details.
+- Responses include a `costDollars` object with billing breakdown.
+
+## Methods
+
+### POST /search
+
+Perform a web search and optionally retrieve page contents inline.
+
+**Endpoint:** `POST https://api.exa.ai/search`
+
+#### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `query` | string | Yes | -- | The search query |
+| `type` | string | No | `"auto"` | Search mode: `"instant"`, `"fast"`, `"auto"`, `"neural"`, `"deep"`, `"deep-reasoning"` |
+| `numResults` | integer | No | `10` | Number of results (max 100, varies by type) |
+| `category` | string | No | -- | Filter: `"company"`, `"people"`, `"research paper"`, `"news"`, `"tweet"`, `"personal site"`, `"financial report"` |
+| `userLocation` | string | No | -- | ISO 3166-1 alpha-2 country code for geographic biasing |
+| `includeDomains` | string[] | No | -- | Restrict results to these domains (max 1200). Supports paths, e.g. `"stripe.com/blog"` |
+| `excludeDomains` | string[] | No | -- | Exclude these domains (max 1200). Supports wildcard `"*.domain.com"` |
+| `startPublishedDate` | string | No | -- | ISO 8601 minimum publication date |
+| `endPublishedDate` | string | No | -- | ISO 8601 maximum publication date |
+| `startCrawlDate` | string | No | -- | ISO 8601 minimum crawl/discovery date |
+| `endCrawlDate` | string | No | -- | ISO 8601 maximum crawl/discovery date |
+| `includeText` | string[] | No | -- | Strings that must appear in results (max 1 string, 5 words) |
+| `excludeText` | string[] | No | -- | Strings to exclude (checked in first 1000 words) |
+| `moderation` | boolean | No | `false` | Filter unsafe content |
+| `contents` | object | No | -- | Inline content retrieval options (see Contents Parameters below) |
+| `additionalQueries` | string[] | No | -- | Query variations (deep search only) |
+| `systemPrompt` | string | No | -- | Custom instructions (deep search only) |
+| `outputSchema` | object | No | -- | JSON Schema for structured output (deep search only) |
+
+#### Contents Parameters (nested under `contents`)
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `text` | bool or object | -- | `true` for full text; or object with `maxCharacters`, `includeHtmlTags`, `verbosity` |
+| `highlights` | bool or object | -- | `true` for highlights; or object with `maxCharacters`, `query`, `numSentences` |
+| `summary` | object | -- | Object with optional `query` (string) and `schema` (JSON Schema) |
+| `livecrawl` | string | -- | `"never"`, `"fallback"`, `"preferred"`, `"always"` (deprecated; use `maxAgeHours`) |
+| `maxAgeHours` | integer | -- | Cache freshness: positive = use cache if fresher, `0` = always livecrawl, `-1` = cache only |
+| `livecrawlTimeout` | integer | `10000` | Livecrawl timeout in milliseconds |
+| `subpages` | integer | `0` | Number of subpages to crawl per result |
+| `subpageTarget` | string or string[] | -- | Terms to identify specific subpages |
+| `extras` | object | -- | `{"links": <int>, "imageLinks": <int>}` for additional data |
+
+#### Example
+
+```python
+import httpx
+import asyncio
+
+async def search_exa():
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            "https://api.exa.ai/search",
+            headers={
+                "x-api-key": "your-api-key",
+                "Content-Type": "application/json",
+            },
+            json={
+                "query": "best practices for RAG pipelines",
+                "type": "auto",
+                "numResults": 5,
+                "contents": {
+                    "text": {"maxCharacters": 2000},
+                    "highlights": {"maxCharacters": 500},
+                },
+            },
+            timeout=30.0,
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        for result in data["results"]:
+            print(f"{result['title']}: {result['url']}")
+            if result.get("highlights"):
+                for h in result["highlights"]:
+                    print(f"  - {h[:100]}...")
+
+        return data
+
+asyncio.run(search_exa())
+```
+
+#### Response Shape
+
+```json
+{
+  "requestId": "string",
+  "searchType": "neural | deep | deep-reasoning",
+  "results": [
+    {
+      "id": "string",
+      "url": "string",
+      "title": "string",
+      "publishedDate": "ISO 8601 | null",
+      "author": "string | null",
+      "image": "URI | null",
+      "favicon": "URI | null",
+      "text": "string (if requested)",
+      "highlights": ["string"],
+      "highlightScores": [0.0],
+      "summary": "string (if requested)"
+    }
+  ],
+  "costDollars": { "total": 0.0 }
+}
+```
+
+For `deep` / `deep-reasoning` types, the response also includes:
+
+```json
+{
+  "output": {
+    "content": "string or object",
+    "grounding": [
+      {
+        "field": "string",
+        "citations": [{"url": "string", "title": "string"}],
+        "confidence": "low | medium | high"
+      }
+    ]
+  }
+}
+```
+
+---
+
+### POST /contents
+
+Retrieve clean page content, summaries, and metadata for a list of URLs.
+
+**Endpoint:** `POST https://api.exa.ai/contents`
+
+#### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `urls` | string[] | Yes* | -- | Array of URLs to crawl |
+| `ids` | string[] | No | -- | Array of document IDs from prior search results (alternative to `urls`) |
+| `text` | bool or object | No | -- | `true` for defaults; or object: `{maxCharacters, includeHtmlTags, verbosity, includeSections, excludeSections}` |
+| `highlights` | bool or object | No | -- | `true` for defaults; or object: `{maxCharacters, query, numSentences}` |
+| `summary` | object | No | -- | `{query, schema}` for LLM-generated summaries |
+| `maxAgeHours` | integer | No | -- | Cache freshness control |
+| `livecrawlTimeout` | integer | No | `10000` | Timeout in ms |
+| `subpages` | integer | No | `0` | Number of subpages to crawl |
+| `subpageTarget` | string or string[] | No | -- | Terms to find specific subpages |
+| `extras` | object | No | -- | `{"links": <int>, "imageLinks": <int>}` |
+
+*Either `urls` or `ids` must be provided.
+
+#### Example
+
+```python
+import httpx
+import asyncio
+
+async def get_contents():
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            "https://api.exa.ai/contents",
+            headers={
+                "x-api-key": "your-api-key",
+                "Content-Type": "application/json",
+            },
+            json={
+                "urls": [
+                    "https://example.com/article-1",
+                    "https://example.com/article-2",
+                ],
+                "text": {"maxCharacters": 5000},
+                "highlights": True,
+                "summary": {"query": "What is the main argument?"},
+            },
+            timeout=30.0,
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        for result in data["results"]:
+            print(f"{result['title']}: {result.get('summary', 'N/A')}")
+
+        # Check per-URL status
+        for status in data.get("statuses", []):
+            if status["status"] == "error":
+                print(f"Failed: {status['id']} - {status['error']['tag']}")
+
+        return data
+
+asyncio.run(get_contents())
+```
+
+#### Response Shape
+
+```json
+{
+  "requestId": "string",
+  "results": [
+    {
+      "id": "string",
+      "url": "string",
+      "title": "string",
+      "publishedDate": "ISO 8601 | null",
+      "author": "string | null",
+      "text": "string",
+      "highlights": ["string"],
+      "highlightScores": [0.0],
+      "summary": "string",
+      "subpages": [],
+      "extras": {"links": [], "imageLinks": []}
+    }
+  ],
+  "statuses": [
+    {
+      "id": "string",
+      "status": "success | error",
+      "error": {"tag": "CRAWL_NOT_FOUND | CRAWL_TIMEOUT | ...", "httpStatusCode": 404}
+    }
+  ],
+  "costDollars": { "total": 0.0 }
+}
+```
+
+---
+
+### POST /answer
+
+Get an LLM-generated answer grounded in real-time web search results with citations.
+
+**Endpoint:** `POST https://api.exa.ai/answer`
+
+#### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `query` | string | Yes | -- | The question to answer (min 1 character) |
+| `stream` | boolean | No | `false` | Return response as server-sent events stream |
+| `text` | boolean | No | `false` | Include full text content in citation results |
+| `outputSchema` | object | No | -- | JSON Schema Draft 7 for structured answer output |
+
+#### Example
+
+```python
+import httpx
+import asyncio
+
+async def ask_exa():
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            "https://api.exa.ai/answer",
+            headers={
+                "x-api-key": "your-api-key",
+                "Content-Type": "application/json",
+            },
+            json={
+                "query": "What are the latest advances in protein folding?",
+                "text": True,
+            },
+            timeout=60.0,
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        print("Answer:", data["answer"])
+        print("\nCitations:")
+        for cite in data["citations"]:
+            print(f"  - {cite['title']}: {cite['url']}")
+
+        return data
+
+asyncio.run(ask_exa())
+```
+
+#### Response Shape
+
+```json
+{
+  "answer": "string (or object if outputSchema provided)",
+  "citations": [
+    {
+      "id": "string",
+      "url": "string",
+      "title": "string",
+      "author": "string | null",
+      "publishedDate": "ISO 8601 | null",
+      "text": "string (if text=true)",
+      "image": "URI | null",
+      "favicon": "URI | null"
+    }
+  ],
+  "costDollars": { "total": 0.0 }
+}
+```
+
+## Error Handling
+
+Exa returns standard HTTP status codes. Common errors:
+
+| Status | Meaning |
+|--------|---------|
+| `400` | Bad request -- invalid parameters or malformed JSON |
+| `401` | Unauthorized -- missing or invalid API key |
+| `403` | Forbidden -- insufficient permissions |
+| `429` | Rate limited -- too many requests |
+| `500` | Internal server error |
+
+```python
+import httpx
+import asyncio
+
+async def search_with_error_handling():
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.post(
+                "https://api.exa.ai/search",
+                headers={
+                    "x-api-key": "your-api-key",
+                    "Content-Type": "application/json",
+                },
+                json={"query": "example search"},
+                timeout=30.0,
+            )
+            response.raise_for_status()
+            return response.json()
+
+        except httpx.HTTPStatusError as e:
+            status = e.response.status_code
+            body = e.response.text
+            if status == 401:
+                print("Invalid API key. Check your x-api-key header.")
+            elif status == 429:
+                print("Rate limited. Back off and retry.")
+            else:
+                print(f"HTTP {status}: {body}")
+            raise
+
+        except httpx.TimeoutException:
+            print("Request timed out. Use a longer timeout for deep searches.")
+            raise
+
+        except httpx.RequestError as e:
+            print(f"Network error: {e}")
+            raise
+
+asyncio.run(search_with_error_handling())
+```
+
+## Common Pitfalls
+
+- **Forgetting `Content-Type` header:** All POST requests require `"Content-Type": "application/json"`.
+- **Using `type: "deep"` without sufficient timeout:** Deep searches can take 5-60 seconds. Set `timeout=60.0` or higher on your httpx client.
+- **`outputSchema` only works with deep search:** The `outputSchema` parameter is ignored unless `type` is `"deep"` or `"deep-reasoning"`.
+- **`category` limits filtering:** The `"company"` and `"people"` categories do not support date or text filters.
+- **`includeText` is restrictive:** Max 1 string, max 5 words. It filters on exact presence, not semantic match.
+- **`livecrawl` is deprecated:** Use `maxAgeHours` instead for cache freshness control. `0` forces a live crawl, `-1` forces cache-only.
+- **Contents endpoint requires `urls` or `ids`:** You must provide at least one. Use `ids` from a prior `/search` response or `urls` directly.
+- **Highlights vs. text for token efficiency:** Use `highlights` with a `maxCharacters` limit (e.g., 4000) for RAG pipelines instead of full `text` to reduce token usage.
+- **Free tier is heavily throttled:** 3 QPS and 150 calls/day. Plan for rate limiting in development.
+- **Check `statuses` in `/contents` response:** Individual URLs can fail (CRAWL_NOT_FOUND, CRAWL_TIMEOUT) even when the request succeeds overall.
+- **`findSimilar` endpoint path is camelCase:** The path is `/findSimilar`, not `/find_similar` or `/find-similar`.
+- **Streaming for `/answer` returns SSE:** When `stream: true`, parse as `text/event-stream`, not JSON.

--- a/content/exotel/docs/rest-api/python/DOC.md
+++ b/content/exotel/docs/rest-api/python/DOC.md
@@ -1,0 +1,244 @@
+---
+name: rest-api
+description: "Exotel - Indian Cloud Telephony & SMS API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-13"
+  source: community
+  tags: "exotel,telephony,voice,sms,ivr,cloud-calling,india,click-to-call,call-recording,api,integration"
+---
+
+# Exotel Cloud Telephony API
+
+> **Golden Rule:** Exotel has no official Python SDK for REST API access. Use `httpx` with HTTP Basic Auth (`api_key:api_token`). Default response format is **XML** -- always append `.json` to endpoint paths. Base URL includes your account SID. Voice and SMS are separate endpoint families.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+```
+https://<subdomain>/v1/Accounts/<your_sid>/
+```
+
+| Cluster | Subdomain |
+|---|---|
+| Mumbai (India) | `api.in.exotel.com` |
+| Singapore | `api.exotel.com` |
+
+## Authentication
+
+**Type:** HTTP Basic Auth (API Key + API Token)
+
+```python
+import httpx
+
+API_KEY = "your-exotel-api-key"
+API_TOKEN = "your-exotel-api-token"
+SID = "your-account-sid"
+SUBDOMAIN = "api.in.exotel.com"  # or api.exotel.com
+BASE_URL = f"https://{SUBDOMAIN}/v1/Accounts/{SID}"
+
+client = httpx.AsyncClient(auth=(API_KEY, API_TOKEN), timeout=30.0)
+```
+
+**Important:** Get credentials from Exotel Dashboard > API Settings.
+
+## Rate Limiting
+
+| API Type | Limit |
+|---|---|
+| Voice APIs | 200 calls/minute |
+| SMS APIs | Platform-dependent (HTTP 503 when exceeded) |
+
+## Methods
+
+### `make_call`
+
+**Endpoint:** `POST /v1/Accounts/{sid}/Calls/connect.json`
+
+Connect two phone numbers. Calls the `From` number first; once answered, connects to `To`.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `From` | `str` | **required** (agent number) |
+| `To` | `str` | **required** (customer number) |
+| `CallerId` | `str` | **required** (ExoPhone virtual number) |
+| `CallType` | `str` | `None` (`trans` for transactional) |
+| `TimeLimit` | `int` | `None` (max 14400 = 4 hours) |
+| `TimeOut` | `int` | `None` (ring timeout in seconds) |
+| `Record` | `bool` | `None` |
+| `StatusCallback` | `str` | `None` (webhook URL) |
+
+**Returns:** JSON with `Call` object containing `Sid`, `Status`, `Direction`
+
+```python
+data = {
+    "From": "09876543210",
+    "To": "09123456789",
+    "CallerId": "0XXXXXXX4890",
+    "Record": "true"
+}
+response = await client.post(f"{BASE_URL}/Calls/connect.json", data=data)
+response.raise_for_status()
+call = response.json()
+call_sid = call["Call"]["Sid"]
+call_status = call["Call"]["Status"]  # "queued"
+```
+
+### `connect_to_ivr`
+
+**Endpoint:** `POST /v1/Accounts/{sid}/Calls/connect.json`
+
+Call a number and connect to an IVR/Applet flow.
+
+```python
+data = {
+    "From": "09876543210",
+    "CallerId": "0XXXXXXX4890",
+    "Url": f"http://my.exotel.com/{SID}/exoml/start_voice/your_app_id"
+}
+response = await client.post(f"{BASE_URL}/Calls/connect.json", data=data)
+response.raise_for_status()
+```
+
+### `get_call_details`
+
+**Endpoint:** `GET /v1/Accounts/{sid}/Calls/{call_sid}.json`
+
+Retrieve details and status of a specific call.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `details` | `str` | `None` (`true` for leg-wise breakdown) |
+| `RecordingUrlValidity` | `int` | `None` (5-60 minutes for pre-signed URL) |
+
+**Returns:** JSON with `Call` object including `Duration`, `Price`, `RecordingUrl`, `Status`
+
+```python
+call_sid = "unique-call-id"
+response = await client.get(
+    f"{BASE_URL}/Calls/{call_sid}.json",
+    params={"details": "true"}
+)
+response.raise_for_status()
+call = response.json()
+status = call["Call"]["Status"]  # "completed", "failed", "busy", "no-answer"
+duration = call["Call"]["Duration"]
+recording = call["Call"]["RecordingUrl"]
+```
+
+### `list_calls`
+
+**Endpoint:** `GET /v1/Accounts/{sid}/Calls.json`
+
+Query calls with filters and pagination.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `Status` | `str` | `None` (`completed`, `failed`, `busy`, `no-answer`) |
+| `DateCreated` | `str` | `None` (range: `gte:YYYY-MM-DD`, `lte:YYYY-MM-DD`) |
+| `PageSize` | `int` | `50` (max 100) |
+| `SortBy` | `str` | `DateCreated:desc` |
+
+```python
+params = {
+    "Status": "completed",
+    "PageSize": 50,
+    "SortBy": "DateCreated:desc"
+}
+response = await client.get(f"{BASE_URL}/Calls.json", params=params)
+response.raise_for_status()
+data = response.json()
+calls = data["Calls"]
+total = data["Metadata"]["Total"]
+```
+
+### `send_sms`
+
+**Endpoint:** `POST /v1/Accounts/{sid}/Sms/send.json`
+
+Send an SMS message.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `From` | `str` | **required** (ExoPhone or Sender ID) |
+| `To` | `str` | **required** (recipient number) |
+| `Body` | `str` | **required** (max 2000 chars) |
+| `DltEntityId` | `str` | **required for India** (DLT registration ID) |
+| `Priority` | `str` | `normal` (`high` for OTP only) |
+| `StatusCallback` | `str` | `None` (webhook URL) |
+
+**Returns:** JSON with `SMSMessage` containing `Sid`, `Status`, `SmsUnits`
+
+```python
+data = {
+    "From": "0XXXXXXX4890",
+    "To": "09123456789",
+    "Body": "Your OTP is 123456",
+    "DltEntityId": "your-dlt-entity-id"
+}
+response = await client.post(f"{BASE_URL}/Sms/send.json", data=data)
+response.raise_for_status()
+sms = response.json()
+sms_sid = sms["SMSMessage"]["Sid"]
+sms_status = sms["SMSMessage"]["Status"]  # "queued"
+```
+
+### `get_number_info`
+
+**Endpoint:** `GET /v1/Accounts/{sid}/Numbers/{phone_number}.json`
+
+Look up metadata for a phone number (operator, circle, DND status).
+
+```python
+phone = "09123456789"
+response = await client.get(f"{BASE_URL}/Numbers/{phone}.json")
+response.raise_for_status()
+info = response.json()
+operator = info["Number"]["OperatorName"]  # "Reliance Jio"
+circle = info["Number"]["CircleName"]      # "Maharashtra"
+is_dnd = info["Number"]["DND"]             # "Yes" or "No"
+```
+
+## Error Handling
+
+```python
+import httpx
+
+try:
+    response = await client.post(f"{BASE_URL}/Calls/connect.json", data=data)
+    response.raise_for_status()
+    result = response.json()
+except httpx.HTTPStatusError as e:
+    if e.response.status_code == 401:
+        print("Auth failed -- check API key and token")
+    elif e.response.status_code == 402:
+        print("Payment required -- plan limit exceeded")
+    elif e.response.status_code == 429:
+        print("Rate limited -- max 200 calls/minute")
+    elif e.response.status_code == 503:
+        print("SMS platform limit exceeded -- retry later")
+    else:
+        print(f"Exotel error {e.response.status_code}: {e.response.text}")
+except httpx.RequestError as e:
+    print(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+- **Default response is XML** -- always append `.json` to endpoint paths (e.g., `Calls/connect.json`, not `Calls/connect`)
+- HTTP 200 does **not** mean a successful call -- it only means the API accepted the request; check the `Status` field
+- Call details (`Duration`, `Price`, `EndTime`) are populated **~2 minutes after call ends** -- use StatusCallback or poll
+- **ExoPhones** are virtual numbers from the Exotel dashboard -- you need one as `CallerId`
+- Phone numbers use E.164 format; landlines need STD code prefix (e.g., `080XXXX2400`)
+- **DLT compliance is mandatory for SMS in India** -- include `DltEntityId` and use DLT-approved templates
+- Call recordings are returned as MP3 URLs; use `RecordingUrlValidity` (5-60 min) for pre-signed secure URLs
+- `TimeLimit` max is 14400 seconds (4 hours)
+- SMS status values: `queued` → `sending` → `submitted` → `sent` or `failed`/`failed-dnd`
+- Set `StatusCallbackContentType` to `application/json` if you want JSON webhook payloads (default is `multipart/form-data`)

--- a/content/fal/docs/rest-api/python/DOC.md
+++ b/content/fal/docs/rest-api/python/DOC.md
@@ -1,0 +1,370 @@
+---
+name: rest-api
+description: "fal.ai - Generative Media Model API (Image/Video/Audio)"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "fal,image-generation,video,audio,flux,stable-diffusion,generative-ai,api"
+---
+
+# fal.ai REST API Reference (Python / httpx)
+
+## Golden Rule
+
+Always use the **queue-based async pattern** for production workloads. Submit a request, poll for status, then fetch the result. Direct synchronous calls (`fal.run`) lack automatic retries and should only be used for quick prototyping. The queue guarantees delivery -- requests are never dropped, retried automatically up to 10 times on transient failures (503, 504, connection errors), and the queue size is unlimited.
+
+## Installation
+
+```bash
+pip install httpx python-dotenv
+```
+
+All examples in this document use `httpx` with `asyncio`. Do **not** use `requests` (blocking) or the `fal-client` SDK -- this guide covers raw HTTP calls only.
+
+## Base URL
+
+| Purpose | Base URL |
+|---------|----------|
+| Queue submit / status / result | `https://queue.fal.run` |
+| Synchronous (direct) call | `https://fal.run` |
+
+Endpoint pattern: `https://queue.fal.run/{owner}/{model}` (e.g., `fal-ai/flux/schnell`).
+
+## Authentication
+
+Every request must include the API key in the `Authorization` header:
+
+```
+Authorization: Key {FAL_KEY}
+```
+
+Obtain a key at <https://fal.ai/dashboard/keys>. Store it in the `FAL_KEY` environment variable:
+
+```bash
+export FAL_KEY="your-api-key-here"
+```
+
+There are two key scopes:
+
+| Scope | Permissions |
+|-------|------------|
+| **API** | Model inference and deployed endpoints; platform API access |
+| **ADMIN** | Everything in API plus CLI operations, app management, admin platform APIs |
+
+Start with **API** scope. Only create ADMIN keys when you need deployment capabilities.
+
+## Rate Limiting
+
+fal enforces **concurrency limits** on in-progress requests (queued requests do not count):
+
+| Account Tier | Concurrent Requests |
+|-------------|---------------------|
+| New account | 2 |
+| Self-serve max | 40 (scales with credit purchases over last 4 weeks) |
+| Enterprise | Custom (contact sales) |
+
+When you exceed the limit, the API returns **HTTP 429** with:
+- Body field `type`: `concurrent_requests_limit`
+- Header `X-Fal-needs-retry: 1`
+
+Retry with exponential backoff.
+
+## Methods
+
+### 1. Synchronous Submit (Direct Call)
+
+Sends a blocking request and returns the result directly. No queue, no automatic retries.
+
+```python
+import httpx
+import os
+
+FAL_KEY = os.environ["FAL_KEY"]
+BASE = "https://fal.run"
+MODEL = "fal-ai/flux/schnell"
+
+async def generate_sync():
+    async with httpx.AsyncClient(timeout=120) as client:
+        resp = await client.post(
+            f"{BASE}/{MODEL}",
+            headers={
+                "Authorization": f"Key {FAL_KEY}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "prompt": "a sunset over mountains, cinematic lighting",
+                "image_size": "landscape_4_3",
+                "num_inference_steps": 4,
+                "num_images": 1,
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        print(data["images"][0]["url"])
+```
+
+### 2. Queue Submit
+
+Submit work to the queue and receive a `request_id` for tracking.
+
+**Endpoint:** `POST https://queue.fal.run/{model_id}`
+
+```python
+import httpx
+import os
+
+FAL_KEY = os.environ["FAL_KEY"]
+QUEUE_BASE = "https://queue.fal.run"
+MODEL = "fal-ai/flux/schnell"
+
+async def queue_submit():
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{QUEUE_BASE}/{MODEL}",
+            headers={
+                "Authorization": f"Key {FAL_KEY}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "prompt": "a sunset over mountains, cinematic lighting",
+                "image_size": "landscape_4_3",
+                "num_inference_steps": 4,
+                "num_images": 1,
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        # data contains: request_id, response_url, status_url, cancel_url, queue_position
+        return data["request_id"]
+```
+
+**Response:**
+
+```json
+{
+  "request_id": "abc-123-def",
+  "response_url": "https://queue.fal.run/fal-ai/flux/schnell/requests/abc-123-def",
+  "status_url": "https://queue.fal.run/fal-ai/flux/schnell/requests/abc-123-def/status",
+  "cancel_url": "https://queue.fal.run/fal-ai/flux/schnell/requests/abc-123-def/cancel",
+  "queue_position": 0
+}
+```
+
+**Optional request headers:**
+
+| Header | Purpose |
+|--------|---------|
+| `X-Fal-Request-Timeout` | Server-side deadline in seconds |
+| `X-Fal-Queue-Priority` | Set to `"low"` for deprioritized jobs |
+| `X-Fal-Runner-Hint` | Route to same runner (session affinity) |
+| `X-Fal-No-Retry` | Set to `1` to skip automatic retries |
+
+### 3. Queue Status
+
+Poll for the current state of a queued request.
+
+**Endpoint:** `GET https://queue.fal.run/{model_id}/requests/{request_id}/status`
+
+Add `?logs=1` to include runner log output.
+
+```python
+async def queue_status(client: httpx.AsyncClient, request_id: str):
+    resp = await client.get(
+        f"{QUEUE_BASE}/{MODEL}/requests/{request_id}/status",
+        headers={"Authorization": f"Key {FAL_KEY}"},
+        params={"logs": 1},
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+**Status lifecycle:**
+
+| Status | Meaning | Notable Fields |
+|--------|---------|----------------|
+| `IN_QUEUE` | Waiting for a runner | `queue_position` |
+| `IN_PROGRESS` | Actively processing | `logs[]` |
+| `COMPLETED` | Result ready to fetch | `logs[]`, `metrics.inference_time` |
+
+**Streaming status** (SSE) is also available at:
+`GET https://queue.fal.run/{model_id}/requests/{request_id}/status/stream?logs=1`
+
+### 4. Queue Result
+
+Fetch the final output once status is `COMPLETED`.
+
+**Endpoint:** `GET https://queue.fal.run/{model_id}/requests/{request_id}`
+
+```python
+async def queue_result(client: httpx.AsyncClient, request_id: str):
+    resp = await client.get(
+        f"{QUEUE_BASE}/{MODEL}/requests/{request_id}",
+        headers={"Authorization": f"Key {FAL_KEY}"},
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+**Image model response (e.g., flux/schnell):**
+
+```json
+{
+  "images": [
+    {
+      "url": "https://fal.media/files/...",
+      "width": 1024,
+      "height": 768,
+      "content_type": "image/jpeg"
+    }
+  ],
+  "prompt": "a sunset over mountains, cinematic lighting",
+  "seed": 42,
+  "timings": {},
+  "has_nsfw_concepts": [false]
+}
+```
+
+### 5. Cancel Request
+
+**Endpoint:** `PUT https://queue.fal.run/{model_id}/requests/{request_id}/cancel`
+
+| Response Code | Body Status | Meaning |
+|---------------|-------------|---------|
+| 202 | `CANCELLATION_REQUESTED` | Cancel accepted |
+| 400 | `ALREADY_COMPLETED` | Too late to cancel |
+| 404 | `NOT_FOUND` | Unknown request ID |
+
+## Complete Queue Workflow Example
+
+```python
+import asyncio
+import httpx
+import os
+
+FAL_KEY = os.environ["FAL_KEY"]
+QUEUE_BASE = "https://queue.fal.run"
+MODEL = "fal-ai/flux/schnell"
+
+
+async def generate_image(prompt: str) -> dict:
+    headers = {
+        "Authorization": f"Key {FAL_KEY}",
+        "Content-Type": "application/json",
+    }
+
+    async with httpx.AsyncClient(timeout=300) as client:
+        # 1. Submit to queue
+        submit_resp = await client.post(
+            f"{QUEUE_BASE}/{MODEL}",
+            headers=headers,
+            json={
+                "prompt": prompt,
+                "image_size": "landscape_4_3",
+                "num_inference_steps": 4,
+                "num_images": 1,
+            },
+        )
+        submit_resp.raise_for_status()
+        request_id = submit_resp.json()["request_id"]
+        print(f"Submitted: {request_id}")
+
+        # 2. Poll for completion
+        while True:
+            status_resp = await client.get(
+                f"{QUEUE_BASE}/{MODEL}/requests/{request_id}/status",
+                headers={"Authorization": f"Key {FAL_KEY}"},
+                params={"logs": 1},
+            )
+            status_resp.raise_for_status()
+            status_data = status_resp.json()
+            status = status_data["status"]
+            print(f"Status: {status}")
+
+            if status == "COMPLETED":
+                break
+            elif status == "IN_QUEUE":
+                await asyncio.sleep(0.5)
+            elif status == "IN_PROGRESS":
+                await asyncio.sleep(0.3)
+            else:
+                raise RuntimeError(f"Unexpected status: {status}")
+
+        # 3. Fetch result
+        result_resp = await client.get(
+            f"{QUEUE_BASE}/{MODEL}/requests/{request_id}",
+            headers={"Authorization": f"Key {FAL_KEY}"},
+        )
+        result_resp.raise_for_status()
+        return result_resp.json()
+
+
+async def main():
+    result = await generate_image("a sunset over mountains, cinematic lighting")
+    for img in result["images"]:
+        print(f"Image URL: {img['url']} ({img['width']}x{img['height']})")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+## Error Handling
+
+| HTTP Code | Meaning | Action |
+|-----------|---------|--------|
+| 400 | Bad request / invalid parameters | Fix the request body |
+| 401 | Invalid or missing API key | Check `FAL_KEY` and `Authorization` header |
+| 404 | Model or request ID not found | Verify model path and request ID |
+| 422 | Validation error (wrong types, missing fields) | Check input schema for the model |
+| 429 | Concurrency limit exceeded | Retry with exponential backoff; check `X-Fal-needs-retry` header |
+| 500 | Internal server error | Automatic retry if using queue; otherwise retry manually |
+| 503/504 | Service unavailable / gateway timeout | Queue auto-retries up to 10 times; for sync calls, retry manually |
+
+Example error handling with httpx:
+
+```python
+import httpx
+
+async def safe_request(client: httpx.AsyncClient, method: str, url: str, **kwargs):
+    try:
+        resp = await client.request(method, url, **kwargs)
+        resp.raise_for_status()
+        return resp.json()
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 429:
+            # Concurrency limit -- back off and retry
+            raise
+        elif e.response.status_code == 401:
+            raise ValueError("Invalid FAL_KEY -- check your API key")
+        else:
+            print(f"HTTP {e.response.status_code}: {e.response.text}")
+            raise
+    except httpx.TimeoutException:
+        print("Request timed out -- consider increasing timeout or using queue")
+        raise
+```
+
+## Common Pitfalls
+
+1. **Using `requests` instead of `httpx`** -- The `requests` library is synchronous and blocks the event loop. Use `httpx.AsyncClient` for async workflows.
+
+2. **Polling the result endpoint before COMPLETED** -- The result endpoint (`GET .../requests/{request_id}`) only returns data after the status is `COMPLETED`. Always check status first.
+
+3. **Forgetting `Content-Type: application/json`** -- The submit endpoint expects JSON. Omitting this header can cause 400 errors.
+
+4. **Using `Bearer` instead of `Key`** -- The auth header format is `Authorization: Key {FAL_KEY}`, not `Bearer`. Using Bearer will return 401.
+
+5. **Not handling 429 concurrency limits** -- New accounts start with only 2 concurrent requests. Queue submissions still succeed (they wait), but direct sync calls will fail with 429.
+
+6. **Polling too aggressively** -- Use 300-500ms intervals. For long-running models (video generation), increase to 1-2 seconds. Alternatively, use the SSE streaming status endpoint or webhooks.
+
+7. **Ignoring `sync_mode` vs queue** -- Setting `sync_mode: true` in the request body is a model-level parameter that returns base64 data URIs instead of CDN URLs. It is not the same as calling the synchronous `fal.run` endpoint.
+
+8. **Hardcoding model paths** -- Model IDs can change. Use the model page on fal.ai to confirm the current endpoint path (e.g., `fal-ai/flux/schnell`, `fal-ai/stable-diffusion-v35-large`).
+
+9. **Not setting timeouts** -- Always configure `httpx.AsyncClient(timeout=...)`. Image models typically complete in 2-10 seconds; video models can take minutes.
+
+10. **Missing `num_inference_steps`** -- Each model has a default, but explicitly setting this (e.g., 4 for flux/schnell) ensures predictable speed and quality tradeoffs.

--- a/content/firecrawl/docs/rest-api/python/DOC.md
+++ b/content/firecrawl/docs/rest-api/python/DOC.md
@@ -1,0 +1,289 @@
+---
+name: rest-api
+description: "Firecrawl - Web Scraping and Crawling API for AI"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "firecrawl,scraping,crawling,web-data,extraction,ai,rag,api"
+---
+
+# Firecrawl REST API Reference (Python / httpx)
+
+## Golden Rule
+
+Always use the REST API directly with `httpx` for full control over requests, retries, and async patterns. Do not use the `firecrawl` Python SDK -- it adds abstraction that hides rate-limit headers and makes debugging harder. The API is versioned at `v1` (current production path maps v1 -> v2 internally). All endpoints accept JSON and return JSON.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+All examples below use `httpx.AsyncClient` for non-blocking I/O. For synchronous usage, replace `async`/`await` with `httpx.Client` and drop the `async` keyword.
+
+## Base URL
+
+```
+https://api.firecrawl.dev
+```
+
+All endpoint paths below are relative to this base.
+
+## Authentication
+
+Every request must include a Bearer token in the `Authorization` header.
+
+```python
+import httpx
+
+FIRECRAWL_API_KEY = "fc-..."  # your API key
+
+headers = {
+    "Authorization": f"Bearer {FIRECRAWL_API_KEY}",
+    "Content-Type": "application/json",
+}
+```
+
+## Rate Limiting
+
+Limits are per-plan and per-endpoint (requests/minute):
+
+| Plan     | /scrape | /map   | /crawl | /search | /extract |
+|----------|---------|--------|--------|---------|----------|
+| Free     | 10      | 10     | 1      | 5       | 10       |
+| Hobby    | 100     | 100    | 15     | 50      | 100      |
+| Standard | 500     | 500    | 50     | 250     | 500      |
+| Growth   | 5,000   | 5,000  | 250    | 2,500   | 1,000    |
+| Scale    | 7,500   | 7,500  | 750    | 7,500   | 1,000    |
+
+When rate-limited, the API returns HTTP `429`. Implement exponential backoff.
+
+Status-polling endpoints (`/crawl/{id}`, `/extract/{id}`) have much higher limits (1,500-25,000 req/min).
+
+---
+
+## Methods
+
+### POST /v1/scrape
+
+Scrape a single URL and return its content in one or more formats.
+
+**Request Body:**
+
+| Parameter          | Type     | Required | Default | Description                                      |
+|--------------------|----------|----------|---------|--------------------------------------------------|
+| `url`              | string   | Yes      | --      | The URL to scrape                                |
+| `formats`          | string[] | No       | `["markdown"]` | Output formats: `markdown`, `html`, `rawHtml`, `links`, `screenshot`, `json` |
+| `onlyMainContent`  | boolean  | No       | `true`  | Strip navs, footers, sidebars                    |
+| `includeTags`      | string[] | No       | --      | HTML tags to include                             |
+| `excludeTags`      | string[] | No       | --      | HTML tags to exclude                             |
+| `waitFor`          | integer  | No       | `0`     | Milliseconds to wait before scraping (for JS-rendered pages) |
+| `timeout`          | integer  | No       | `30000` | Request timeout in ms (1000-300000)              |
+| `mobile`           | boolean  | No       | `false` | Emulate mobile device                            |
+| `headers`          | object   | No       | --      | Custom HTTP headers                              |
+| `actions`          | array    | No       | --      | Browser actions: `wait`, `click`, `write`, `scroll`, `screenshot`, `executeJavascript` |
+| `removeBase64Images` | boolean | No     | `true`  | Strip base64 images from markdown output         |
+| `blockAds`         | boolean  | No       | `true`  | Enable ad-blocking                               |
+| `location`         | object   | No       | --      | Country code and language preferences            |
+
+**Example:**
+
+```python
+import httpx
+
+async def scrape_url(url: str) -> dict:
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            "https://api.firecrawl.dev/v1/scrape",
+            headers=headers,
+            json={
+                "url": url,
+                "formats": ["markdown", "html", "links"],
+                "onlyMainContent": True,
+                "timeout": 30000,
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+        # {success, data: {markdown, html, links, metadata: {title, url, statusCode}}}
+```
+
+---
+
+### POST /v1/crawl
+
+Start an asynchronous crawl job. Returns a job ID -- you must poll for results.
+
+**Request Body:**
+
+| Parameter             | Type     | Required | Default  | Description                                     |
+|-----------------------|----------|----------|----------|-------------------------------------------------|
+| `url`                 | string   | Yes      | --       | Starting URL for the crawl                      |
+| `limit`               | integer  | No       | `10000`  | Max pages to crawl                              |
+| `maxDiscoveryDepth`   | integer  | No       | --       | Max link-depth from start URL                   |
+| `includePaths`        | string[] | No       | --       | Regex patterns for URLs to include              |
+| `excludePaths`        | string[] | No       | --       | Regex patterns for URLs to exclude              |
+| `allowExternalLinks`  | boolean  | No       | `false`  | Follow links to other domains                   |
+| `allowSubdomains`     | boolean  | No       | `false`  | Follow subdomain links                          |
+| `delay`               | number   | No       | --       | Seconds to wait between page scrapes            |
+| `maxConcurrency`      | integer  | No       | --       | Max concurrent scrapes                          |
+| `sitemap`             | string   | No       | `"include"` | Sitemap strategy: `skip`, `include`, `only`  |
+| `scrapeOptions`       | object   | No       | --       | Nested scrape config (formats, headers, etc.)   |
+| `webhook`             | object   | No       | --       | Webhook URL, headers, and event types           |
+
+**Example -- submit a crawl job:**
+
+**Combined submit + poll pattern:**
+
+```python
+async def crawl_and_wait(
+    url: str, max_pages: int = 100, poll_interval: float = 2.0,
+) -> list[dict]:
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        resp = await client.post(
+            "https://api.firecrawl.dev/v1/crawl",
+            headers=headers,
+            json={
+                "url": url,
+                "limit": max_pages,
+                "scrapeOptions": {"formats": ["markdown"], "onlyMainContent": True},
+            },
+        )
+        resp.raise_for_status()
+        job_id = resp.json()["id"]
+
+        all_data = []
+        while True:
+            status_resp = await client.get(
+                f"https://api.firecrawl.dev/v1/crawl/{job_id}", headers=headers,
+            )
+            status_resp.raise_for_status()
+            result = status_resp.json()
+            if result["status"] == "completed":
+                all_data.extend(result.get("data", []))
+                next_url = result.get("next")
+                while next_url:
+                    page_resp = await client.get(next_url, headers=headers)
+                    page_resp.raise_for_status()
+                    page_result = page_resp.json()
+                    all_data.extend(page_result.get("data", []))
+                    next_url = page_result.get("next")
+                return all_data
+            if result["status"] == "failed":
+                raise RuntimeError(f"Crawl {job_id} failed")
+            await asyncio.sleep(poll_interval)
+```
+
+`GET /v1/crawl/{id}` returns: `status` (scraping/completed/failed), `total`, `completed`, `creditsUsed`, `expiresAt`, `next` (pagination URL if >10MB), `data` (array of page objects).
+
+---
+
+### POST /v1/map
+
+Discover all URLs on a website without scraping content. Fast site-map generation.
+
+**Request Body:**
+
+| Parameter              | Type    | Required | Default    | Description                                |
+|------------------------|---------|----------|------------|--------------------------------------------|
+| `url`                  | string  | Yes      | --         | Base URL to map                            |
+| `search`               | string  | No       | --         | Order results by relevance to this query   |
+| `sitemap`              | string  | No       | `"include"`| `skip`, `include`, or `only`               |
+| `includeSubdomains`    | boolean | No       | `true`     | Include subdomain URLs                     |
+| `ignoreQueryParameters`| boolean | No       | `true`     | Deduplicate URLs ignoring query params     |
+| `limit`                | integer | No       | `5000`     | Max links to return (max 100,000)          |
+| `timeout`              | integer | No       | --         | Timeout in milliseconds                    |
+
+**Example:**
+
+```python
+async def map_site(url: str, search: str | None = None) -> list[dict]:
+    async with httpx.AsyncClient() as client:
+        payload = {"url": url, "limit": 5000}
+        if search:
+            payload["search"] = search
+        resp = await client.post(
+            "https://api.firecrawl.dev/v1/map",
+            headers=headers,
+            json=payload,
+        )
+        resp.raise_for_status()
+        return resp.json()["links"]
+        # {success, links: [{url, title, description}, ...]}
+```
+
+---
+
+Additional endpoints (`/v1/search`, `/v1/extract`, `GET /v1/extract/{id}`) follow the same patterns. See the [Firecrawl docs](https://docs.firecrawl.dev) for details.
+
+---
+
+## Error Handling
+
+All endpoints return consistent error shapes:
+
+| Status | Meaning                  | Action                                      |
+|--------|--------------------------|---------------------------------------------|
+| `200`  | Success                  | Parse `response.json()`                     |
+| `400`  | Bad request              | Check request body and parameters           |
+| `401`  | Unauthorized             | Verify API key                              |
+| `402`  | Payment required         | Check plan credits / billing                |
+| `429`  | Rate limit exceeded      | Back off and retry with exponential delay    |
+| `500`  | Server error             | Retry with backoff; contact support if persistent |
+
+**Recommended retry wrapper:**
+
+```python
+import httpx
+import asyncio
+from typing import Any
+
+async def firecrawl_request(
+    client: httpx.AsyncClient,
+    method: str,
+    url: str,
+    max_retries: int = 3,
+    **kwargs: Any,
+) -> dict:
+    """Make a Firecrawl API request with exponential backoff on 429/5xx."""
+    for attempt in range(max_retries):
+        resp = await client.request(method, url, headers=headers, **kwargs)
+
+        if resp.status_code == 200:
+            return resp.json()
+
+        if resp.status_code == 429 or resp.status_code >= 500:
+            wait = 2 ** attempt
+            await asyncio.sleep(wait)
+            continue
+
+        # Non-retryable error
+        resp.raise_for_status()
+
+    raise httpx.HTTPStatusError(
+        f"Failed after {max_retries} retries",
+        request=resp.request,
+        response=resp,
+    )
+```
+
+---
+
+## Common Pitfalls
+
+1. **Crawl/extract are async.** `POST /v1/crawl` and `/v1/extract` return a job ID immediately. You must poll until `status == "completed"`. Use 2-5 second poll intervals.
+
+2. **Handle pagination on large crawls.** When results exceed 10MB, the response includes a `next` URL. Follow it to get all pages.
+
+3. **Ignoring rate limits.** Free-tier allows only 10 scrapes/min. Always implement backoff on HTTP 429.
+
+4. **Use `markdown` format for LLM consumption.** The `html` format returns cleaned HTML; `rawHtml` is unmodified source. Keep `onlyMainContent: true` (default) for cleaner output.
+
+5. **Use `map` before `crawl`.** If you only need URLs from a site (e.g., to filter before crawling), `POST /v1/map` is instant and costs fewer credits than a full crawl.
+
+6. **Set `timeout`/`waitFor` for JS-heavy pages.** Pages relying on client-side rendering need longer timeouts to ensure content loads.
+
+7. **Results expire.** Download and store crawl/extract results before the `expiresAt` timestamp.

--- a/content/fireworks/docs/rest-api/python/DOC.md
+++ b/content/fireworks/docs/rest-api/python/DOC.md
@@ -1,0 +1,496 @@
+---
+name: rest-api
+description: "Fireworks AI - Enterprise Fast Inference API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "fireworks,inference,llm,fast-inference,chat,embeddings,function-calling,api"
+---
+
+# Fireworks AI REST API - Python (httpx)
+
+## Golden Rule
+
+Fireworks AI exposes an **OpenAI-compatible** REST API. Any code targeting the OpenAI `/v1/chat/completions`, `/v1/completions`, or `/v1/embeddings` endpoints works with Fireworks by swapping the base URL and API key. All examples below use **`httpx`** (async) for HTTP calls -- do NOT use `requests` or the Fireworks SDK.
+
+---
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+---
+
+## Base URL
+
+```
+https://api.fireworks.ai/inference/v1
+```
+
+All endpoint paths are appended to this base (e.g., `/chat/completions`).
+
+---
+
+## Authentication
+
+Every request must include a **Bearer** token in the `Authorization` header. Obtain an API key from the Fireworks dashboard at <https://app.fireworks.ai/settings/users/api-keys>.
+
+```python
+import os
+
+FIREWORKS_API_KEY = os.environ["FIREWORKS_API_KEY"]
+
+headers = {
+    "Authorization": f"Bearer {FIREWORKS_API_KEY}",
+    "Content-Type": "application/json",
+}
+```
+
+---
+
+## Rate Limiting
+
+### Serverless Tier Limits
+
+| Condition | RPM (spike arrest max) |
+|---|---|
+| No payment method | 10 RPM |
+| With payment method | Up to 6,000 RPM (dynamic) |
+
+Soft baseline limits (scale up with sustained usage):
+- 1 request/second
+- 1,000 input tokens/second
+- 200 output tokens/second
+
+### Spending Tiers
+
+| Tier | Cumulative Spend | Monthly Budget Cap |
+|---|---|---|
+| 1 | Valid payment method | $50 |
+| 2 | $50 | $500 |
+| 3 | $500 | $5,000 |
+| 4 | $5,000 | $50,000 |
+| Unlimited | Contact support | Unlimited |
+
+### Response Headers
+
+Monitor rate-limit state via these headers:
+- `x-ratelimit-limit-requests` -- current minimum limit
+- `x-ratelimit-remaining-requests` -- remaining capacity
+- `x-ratelimit-over-limit: yes` -- near-capacity warning
+
+When rate-limited, the API returns **HTTP 429**. Use exponential backoff with jitter for retries.
+
+---
+
+## Methods
+
+### 1. Chat Completions
+
+**Endpoint:** `POST /chat/completions`
+
+#### Basic Request
+
+```python
+import httpx
+import os
+
+FIREWORKS_API_KEY = os.environ["FIREWORKS_API_KEY"]
+BASE_URL = "https://api.fireworks.ai/inference/v1"
+
+async def chat_completion():
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{BASE_URL}/chat/completions",
+            headers={
+                "Authorization": f"Bearer {FIREWORKS_API_KEY}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": "accounts/fireworks/models/deepseek-v3p1",
+                "messages": [
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": "Explain quantum entanglement briefly."},
+                ],
+                "max_tokens": 256,
+                "temperature": 0.7,
+                "top_p": 1.0,
+            },
+            timeout=30.0,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return data["choices"][0]["message"]["content"]
+```
+
+#### Streaming Request
+
+```python
+import httpx
+import json
+import os
+
+FIREWORKS_API_KEY = os.environ["FIREWORKS_API_KEY"]
+BASE_URL = "https://api.fireworks.ai/inference/v1"
+
+async def chat_completion_stream():
+    async with httpx.AsyncClient() as client:
+        async with client.stream(
+            "POST",
+            f"{BASE_URL}/chat/completions",
+            headers={
+                "Authorization": f"Bearer {FIREWORKS_API_KEY}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": "accounts/fireworks/models/deepseek-v3p1",
+                "messages": [
+                    {"role": "user", "content": "Write a haiku about fast inference."},
+                ],
+                "max_tokens": 128,
+                "temperature": 0.7,
+                "stream": True,
+            },
+            timeout=60.0,
+        ) as resp:
+            resp.raise_for_status()
+            async for line in resp.aiter_lines():
+                if line.startswith("data: "):
+                    payload = line[len("data: "):]
+                    if payload.strip() == "[DONE]":
+                        break
+                    chunk = json.loads(payload)
+                    delta = chunk["choices"][0].get("delta", {})
+                    content = delta.get("content", "")
+                    if content:
+                        print(content, end="", flush=True)
+```
+
+#### Parameters Reference
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `model` | string | **required** | Model identifier, e.g. `accounts/fireworks/models/deepseek-v3p1` |
+| `messages` | array | **required** | Conversation messages (`role` + `content`) |
+| `temperature` | float | 1.0 | Sampling temperature (0-2) |
+| `top_p` | float | 1.0 | Nucleus sampling threshold (0-1) |
+| `top_k` | int | -- | Top-k filtering (0-100) |
+| `max_tokens` | int | -- | Maximum tokens to generate |
+| `n` | int | 1 | Number of completions (1-128) |
+| `stop` | string/array | -- | Up to 4 stop sequences |
+| `stream` | bool | false | Enable SSE streaming |
+| `frequency_penalty` | float | 0.0 | Penalize repeated tokens (-2 to 2) |
+| `presence_penalty` | float | 0.0 | Penalize tokens already present (-2 to 2) |
+| `tools` | array | -- | Function definitions for tool calling |
+| `tool_choice` | string/object | "auto" | Control tool invocation: `auto`, `none`, `required` |
+| `response_format` | object | -- | Force output: `json_object`, `json_schema`, `grammar`, `text` |
+| `seed` | int | -- | For deterministic sampling |
+
+#### Response Shape
+
+```json
+{
+  "id": "cmpl-abc123",
+  "object": "chat.completion",
+  "created": 1711234567,
+  "model": "accounts/fireworks/models/deepseek-v3p1",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "..."
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 42,
+    "completion_tokens": 100,
+    "total_tokens": 142
+  }
+}
+```
+
+---
+
+### 2. Text Completions
+
+**Endpoint:** `POST /completions`
+
+Uses raw string prompts instead of structured messages. Useful for lower-level prompt control.
+
+```python
+import httpx
+import os
+
+FIREWORKS_API_KEY = os.environ["FIREWORKS_API_KEY"]
+BASE_URL = "https://api.fireworks.ai/inference/v1"
+
+async def text_completion():
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{BASE_URL}/completions",
+            headers={
+                "Authorization": f"Bearer {FIREWORKS_API_KEY}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": "accounts/fireworks/models/deepseek-v3p1",
+                "prompt": "The three laws of thermodynamics are:\n1.",
+                "max_tokens": 256,
+                "temperature": 0.3,
+            },
+            timeout=30.0,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return data["choices"][0]["text"]
+```
+
+Additional parameters beyond chat completions: `prompt` (string, array, or token IDs), `echo` (repeat prompt in response), `logprobs` (include log probabilities).
+
+---
+
+### 3. Embeddings
+
+**Endpoint:** `POST /embeddings`
+
+```python
+import httpx
+import os
+
+FIREWORKS_API_KEY = os.environ["FIREWORKS_API_KEY"]
+BASE_URL = "https://api.fireworks.ai/inference/v1"
+
+async def get_embeddings(texts: list[str]):
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{BASE_URL}/embeddings",
+            headers={
+                "Authorization": f"Bearer {FIREWORKS_API_KEY}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": "accounts/fireworks/models/qwen3-embedding-8b",
+                "input": texts,
+                "dimensions": 512,  # optional: variable-length embeddings
+            },
+            timeout=30.0,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return [item["embedding"] for item in data["data"]]
+```
+
+Available embedding models include:
+- `accounts/fireworks/models/qwen3-embedding-8b` (and 4b, 0p6b variants)
+- BAAI, nomic-ai, mixedbread-ai, sentence-transformers hosted models
+- Any LLM on Fireworks can also be queried for embeddings
+
+The `dimensions` parameter allows generating variable-length embedding vectors.
+
+---
+
+### 4. Function Calling (Tool Use)
+
+Fireworks supports OpenAI-compatible function calling. Use models that support the `tools` parameter (check `supportsTools` in model metadata). Use low temperature (0.0-0.3) for reliable function calling.
+
+```python
+import httpx
+import json
+import os
+
+FIREWORKS_API_KEY = os.environ["FIREWORKS_API_KEY"]
+BASE_URL = "https://api.fireworks.ai/inference/v1"
+
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get current weather for a city.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string", "description": "City name"},
+                    "units": {
+                        "type": "string",
+                        "enum": ["celsius", "fahrenheit"],
+                        "description": "Temperature unit",
+                    },
+                },
+                "required": ["city"],
+            },
+        },
+    }
+]
+
+async def function_calling_example():
+    async with httpx.AsyncClient() as client:
+        # Step 1: Send request with tools
+        response = await client.post(
+            f"{BASE_URL}/chat/completions",
+            headers={
+                "Authorization": f"Bearer {FIREWORKS_API_KEY}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": "accounts/fireworks/models/kimi-k2-instruct-0905",
+                "messages": [
+                    {"role": "user", "content": "What's the weather in Tokyo?"},
+                ],
+                "tools": tools,
+                "tool_choice": "auto",
+                "temperature": 0.1,
+            },
+            timeout=30.0,
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        assistant_message = data["choices"][0]["message"]
+        tool_calls = assistant_message.get("tool_calls", [])
+
+        if not tool_calls:
+            return assistant_message["content"]
+
+        # Step 2: Execute tool and return result
+        tool_call = tool_calls[0]
+        args = json.loads(tool_call["function"]["arguments"])
+
+        # Simulate tool execution
+        weather_result = {"temp": 22, "condition": "sunny", "city": args["city"]}
+
+        # Step 3: Send tool result back
+        response = await client.post(
+            f"{BASE_URL}/chat/completions",
+            headers={
+                "Authorization": f"Bearer {FIREWORKS_API_KEY}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": "accounts/fireworks/models/kimi-k2-instruct-0905",
+                "messages": [
+                    {"role": "user", "content": "What's the weather in Tokyo?"},
+                    assistant_message,
+                    {
+                        "role": "tool",
+                        "tool_call_id": tool_call["id"],
+                        "content": json.dumps(weather_result),
+                    },
+                ],
+                "tools": tools,
+                "temperature": 0.1,
+            },
+            timeout=30.0,
+        )
+        response.raise_for_status()
+        final = response.json()
+        return final["choices"][0]["message"]["content"]
+```
+
+#### tool_choice Options
+
+| Value | Behavior |
+|---|---|
+| `"auto"` | Model decides whether to call tools (default) |
+| `"none"` | Disables tool invocation |
+| `"required"` | Forces at least one tool call |
+| `{"type": "function", "function": {"name": "..."}}` | Forces a specific function |
+
+---
+
+## Error Handling
+
+### HTTP Status Codes
+
+| Code | Meaning | Action |
+|---|---|---|
+| 400 | Bad Request -- invalid input or malformed request | Validate parameters |
+| 401 | Unauthorized -- invalid API key | Check API key |
+| 402 | Payment Required -- no paid plan or exceeded usage | Check billing |
+| 403 | Forbidden -- insufficient permissions | Verify API key permissions |
+| 404 | Not Found -- bad endpoint or unavailable model | Check URL and model name |
+| 408 | Request Timeout | Retry with backoff |
+| 413 | Payload Too Large | Reduce input size |
+| 422 | Validation Error | Fix request body schema |
+| 429 | Too Many Requests -- rate limited | Exponential backoff with jitter |
+| 500 | Internal Server Error | Contact Fireworks support |
+| 502 | Bad Gateway | Retry; check status page |
+| 503 | Service Unavailable | Retry later |
+| 504 | Gateway Timeout | Retry; shorten prompts |
+
+### Retry Pattern with Exponential Backoff
+
+```python
+import httpx
+import asyncio
+import random
+import os
+
+FIREWORKS_API_KEY = os.environ["FIREWORKS_API_KEY"]
+BASE_URL = "https://api.fireworks.ai/inference/v1"
+
+async def request_with_retry(
+    payload: dict,
+    endpoint: str = "/chat/completions",
+    max_retries: int = 5,
+    base_delay: float = 1.0,
+):
+    headers = {
+        "Authorization": f"Bearer {FIREWORKS_API_KEY}",
+        "Content-Type": "application/json",
+    }
+    async with httpx.AsyncClient() as client:
+        for attempt in range(max_retries):
+            try:
+                response = await client.post(
+                    f"{BASE_URL}{endpoint}",
+                    headers=headers,
+                    json=payload,
+                    timeout=60.0,
+                )
+                if response.status_code == 429:
+                    delay = base_delay * (2 ** attempt) + random.uniform(0, 1)
+                    await asyncio.sleep(delay)
+                    continue
+                response.raise_for_status()
+                return response.json()
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code in (500, 502, 503, 504) and attempt < max_retries - 1:
+                    delay = base_delay * (2 ** attempt) + random.uniform(0, 1)
+                    await asyncio.sleep(delay)
+                    continue
+                raise
+    raise RuntimeError(f"Request failed after {max_retries} retries")
+```
+
+---
+
+## Common Pitfalls
+
+1. **Model name format** -- Fireworks model identifiers use the `accounts/fireworks/models/<name>` prefix. Omitting the prefix results in a 404.
+
+2. **Streaming parse errors** -- SSE lines are prefixed with `data: `. The stream ends with `data: [DONE]`. Always check for `[DONE]` before parsing JSON.
+
+3. **Timeout too low** -- Long generations can exceed default httpx timeouts (5s). Set `timeout=60.0` or higher for large `max_tokens` values.
+
+4. **Function calling temperature** -- Use low temperature (0.0-0.3) for tool-calling requests. Higher values cause hallucinated arguments.
+
+5. **Rate limit soft scaling** -- Soft limits start low (1 req/s) and double roughly hourly with sustained usage. New accounts hitting 429 early should ramp up gradually.
+
+6. **No payment method** -- Without a payment method on file, the account is capped at 10 RPM. Add a payment method for dynamic scaling up to 6,000 RPM.
+
+7. **Token counting** -- The `usage` object in responses reports `prompt_tokens`, `completion_tokens`, and `total_tokens`. Monitor these for cost control.
+
+8. **Content-Type header** -- Always include `Content-Type: application/json`. Missing it causes 400 errors.
+
+9. **Embeddings dimensions** -- The `dimensions` parameter is optional. If omitted, the model returns its native vector length. Not all models support truncated dimensions.
+
+10. **tool_call_id mismatch** -- When returning tool results, the `tool_call_id` in the tool message must match the `id` from the model's `tool_calls` response. Mismatches cause validation errors.

--- a/content/fitbit/docs/rest-api/python/DOC.md
+++ b/content/fitbit/docs/rest-api/python/DOC.md
@@ -1,0 +1,323 @@
+---
+name: rest-api
+description: "Fitbit Web API for health and fitness data (activity, heart rate, sleep, SpO2)"
+metadata:
+  languages: "python"
+  versions: "1.2.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "fitbit,health,fitness,wearable,sleep,heart-rate,steps,api"
+---
+
+# Fitbit Web API
+
+> **Golden Rule:** Fitbit has no official Python REST client. Use `httpx` (async) for direct REST API access. All data endpoints are GET returning JSON. Authentication uses OAuth 2.0 Authorization Code Grant with PKCE. Rate limit is 150 requests/hour per user. Access tokens last 8 hours; use refresh tokens for renewal.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+`https://api.fitbit.com`
+
+OAuth authorize URL: `https://www.fitbit.com/oauth2/authorize`
+Token endpoint: `https://api.fitbit.com/oauth2/token`
+
+Register your app at: https://dev.fitbit.com/apps/new
+
+## Authentication
+
+**Type:** OAuth 2.0 Authorization Code Grant with PKCE (RFC 7636)
+
+### Step 1: Generate PKCE Credentials
+
+```python
+import hashlib
+import base64
+import secrets
+
+code_verifier = secrets.token_urlsafe(64)[:128]
+code_challenge = base64.urlsafe_b64encode(
+    hashlib.sha256(code_verifier.encode()).digest()
+).rstrip(b"=").decode()
+```
+
+### Step 2: Build Authorization URL
+
+```python
+CLIENT_ID = "your-client-id"
+REDIRECT_URI = "https://your-app.com/callback"
+SCOPES = "activity heartrate sleep oxygen_saturation profile weight temperature respiratory_rate"
+
+auth_url = (
+    f"https://www.fitbit.com/oauth2/authorize"
+    f"?response_type=code"
+    f"&client_id={CLIENT_ID}"
+    f"&redirect_uri={REDIRECT_URI}"
+    f"&scope={SCOPES}"
+    f"&code_challenge={code_challenge}"
+    f"&code_challenge_method=S256"
+)
+# Direct user to auth_url in browser
+```
+
+### Step 3: Exchange Code for Tokens
+
+```python
+import httpx
+
+CLIENT_SECRET = "your-client-secret"
+
+async def exchange_code(authorization_code: str) -> dict:
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            "https://api.fitbit.com/oauth2/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": authorization_code,
+                "redirect_uri": REDIRECT_URI,
+                "code_verifier": code_verifier,
+                "client_id": CLIENT_ID,
+            },
+            auth=(CLIENT_ID, CLIENT_SECRET),
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        response.raise_for_status()
+        return response.json()
+        # Returns: access_token, refresh_token, user_id, expires_in (28800s = 8h)
+```
+
+### Step 4: Make Authenticated Requests
+
+```python
+ACCESS_TOKEN = "your-access-token"
+
+client = httpx.AsyncClient(
+    base_url="https://api.fitbit.com",
+    headers={"Authorization": f"Bearer {ACCESS_TOKEN}"},
+    timeout=30.0,
+)
+```
+
+### Refresh Token
+
+```python
+async def refresh_access_token(refresh_token: str) -> dict:
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            "https://api.fitbit.com/oauth2/token",
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": CLIENT_ID,
+            },
+            auth=(CLIENT_ID, CLIENT_SECRET),
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        response.raise_for_status()
+        return response.json()
+```
+
+## Rate Limiting
+
+| Scope | Limit |
+|---|---|
+| Per user | 150 requests/hour |
+| Reset | Top of each hour |
+
+Rate limit headers (approximate, async-updated):
+- `Fitbit-Rate-Limit-Limit`: Max requests per hour
+- `Fitbit-Rate-Limit-Remaining`: Remaining requests
+- `Fitbit-Rate-Limit-Reset`: Seconds until reset
+
+## Methods
+
+### Activity (Daily Summary)
+
+**Endpoint:** `GET /1/user/-/activities/date/{date}.json`
+
+```python
+# Get today's activity summary
+response = await client.get("/1/user/-/activities/date/today.json")
+response.raise_for_status()
+data = response.json()
+summary = data.get("summary", {})
+print(f"Steps: {summary.get('steps', 0)}")
+print(f"Calories: {summary.get('caloriesOut', 0)}")
+print(f"Active minutes: {summary.get('fairlyActiveMinutes', 0) + summary.get('veryActiveMinutes', 0)}")
+```
+
+### Activity Time Series
+
+**Endpoint:** `GET /1/user/-/activities/{resource}/date/{start}/{end}.json`
+
+Resources: `steps`, `calories`, `distance`, `floors`, `minutesSedentary`, `minutesLightlyActive`, `minutesFairlyActive`, `minutesVeryActive`
+
+```python
+# Get steps for the past week
+response = await client.get("/1/user/-/activities/steps/date/today/7d.json")
+response.raise_for_status()
+data = response.json()
+for day in data.get("activities-steps", []):
+    print(f"{day['dateTime']}: {day['value']} steps")
+```
+
+### Heart Rate Time Series
+
+**Endpoint:** `GET /1/user/-/activities/heart/date/{start}/{end}.json`
+
+```python
+# Get heart rate data for the past 7 days
+response = await client.get("/1/user/-/activities/heart/date/today/7d.json")
+response.raise_for_status()
+data = response.json()
+for day in data.get("activities-heart", []):
+    resting = day.get("value", {}).get("restingHeartRate", "N/A")
+    print(f"{day['dateTime']}: Resting HR {resting} bpm")
+```
+
+### Heart Rate Intraday
+
+**Endpoint:** `GET /1/user/-/activities/heart/date/{date}/1d/1min.json`
+
+```python
+# Get minute-by-minute heart rate for today
+response = await client.get("/1/user/-/activities/heart/date/today/1d/1min.json")
+response.raise_for_status()
+data = response.json()
+intraday = data.get("activities-heart-intraday", {}).get("dataset", [])
+for entry in intraday[:5]:
+    print(f"{entry['time']}: {entry['value']} bpm")
+```
+
+### Sleep Log
+
+**Endpoint:** `GET /1.2/user/-/sleep/date/{date}.json`
+
+```python
+# Get last night's sleep data
+response = await client.get("/1.2/user/-/sleep/date/today.json")
+response.raise_for_status()
+data = response.json()
+for sleep in data.get("sleep", []):
+    print(f"Duration: {sleep.get('duration', 0) / 3600000:.1f} hours")
+    print(f"Efficiency: {sleep.get('efficiency', 'N/A')}%")
+    levels = sleep.get("levels", {}).get("summary", {})
+    for stage, info in levels.items():
+        print(f"  {stage}: {info.get('minutes', 0)} min")
+```
+
+### Sleep Time Series
+
+**Endpoint:** `GET /1.2/user/-/sleep/date/{start}/{end}.json`
+
+```python
+# Get sleep data for the past week
+response = await client.get("/1.2/user/-/sleep/date/2025-01-01/2025-01-07.json")
+response.raise_for_status()
+data = response.json()
+```
+
+### SpO2 (Blood Oxygen)
+
+**Endpoint:** `GET /1/user/-/spo2/date/{date}.json`
+
+```python
+response = await client.get("/1/user/-/spo2/date/today.json")
+response.raise_for_status()
+data = response.json()
+print(f"SpO2: {data.get('value', {}).get('avg', 'N/A')}%")
+```
+
+### Breathing Rate
+
+**Endpoint:** `GET /1/user/-/br/date/{date}.json`
+
+```python
+response = await client.get("/1/user/-/br/date/today.json")
+response.raise_for_status()
+data = response.json()
+for entry in data.get("br", []):
+    rate = entry.get("value", {}).get("breathingRate", "N/A")
+    print(f"Breathing rate: {rate} breaths/min")
+```
+
+### Temperature (Skin)
+
+**Endpoint:** `GET /1/user/-/temp/skin/date/{date}.json`
+
+```python
+response = await client.get("/1/user/-/temp/skin/date/today.json")
+response.raise_for_status()
+data = response.json()
+```
+
+### User Profile
+
+**Endpoint:** `GET /1/user/-/profile.json`
+
+```python
+response = await client.get("/1/user/-/profile.json")
+response.raise_for_status()
+data = response.json()
+user = data.get("user", {})
+print(f"Name: {user.get('displayName', 'N/A')}")
+print(f"Age: {user.get('age', 'N/A')}")
+```
+
+### Devices
+
+**Endpoint:** `GET /1/user/-/devices.json`
+
+```python
+response = await client.get("/1/user/-/devices.json")
+response.raise_for_status()
+devices = response.json()
+for device in devices:
+    print(f"{device['deviceVersion']} - Battery: {device['battery']}")
+```
+
+## Error Handling
+
+```python
+import httpx
+
+try:
+    response = await client.get("/1/user/-/activities/date/today.json")
+    response.raise_for_status()
+    data = response.json()
+except httpx.HTTPStatusError as e:
+    if e.response.status_code == 401:
+        print("Access token expired -- refresh with refresh_token")
+    elif e.response.status_code == 429:
+        reset = e.response.headers.get("Fitbit-Rate-Limit-Reset", "unknown")
+        print(f"Rate limited -- retry after {reset} seconds")
+    elif e.response.status_code == 403:
+        print("Insufficient scope -- check OAuth scopes requested")
+    elif e.response.status_code == 400:
+        print(f"Bad request: {e.response.text}")
+    else:
+        print(f"Fitbit API error {e.response.status_code}: {e.response.text}")
+except httpx.RequestError as e:
+    print(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+- All data endpoints use **GET** (not POST)
+- The `-` in `/user/-/` means "current authenticated user"
+- Date format is `YYYY-MM-DD` or the string `today`
+- Period shortcuts: `1d`, `7d`, `30d`, `1w`, `1m`, `3m`, `6m`, `1y`
+- Sleep endpoints use API version **1.2** (`/1.2/user/...`), others use **1**
+- Access tokens expire after 8 hours; always implement refresh token flow
+- Rate limit is **per user** (150/hour), not per app -- track per-user usage
+- Rate limit headers are approximate and asynchronously updated
+- OAuth requires PKCE (code_challenge) -- plain authorization code flow is not supported
+- Intraday data (minute-level) requires special app permissions or personal app type
+- Scopes must be explicitly requested at authorization time -- cannot be added later
+- Token endpoint requires `Content-Type: application/x-www-form-urlencoded` (not JSON)
+- Set a reasonable timeout: `httpx.AsyncClient(timeout=30.0)`

--- a/content/flutterwave/docs/rest-api/python/DOC.md
+++ b/content/flutterwave/docs/rest-api/python/DOC.md
@@ -1,0 +1,246 @@
+---
+name: rest-api
+description: "Flutterwave - African Payment Gateway REST API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "flutterwave,payments,africa,nigeria,mobile-money,cards,api"
+---
+
+# Flutterwave REST API — Python (httpx)
+
+## Golden Rule
+
+Always use your **Secret Key** for server-side API calls — never expose it in client code. Amounts are in the **smallest currency unit** of the target country (e.g., NGN kobo = NGN * 100 is NOT required — Flutterwave uses major units). All requests must be over HTTPS. Include `Content-Type: application/json` and `Authorization: Bearer <SECRET_KEY>` on every request. Use `tx_ref` (your unique transaction reference) to reconcile payments.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+```
+https://api.flutterwave.com/v3
+```
+
+Flutterwave v3 is the current stable version. A v4 public beta exists with OAuth 2.0 auth, but v3 remains fully supported with no deprecation plans.
+
+## Authentication
+
+Flutterwave v3 uses a static **Secret Key** passed as a Bearer token.
+
+```python
+import httpx
+import os
+
+SECRET_KEY = os.environ["FLUTTERWAVE_SECRET_KEY"]
+
+headers = {
+    "Authorization": f"Bearer {SECRET_KEY}",
+    "Content-Type": "application/json",
+}
+
+async def get_client() -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        base_url="https://api.flutterwave.com/v3",
+        headers=headers,
+        timeout=30.0,
+    )
+```
+
+**Key types:**
+- `FLWSECK-...` — Secret key (server-side only)
+- `FLWPUBK-...` — Public key (client-side, e.g., inline checkout)
+- Test keys contain `_TEST-`, live keys contain `_LIVE-`
+
+## Rate Limiting
+
+Flutterwave does not publish fixed rate limits. In practice, sustained bursts above ~100 req/s trigger HTTP 429 responses. Implement exponential backoff:
+
+```python
+import asyncio
+
+async def request_with_retry(client: httpx.AsyncClient, method: str, url: str, **kwargs):
+    for attempt in range(5):
+        resp = await client.request(method, url, **kwargs)
+        if resp.status_code == 429:
+            wait = 2 ** attempt
+            await asyncio.sleep(wait)
+            continue
+        resp.raise_for_status()
+        return resp.json()
+    raise Exception("Rate limit exceeded after retries")
+```
+
+## Methods
+
+### Collect Payment (Standard)
+
+Initiate a payment — returns a hosted checkout link.
+
+```python
+async def initiate_payment(client: httpx.AsyncClient, amount: float, currency: str,
+                           email: str, tx_ref: str, redirect_url: str):
+    payload = {
+        "tx_ref": tx_ref,
+        "amount": amount,
+        "currency": currency,
+        "redirect_url": redirect_url,
+        "customer": {"email": email},
+        "payment_options": "card,mobilemoney,ussd,banktransfer",
+    }
+    resp = await client.post("/payments", json=payload)
+    resp.raise_for_status()
+    data = resp.json()
+    return data["data"]["link"]  # redirect customer here
+```
+
+### Verify Transaction
+
+Always verify server-side after redirect or webhook.
+
+```python
+async def verify_transaction(client: httpx.AsyncClient, transaction_id: int):
+    resp = await client.get(f"/transactions/{transaction_id}/verify")
+    resp.raise_for_status()
+    data = resp.json()
+    tx = data["data"]
+    assert tx["status"] == "successful"
+    assert tx["currency"] == "NGN"  # match expected currency
+    # assert tx["amount"] >= expected_amount
+    return tx
+```
+
+### Charge via Mobile Money
+
+Direct charge for mobile money (Ghana, Uganda, Rwanda, Francophone, etc.).
+
+```python
+async def charge_mobile_money(client: httpx.AsyncClient, amount: float,
+                               phone: str, currency: str, tx_ref: str,
+                               network: str, email: str):
+    """currency examples: GHS, UGX, RWF, XOF"""
+    type_map = {
+        "GHS": "mobile_money_ghana",
+        "UGX": "mobile_money_uganda",
+        "RWF": "mobile_money_rwanda",
+        "XOF": "mobile_money_franco",
+        "KES": "mpesa",
+    }
+    payload = {
+        "tx_ref": tx_ref,
+        "amount": amount,
+        "currency": currency,
+        "phone_number": phone,
+        "network": network,
+        "email": email,
+    }
+    resp = await client.post(
+        f"/charges?type={type_map[currency]}", json=payload
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Create Transfer (Payout)
+
+Send money to a bank account or mobile wallet.
+
+```python
+async def create_transfer(client: httpx.AsyncClient, account_bank: str,
+                           account_number: str, amount: float,
+                           currency: str, reference: str, narration: str):
+    payload = {
+        "account_bank": account_bank,
+        "account_number": account_number,
+        "amount": amount,
+        "currency": currency,
+        "reference": reference,
+        "narration": narration,
+        "debit_currency": currency,
+    }
+    resp = await client.post("/transfers", json=payload)
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Create Virtual Account
+
+Generate a bank account number for collecting payments.
+
+```python
+async def create_virtual_account(client: httpx.AsyncClient, email: str,
+                                  tx_ref: str, amount: float, currency: str = "NGN"):
+    payload = {
+        "email": email,
+        "tx_ref": tx_ref,
+        "amount": amount,
+        "is_permanent": False,
+    }
+    resp = await client.post("/virtual-account-numbers", json=payload)
+    resp.raise_for_status()
+    return resp.json()["data"]
+```
+
+### List Transactions
+
+```python
+async def list_transactions(client: httpx.AsyncClient, page: int = 1,
+                             status: str = "successful"):
+    resp = await client.get("/transactions", params={"page": page, "status": status})
+    resp.raise_for_status()
+    return resp.json()["data"]
+```
+
+## Error Handling
+
+Flutterwave returns structured error responses:
+
+```json
+{
+  "status": "error",
+  "message": "Invalid card number",
+  "data": null
+}
+```
+
+HTTP status codes:
+- **200** — Success
+- **400** — Bad request (validation error, missing fields)
+- **401** — Invalid or missing secret key
+- **403** — Forbidden (IP whitelist, permissions)
+- **404** — Resource not found
+- **429** — Rate limited
+- **500** — Flutterwave server error
+
+```python
+class FlutterwaveError(Exception):
+    def __init__(self, status_code: int, message: str, data=None):
+        self.status_code = status_code
+        self.message = message
+        self.data = data
+        super().__init__(f"[{status_code}] {message}")
+
+async def safe_request(client: httpx.AsyncClient, method: str, url: str, **kwargs):
+    resp = await client.request(method, url, **kwargs)
+    body = resp.json()
+    if resp.status_code >= 400 or body.get("status") == "error":
+        raise FlutterwaveError(resp.status_code, body.get("message", "Unknown error"), body.get("data"))
+    return body
+```
+
+## Common Pitfalls
+
+1. **Not verifying transactions server-side** — Never trust client-side redirect params alone. Always call `/transactions/{id}/verify`.
+2. **Wrong charge type for mobile money** — Each country has its own `?type=` query param (e.g., `mobile_money_ghana`, `mpesa`). Using the wrong type returns a 400.
+3. **Currency mismatch** — The `currency` in charge must match the payment method's country. You cannot charge GHS on a Nigerian card.
+4. **Duplicate `tx_ref`** — Each payment must have a unique `tx_ref`. Reusing one returns the old transaction.
+5. **Test vs. live keys** — Test keys (containing `_TEST-`) only work in sandbox. Transactions appear successful but no real money moves.
+6. **Webhook signature verification** — Always verify the `verif-hash` header on webhooks matches your secret hash configured in the dashboard.
+7. **Encryption for direct card charges** — Direct card tokenization in v3 requires encrypting the card payload with your encryption key before sending. Use the standard payment flow when possible.
+8. **Transfer debit currency** — When sending cross-border transfers, set `debit_currency` to specify which wallet to debit.

--- a/content/freshdesk/docs/rest-api/python/DOC.md
+++ b/content/freshdesk/docs/rest-api/python/DOC.md
@@ -1,0 +1,120 @@
+---
+name: rest-api
+description: "Freshdesk API integration with 2 methods"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-13"
+  source: community
+  tags: "freshdesk,support,helpdesk,tickets,api,integration"
+---
+
+# Freshdesk API
+
+> **Golden Rule:** Freshdesk has no official Python SDK. Use `httpx` (async) or `requests` (sync) for direct REST API access. Always handle rate limits, retries, and error responses explicitly.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+`https://<domain>.freshdesk.com/api/v2`
+
+## Authentication
+
+**Type:** Basic
+
+```python
+import httpx
+
+API_KEY = "your-api-key"
+DOMAIN = "your-domain"
+BASE_URL = f"https://{DOMAIN}.freshdesk.com/api/v2"
+
+# Basic auth: API key as username, "X" as password
+auth = httpx.BasicAuth(API_KEY, "X")
+client = httpx.AsyncClient(auth=auth)
+```
+
+## Rate Limiting
+
+**Limit:** 100 requests/minute
+
+The API enforces rate limits. Check `X-RateLimit-Remaining` and `Retry-After` response headers. Implement exponential backoff on 429 responses.
+
+## Methods
+
+### `list_tickets`
+
+**Endpoint:** `GET /tickets`
+
+
+
+| Parameter | Type | Default |
+|---|---|---|
+| `limit` | `int` | `30` |
+
+**Returns:** JSON response
+
+```python
+params = {
+    "limit": 30
+}
+response = await client.get(f"{BASE_URL}/tickets", params=params)
+response.raise_for_status()
+data = response.json()
+```
+
+### `list_contacts`
+
+**Endpoint:** `GET /contacts`
+
+
+
+| Parameter | Type | Default |
+|---|---|---|
+| `limit` | `int` | `30` |
+
+**Returns:** JSON response
+
+```python
+params = {
+    "limit": 30
+}
+response = await client.get(f"{BASE_URL}/contacts", params=params)
+response.raise_for_status()
+data = response.json()
+```
+
+## Error Handling
+
+```python
+import httpx
+
+try:
+    response = await client.get(f"{BASE_URL}/tickets")
+    response.raise_for_status()
+    data = response.json()
+except httpx.HTTPStatusError as e:
+    if e.response.status_code == 401:
+        print("Authentication failed -- check your API key")
+    elif e.response.status_code == 429:
+        retry_after = e.response.headers.get("Retry-After", "60")
+        print(f"Rate limited -- retry after {retry_after}s")
+    else:
+        print(f"Freshdesk API error {e.response.status_code}: {e.response.text}")
+except httpx.RequestError as e:
+    print(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+- Always call `response.raise_for_status()` to catch HTTP errors
+- Use `async with httpx.AsyncClient() as client:` to auto-close connections
+- Handle 429 (rate limit) responses with exponential backoff
+- Set a reasonable timeout: `httpx.AsyncClient(timeout=30.0)`
+- The `limit` / `per_page` parameter controls page size, not total results -- paginate to get all data

--- a/content/globalgiving/docs/rest-api/python/DOC.md
+++ b/content/globalgiving/docs/rest-api/python/DOC.md
@@ -1,0 +1,369 @@
+---
+name: rest-api
+description: "GlobalGiving - World's largest crowdfunding community for nonprofits. Search projects, organizations, themes, and submit donations."
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "globalgiving,charity,nonprofit,crowdfunding,donations,projects,api"
+---
+
+# GlobalGiving REST API - Python Reference (httpx)
+
+## Golden Rule
+
+Authentication uses an `api_key` **query parameter** on every request. Request a free API key by creating an account at https://www.globalgiving.org/api/. All responses default to XML; always pass the `Accept: application/json` header or append `&json=true` to get JSON. Paginated endpoints return a maximum of 10 results per page by default -- use `nextProjectId` or `nextOrgId` to page through results. Featured projects always return exactly 10 results and rotate hourly.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+All examples use `httpx` with async/await. For scripts that need a synchronous entrypoint:
+
+```python
+import asyncio
+import httpx
+
+async def main():
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{BASE_URL}/all/projects",
+            params={"api_key": API_KEY},
+            headers={"Accept": "application/json"},
+        )
+        print(resp.json())
+
+asyncio.run(main())
+```
+
+## Base URL
+
+```
+https://api.globalgiving.org/api/public/projectservice
+```
+
+```python
+import os
+
+API_KEY = os.environ["GLOBALGIVING_API_KEY"]
+BASE_URL = "https://api.globalgiving.org/api/public/projectservice"
+HEADERS = {"Accept": "application/json"}
+```
+
+## Authentication
+
+GlobalGiving uses an **API key as a query parameter** on every request:
+
+```
+https://api.globalgiving.org/api/public/projectservice/all/projects?api_key=YOUR_API_KEY
+```
+
+There are no authorization headers. The key is always the `api_key` parameter. Obtain a key at https://www.globalgiving.org/api/getting-started/.
+
+## Rate Limiting
+
+GlobalGiving does not publicly document specific rate limits, but excessive usage may result in throttling. Implement reasonable delays between batch requests.
+
+```python
+import asyncio
+
+async def gg_request(
+    client: httpx.AsyncClient,
+    path: str,
+    params: dict = None,
+    max_retries: int = 3,
+) -> dict:
+    request_params = {**(params or {}), "api_key": API_KEY}
+    url = f"{BASE_URL}{path}"
+
+    for attempt in range(max_retries):
+        try:
+            resp = await client.get(url, params=request_params, headers=HEADERS)
+        except httpx.RequestError as e:
+            await asyncio.sleep(2 ** attempt)
+            continue
+
+        if resp.status_code == 200:
+            return resp.json()
+
+        if resp.status_code == 429:
+            wait = min(2 ** attempt, 30)
+            await asyncio.sleep(wait)
+            continue
+
+        resp.raise_for_status()
+
+    raise Exception("Max retries exceeded")
+```
+
+## Methods
+
+### Get All Projects
+
+Retrieve all active projects with pagination. Returns max 10 projects per request.
+
+**Parameters:**
+- `nextProjectId` (int) -- Starting project ID for pagination (from `hasNext`/`nextProjectId` in response)
+
+```python
+async def get_all_projects(client: httpx.AsyncClient, next_project_id: int = None) -> dict:
+    params = {}
+    if next_project_id:
+        params["nextProjectId"] = next_project_id
+    return await gg_request(client, "/all/projects", params)
+
+# Usage -- paginate through all projects
+projects = await get_all_projects(client)
+project_list = projects["projects"]["project"]
+if projects["projects"].get("hasNext"):
+    next_page = await get_all_projects(client, projects["projects"]["nextProjectId"])
+```
+
+### Get Featured Projects
+
+Retrieve 10 featured projects. Rotated hourly based on ranking algorithm. Always returns exactly 10 results.
+
+```python
+async def get_featured_projects(client: httpx.AsyncClient) -> dict:
+    return await gg_request(client, "/featured/projects")
+
+# Usage
+featured = await get_featured_projects(client)
+for proj in featured["projects"]["project"]:
+    print(f"{proj['id']}: {proj['title']} - {proj['country']}")
+```
+
+### Get Specific Project
+
+Retrieve full details for a single project by ID.
+
+```python
+async def get_project(client: httpx.AsyncClient, project_id: int) -> dict:
+    return await gg_request(client, f"/projects/{project_id}")
+
+# Usage
+project = await get_project(client, 1234)
+print(project["project"]["title"])
+print(project["project"]["funding"])
+```
+
+### Search Projects
+
+Search projects by keyword.
+
+**Parameters:**
+- `q` (str) -- Search keyword
+
+```python
+async def search_projects(client: httpx.AsyncClient, query: str) -> dict:
+    return await gg_request(client, "/search/projects", {"q": query})
+
+# Usage
+results = await search_projects(client, "clean water")
+for proj in results["search"]["response"]["projects"]["project"]:
+    print(f"{proj['id']}: {proj['title']}")
+```
+
+### Get Projects by Theme
+
+Retrieve all projects for a specific theme.
+
+```python
+async def get_projects_by_theme(client: httpx.AsyncClient, theme_id: str) -> dict:
+    return await gg_request(client, f"/themes/{theme_id}/projects")
+
+# Usage -- theme IDs: climate, edu, health, hunger, etc.
+projects = await get_projects_by_theme(client, "edu")
+```
+
+### Get Projects by Country/Region
+
+Retrieve all projects for a specific country or region.
+
+```python
+async def get_projects_by_country(client: httpx.AsyncClient, country_iso: str) -> dict:
+    return await gg_request(client, f"/countries/{country_iso}/projects")
+
+# Usage -- ISO 3166-1 alpha-2 country codes
+projects = await get_projects_by_country(client, "KE")
+```
+
+### Get Projects by Organization
+
+Retrieve all projects for a specific organization.
+
+```python
+async def get_org_projects(
+    client: httpx.AsyncClient,
+    org_id: int,
+    next_project_id: int = None,
+) -> dict:
+    params = {}
+    if next_project_id:
+        params["nextProjectId"] = next_project_id
+    return await gg_request(client, f"/organizations/{org_id}/projects", params)
+
+# Usage
+org_projects = await get_org_projects(client, 189)
+```
+
+### Get Organization
+
+Retrieve details for a specific organization.
+
+```python
+async def get_organization(client: httpx.AsyncClient, org_id: int) -> dict:
+    return await gg_request(client, f"/organizations/{org_id}")
+
+# Usage
+org = await get_organization(client, 189)
+print(org["organization"]["name"])
+```
+
+### Get All Organizations (Bulk)
+
+Retrieve all organizations. Max 10 per request; paginate with `nextOrgId`.
+
+```python
+async def get_all_organizations(client: httpx.AsyncClient, next_org_id: int = None) -> dict:
+    params = {}
+    if next_org_id:
+        params["nextOrgId"] = next_org_id
+    return await gg_request(client, "/organizations", params)
+
+# Usage -- paginate
+orgs = await get_all_organizations(client)
+```
+
+### Get Themes
+
+Retrieve all available project themes.
+
+```python
+async def get_themes(client: httpx.AsyncClient) -> dict:
+    return await gg_request(client, "/themes")
+
+# Usage
+themes = await get_themes(client)
+for theme in themes["themes"]["theme"]:
+    print(f"{theme['id']}: {theme['name']}")
+```
+
+### Get Themes with Project IDs
+
+Retrieve themes along with their associated project IDs.
+
+```python
+async def get_themes_with_projects(client: httpx.AsyncClient) -> dict:
+    return await gg_request(client, "/themes/projects/ids")
+```
+
+### Get Regions
+
+Retrieve all regions with project counts.
+
+```python
+async def get_regions(client: httpx.AsyncClient) -> dict:
+    return await gg_request(client, "/regions")
+```
+
+### Get Image Gallery
+
+Retrieve the image gallery for a specific project.
+
+```python
+async def get_image_gallery(client: httpx.AsyncClient, project_id: int) -> dict:
+    return await gg_request(client, f"/projects/{project_id}/imagegallery")
+```
+
+### Get Progress Report
+
+Retrieve the latest progress report for a project.
+
+```python
+async def get_progress_report(client: httpx.AsyncClient, project_id: int) -> dict:
+    return await gg_request(client, f"/projects/{project_id}/report")
+```
+
+## Error Handling
+
+Successful responses return HTTP 200 with a JSON or XML body.
+
+**Common status codes:**
+
+| Code | Meaning |
+|---|---|
+| 200 | Success |
+| 400 | Bad Request -- missing or invalid parameters |
+| 401 | Unauthorized -- invalid or missing API key |
+| 404 | Not Found -- project/organization does not exist |
+| 429 | Too Many Requests -- rate limit exceeded |
+| 500 | Internal Server Error |
+
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+
+class GlobalGivingError(Exception):
+    def __init__(self, status_code: int, message: str):
+        self.status_code = status_code
+        self.message = message
+        super().__init__(f"[{status_code}] {message}")
+
+async def gg_request_safe(
+    client: httpx.AsyncClient,
+    path: str,
+    params: dict = None,
+    max_retries: int = 3,
+) -> dict:
+    request_params = {**(params or {}), "api_key": API_KEY}
+    url = f"{BASE_URL}{path}"
+
+    for attempt in range(max_retries):
+        try:
+            resp = await client.get(url, params=request_params, headers=HEADERS)
+        except httpx.RequestError as e:
+            logger.warning(f"Network error (attempt {attempt+1}): {e}")
+            await asyncio.sleep(2 ** attempt)
+            continue
+
+        if resp.status_code == 200:
+            return resp.json()
+
+        if resp.status_code == 429:
+            wait = min(2 ** attempt, 30)
+            logger.warning(f"Rate limited, retrying in {wait}s")
+            await asyncio.sleep(wait)
+            continue
+
+        raise GlobalGivingError(resp.status_code, resp.text)
+
+    raise GlobalGivingError(429, "Max retries exceeded")
+```
+
+## Common Pitfalls
+
+1. **Default response format is XML.** Always set `Accept: application/json` header or append `json=true` parameter. Forgetting this returns XML which will fail JSON parsing.
+
+2. **Pagination returns max 10 items.** Every list endpoint paginates with 10 results per page. Check the `hasNext` field and use `nextProjectId` or `nextOrgId` to continue.
+
+3. **Featured projects always return exactly 10.** There is no "get more" -- the featured set rotates hourly.
+
+4. **Project IDs are not sequential.** Do not assume project IDs are contiguous. Always use the pagination tokens from the API response.
+
+5. **Some projects may be inactive.** The API returns active projects by default. Check the `active` field if you need to filter.
+
+6. **Organization bulk download is slow.** With max 10 per page, downloading all organizations requires many requests. Implement delays between requests.
+
+7. **Country codes use ISO 3166-1 alpha-2.** Use two-letter country codes (e.g., `KE` for Kenya, `IN` for India).
+
+8. **Theme IDs are string slugs.** Theme identifiers are strings like `climate`, `edu`, `health`, not numeric IDs.
+
+9. **The API key must be in query parameters.** Unlike many modern APIs, GlobalGiving does not support API keys in headers.
+
+10. **JSON responses wrap data in nested objects.** Projects are inside `projects.project`, organizations inside `organizations.organization`. Always navigate the nesting correctly.

--- a/content/gocardless/docs/rest-api/python/DOC.md
+++ b/content/gocardless/docs/rest-api/python/DOC.md
@@ -1,0 +1,323 @@
+---
+name: rest-api
+description: "GoCardless - Direct debit and bank payment collection via SEPA, Bacs, and ACH"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "gocardless,direct-debit,bank-payments,sepa,europe,recurring,api"
+---
+
+# GoCardless REST API - Python (`httpx`)
+
+## Golden Rule
+
+Always include both `Authorization` and `GoCardless-Version` headers on every request. GoCardless uses date-based API versioning (e.g., `2015-07-06`) -- pin your integration to a specific version. All resources are wrapped in an envelope object (e.g., `{"payments": {...}}`). Direct debit payments are asynchronous -- use webhooks to track status changes, not polling. Always use idempotency keys on create operations.
+
+## Installation
+
+```bash
+pip install httpx python-dotenv
+```
+
+## Base URL
+
+| Environment | URL |
+|-------------|-----|
+| Production  | `https://api.gocardless.com` |
+| Sandbox     | `https://api-sandbox.gocardless.com` |
+
+## Authentication
+
+GoCardless uses Bearer token authentication. Create access tokens from the GoCardless Dashboard under Developers.
+
+```python
+import httpx
+import os
+
+GC_ACCESS_TOKEN = os.environ["GOCARDLESS_ACCESS_TOKEN"]
+BASE_URL = os.environ.get("GOCARDLESS_BASE_URL", "https://api-sandbox.gocardless.com")
+
+headers = {
+    "Authorization": f"Bearer {GC_ACCESS_TOKEN}",
+    "GoCardless-Version": "2015-07-06",
+    "Content-Type": "application/json",
+}
+```
+
+## Rate Limiting
+
+- **1,000 requests per minute** per access token.
+- Partner integrations: 1,000 requests per minute per merchant.
+- Response headers: `ratelimit-limit`, `ratelimit-remaining`, `ratelimit-reset`.
+
+```python
+import asyncio
+
+async def gc_request(
+    client: httpx.AsyncClient, method: str, url: str, **kwargs
+) -> dict:
+    for attempt in range(5):
+        resp = await client.request(method, url, headers=headers, **kwargs)
+        if resp.status_code == 429:
+            reset = resp.headers.get("ratelimit-reset")
+            wait = int(reset) if reset else 2 ** attempt
+            await asyncio.sleep(wait)
+            continue
+        resp.raise_for_status()
+        return resp.json()
+    raise Exception("Rate limit exceeded after retries")
+```
+
+## Methods
+
+### Create Customer
+
+```python
+async def create_customer(
+    client: httpx.AsyncClient,
+    email: str,
+    given_name: str,
+    family_name: str,
+    country_code: str,
+    idempotency_key: str,
+) -> dict:
+    payload = {
+        "customers": {
+            "email": email,
+            "given_name": given_name,
+            "family_name": family_name,
+            "country_code": country_code,
+        }
+    }
+    req_headers = {**headers, "Idempotency-Key": idempotency_key}
+    resp = await client.post(
+        f"{BASE_URL}/customers", headers=req_headers, json=payload
+    )
+    resp.raise_for_status()
+    return resp.json()["customers"]
+```
+
+### Create Mandate (Direct Debit Authorization)
+
+Mandates authorize you to collect payments from a customer's bank account.
+
+```python
+async def create_mandate(
+    client: httpx.AsyncClient,
+    customer_bank_account_id: str,
+    scheme: str,
+    idempotency_key: str,
+) -> dict:
+    payload = {
+        "mandates": {
+            "links": {"customer_bank_account": customer_bank_account_id},
+            "scheme": scheme,  # "sepa_core", "bacs", "ach", "autogiro", etc.
+        }
+    }
+    req_headers = {**headers, "Idempotency-Key": idempotency_key}
+    resp = await client.post(
+        f"{BASE_URL}/mandates", headers=req_headers, json=payload
+    )
+    resp.raise_for_status()
+    return resp.json()["mandates"]
+```
+
+### Create Payment
+
+Collect a payment against an active mandate.
+
+```python
+async def create_payment(
+    client: httpx.AsyncClient,
+    amount: int,
+    currency: str,
+    mandate_id: str,
+    description: str,
+    charge_date: str | None = None,
+    idempotency_key: str | None = None,
+) -> dict:
+    payload = {
+        "payments": {
+            "amount": amount,  # In minor units (pence, cents)
+            "currency": currency,
+            "description": description,
+            "links": {"mandate": mandate_id},
+        }
+    }
+    if charge_date:
+        payload["payments"]["charge_date"] = charge_date  # "2026-04-01"
+
+    req_headers = {**headers}
+    if idempotency_key:
+        req_headers["Idempotency-Key"] = idempotency_key
+
+    resp = await client.post(
+        f"{BASE_URL}/payments", headers=req_headers, json=payload
+    )
+    resp.raise_for_status()
+    return resp.json()["payments"]
+```
+
+### List Payments
+
+```python
+async def list_payments(
+    client: httpx.AsyncClient,
+    limit: int = 50,
+    cursor: str | None = None,
+    status: str | None = None,
+) -> dict:
+    params: dict = {"limit": limit}
+    if cursor:
+        params["after"] = cursor
+    if status:
+        params["status"] = status
+    resp = await client.get(
+        f"{BASE_URL}/payments", headers=headers, params=params
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Create Subscription
+
+Set up recurring payments collected automatically on a schedule.
+
+```python
+async def create_subscription(
+    client: httpx.AsyncClient,
+    mandate_id: str,
+    amount: int,
+    currency: str,
+    interval_unit: str,
+    interval: int,
+    name: str,
+    idempotency_key: str,
+) -> dict:
+    payload = {
+        "subscriptions": {
+            "amount": amount,
+            "currency": currency,
+            "interval_unit": interval_unit,  # "weekly", "monthly", "yearly"
+            "interval": interval,  # e.g., 1 for every month
+            "name": name,
+            "links": {"mandate": mandate_id},
+        }
+    }
+    req_headers = {**headers, "Idempotency-Key": idempotency_key}
+    resp = await client.post(
+        f"{BASE_URL}/subscriptions", headers=req_headers, json=payload
+    )
+    resp.raise_for_status()
+    return resp.json()["subscriptions"]
+```
+
+### Create Redirect Flow (Hosted Mandate Setup)
+
+Use redirect flows to set up mandates via a hosted page.
+
+```python
+async def create_redirect_flow(
+    client: httpx.AsyncClient,
+    description: str,
+    session_token: str,
+    success_redirect_url: str,
+    scheme: str,
+) -> dict:
+    payload = {
+        "redirect_flows": {
+            "description": description,
+            "session_token": session_token,
+            "success_redirect_url": success_redirect_url,
+            "scheme": scheme,
+        }
+    }
+    resp = await client.post(
+        f"{BASE_URL}/redirect_flows", headers=headers, json=payload
+    )
+    resp.raise_for_status()
+    return resp.json()["redirect_flows"]
+```
+
+### Get Payout
+
+```python
+async def get_payout(client: httpx.AsyncClient, payout_id: str) -> dict:
+    resp = await client.get(
+        f"{BASE_URL}/payouts/{payout_id}", headers=headers
+    )
+    resp.raise_for_status()
+    return resp.json()["payouts"]
+```
+
+### Cancel Mandate
+
+```python
+async def cancel_mandate(client: httpx.AsyncClient, mandate_id: str) -> dict:
+    resp = await client.post(
+        f"{BASE_URL}/mandates/{mandate_id}/actions/cancel", headers=headers
+    )
+    resp.raise_for_status()
+    return resp.json()["mandates"]
+```
+
+## Error Handling
+
+GoCardless wraps errors in an `error` envelope:
+
+```json
+{
+  "error": {
+    "message": "amount must be greater than or equal to 1",
+    "type": "validation_failed",
+    "code": 422,
+    "errors": [
+      {
+        "field": "amount",
+        "message": "must be greater than or equal to 1",
+        "request_pointer": "/payments/amount"
+      }
+    ],
+    "request_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  }
+}
+```
+
+```python
+class GoCardlessAPIError(Exception):
+    def __init__(self, status: int, body: dict):
+        self.status = status
+        err = body.get("error", {})
+        self.error_type = err.get("type", "unknown")
+        self.message = err.get("message", str(body))
+        self.request_id = err.get("request_id")
+        self.field_errors = err.get("errors", [])
+        super().__init__(
+            f"HTTP {status} [{self.error_type}]: {self.message} (req: {self.request_id})"
+        )
+
+
+async def gc_request_safe(
+    client: httpx.AsyncClient, method: str, url: str, **kwargs
+) -> dict:
+    resp = await client.request(method, url, headers=headers, **kwargs)
+    if resp.status_code >= 400:
+        raise GoCardlessAPIError(resp.status_code, resp.json())
+    return resp.json()
+```
+
+Error types: `validation_failed` (422), `invalid_api_usage` (400), `authentication_error` (401), `forbidden` (403), `invalid_state` (409), `rate_limit` (429), `internal_error` (500).
+
+## Common Pitfalls
+
+1. **Envelope wrapping** -- All request and response bodies are wrapped in a resource key (e.g., `{"payments": {...}}`). Forgetting the wrapper on requests causes 400 errors.
+2. **GoCardless-Version header** -- Required on every request. Omitting it may result in unexpected behavior or use of a different API version.
+3. **Asynchronous payments** -- Direct debit payments are not instant. A created payment starts as `pending_submission` and transitions through states over days. Always use webhooks for status tracking.
+4. **Charge date timing** -- Payments can only be charged on banking days. The `charge_date` must be at least 2 banking days in the future for SEPA, 3 for Bacs. The API will adjust if you provide a non-banking day.
+5. **Idempotency keys** -- Always provide an `Idempotency-Key` header on create operations. GoCardless returns the original response for duplicate keys within 24 hours.
+6. **Mandate schemes** -- Different countries use different schemes (SEPA for EU, Bacs for UK, ACH for US). Ensure the scheme matches the customer's bank account country.
+7. **Webhook signature verification** -- Always verify webhook signatures using the secret from your GoCardless dashboard. Never trust webhook payloads without verification.
+8. **Cursor-based pagination** -- Use the `after` parameter with the last resource ID. Do not use offset-based pagination.

--- a/content/google-classroom/docs/rest-api/python/DOC.md
+++ b/content/google-classroom/docs/rest-api/python/DOC.md
@@ -1,0 +1,471 @@
+---
+name: rest-api
+description: "Google Classroom REST API - Manage courses, assignments, students, and submissions"
+metadata:
+  languages: "python"
+  versions: "v1"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "google-classroom,education,courses,assignments,students,teachers,api"
+---
+
+# Google Classroom REST API - Python Reference (httpx)
+
+## Golden Rule
+
+All requests go to `https://classroom.googleapis.com/v1`. Authentication requires **OAuth 2.0** with Google-issued access tokens -- there is no API key option for most endpoints. The API is designed for Google Workspace for Education accounts but also works with consumer Google accounts for limited use. Choose the most restrictive OAuth scope that fits your needs. Pagination uses `pageToken`/`nextPageToken` pattern. Always request a GCP project with the Classroom API enabled.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+All examples use `httpx` with async/await. For scripts that need a synchronous entrypoint:
+
+```python
+import asyncio
+import httpx
+
+async def main():
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{BASE_URL}/courses",
+            headers=HEADERS,
+            params={"pageSize": 20},
+        )
+        print(resp.json())
+
+asyncio.run(main())
+```
+
+## Base URL
+
+```
+https://classroom.googleapis.com/v1
+```
+
+```python
+import os
+
+ACCESS_TOKEN = os.environ["GOOGLE_ACCESS_TOKEN"]
+BASE_URL = "https://classroom.googleapis.com/v1"
+HEADERS = {"Authorization": f"Bearer {ACCESS_TOKEN}"}
+```
+
+## Authentication
+
+Google Classroom uses **OAuth 2.0** exclusively. Obtain tokens via the Google OAuth2 flow with appropriate scopes.
+
+### Common OAuth Scopes
+
+| Scope | Access |
+|---|---|
+| `classroom.courses` | Create, edit, delete courses |
+| `classroom.courses.readonly` | View courses |
+| `classroom.coursework.students` | Manage coursework and submissions for students |
+| `classroom.coursework.students.readonly` | View coursework and submissions |
+| `classroom.coursework.me` | Manage own coursework submissions |
+| `classroom.coursework.me.readonly` | View own submissions |
+| `classroom.rosters` | Manage course rosters |
+| `classroom.rosters.readonly` | View course rosters |
+| `classroom.profile.emails` | View student/teacher emails |
+| `classroom.profile.photos` | View student/teacher photos |
+| `classroom.announcements` | Create and manage announcements |
+| `classroom.announcements.readonly` | View announcements |
+| `classroom.topics` | Manage course topics |
+| `classroom.topics.readonly` | View course topics |
+
+All scope URLs are prefixed with `https://www.googleapis.com/auth/`.
+
+### Token Refresh Pattern
+
+```python
+async def refresh_access_token(
+    client: httpx.AsyncClient,
+    client_id: str,
+    client_secret: str,
+    refresh_token: str,
+) -> str:
+    resp = await client.post(
+        "https://oauth2.googleapis.com/token",
+        data={
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "refresh_token": refresh_token,
+            "grant_type": "refresh_token",
+        },
+    )
+    resp.raise_for_status()
+    return resp.json()["access_token"]
+```
+
+## Rate Limiting
+
+Google Classroom API follows Google's standard quota system. Default quotas are per-project and include:
+- Read requests per minute per user
+- Write requests per minute per user
+
+Check the Google Cloud Console > APIs & Services > Quotas for your exact limits. When exceeded, the API returns `429` with a `Retry-After` header.
+
+```python
+import asyncio
+
+async def classroom_request(
+    client: httpx.AsyncClient,
+    method: str,
+    path: str,
+    params: dict = None,
+    json_data: dict = None,
+    max_retries: int = 3,
+) -> httpx.Response:
+    for attempt in range(max_retries):
+        resp = await client.request(
+            method,
+            f"{BASE_URL}{path}",
+            headers=HEADERS,
+            params=params,
+            json=json_data,
+        )
+        if resp.status_code == 429:
+            wait = int(resp.headers.get("Retry-After", 2 ** attempt))
+            await asyncio.sleep(wait)
+            continue
+        if resp.status_code == 401:
+            raise Exception("Access token expired -- refresh and retry")
+        resp.raise_for_status()
+        return resp
+    raise Exception("Max retries exceeded due to rate limiting")
+```
+
+## Pagination
+
+Google Classroom uses `pageToken`/`nextPageToken` pagination.
+
+```python
+async def paginate(
+    client: httpx.AsyncClient,
+    path: str,
+    result_key: str,
+    params: dict = None,
+    page_size: int = 100,
+) -> list:
+    all_items = []
+    request_params = {**(params or {}), "pageSize": page_size}
+
+    while True:
+        resp = await classroom_request(client, "GET", path, params=request_params)
+        data = resp.json()
+        all_items.extend(data.get(result_key, []))
+
+        next_token = data.get("nextPageToken")
+        if not next_token:
+            break
+        request_params["pageToken"] = next_token
+
+    return all_items
+```
+
+## Methods
+
+### Courses
+
+#### List Courses
+
+**Parameters:**
+- `studentId` (str) -- Filter to courses where this user is a student (`me` for current user)
+- `teacherId` (str) -- Filter to courses where this user is a teacher
+- `courseStates` (str) -- Filter by state: `ACTIVE`, `ARCHIVED`, `PROVISIONED`, `DECLINED`, `SUSPENDED`
+- `pageSize` (int) -- Max results per page (default 100)
+
+```python
+async def list_courses(
+    client: httpx.AsyncClient,
+    student_id: str = None,
+    teacher_id: str = None,
+    course_states: list[str] = None,
+) -> list:
+    params = {}
+    if student_id:
+        params["studentId"] = student_id
+    if teacher_id:
+        params["teacherId"] = teacher_id
+    if course_states:
+        params["courseStates"] = course_states
+    return await paginate(client, "/courses", "courses", params)
+
+# Usage
+my_courses = await list_courses(client, student_id="me", course_states=["ACTIVE"])
+for c in my_courses:
+    print(f"{c['id']}: {c['name']} -- {c.get('section', '')}")
+```
+
+#### Create a Course
+
+```python
+async def create_course(
+    client: httpx.AsyncClient,
+    name: str,
+    section: str = None,
+    description: str = None,
+    room: str = None,
+    owner_id: str = "me",
+) -> dict:
+    payload = {"name": name, "ownerId": owner_id}
+    if section:
+        payload["section"] = section
+    if description:
+        payload["descriptionHeading"] = description
+    if room:
+        payload["room"] = room
+    resp = await classroom_request(client, "POST", "/courses", json_data=payload)
+    return resp.json()
+```
+
+#### Get / Update / Delete a Course
+
+```python
+async def get_course(client: httpx.AsyncClient, course_id: str) -> dict:
+    resp = await classroom_request(client, "GET", f"/courses/{course_id}")
+    return resp.json()
+
+async def update_course(client: httpx.AsyncClient, course_id: str, update_mask: str, **kwargs) -> dict:
+    resp = await classroom_request(
+        client, "PATCH", f"/courses/{course_id}",
+        params={"updateMask": update_mask},
+        json_data=kwargs,
+    )
+    return resp.json()
+
+async def delete_course(client: httpx.AsyncClient, course_id: str) -> None:
+    await classroom_request(client, "DELETE", f"/courses/{course_id}")
+```
+
+### Course Work (Assignments)
+
+#### List Course Work
+
+```python
+async def list_coursework(
+    client: httpx.AsyncClient,
+    course_id: str,
+    course_work_states: list[str] = None,
+    order_by: str = None,
+) -> list:
+    params = {}
+    if course_work_states:
+        params["courseWorkStates"] = course_work_states
+    if order_by:
+        params["orderBy"] = order_by  # e.g., "dueDate asc", "updateTime desc"
+    return await paginate(client, f"/courses/{course_id}/courseWork", "courseWork", params)
+
+# Usage
+assignments = await list_coursework(client, "123456", course_work_states=["PUBLISHED"])
+for a in assignments:
+    print(f"{a['title']} -- due: {a.get('dueDate', 'no date')}")
+```
+
+#### Create Course Work
+
+```python
+async def create_coursework(
+    client: httpx.AsyncClient,
+    course_id: str,
+    title: str,
+    work_type: str = "ASSIGNMENT",
+    description: str = "",
+    max_points: float = 100,
+    due_date: dict = None,
+    due_time: dict = None,
+    state: str = "PUBLISHED",
+) -> dict:
+    payload = {
+        "title": title,
+        "workType": work_type,  # ASSIGNMENT, SHORT_ANSWER_QUESTION, MULTIPLE_CHOICE_QUESTION
+        "description": description,
+        "maxPoints": max_points,
+        "state": state,
+    }
+    if due_date:
+        payload["dueDate"] = due_date  # {"year": 2026, "month": 4, "day": 1}
+    if due_time:
+        payload["dueTime"] = due_time  # {"hours": 23, "minutes": 59}
+    resp = await classroom_request(client, "POST", f"/courses/{course_id}/courseWork", json_data=payload)
+    return resp.json()
+
+# Usage
+assignment = await create_coursework(
+    client, "123456",
+    title="Week 5 Reading Response",
+    description="Write a 300-word response to Chapter 5.",
+    max_points=50,
+    due_date={"year": 2026, "month": 4, "day": 1},
+    due_time={"hours": 23, "minutes": 59},
+)
+```
+
+### Student Submissions
+
+#### List Submissions
+
+```python
+async def list_submissions(
+    client: httpx.AsyncClient,
+    course_id: str,
+    coursework_id: str,
+    states: list[str] = None,
+) -> list:
+    params = {}
+    if states:
+        params["states"] = states  # NEW, CREATED, TURNED_IN, RETURNED, RECLAIMED_BY_STUDENT
+    return await paginate(
+        client,
+        f"/courses/{course_id}/courseWork/{coursework_id}/studentSubmissions",
+        "studentSubmissions",
+        params,
+    )
+```
+
+#### Grade and Return a Submission
+
+```python
+async def grade_submission(
+    client: httpx.AsyncClient,
+    course_id: str,
+    coursework_id: str,
+    submission_id: str,
+    grade: float,
+) -> dict:
+    resp = await classroom_request(
+        client, "PATCH",
+        f"/courses/{course_id}/courseWork/{coursework_id}/studentSubmissions/{submission_id}",
+        params={"updateMask": "assignedGrade,draftGrade"},
+        json_data={"assignedGrade": grade, "draftGrade": grade},
+    )
+    return resp.json()
+
+async def return_submission(
+    client: httpx.AsyncClient,
+    course_id: str,
+    coursework_id: str,
+    submission_id: str,
+) -> None:
+    await classroom_request(
+        client, "POST",
+        f"/courses/{course_id}/courseWork/{coursework_id}/studentSubmissions/{submission_id}:return",
+    )
+```
+
+### Students and Teachers
+
+```python
+async def list_students(client: httpx.AsyncClient, course_id: str) -> list:
+    return await paginate(client, f"/courses/{course_id}/students", "students")
+
+async def list_teachers(client: httpx.AsyncClient, course_id: str) -> list:
+    return await paginate(client, f"/courses/{course_id}/teachers", "teachers")
+
+async def add_student(client: httpx.AsyncClient, course_id: str, email: str) -> dict:
+    resp = await classroom_request(
+        client, "POST", f"/courses/{course_id}/students",
+        json_data={"userId": email},
+    )
+    return resp.json()
+```
+
+### Announcements
+
+```python
+async def list_announcements(
+    client: httpx.AsyncClient,
+    course_id: str,
+    states: list[str] = None,
+) -> list:
+    params = {}
+    if states:
+        params["announcementStates"] = states
+    return await paginate(client, f"/courses/{course_id}/announcements", "announcements", params)
+
+async def create_announcement(
+    client: httpx.AsyncClient,
+    course_id: str,
+    text: str,
+    state: str = "PUBLISHED",
+) -> dict:
+    resp = await classroom_request(
+        client, "POST", f"/courses/{course_id}/announcements",
+        json_data={"text": text, "state": state},
+    )
+    return resp.json()
+```
+
+### Topics
+
+```python
+async def list_topics(client: httpx.AsyncClient, course_id: str) -> list:
+    return await paginate(client, f"/courses/{course_id}/topics", "topic")
+
+async def create_topic(client: httpx.AsyncClient, course_id: str, name: str) -> dict:
+    resp = await classroom_request(
+        client, "POST", f"/courses/{course_id}/topics",
+        json_data={"name": name},
+    )
+    return resp.json()
+```
+
+## Error Handling
+
+| Code | Meaning |
+|---|---|
+| 200 | Success |
+| 400 | Bad Request -- invalid parameters |
+| 401 | Unauthorized -- expired or invalid token |
+| 403 | Forbidden -- insufficient scope or not a course member |
+| 404 | Not Found -- course or resource does not exist |
+| 409 | Conflict -- resource already exists (e.g., student already enrolled) |
+| 429 | Too Many Requests -- quota exceeded |
+
+```python
+class ClassroomError(Exception):
+    def __init__(self, status_code: int, message: str):
+        self.status_code = status_code
+        self.message = message
+        super().__init__(f"[{status_code}] {message}")
+
+async def safe_classroom_request(client: httpx.AsyncClient, method: str, path: str, **kwargs) -> dict | None:
+    try:
+        resp = await classroom_request(client, method, path, **kwargs)
+        if resp.status_code == 204:
+            return None
+        return resp.json()
+    except httpx.HTTPStatusError as e:
+        body = e.response.json() if e.response.content else {}
+        error = body.get("error", {})
+        raise ClassroomError(
+            e.response.status_code,
+            error.get("message", "Unknown error"),
+        ) from e
+```
+
+## Common Pitfalls
+
+1. **Enable the Classroom API in GCP Console first.** You must enable the Google Classroom API for your GCP project before making any requests.
+
+2. **Due dates use separate date and time objects.** The `dueDate` is `{"year": YYYY, "month": M, "day": D}` and `dueTime` is `{"hours": H, "minutes": M}` in UTC. These are not ISO 8601 strings.
+
+3. **`updateMask` is required for PATCH requests.** You must specify which fields are being updated as a comma-separated string in the `updateMask` query parameter.
+
+4. **Course states affect visibility.** Only `ACTIVE` courses are visible to students. `ARCHIVED` courses are read-only. Use `courseStates` filter to find non-active courses.
+
+5. **User IDs can be `me` or an email.** Use `"me"` for the authenticated user. For other users, pass their email address or numeric ID.
+
+6. **Grading requires two fields.** Set both `assignedGrade` (visible to student) and `draftGrade` (teacher's working grade). Then call the `:return` action to make the grade visible.
+
+7. **`workType` is immutable after creation.** You cannot change an assignment to a quiz or vice versa after it is created.
+
+8. **Consumer Google accounts have limited access.** The full Classroom experience is designed for Google Workspace for Education. Consumer accounts can create courses but face restrictions on roster management.
+
+9. **409 on duplicate enrollment is expected.** Adding a student who is already enrolled returns 409. Handle this as a success case in your code.
+
+10. **Submissions have a lifecycle.** States progress: `NEW` -> `CREATED` -> `TURNED_IN` -> `RETURNED`. Use `:turnIn`, `:return`, `:reclaim` actions to advance the state.

--- a/content/groq/docs/rest-api/python/DOC.md
+++ b/content/groq/docs/rest-api/python/DOC.md
@@ -1,0 +1,421 @@
+---
+name: rest-api
+description: "Groq - Fast LLM Inference REST API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "groq,inference,llm,fast-inference,chat,completions,whisper,vision,api"
+---
+
+# Groq REST API Guide (Python / httpx)
+
+## Golden Rule
+
+Use this entry when you need direct HTTP access to Groq's inference API without the official SDK. All examples use `httpx` with async. For the SDK approach, see `groq/docs/package/`.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+Or with `uv`:
+
+```bash
+uv add httpx
+```
+
+## Base URL
+
+```
+https://api.groq.com/openai/v1
+```
+
+Groq exposes an OpenAI-compatible REST surface. All endpoint paths below are relative to this base.
+
+## Authentication
+
+Every request requires a Bearer token in the `Authorization` header. Obtain your key from the GroqCloud console at `console.groq.com/keys`.
+
+```bash
+export GROQ_API_KEY="gsk_..."
+```
+
+```python
+import os
+
+GROQ_API_KEY = os.environ["GROQ_API_KEY"]
+HEADERS = {
+    "Authorization": f"Bearer {GROQ_API_KEY}",
+    "Content-Type": "application/json",
+}
+```
+
+## Rate Limiting
+
+Groq enforces rate limits at the organization level using multiple metrics:
+
+| Metric | Meaning |
+|--------|---------|
+| RPM | Requests per minute |
+| RPD | Requests per day |
+| TPM | Tokens per minute |
+| TPD | Tokens per day |
+| ASH | Audio seconds per hour |
+| ASD | Audio seconds per day |
+
+Limits vary by plan tier and model. Free-tier examples:
+
+| Model | RPM | RPD | TPM | TPD |
+|-------|-----|-----|-----|-----|
+| llama-3.1-8b-instant | 30 | 14,400 | 6,000 | 500,000 |
+| llama-3.3-70b-versatile | 30 | 1,000 | 12,000 | 100,000 |
+
+**Rate limit headers** returned on every response:
+
+| Header | Description |
+|--------|-------------|
+| `x-ratelimit-limit-requests` | Daily request quota |
+| `x-ratelimit-limit-tokens` | Per-minute token quota |
+| `x-ratelimit-remaining-requests` | Requests remaining today |
+| `x-ratelimit-remaining-tokens` | Tokens remaining this minute |
+| `x-ratelimit-reset-requests` | Time until daily quota resets |
+| `x-ratelimit-reset-tokens` | Time until minute quota resets |
+| `retry-after` | Seconds to wait (only on 429) |
+
+Cached tokens do not count toward rate limits.
+
+## Methods
+
+### Chat Completions
+
+**POST** `/chat/completions`
+
+The primary endpoint for text generation. Accepts a conversation history and returns a model response.
+
+```python
+import httpx
+import os
+
+GROQ_API_KEY = os.environ["GROQ_API_KEY"]
+BASE_URL = "https://api.groq.com/openai/v1"
+HEADERS = {
+    "Authorization": f"Bearer {GROQ_API_KEY}",
+    "Content-Type": "application/json",
+}
+
+
+async def chat_completion():
+    payload = {
+        "model": "llama-3.3-70b-versatile",
+        "messages": [
+            {"role": "system", "content": "You are a concise assistant."},
+            {"role": "user", "content": "What is LoRA fine-tuning?"},
+        ],
+        "temperature": 0.7,
+        "max_completion_tokens": 512,
+    }
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{BASE_URL}/chat/completions",
+            headers=HEADERS,
+            json=payload,
+            timeout=30.0,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return data["choices"][0]["message"]["content"]
+```
+
+**Key request parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `model` | string | required | Model ID (e.g. `llama-3.3-70b-versatile`) |
+| `messages` | array | required | Conversation history with `role` and `content` |
+| `temperature` | number | 1 | Randomness (0-2). Lower is more deterministic |
+| `top_p` | number | 1 | Nucleus sampling threshold (0-1) |
+| `max_completion_tokens` | integer | varies | Upper bound on generated tokens |
+| `stop` | string/array | null | Up to 4 stop sequences |
+| `stream` | boolean | false | Enable server-sent events streaming |
+| `tools` | array | null | Function definitions (max 128) |
+| `tool_choice` | string/object | auto | `none`, `auto`, `required`, or specific function |
+| `parallel_tool_calls` | boolean | true | Allow simultaneous tool invocations |
+| `response_format` | object | null | `{"type": "json_object"}` or JSON schema |
+| `reasoning_format` | string | null | `hidden`, `raw`, or `parsed` |
+
+**Response structure:**
+
+```json
+{
+  "id": "chatcmpl-...",
+  "object": "chat.completion",
+  "created": 1710000000,
+  "model": "llama-3.3-70b-versatile",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "LoRA (Low-Rank Adaptation) is..."
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 25,
+    "completion_tokens": 100,
+    "total_tokens": 125
+  },
+  "system_fingerprint": "fp_..."
+}
+```
+
+### Chat Completions with Streaming
+
+**POST** `/chat/completions` with `"stream": true`
+
+Returns server-sent events. Each chunk contains a delta of the response.
+
+```python
+import httpx
+import os
+
+GROQ_API_KEY = os.environ["GROQ_API_KEY"]
+BASE_URL = "https://api.groq.com/openai/v1"
+HEADERS = {
+    "Authorization": f"Bearer {GROQ_API_KEY}",
+    "Content-Type": "application/json",
+}
+
+
+async def chat_stream():
+    payload = {
+        "model": "llama-3.3-70b-versatile",
+        "messages": [
+            {"role": "user", "content": "Explain gradient descent in three sentences."},
+        ],
+        "stream": True,
+    }
+    async with httpx.AsyncClient() as client:
+        async with client.stream(
+            "POST",
+            f"{BASE_URL}/chat/completions",
+            headers=HEADERS,
+            json=payload,
+            timeout=60.0,
+        ) as resp:
+            resp.raise_for_status()
+            async for line in resp.aiter_lines():
+                if line.startswith("data: ") and line != "data: [DONE]":
+                    import json
+                    chunk = json.loads(line[6:])
+                    delta = chunk["choices"][0]["delta"].get("content", "")
+                    print(delta, end="", flush=True)
+```
+
+### Chat Completions with Tool Calling
+
+**POST** `/chat/completions` with `tools` array
+
+```python
+import httpx
+import json
+import os
+
+GROQ_API_KEY = os.environ["GROQ_API_KEY"]
+BASE_URL = "https://api.groq.com/openai/v1"
+HEADERS = {
+    "Authorization": f"Bearer {GROQ_API_KEY}",
+    "Content-Type": "application/json",
+}
+
+
+async def chat_with_tools():
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get the current weather for a location",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": {"type": "string", "description": "City name"},
+                    },
+                    "required": ["location"],
+                },
+            },
+        }
+    ]
+    payload = {
+        "model": "llama-3.3-70b-versatile",
+        "messages": [
+            {"role": "user", "content": "What is the weather in Tokyo?"},
+        ],
+        "tools": tools,
+        "tool_choice": "auto",
+    }
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{BASE_URL}/chat/completions",
+            headers=HEADERS,
+            json=payload,
+            timeout=30.0,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        message = data["choices"][0]["message"]
+        if message.get("tool_calls"):
+            for tc in message["tool_calls"]:
+                print(f"Function: {tc['function']['name']}")
+                print(f"Args: {tc['function']['arguments']}")
+```
+
+### Audio Transcription
+
+**POST** `/audio/transcriptions`
+
+Converts speech audio to text using Whisper models. Uses multipart form data.
+
+```python
+import httpx
+import os
+
+GROQ_API_KEY = os.environ["GROQ_API_KEY"]
+BASE_URL = "https://api.groq.com/openai/v1"
+
+
+async def transcribe_audio(file_path: str):
+    async with httpx.AsyncClient() as client:
+        with open(file_path, "rb") as f:
+            resp = await client.post(
+                f"{BASE_URL}/audio/transcriptions",
+                headers={"Authorization": f"Bearer {GROQ_API_KEY}"},
+                files={"file": (os.path.basename(file_path), f, "audio/wav")},
+                data={
+                    "model": "whisper-large-v3",
+                    "response_format": "json",
+                    "language": "en",
+                },
+                timeout=60.0,
+            )
+            resp.raise_for_status()
+            return resp.json()["text"]
+```
+
+### List Models
+
+**GET** `/models`
+
+Returns all models available to your account.
+
+```python
+import httpx
+import os
+
+GROQ_API_KEY = os.environ["GROQ_API_KEY"]
+BASE_URL = "https://api.groq.com/openai/v1"
+HEADERS = {"Authorization": f"Bearer {GROQ_API_KEY}"}
+
+
+async def list_models():
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{BASE_URL}/models",
+            headers=HEADERS,
+            timeout=10.0,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return [m["id"] for m in data["data"]]
+```
+
+## Error Handling
+
+Groq returns standard HTTP status codes with a JSON error body.
+
+**Error response structure:**
+
+```json
+{
+  "error": {
+    "message": "Descriptive error message",
+    "type": "invalid_request_error"
+  }
+}
+```
+
+**Status codes:**
+
+| Code | Meaning | Action |
+|------|---------|--------|
+| 200 | Success | No action needed |
+| 400 | Bad Request | Fix request syntax or parameters |
+| 401 | Unauthorized | Check API key |
+| 403 | Forbidden | Check resource permissions |
+| 404 | Not Found | Verify endpoint URL or resource ID |
+| 413 | Payload Too Large | Reduce request body size |
+| 422 | Unprocessable Entity | Fix semantic errors in request |
+| 429 | Rate Limited | Back off and retry after `retry-after` seconds |
+| 498 | Flex Capacity Exceeded | Retry later |
+| 500 | Internal Server Error | Retry later |
+| 502 | Bad Gateway | Retry later |
+| 503 | Service Unavailable | Wait and retry |
+
+**Robust error handling with retry:**
+
+```python
+import httpx
+import asyncio
+import os
+
+GROQ_API_KEY = os.environ["GROQ_API_KEY"]
+BASE_URL = "https://api.groq.com/openai/v1"
+HEADERS = {
+    "Authorization": f"Bearer {GROQ_API_KEY}",
+    "Content-Type": "application/json",
+}
+
+
+async def chat_with_retry(payload: dict, max_retries: int = 3):
+    async with httpx.AsyncClient() as client:
+        for attempt in range(max_retries):
+            resp = await client.post(
+                f"{BASE_URL}/chat/completions",
+                headers=HEADERS,
+                json=payload,
+                timeout=30.0,
+            )
+            if resp.status_code == 429:
+                retry_after = float(resp.headers.get("retry-after", 2))
+                await asyncio.sleep(retry_after)
+                continue
+            if resp.status_code >= 500:
+                await asyncio.sleep(2 ** attempt)
+                continue
+            resp.raise_for_status()
+            return resp.json()
+    raise RuntimeError("Max retries exceeded")
+```
+
+## Common Pitfalls
+
+1. **Missing `Content-Type` header.** POST requests must include `Content-Type: application/json`. The `httpx` `json=` parameter sets this automatically, but if you use `content=` or `data=`, set it manually.
+
+2. **Confusing `max_tokens` with `max_completion_tokens`.** The Groq API uses `max_completion_tokens`. Using `max_tokens` may work for backward compatibility but `max_completion_tokens` is the canonical parameter.
+
+3. **Not handling streaming termination.** Streamed responses end with `data: [DONE]`. Always check for this sentinel before parsing JSON.
+
+4. **Audio endpoints require multipart form data.** Do not send JSON to `/audio/transcriptions` or `/audio/translations`. Use `files=` and `data=` parameters in httpx.
+
+5. **Rate limit scope is per-organization, not per-key.** Multiple API keys under the same org share the same rate limits.
+
+6. **Timeout too short for large completions.** Default httpx timeout is 5 seconds. Always set an explicit `timeout=` for inference calls (30-60 seconds recommended).
+
+7. **Forgetting to check `finish_reason`.** A response with `finish_reason: "length"` means the output was truncated. Check this field and increase `max_completion_tokens` if needed.
+
+8. **Using the wrong base URL.** The base is `https://api.groq.com/openai/v1`, not `https://api.groq.com/v1`. The `/openai` prefix is required for the OpenAI-compatible surface.

--- a/content/gstn/docs/rest-api/python/DOC.md
+++ b/content/gstn/docs/rest-api/python/DOC.md
@@ -1,0 +1,415 @@
+---
+name: rest-api
+description: "GSTN (GST Network) - India's Goods and Services Tax filing, verification, e-Invoice, and e-Way Bill APIs"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "india,gst,gstn,tax,e-invoice,e-waybill,compliance,government"
+---
+
+# GSTN (GST Network) REST API
+
+## Golden Rule
+
+GSTN APIs are **not directly accessible** to end developers. Access is mediated through licensed **GST Suvidha Providers (GSPs)** who act as authorized gateways to the GSTN system. You must either become a GSP (heavy licensing process) or integrate through an existing GSP (e.g., Vayana, ClearTax, MasterGST, WhiteBooks, FinAGG). The GSP handles connectivity to GSTN and provides you with API credentials. All payloads involving sensitive data are encrypted using AES-256 with a session encryption key (SEK) that is itself encrypted with RSA. The **sandbox OTP for testing is always `575757`**.
+
+## Installation
+
+```bash
+pip install httpx cryptography
+```
+
+Cryptography is needed for AES/RSA encryption of payloads.
+
+## Base URL
+
+GSTN APIs are accessed through your chosen GSP's gateway, which proxies to GSTN's `taxpayerapi` and `commonapi` endpoints.
+
+### Via Vayana GSP
+
+| Environment | Base URL |
+|-------------|----------|
+| Sandbox | `https://yoda.api.vayanagsp.in/gus` |
+| Production | `https://api.gsp.vayana.com/gus` |
+
+### Via MasterGST
+
+| Environment | Base URL |
+|-------------|----------|
+| Production | `https://api.mastergst.com` |
+
+### Via WhiteBooks
+
+| Environment | Base URL |
+|-------------|----------|
+| Sandbox | `https://apisandbox.whitebooks.in` |
+| Production | `https://api.whitebooks.in` |
+
+### GSTN Endpoint Patterns (via GSP)
+
+| Path Pattern | Purpose |
+|--------------|---------|
+| `/gus/taxpayerapi/v1.0/authenticate` | Authentication |
+| `/gus/taxpayerapi/v1.0/returns/gstr1` | GSTR-1 (outward supplies) |
+| `/gus/taxpayerapi/v1.0/returns/gstr2a` | GSTR-2A (inward supplies) |
+| `/gus/taxpayerapi/v1.0/returns/gstr3b` | GSTR-3B (summary return) |
+| `/gus/commonapi/v1.1/search` | Taxpayer search (public) |
+| `/gus/gstn-health/main` | Health check |
+
+### e-Invoice IRPs (6 authorized portals)
+
+| IRP | Production URL | Sandbox URL |
+|-----|---------------|-------------|
+| NIC-IRP 1 | `https://einvoice1.gst.gov.in` | `https://einv-apisandbox.nic.in` |
+| NIC-IRP 2 | `https://einvoice2.gst.gov.in` | `https://einv-apisandbox.nic.in` |
+| Cygnet | `https://einvoice3.gst.gov.in` | `https://sandbox.einvoice3.gst.gov.in` |
+| Clear | `https://einvoice4.gst.gov.in` | `https://irp-sandbox.clear.in` |
+| EY | `https://einvoice5.gst.gov.in` | `https://sandbox.einvoice5.gst.gov.in` |
+| IRIS | `https://einvoice6.gst.gov.in` | Via portal registration |
+
+### e-Way Bill
+
+| Environment | Base URL |
+|-------------|----------|
+| Documentation | `https://docs.ewaybillgst.gov.in/apidocs/` |
+
+## Authentication
+
+GSTN uses a multi-step authentication process with OTP verification and encrypted session keys.
+
+### Step 1: Authenticate with GSTN (via GSP)
+
+```python
+import httpx
+import json
+import os
+import base64
+from cryptography.hazmat.primitives.asymmetric import padding as asym_padding
+from cryptography.hazmat.primitives import serialization, hashes
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+
+GSP_BASE_URL = "https://yoda.api.vayanagsp.in/gus"  # Vayana sandbox
+
+
+def encrypt_with_public_key(data: bytes, public_key_pem: bytes) -> str:
+    """Encrypt data with GSTN's RSA public key."""
+    public_key = serialization.load_pem_public_key(public_key_pem)
+    encrypted = public_key.encrypt(data, asym_padding.PKCS1v15())
+    return base64.b64encode(encrypted).decode()
+
+
+async def authenticate_gstn(
+    username: str, gstin: str, otp: str, public_key_pem: bytes
+) -> dict:
+    """
+    Authenticate with GSTN. Returns auth_token and encrypted SEK.
+    In sandbox, use OTP '575757'.
+    """
+    # Generate a random 256-bit AES key as the app_key
+    app_key = os.urandom(32)
+    encrypted_app_key = encrypt_with_public_key(app_key, public_key_pem)
+    encrypted_otp = encrypt_with_public_key(otp.encode(), public_key_pem)
+
+    headers = {
+        "Content-Type": "application/json",
+        "clientid": "your-gsp-client-id",
+        "client-secret": "your-gsp-client-secret",
+        "state-cd": gstin[:2],           # First 2 digits of GSTIN
+        "ip-usr": "127.0.0.1",
+        "txn": "unique-transaction-id",
+    }
+
+    payload = {
+        "action": "AUTHTOKEN",
+        "username": username,
+        "app_key": encrypted_app_key,
+        "otp": encrypted_otp,
+    }
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{GSP_BASE_URL}/taxpayerapi/v1.0/authenticate",
+            headers=headers,
+            json=payload,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        # data: { "status_cd": "1", "auth_token": "...", "expiry": 120, "sek": "..." }
+        # The SEK must be decrypted with your app_key using AES
+        return data
+```
+
+### Step 2: Decrypt Session Encryption Key
+
+```python
+def decrypt_sek(encrypted_sek_b64: str, app_key: bytes) -> bytes:
+    """Decrypt the Session Encryption Key using your app_key."""
+    encrypted_sek = base64.b64decode(encrypted_sek_b64)
+    cipher = Cipher(algorithms.AES(app_key), modes.ECB())
+    decryptor = cipher.decryptor()
+    sek = decryptor.update(encrypted_sek) + decryptor.finalize()
+    return sek
+```
+
+### Headers for Authenticated Requests
+
+| Header | Description |
+|--------|-------------|
+| `Content-Type` | `application/json` |
+| `clientid` | GSP-assigned client ID |
+| `client-secret` | GSP-assigned client secret |
+| `state-cd` | First 2 digits of GSTIN |
+| `ip-usr` | Requester IP address |
+| `txn` | Unique transaction identifier |
+| `username` | GSTN username |
+| `auth-token` | Token from authentication response |
+| `gstin` | GSTIN of the taxpayer |
+
+## Rate Limiting
+
+GSTN enforces rate limits through the GSP layer. Specific limits vary by GSP but typically:
+
+- Authentication: 1 request per 6 hours (token is reused)
+- Return filing APIs: Subject to GSTN system load
+- Search API: Fair-use limits apply
+- e-Invoice auth token: Valid 6 hours (production), 1 hour (sandbox); same token returned within validity
+
+Implement exponential backoff for HTTP 429 or GSTN error codes indicating throttling.
+
+## Methods
+
+### Search Taxpayer (Public API)
+
+`GET /commonapi/v1.1/search`
+
+Search for a taxpayer by GSTIN. This is a **public** endpoint that does not require authentication.
+
+```python
+async def search_taxpayer(gstin: str) -> dict:
+    """Search for a taxpayer by GSTIN. Public API - no auth needed."""
+    headers = {
+        "Content-Type": "application/json",
+        "clientid": "your-gsp-client-id",
+        "client-secret": "your-gsp-client-secret",
+        "state-cd": gstin[:2],
+        "ip-usr": "127.0.0.1",
+        "txn": "unique-txn-id",
+    }
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{GSP_BASE_URL}/commonapi/v1.1/search",
+            headers=headers,
+            params={"action": "TP", "gstin": gstin},
+        )
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### File GSTR-1 (Outward Supplies)
+
+`POST /taxpayerapi/v1.0/returns/gstr1`
+
+Submit outward supply details. Payload must be encrypted with the SEK.
+
+```python
+def encrypt_payload(payload_json: str, sek: bytes) -> str:
+    """Encrypt a JSON payload using AES-256-ECB with the session key."""
+    # PKCS5 padding
+    block_size = 16
+    pad_len = block_size - (len(payload_json.encode()) % block_size)
+    padded = payload_json.encode() + bytes([pad_len] * pad_len)
+
+    cipher = Cipher(algorithms.AES(sek), modes.ECB())
+    encryptor = cipher.encryptor()
+    encrypted = encryptor.update(padded) + encryptor.finalize()
+    return base64.b64encode(encrypted).decode()
+
+
+async def save_gstr1(
+    gstin: str, return_period: str, data: dict,
+    auth_token: str, sek: bytes,
+) -> dict:
+    """Save GSTR-1 data. The payload is AES-encrypted with the SEK."""
+    encrypted_data = encrypt_payload(json.dumps(data), sek)
+
+    headers = {
+        "Content-Type": "application/json",
+        "clientid": "your-gsp-client-id",
+        "client-secret": "your-gsp-client-secret",
+        "state-cd": gstin[:2],
+        "ip-usr": "127.0.0.1",
+        "txn": "unique-txn-id",
+        "username": "your-gstn-username",
+        "auth-token": auth_token,
+        "gstin": gstin,
+    }
+
+    payload = {
+        "action": "RETSAVE",
+        "data": encrypted_data,
+    }
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{GSP_BASE_URL}/taxpayerapi/v1.0/returns/gstr1",
+            headers=headers,
+            json=payload,
+        )
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### e-Invoice Authentication (NIC IRP)
+
+`POST /eivital/v1.03/auth`
+
+Authenticate with the e-Invoice system to obtain an access token.
+
+```python
+E_INVOICE_SANDBOX = "https://einv-apisandbox.nic.in"
+
+
+async def einvoice_authenticate(
+    client_id: str, client_secret: str, username: str, password: str,
+) -> dict:
+    """Authenticate with the e-Invoice IRP system."""
+    headers = {
+        "Content-Type": "application/json",
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "user_name": username,
+        "Gstin": "your-gstin",
+    }
+
+    # Password is encrypted with the IRP's public key (RSA/ECB/PKCS1Padding)
+    # and the response SEK is decrypted with AES-256
+    payload = {
+        "UserName": username,
+        "Password": password,  # Must be encrypted with IRP public key
+        "ForceRefreshAccessToken": "true",
+    }
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{E_INVOICE_SANDBOX}/eivital/v1.03/auth",
+            headers=headers,
+            json=payload,
+        )
+        resp.raise_for_status()
+        return resp.json()
+        # Returns: AuthToken, Sek, TokenExpiry (360 min prod, 60 min sandbox)
+```
+
+### Generate e-Invoice
+
+`POST /eicore/v1.03/Invoice`
+
+Generate an IRN (Invoice Reference Number) for an e-Invoice.
+
+```python
+async def generate_einvoice(
+    auth_token: str, sek: bytes, invoice_data: dict, gstin: str,
+) -> dict:
+    """Generate an e-Invoice and obtain an IRN."""
+    encrypted_payload = encrypt_payload(json.dumps(invoice_data), sek)
+
+    headers = {
+        "Content-Type": "application/json",
+        "client_id": "your-client-id",
+        "client_secret": "your-client-secret",
+        "Gstin": gstin,
+        "user_name": "your-username",
+        "AuthToken": auth_token,
+    }
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{E_INVOICE_SANDBOX}/eicore/v1.03/Invoice",
+            headers=headers,
+            json={"Data": encrypted_payload},
+        )
+        resp.raise_for_status()
+        return resp.json()
+```
+
+## Error Handling
+
+```python
+import httpx
+
+
+GSTN_ERROR_CODES = {
+    "AUTH4033": "Invalid credentials",
+    "AUTH4034": "OTP expired",
+    "AUTH4035": "Account locked - too many failed attempts",
+    "RET11402": "Return period invalid",
+    "RET11403": "GSTIN mismatch",
+    "RET11416": "Return already filed for this period",
+}
+
+
+async def safe_gstn_call(url: str, headers: dict, payload: dict) -> dict:
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        try:
+            resp = await client.post(url, headers=headers, json=payload)
+            resp.raise_for_status()
+            data = resp.json()
+
+            # GSTN returns status_cd "0" for errors even with HTTP 200
+            if data.get("status_cd") == "0":
+                error = data.get("error", {})
+                error_cd = error.get("error_cd", "UNKNOWN")
+                message = GSTN_ERROR_CODES.get(
+                    error_cd, error.get("message", "Unknown GSTN error")
+                )
+                raise ValueError(f"GSTN error {error_cd}: {message}")
+
+            return data
+
+        except httpx.HTTPStatusError as e:
+            status = e.response.status_code
+            if status == 401:
+                print("Auth token expired - re-authenticate")
+            elif status == 403:
+                print("Forbidden - check GSP credentials")
+            elif status == 429:
+                print("Rate limited - backoff and retry")
+            elif status == 503:
+                print("GSTN system unavailable - retry later")
+            raise
+```
+
+| HTTP Code | Meaning |
+|-----------|---------|
+| 200 | Success (check `status_cd` in body) |
+| 401 | Authentication token expired |
+| 403 | Invalid GSP credentials |
+| 429 | Rate limited |
+| 500 | GSP/GSTN internal error |
+| 503 | GSTN system temporarily unavailable |
+
+## Common Pitfalls
+
+1. **HTTP 200 does not mean success** - GSTN returns `status_cd: "0"` in the response body for business errors, even with an HTTP 200 status. Always check the `status_cd` field.
+
+2. **Auth token reuse** - The authentication token is valid for approximately 6 hours. Hitting the auth endpoint within that window returns the same token. Do not authenticate on every API call.
+
+3. **Payload encryption is mandatory** - All sensitive payloads (returns, invoices) must be AES-256-ECB encrypted with the SEK. Sending plaintext will result in errors.
+
+4. **SEK decryption** - The SEK returned by the auth endpoint is itself encrypted with your app_key. You must decrypt it with AES before using it to encrypt/decrypt payloads.
+
+5. **Sandbox OTP is always 575757** - For GSTN sandbox testing, use the default OTP `575757`. In production, the OTP is sent to the registered mobile/email.
+
+6. **GSP is mandatory** - You cannot call GSTN endpoints directly. You must go through a licensed GSP. Choose a GSP, register, and obtain API credentials from them.
+
+7. **State code in headers** - The `state-cd` header must match the first 2 digits of the GSTIN being queried. Mismatches cause silent failures.
+
+8. **e-Invoice IRP selection** - There are 6 authorized IRPs. All offer the same core APIs. Choose based on pricing and reliability. NIC IRPs (1 and 2) are the original government portals.
+
+9. **GSTIN format** - A GSTIN is a 15-character alphanumeric code: `{2-digit state code}{10-digit PAN}{1-digit entity code}{1-digit check digit}{Z}`. Validate format before API calls.
+
+10. **SSL certificates** - Some GSPs require specific SSL certificates for production. Check your GSP's documentation for certificate requirements.

--- a/content/gupshup/docs/rest-api/python/DOC.md
+++ b/content/gupshup/docs/rest-api/python/DOC.md
@@ -1,0 +1,227 @@
+---
+name: rest-api
+description: "Gupshup - WhatsApp Business Messaging API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-13"
+  source: community
+  tags: "gupshup,whatsapp,messaging,whatsapp-business,templates,notifications,conversational,api,integration"
+---
+
+# Gupshup WhatsApp Business API
+
+> **Golden Rule:** Gupshup has no official Python SDK. Use `httpx` for direct REST access. Auth uses an `apikey` header. **Critical:** All message-sending endpoints use `application/x-www-form-urlencoded`, NOT JSON. The `message` field is a JSON string within a form body. Session messages require a 24-hour window; template messages can be sent anytime.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URLs
+
+| Purpose | URL |
+|---|---|
+| Session Messages | `https://api.gupshup.io/wa/api/v1/msg` |
+| Template Messages | `https://api.gupshup.io/wa/api/v1/template/msg` |
+
+## Authentication
+
+**Type:** API Key (custom header)
+
+```python
+import httpx
+import json
+
+API_KEY = "your-gupshup-api-key"
+SOURCE_NUMBER = "919876543210"  # Your registered WhatsApp Business number
+APP_NAME = "YourAppName"       # Gupshup app name for the source number
+
+headers = {"apikey": API_KEY}
+client = httpx.AsyncClient(headers=headers)
+```
+
+**Important:** Get your API key from Gupshup Dashboard > App Settings.
+
+## Rate Limiting
+
+| Limit Type | Value |
+|---|---|
+| Gupshup API | ~20 messages/second per app |
+| WhatsApp platform | 20-50 API calls/second (varies by tier) |
+| Daily unique users | Tiered: 250 / 1K / 10K / 100K / unlimited |
+
+## Methods
+
+### `send_session_message`
+
+**Endpoint:** `POST https://api.gupshup.io/wa/api/v1/msg`
+
+Send a free-form message within the 24-hour customer session window.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `channel` | `str` | **required** (`whatsapp`) |
+| `source` | `str` | **required** (your WhatsApp Business number) |
+| `src.name` | `str` | **required** (Gupshup app name) |
+| `destination` | `str` | **required** (recipient number) |
+| `message` | `str` | **required** (JSON string of message payload) |
+
+**Returns:** JSON with `status` (`submitted`) and `messageId`
+
+```python
+import json
+
+message_payload = json.dumps({"type": "text", "text": "Hello from Gupshup!"})
+
+data = {
+    "channel": "whatsapp",
+    "source": SOURCE_NUMBER,
+    "src.name": APP_NAME,
+    "destination": "919123456789",
+    "message": message_payload
+}
+response = await client.post(
+    "https://api.gupshup.io/wa/api/v1/msg",
+    data=data,  # form-encoded, NOT json=
+    headers={"Content-Type": "application/x-www-form-urlencoded", **headers}
+)
+response.raise_for_status()
+result = response.json()
+message_id = result["messageId"]
+```
+
+### `send_image_message`
+
+**Endpoint:** `POST https://api.gupshup.io/wa/api/v1/msg`
+
+Send an image within a session window.
+
+```python
+message_payload = json.dumps({
+    "type": "image",
+    "originalUrl": "https://example.com/image.jpg",
+    "caption": "Check this out",
+    "previewUrl": "https://example.com/thumb.jpg"
+})
+
+data = {
+    "channel": "whatsapp",
+    "source": SOURCE_NUMBER,
+    "src.name": APP_NAME,
+    "destination": "919123456789",
+    "message": message_payload
+}
+response = await client.post(
+    "https://api.gupshup.io/wa/api/v1/msg",
+    data=data,
+    headers={"Content-Type": "application/x-www-form-urlencoded", **headers}
+)
+response.raise_for_status()
+```
+
+### `send_template_message`
+
+**Endpoint:** `POST https://api.gupshup.io/wa/api/v1/template/msg`
+
+Send a pre-approved template message (works outside the 24-hour session window).
+
+| Parameter | Type | Default |
+|---|---|---|
+| `source` | `str` | **required** (sender number) |
+| `src.name` | `str` | **required** (app name) |
+| `destination` | `str` | **required** (recipient number) |
+| `template` | `str` | **required** (JSON string with `id` and `params`) |
+
+**Returns:** JSON with `messageId` and `status`
+
+```python
+template_payload = json.dumps({
+    "id": "your_template_id",
+    "params": ["John", "Order #12345"]
+})
+
+data = {
+    "source": SOURCE_NUMBER,
+    "src.name": APP_NAME,
+    "destination": "919123456789",
+    "template": template_payload
+}
+response = await client.post(
+    "https://api.gupshup.io/wa/api/v1/template/msg",
+    data=data,
+    headers={"Content-Type": "application/x-www-form-urlencoded", **headers}
+)
+response.raise_for_status()
+result = response.json()
+```
+
+### `send_location_message`
+
+**Endpoint:** `POST https://api.gupshup.io/wa/api/v1/msg`
+
+Send a location pin within a session window.
+
+```python
+message_payload = json.dumps({
+    "type": "location",
+    "longitude": 72.8777,
+    "latitude": 19.0760,
+    "name": "Mumbai",
+    "address": "Maharashtra, India"
+})
+
+data = {
+    "channel": "whatsapp",
+    "source": SOURCE_NUMBER,
+    "src.name": APP_NAME,
+    "destination": "919123456789",
+    "message": message_payload
+}
+response = await client.post(
+    "https://api.gupshup.io/wa/api/v1/msg",
+    data=data,
+    headers={"Content-Type": "application/x-www-form-urlencoded", **headers}
+)
+response.raise_for_status()
+```
+
+## Error Handling
+
+```python
+import httpx
+
+try:
+    response = await client.post(
+        "https://api.gupshup.io/wa/api/v1/msg",
+        data=data,
+        headers={"Content-Type": "application/x-www-form-urlencoded", **headers}
+    )
+    response.raise_for_status()
+    result = response.json()
+    if result.get("status") == "error":
+        print(f"Gupshup error: {result.get('message')}")
+except httpx.HTTPStatusError as e:
+    if e.response.status_code == 401:
+        print("Auth failed -- check apikey header")
+    elif e.response.status_code == 429:
+        print("Rate limited -- reduce message throughput")
+    else:
+        print(f"Gupshup API error {e.response.status_code}: {e.response.text}")
+except httpx.RequestError as e:
+    print(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+- **Content-Type is `application/x-www-form-urlencoded`**, NOT `application/json` -- this is the #1 mistake
+- The `message` field is a **JSON string inside a form body** -- use `json.dumps()` then pass via `data=`
+- **24-hour session window**: Free-form messages only work within 24 hours of user's last message; use template messages outside this window
+- Templates must be **pre-approved by Meta** before use
+- Phone numbers use **E.164 without the `+` prefix** (e.g., `919876543210` for India)
+- API response `"status": "submitted"` means Gupshup accepted it -- NOT that it was delivered; use webhooks for delivery confirmation
+- Message processing is **asynchronous** -- delivery is not guaranteed by a 200 response
+- Gupshup error codes: `1002` = number not on WhatsApp, `1003` = insufficient wallet balance, `1004` = user not opted-in
+- Set a reasonable timeout: `httpx.AsyncClient(timeout=30.0)`

--- a/content/habitica/docs/rest-api/python/DOC.md
+++ b/content/habitica/docs/rest-api/python/DOC.md
@@ -1,0 +1,380 @@
+---
+name: rest-api
+description: "Habitica API v3 - Gamified habit and task tracker for productivity and neurodivergent support"
+metadata:
+  languages: "python"
+  versions: "v3"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "habitica,habits,tasks,gamification,adhd,neurodivergent,productivity,api"
+---
+
+# Habitica API v3 - Python Reference (httpx)
+
+## Golden Rule
+
+All requests go to `https://habitica.com/api/v3`. Authentication uses three custom headers on every request: `x-api-user` (your User ID), `x-api-key` (your API token), and `x-client` (your tool identifier in `UserID-AppName` format). Rate limit is **30 requests per 60 seconds per user**. All responses are JSON wrapped in `{"success": true, "data": ...}`. Task types are `habit`, `daily`, `todo`, and `reward`.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+All examples use `httpx` with async/await. For scripts that need a synchronous entrypoint:
+
+```python
+import asyncio
+import httpx
+
+async def main():
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{BASE_URL}/tasks/user",
+            headers=HEADERS,
+        )
+        print(resp.json())
+
+asyncio.run(main())
+```
+
+## Base URL
+
+```
+https://habitica.com/api/v3
+```
+
+```python
+import os
+
+USER_ID = os.environ["HABITICA_USER_ID"]
+API_TOKEN = os.environ["HABITICA_API_TOKEN"]
+BASE_URL = "https://habitica.com/api/v3"
+HEADERS = {
+    "x-api-user": USER_ID,
+    "x-api-key": API_TOKEN,
+    "x-client": f"{USER_ID}-MyHabiticaApp",
+    "Content-Type": "application/json",
+}
+```
+
+## Authentication
+
+Habitica uses **custom headers** for authentication on every request:
+
+| Header | Value | Required |
+|---|---|---|
+| `x-api-user` | Your Habitica User ID | Yes |
+| `x-api-key` | Your Habitica API Token | Yes |
+| `x-client` | `UserID-AppName` (identifies your tool) | Yes |
+
+Find your User ID and API Token at: Settings > Site Data (API) in the Habitica web app.
+
+## Rate Limiting
+
+| Limit | Value |
+|---|---|
+| Requests per user | 30 per 60 seconds |
+
+Response headers indicate quota status:
+
+| Header | Meaning |
+|---|---|
+| `X-RateLimit-Limit` | Total requests allowed (always 30) |
+| `X-RateLimit-Remaining` | Requests remaining in current window |
+| `X-RateLimit-Reset` | Timestamp when the window resets |
+
+When exceeded, the API returns HTTP `429 Too Many Requests`.
+
+```python
+import asyncio
+
+async def habitica_request(
+    client: httpx.AsyncClient,
+    method: str,
+    path: str,
+    params: dict = None,
+    json_data: dict = None,
+    max_retries: int = 3,
+) -> dict:
+    for attempt in range(max_retries):
+        resp = await client.request(
+            method,
+            f"{BASE_URL}{path}",
+            headers=HEADERS,
+            params=params,
+            json=json_data,
+        )
+        if resp.status_code == 429:
+            reset = resp.headers.get("X-RateLimit-Reset")
+            if reset:
+                import datetime
+                reset_time = datetime.datetime.fromisoformat(reset.replace("Z", "+00:00"))
+                wait = max((reset_time - datetime.datetime.now(datetime.timezone.utc)).total_seconds(), 1)
+            else:
+                wait = min(2 ** attempt, 60)
+            await asyncio.sleep(wait)
+            continue
+        resp.raise_for_status()
+        data = resp.json()
+        if not data.get("success"):
+            raise Exception(f"Habitica error: {data.get('message', 'Unknown')}")
+        return data["data"]
+    raise Exception("Max retries exceeded due to rate limiting")
+```
+
+## Methods
+
+### Get User Data
+
+```python
+async def get_user(client: httpx.AsyncClient) -> dict:
+    return await habitica_request(client, "GET", "/user")
+
+# Returns extensive user object including:
+# - stats (hp, mp, exp, gp, lvl, class)
+# - preferences, items, achievements
+# - tasksOrder (lists of task IDs by type)
+
+# Usage
+user = await get_user(client)
+stats = user["stats"]
+print(f"Level {stats['lvl']} {stats['class']} -- HP: {stats['hp']}/{stats['maxHealth']}")
+print(f"Gold: {stats['gp']:.0f}, Gems: {user.get('balance', 0) * 4:.0f}")
+```
+
+### Tasks
+
+#### List All Tasks
+
+**Parameters:**
+- `type` (str) -- Filter by type: `habits`, `dailys`, `todos`, `rewards`, `completedTodos`
+
+```python
+async def list_tasks(client: httpx.AsyncClient, task_type: str = None) -> list:
+    params = {}
+    if task_type:
+        params["type"] = task_type  # habits, dailys, todos, rewards, completedTodos
+    return await habitica_request(client, "GET", "/tasks/user", params=params)
+
+# Usage
+todos = await list_tasks(client, "todos")
+for t in todos:
+    print(f"[{'x' if t['completed'] else ' '}] {t['text']} (priority: {t['priority']})")
+```
+
+#### Create a Task
+
+Task types: `habit`, `daily`, `todo`, `reward`
+
+```python
+async def create_task(
+    client: httpx.AsyncClient,
+    text: str,
+    task_type: str = "todo",
+    notes: str = "",
+    priority: float = 1,
+    tags: list[str] = None,
+    checklist: list[dict] = None,
+    **kwargs,
+) -> dict:
+    payload = {
+        "text": text,
+        "type": task_type,
+        "notes": notes,
+        "priority": priority,  # 0.1=trivial, 1=easy, 1.5=medium, 2=hard
+    }
+    if tags:
+        payload["tags"] = tags
+    if checklist:
+        payload["checklist"] = checklist  # [{"text": "Step 1"}, {"text": "Step 2"}]
+    payload.update(kwargs)
+    return await habitica_request(client, "POST", "/tasks/user", json_data=payload)
+
+# Usage -- create a todo with checklist
+task = await create_task(
+    client,
+    text="Pack lunch for school",
+    task_type="todo",
+    priority=1.5,
+    notes="Remember allergen-free snacks!",
+    checklist=[
+        {"text": "Main dish"},
+        {"text": "Fruit"},
+        {"text": "Water bottle"},
+        {"text": "Allergen-free snack"},
+    ],
+)
+```
+
+#### Create a Habit
+
+```python
+async def create_habit(
+    client: httpx.AsyncClient,
+    text: str,
+    up: bool = True,
+    down: bool = True,
+    notes: str = "",
+    priority: float = 1,
+) -> dict:
+    return await create_task(
+        client, text, task_type="habit",
+        up=up, down=down, notes=notes, priority=priority,
+    )
+
+# Usage -- habit that can only be scored up (good habit tracking)
+habit = await create_habit(client, "Drank water", up=True, down=False)
+```
+
+#### Create a Daily
+
+```python
+async def create_daily(
+    client: httpx.AsyncClient,
+    text: str,
+    frequency: str = "weekly",
+    repeat: dict = None,
+    every_x: int = 1,
+    start_date: str = None,
+    notes: str = "",
+    priority: float = 1,
+) -> dict:
+    payload = {
+        "frequency": frequency,  # daily, weekly, monthly, yearly
+        "everyX": every_x,
+    }
+    if repeat:
+        payload["repeat"] = repeat  # {"m": True, "t": True, "w": True, ...}
+    if start_date:
+        payload["startDate"] = start_date  # ISO date string
+    return await create_task(
+        client, text, task_type="daily",
+        notes=notes, priority=priority, **payload,
+    )
+
+# Usage -- daily that repeats on weekdays
+daily = await create_daily(
+    client, "Morning routine checklist",
+    frequency="weekly",
+    repeat={"m": True, "t": True, "w": True, "th": True, "f": True, "s": False, "su": False},
+    notes="Brush teeth, get dressed, pack bag",
+)
+```
+
+#### Get / Update / Delete a Task
+
+```python
+async def get_task(client: httpx.AsyncClient, task_id: str) -> dict:
+    return await habitica_request(client, "GET", f"/tasks/{task_id}")
+
+async def update_task(client: httpx.AsyncClient, task_id: str, **kwargs) -> dict:
+    return await habitica_request(client, "PUT", f"/tasks/{task_id}", json_data=kwargs)
+
+async def delete_task(client: httpx.AsyncClient, task_id: str) -> None:
+    await habitica_request(client, "DELETE", f"/tasks/{task_id}")
+```
+
+#### Score a Task (Complete / +/-)
+
+Scoring a task awards XP, gold, and affects health. This is the core gamification mechanic.
+
+```python
+async def score_task(
+    client: httpx.AsyncClient,
+    task_id: str,
+    direction: str = "up",
+) -> dict:
+    return await habitica_request(client, "POST", f"/tasks/{task_id}/score/{direction}")
+    # direction: "up" (positive/complete) or "down" (negative/undo)
+    # Returns: {"hp": 50, "mp": 25, "exp": 100, "gp": 10.5, "lvl": 5, ...}
+
+# Usage -- complete a todo
+result = await score_task(client, task["_id"], "up")
+print(f"Earned {result.get('gp', 0):.1f} gold, {result.get('exp', 0)} XP!")
+```
+
+### Tags
+
+```python
+async def list_tags(client: httpx.AsyncClient) -> list:
+    return await habitica_request(client, "GET", "/tags")
+
+async def create_tag(client: httpx.AsyncClient, name: str) -> dict:
+    return await habitica_request(client, "POST", "/tags", json_data={"name": name})
+
+async def delete_tag(client: httpx.AsyncClient, tag_id: str) -> None:
+    await habitica_request(client, "DELETE", f"/tags/{tag_id}")
+```
+
+### Challenges
+
+```python
+async def list_user_challenges(client: httpx.AsyncClient) -> list:
+    return await habitica_request(client, "GET", "/challenges/user")
+
+async def join_challenge(client: httpx.AsyncClient, challenge_id: str) -> dict:
+    return await habitica_request(client, "POST", f"/challenges/{challenge_id}/join")
+```
+
+### Cron (Trigger Daily Reset)
+
+```python
+async def run_cron(client: httpx.AsyncClient) -> None:
+    await habitica_request(client, "POST", "/cron")
+    # Processes dailies, applies damage for missed dailies, resets daily counters
+```
+
+## Error Handling
+
+| Code | Meaning |
+|---|---|
+| 200 | Success |
+| 400 | Bad Request -- invalid parameters |
+| 401 | Unauthorized -- invalid or missing auth headers |
+| 404 | Not Found -- task or resource does not exist |
+| 429 | Too Many Requests -- rate limit exceeded (30/min) |
+| 500 | Internal Server Error |
+
+All responses have the shape `{"success": bool, "data": ..., "message": str}`.
+
+```python
+class HabiticaError(Exception):
+    def __init__(self, status_code: int, message: str):
+        self.status_code = status_code
+        self.message = message
+        super().__init__(f"[{status_code}] {message}")
+
+async def safe_habitica_request(client: httpx.AsyncClient, method: str, path: str, **kwargs) -> dict:
+    try:
+        return await habitica_request(client, method, path, **kwargs)
+    except httpx.HTTPStatusError as e:
+        body = e.response.json() if e.response.content else {}
+        raise HabiticaError(
+            e.response.status_code,
+            body.get("message", "Unknown error"),
+        ) from e
+```
+
+## Common Pitfalls
+
+1. **Rate limit is strict: 30 requests per 60 seconds.** This is per-user, not per-app. If the user has multiple tools, they share this quota. Batch operations where possible.
+
+2. **`x-client` header is mandatory.** All API calls must include an `x-client` header with the format `UserID-AppName`. Omitting it may result in requests being blocked.
+
+3. **Priority values are not intuitive.** Priority is a float: `0.1` = trivial, `1` = easy, `1.5` = medium, `2` = hard. This does not match the 1-4 scale you might expect.
+
+4. **Task type plural for list, singular for create.** List endpoint uses plural (`?type=dailys`), but the `type` field in creation payload uses singular (`"type": "daily"`). Note the irregular plural `dailys` (not `dailies`).
+
+5. **Scoring a completed todo again has no effect.** Scoring `"up"` on a todo that is already complete does nothing. Score `"down"` first to uncomplete, then `"up"` again if needed.
+
+6. **Cron must be triggered manually via API.** Unlike the web app, API clients must call `/cron` to process daily resets. Without this, missed dailies do not apply damage and streaks do not update.
+
+7. **The `repeat` object uses short day keys.** For weekly dailies, the repeat object uses: `m`, `t`, `w`, `th`, `f`, `s`, `su` (not full day names).
+
+8. **Habitica uses its own ID format.** Task IDs are UUIDs (e.g., `"550e8400-e29b-41d4-a716-446655440000"`). The user's `tasksOrder` object lists IDs by type for ordering.
+
+9. **Gold and gems are separate currencies.** Gold (`gp`) is earned from tasks. Gems are stored as `balance * 4` (balance is in USD equivalent). Do not confuse them.
+
+10. **Tags are UUIDs, not names.** When creating tasks with tags, use tag IDs (UUIDs), not tag names. List tags first to get the mapping.

--- a/content/home-assistant/docs/rest-api/python/DOC.md
+++ b/content/home-assistant/docs/rest-api/python/DOC.md
@@ -1,0 +1,276 @@
+---
+name: rest-api
+description: "Home Assistant REST API for smart home automation, device control, state management, and accessibility-focused independent living"
+metadata:
+  languages: "python"
+  versions: "2024.1+"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "home-assistant,smart-home,iot,automation,accessibility,api"
+---
+
+# Home Assistant REST API Coding Guidelines (Python)
+
+You are a Home Assistant REST API coding expert. Help me with writing code using httpx async to interact with the Home Assistant REST API for smart home automation, device control, and accessibility-focused solutions.
+
+You can find the official documentation here: https://developers.home-assistant.io/docs/api/rest
+
+## Golden Rule: Use httpx Async for All API Calls
+
+Always use `httpx` with async/await for all Home Assistant REST API interactions.
+
+- **Correct:** `import httpx` / `async with httpx.AsyncClient() as client:` / `response = await client.get(url, headers=headers)`
+- **Incorrect:** Using `requests` (synchronous, blocks event loop)
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+```
+http://<HA_IP>:8123/api/
+```
+
+Default port is 8123. All responses are JSON unless otherwise noted.
+
+## Authentication
+
+Home Assistant uses Long-Lived Access Tokens for REST API authentication.
+
+1. Open Home Assistant web interface
+2. Navigate to your user profile (bottom-left)
+3. Scroll to "Long-Lived Access Tokens"
+4. Click "Create Token" and copy it immediately (shown only once)
+
+Never hardcode tokens. Always use environment variables:
+
+```bash
+export HASS_URL="http://192.168.1.100:8123"
+export HASS_TOKEN="your_long_lived_access_token_here"
+```
+
+```python
+import os
+import httpx
+
+HASS_URL = os.environ["HASS_URL"]
+HASS_TOKEN = os.environ["HASS_TOKEN"]
+
+HEADERS = {
+    "Authorization": f"Bearer {HASS_TOKEN}",
+    "Content-Type": "application/json",
+}
+```
+
+## Rate Limiting
+
+Home Assistant does not impose explicit rate limits on the REST API, but the instance is single-threaded. Avoid flooding with concurrent requests. Use the WebSocket API for real-time subscriptions.
+
+## Methods
+
+### Get Entity State
+
+```python
+async def get_entity_state(entity_id: str):
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{HASS_URL}/api/states/{entity_id}", headers=HEADERS
+        )
+        response.raise_for_status()
+        return response.json()
+```
+
+Returns `entity_id`, `state`, `last_changed`, and `attributes`.
+
+---
+
+### Get All Entity States
+
+```python
+async def get_all_states():
+    async with httpx.AsyncClient() as client:
+        response = await client.get(f"{HASS_URL}/api/states", headers=HEADERS)
+        response.raise_for_status()
+        return response.json()
+```
+
+---
+
+### Create or Update Entity State
+
+Returns 201 for new entities, 200 for updates:
+
+```python
+async def set_entity_state(entity_id: str, state: str, attributes: dict = None):
+    payload = {"state": state}
+    if attributes:
+        payload["attributes"] = attributes
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{HASS_URL}/api/states/{entity_id}", headers=HEADERS, json=payload,
+        )
+        response.raise_for_status()
+        return response.json()
+```
+
+---
+
+### Call Service
+
+Services are the primary way to control devices. Use `POST /api/services/<domain>/<service>`:
+
+```python
+async def call_service(domain: str, service: str, data: dict):
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{HASS_URL}/api/services/{domain}/{service}",
+            headers=HEADERS, json=data,
+        )
+        response.raise_for_status()
+        return response.json()
+
+# Turn on/off any entity
+await call_service("light", "turn_on", {"entity_id": "light.bedroom"})
+await call_service("switch", "turn_off", {"entity_id": "switch.fan"})
+
+# Control lights with parameters
+await call_service("light", "turn_on", {
+    "entity_id": "light.bedroom",
+    "brightness": 100,        # 0-255
+    "color_temp": 300,         # mireds (153-500)
+    "rgb_color": [0, 0, 255],  # RGB tuple
+    "transition": 5,           # seconds
+})
+
+# Set thermostat
+await call_service("climate", "set_temperature", {
+    "entity_id": "climate.thermostat",
+    "temperature": 72.0,
+    "hvac_mode": "heat",
+})
+
+# Lock/unlock doors
+await call_service("lock", "lock", {"entity_id": "lock.front_door"})
+
+# Trigger automation or script
+await call_service("automation", "trigger", {"entity_id": "automation.morning"})
+await call_service("script", "turn_on", {"entity_id": "script.goodnight"})
+
+# Send notification
+await call_service("notify", "notify", {"message": "Door opened", "title": "Alert"})
+```
+
+---
+
+### Render a Jinja2 Template
+
+```python
+async def render_template(template: str):
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{HASS_URL}/api/template", headers=HEADERS,
+            json={"template": template},
+        )
+        response.raise_for_status()
+        return response.text
+
+# Example: "The temperature is {{ states('sensor.temperature') }}."
+```
+
+---
+
+### Get State History
+
+```python
+from datetime import datetime, timedelta
+
+async def get_history(
+    entity_id: str, start_time: datetime = None, end_time: datetime = None,
+    minimal: bool = True,
+):
+    if start_time is None:
+        start_time = datetime.utcnow() - timedelta(hours=24)
+    url = f"{HASS_URL}/api/history/period/{start_time.isoformat()}"
+    params = {"filter_entity_id": entity_id}
+    if end_time:
+        params["end_time"] = end_time.isoformat()
+    if minimal:
+        params["minimal_response"] = ""
+        params["no_attributes"] = ""
+    async with httpx.AsyncClient() as client:
+        response = await client.get(url, headers=HEADERS, params=params)
+        response.raise_for_status()
+        return response.json()
+```
+
+---
+
+### Fire a Custom Event
+
+```python
+async def fire_event(event_type: str, event_data: dict = None):
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{HASS_URL}/api/events/{event_type}",
+            headers=HEADERS, json=event_data or {},
+        )
+        response.raise_for_status()
+        return response.json()
+```
+
+## Error Handling
+
+```python
+async def safe_api_call(method: str, url: str, **kwargs):
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await getattr(client, method)(url, headers=HEADERS, **kwargs)
+            response.raise_for_status()
+            ct = response.headers.get("content-type", "")
+            return response.json() if ct.startswith("application/json") else response.text
+        except httpx.HTTPStatusError as e:
+            status = e.response.status_code
+            if status == 401:
+                print("Error: Invalid or expired access token")
+            elif status == 404:
+                print(f"Error: Resource not found at {url}")
+            elif status == 405:
+                print(f"Error: Method {method.upper()} not allowed")
+            else:
+                print(f"HTTP error {status}: {e.response.text}")
+            raise
+        except httpx.ConnectError:
+            print(f"Error: Cannot connect to Home Assistant at {HASS_URL}")
+            raise
+```
+
+### Common Status Codes
+
+| Status Code | Meaning |
+|-------------|---------|
+| 200 | Success (existing resource updated) |
+| 201 | Success (new resource created) |
+| 400 | Bad request (invalid parameters) |
+| 401 | Unauthorized (invalid or missing token) |
+| 404 | Entity or resource not found |
+| 405 | Method not allowed for endpoint |
+
+## Common Pitfalls
+
+1. **Token must be Long-Lived** -- Tokens do not expire but can be revoked from the user profile. The `api` integration must be enabled (enabled by default with the frontend).
+
+2. **Service call domain must match entity** -- Use `light/turn_on` for lights, `switch/turn_off` for switches. The domain is the prefix before the dot in the entity ID.
+
+3. **REST API is synchronous** -- For real-time subscriptions and streaming, use the WebSocket API instead.
+
+4. **Services return changed state objects** -- The response is an array of state objects that were affected by the service call.
+
+5. **History endpoint performance** -- Use `minimal_response` and `no_attributes` query params for better performance on large datasets.
+
+6. **Timestamps use ISO 8601** -- Format: `YYYY-MM-DDThh:mm:ssTZD`.
+
+7. **Home Assistant Cloud (Nabu Casa)** -- Provides remote API access without port forwarding.

--- a/content/indian-railway/docs/rest-api/python/DOC.md
+++ b/content/indian-railway/docs/rest-api/python/DOC.md
@@ -1,0 +1,399 @@
+---
+name: rest-api
+description: "Indian Railway - Train Schedule, PNR Status & Live Tracking API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "indian-railway,irctc,trains,pnr,schedule,india,transport,api"
+---
+
+# Indian Railway REST API (Python / httpx)
+
+## Golden Rule
+
+There is **no official public IRCTC API**. IRCTC restricts API access to approved
+partners and travel agencies. All publicly available Indian Railway APIs are
+**community / third-party** services that scrape or aggregate data from Indian
+Railways sources. Treat every third-party provider as potentially unstable --
+endpoints break without notice when upstream sites change. Always wrap calls in
+retry logic with exponential back-off and cache aggressively.
+
+The best-documented, most feature-complete community option available on RapidAPI
+is the **IRCTC1 API** (provider: IRCTCAPI). This document uses that as the
+primary reference. A secondary option, **IndianRailAPI.com**, is documented in
+the appendix.
+
+---
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+All examples use `httpx.AsyncClient` for non-blocking I/O.  Indian Railway
+endpoints are notoriously slow (1-10 s response times) so async is strongly
+recommended.
+
+```python
+import httpx
+import asyncio
+```
+
+---
+
+## Base URL
+
+### Primary: IRCTC1 on RapidAPI
+
+| Item          | Value |
+|---------------|-------|
+| Host header   | `irctc1.p.rapidapi.com` |
+| Base URL      | `https://irctc1.p.rapidapi.com` |
+| Protocol      | HTTPS (required) |
+| Response      | JSON |
+
+### Secondary: IndianRailAPI.com
+
+| Item          | Value |
+|---------------|-------|
+| Base URL      | `http://indianrailapi.com/api/v1` |
+| Protocol      | HTTP (some endpoints also on HTTPS) |
+| Response      | JSON |
+
+---
+
+## Authentication
+
+### IRCTC1 (RapidAPI)
+
+Authentication is via two required headers on every request:
+
+```python
+RAPIDAPI_KEY = "your-rapidapi-key-here"
+
+HEADERS = {
+    "x-rapidapi-host": "irctc1.p.rapidapi.com",
+    "x-rapidapi-key": RAPIDAPI_KEY,
+}
+```
+
+Get your key: sign up at <https://rapidapi.com>, subscribe to the **IRCTC1**
+API (free tier available), and copy the key from the dashboard.
+
+### IndianRailAPI.com
+
+API key is embedded in the URL path:
+
+```
+/api/v1/{endpoint}/apikey/{YOUR_API_KEY}/...
+```
+
+Register at <https://indianrailapi.com> to obtain a key.
+
+---
+
+## Rate Limiting
+
+### IRCTC1 (RapidAPI)
+
+| Tier     | Requests / month | Rate          | Cost       |
+|----------|-----------------|---------------|------------|
+| Free     | ~500            | Soft limit    | $0         |
+| Basic    | ~5,000          | Moderate      | ~$10/mo    |
+| Pro      | ~50,000         | Higher        | varies     |
+
+Exact limits are set by the provider and visible on the RapidAPI pricing page.
+RapidAPI returns `429 Too Many Requests` when you exceed your quota.
+
+### IndianRailAPI.com
+
+Rate limits are not publicly documented. Expect throttling on the free tier.
+Contact `info@indianrailapi.com` for commercial plans.
+
+### Defensive Defaults
+
+```python
+import httpx
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+@retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=2, min=2, max=30))
+async def railway_get(client: httpx.AsyncClient, url: str, headers: dict) -> dict:
+    resp = await client.get(url, headers=headers, timeout=30.0)
+    resp.raise_for_status()
+    return resp.json()
+```
+
+---
+
+## Methods
+
+All examples below target the **IRCTC1 RapidAPI** endpoints.
+
+### 1. Trains Between Stations
+
+```python
+async def trains_between_stations(
+    client: httpx.AsyncClient,
+    from_code: str,
+    to_code: str,
+    date: str,  # "YYYY-MM-DD"
+) -> dict:
+    url = "https://irctc1.p.rapidapi.com/api/v3/trainBetweenStations"
+    params = {
+        "fromStationCode": from_code,  # e.g. "NDLS"
+        "toStationCode": to_code,      # e.g. "BRC"
+        "dateOfJourney": date,         # e.g. "2026-04-15"
+    }
+    resp = await client.get(url, headers=HEADERS, params=params, timeout=30.0)
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### 2. PNR Status
+
+```python
+async def get_pnr_status(client: httpx.AsyncClient, pnr: str) -> dict:
+    """pnr: 10-digit PNR number from your ticket."""
+    url = "https://irctc1.p.rapidapi.com/api/v3/getPNRStatus"
+    params = {"pnrNumber": pnr}
+    resp = await client.get(url, headers=HEADERS, params=params, timeout=30.0)
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### 3. Live Train Status
+
+```python
+async def live_train_status(
+    client: httpx.AsyncClient, train_no: str, start_day: int = 1
+) -> dict:
+    """start_day: 1 = today, 2 = started yesterday, etc."""
+    url = "https://irctc1.p.rapidapi.com/api/v1/liveTrainStatus"
+    params = {"trainNo": train_no, "startDay": str(start_day)}
+    resp = await client.get(url, headers=HEADERS, params=params, timeout=30.0)
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### 4. Check Seat Availability
+
+```python
+async def check_seat_availability(
+    client: httpx.AsyncClient,
+    train_no: str,
+    from_code: str,
+    to_code: str,
+    date: str,
+    class_type: str = "SL",
+    quota: str = "GN",
+) -> dict:
+    """
+    class_type: SL, 3A, 2A, 1A, CC, EC, 2S, etc.
+    quota: GN (General), TQ (Tatkal), PT (Premium Tatkal), etc.
+    """
+    url = "https://irctc1.p.rapidapi.com/api/v1/checkSeatAvailability"
+    params = {
+        "trainNo": train_no,
+        "fromStationCode": from_code,
+        "toStationCode": to_code,
+        "date": date,
+        "classType": class_type,
+        "quota": quota,
+    }
+    resp = await client.get(url, headers=HEADERS, params=params, timeout=30.0)
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### 5. Get Fare
+
+```python
+async def get_fare(
+    client: httpx.AsyncClient,
+    train_no: str,
+    from_code: str,
+    to_code: str,
+) -> dict:
+    url = "https://irctc1.p.rapidapi.com/api/v2/getFare"
+    params = {
+        "trainNo": train_no,
+        "fromStationCode": from_code,
+        "toStationCode": to_code,
+    }
+    resp = await client.get(url, headers=HEADERS, params=params, timeout=30.0)
+    resp.raise_for_status()
+    return resp.json()
+```
+
+Additional endpoints: `searchStation`, `searchTrain`, `getTrainSchedule`, `getTrainClasses`, `getTrainsByStation`, `getLiveStation` -- all follow the same GET pattern with `HEADERS` and `timeout=30.0`.
+
+---
+
+## Error Handling
+
+### HTTP Status Codes
+
+| Code | Meaning                  | Action                              |
+|------|--------------------------|-------------------------------------|
+| 200  | Success                  | Parse JSON body                     |
+| 400  | Bad request / invalid params | Check param names & values      |
+| 401  | Unauthorized             | Verify API key is valid             |
+| 403  | Forbidden                | Check subscription tier             |
+| 404  | Not found                | Train/PNR/station does not exist    |
+| 429  | Rate limit exceeded      | Back off; wait before retrying      |
+| 500  | Server error             | Upstream IRCTC may be down; retry   |
+| 502  | Bad gateway              | Upstream timeout; retry with longer timeout |
+| 503  | Service unavailable      | Maintenance window; retry later     |
+
+### Recommended Error Handler
+
+```python
+import httpx
+
+class RailwayAPIError(Exception):
+    def __init__(self, status_code: int, detail: str):
+        self.status_code = status_code
+        self.detail = detail
+        super().__init__(f"HTTP {status_code}: {detail}")
+
+async def safe_railway_get(
+    client: httpx.AsyncClient,
+    url: str,
+    params: dict | None = None,
+) -> dict:
+    try:
+        resp = await client.get(
+            url, headers=HEADERS, params=params, timeout=30.0
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        # Some endpoints wrap errors inside a 200 response
+        if isinstance(data, dict) and data.get("status") is False:
+            raise RailwayAPIError(200, data.get("message", "Unknown API error"))
+        return data
+    except httpx.HTTPStatusError as exc:
+        raise RailwayAPIError(
+            exc.response.status_code,
+            exc.response.text[:300],
+        ) from exc
+    except httpx.TimeoutException as exc:
+        raise RailwayAPIError(504, "Request timed out") from exc
+```
+
+---
+
+## Common Pitfalls
+
+### 1. Station codes, not names
+All endpoints expect **uppercase station codes** (e.g. `NDLS`, `BCT`, `HWH`),
+not city names. Use `searchStation` first to resolve names to codes.
+
+### 2. Date format varies
+The `trainBetweenStations` endpoint expects `YYYY-MM-DD`. Other endpoints may
+accept `DD-MM-YYYY`. Always check the specific endpoint docs.
+
+### 3. Upstream timeouts
+Indian Railway servers are slow. Set `timeout=30.0` minimum. During peak hours
+(8-10 AM IST / Tatkal booking window) expect even longer latencies or outright
+failures.
+
+### 4. 200 OK with error body
+Some endpoints return HTTP 200 but include `"status": false` in the JSON body.
+Always check the `status` field before processing results.
+
+### 5. stale data on Live Status
+`liveTrainStatus` data can lag 10-30 minutes behind real position. Do not use
+for safety-critical decisions.
+
+### 6. Tatkal window blackouts
+During the Tatkal booking window (10:00-12:00 IST), IRCTC upstream servers are
+under extreme load. Seat availability and PNR endpoints may return errors or
+stale data. Avoid polling during this window if possible.
+
+### 7. PNR validity
+PNR numbers are **10 digits**. An invalid or expired PNR returns a 200 with an
+error message, not a 404. Validate format client-side before calling.
+
+### 8. Free tier quota burns fast
+The free RapidAPI tier is limited (~500 req/month). A single user session
+exploring trains can burn 10-20 requests. Implement aggressive caching
+(train schedules rarely change within a day).
+
+### 9. No booking capability
+These community APIs are **read-only**. They provide schedule, status, and
+availability data. Actual ticket booking requires official IRCTC partner
+integration which is not publicly available.
+
+### 10. Class type codes
+Use standard Indian Railway class codes:
+
+| Code | Class                        |
+|------|------------------------------|
+| 1A   | First AC                     |
+| 2A   | Second AC                    |
+| 3A   | Third AC                     |
+| 3E   | Third AC Economy             |
+| SL   | Sleeper                      |
+| CC   | AC Chair Car                 |
+| EC   | Executive Chair Car          |
+| 2S   | Second Sitting               |
+| GN   | General (unreserved)         |
+
+---
+
+## Appendix A: IndianRailAPI.com Endpoints
+
+An alternative community API at `indianrailapi.com`. Registration required.
+
+### Base URL
+
+```
+http://indianrailapi.com/api/v1
+```
+
+### Authentication
+
+API key embedded in URL path:
+
+```python
+INDIAN_RAIL_API_KEY = "your-key-here"
+BASE = "http://indianrailapi.com/api/v1"
+
+async def ira_pnr_status(client: httpx.AsyncClient, pnr: str) -> dict:
+    url = f"{BASE}/pnrstatus/apikey/{INDIAN_RAIL_API_KEY}/pnr/{pnr}/"
+    resp = await client.get(url, timeout=30.0)
+    resp.raise_for_status()
+    return resp.json()
+
+async def ira_train_route(client: httpx.AsyncClient, train_no: str) -> dict:
+    url = f"{BASE}/trainroute/apikey/{INDIAN_RAIL_API_KEY}/trainno/{train_no}/"
+    resp = await client.get(url, timeout=30.0)
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Available Endpoints (30+)
+
+- Live Train Status
+- PNR Check
+- Live Station
+- Station Search / Auto-Complete
+- Seat Availability
+- Train Fare
+- Station Name/Code Conversion
+- Train Information & Schedule
+- Trains Between Stations
+- Cancelled / Rescheduled / Diverted Trains
+- Coach Layout & Position
+- Special, Heritage & Fog-Affected Trains
+
+### Status
+
+The service is marked "UNDER LIMITED USE" as of March 2026. Reliability may
+vary. Contact `info@indianrailapi.com` for current status.
+
+**References:** [RapidAPI IRCTC1](https://rapidapi.com/IRCTCAPI/api/irctc1) | [IndianRailAPI.com](https://indianrailapi.com) | [GitHub topic](https://github.com/topics/indian-railways-api)

--- a/content/isro/docs/rest-api/python/DOC.md
+++ b/content/isro/docs/rest-api/python/DOC.md
@@ -1,0 +1,209 @@
+---
+name: rest-api
+description: "ISRO API - Indian Space Research Organisation Spacecraft, Launcher & Mission Data"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "isro,india,space,spacecraft,rockets,launchers,satellites,missions,open-data,api"
+---
+
+# ISRO API
+
+> **Golden Rule:** The ISRO API is a **free, open-source, no-auth** REST API serving data about ISRO's spacecrafts, launchers, customer satellites, centres, and missions. Use `httpx` for async access. Base URL is `https://isro.vercel.app`. No API key required. Returns JSON. Community-maintained (not official ISRO).
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+```
+https://isro.vercel.app
+```
+
+Source code: https://github.com/isro/api
+
+## Authentication
+
+**Type:** None required. The API is completely open and free to use.
+
+```python
+import httpx
+
+BASE_URL = "https://isro.vercel.app"
+
+client = httpx.AsyncClient(base_url=BASE_URL, timeout=30.0)
+```
+
+## Rate Limiting
+
+Not formally documented. The API is hosted on Vercel's free tier. Use responsibly and implement basic rate limiting on your end to avoid being throttled by the hosting platform.
+
+## Methods
+
+### `list_spacecrafts`
+
+**Endpoint:** `GET /api/spacecrafts`
+
+Retrieve all ISRO spacecrafts with their details.
+
+```python
+import httpx
+
+async def list_spacecrafts():
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.get(f"{BASE_URL}/api/spacecrafts")
+        response.raise_for_status()
+        data = response.json()
+        spacecrafts = data["spacecrafts"]
+        for sc in spacecrafts[:5]:
+            print(f"{sc['name']} - {sc.get('id', 'N/A')}")
+        return spacecrafts
+```
+
+### `list_launchers`
+
+**Endpoint:** `GET /api/launchers`
+
+Retrieve all ISRO launch vehicles (PSLV, GSLV, etc.).
+
+```python
+async def list_launchers():
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.get(f"{BASE_URL}/api/launchers")
+        response.raise_for_status()
+        data = response.json()
+        launchers = data["launchers"]
+        for launcher in launchers:
+            print(f"{launcher['id']} - {launcher.get('name', 'Unknown')}")
+        return launchers
+```
+
+### `list_customer_satellites`
+
+**Endpoint:** `GET /api/customer_satellites`
+
+Retrieve satellites launched by ISRO for other countries/organizations.
+
+```python
+async def list_customer_satellites():
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.get(f"{BASE_URL}/api/customer_satellites")
+        response.raise_for_status()
+        data = response.json()
+        satellites = data["customer_satellites"]
+        for sat in satellites[:5]:
+            print(f"{sat.get('country', 'N/A')}: {sat.get('satellite', 'N/A')} ({sat.get('launch_date', 'N/A')})")
+        return satellites
+```
+
+### `list_centres`
+
+**Endpoint:** `GET /api/centres`
+
+Retrieve all ISRO research centres and facilities.
+
+```python
+async def list_centres():
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.get(f"{BASE_URL}/api/centres")
+        response.raise_for_status()
+        data = response.json()
+        centres = data["centres"]
+        for centre in centres:
+            print(f"{centre.get('name', 'N/A')} - {centre.get('Place', 'N/A')}, {centre.get('State', 'N/A')}")
+        return centres
+```
+
+### `list_spacecraft_missions`
+
+**Endpoint:** `GET /api/spacecraft_missions`
+
+Retrieve ISRO spacecraft mission details.
+
+```python
+async def list_spacecraft_missions():
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.get(f"{BASE_URL}/api/spacecraft_missions")
+        response.raise_for_status()
+        data = response.json()
+        return data
+```
+
+### Full Example: Search and Display
+
+```python
+import httpx
+
+BASE_URL = "https://isro.vercel.app"
+
+async def search_spacecrafts(keyword: str):
+    """Search spacecrafts by name keyword."""
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.get(f"{BASE_URL}/api/spacecrafts")
+        response.raise_for_status()
+        data = response.json()
+        matches = [
+            sc for sc in data["spacecrafts"]
+            if keyword.lower() in sc.get("name", "").lower()
+        ]
+        return matches
+
+async def get_all_data():
+    """Fetch all ISRO data in parallel."""
+    async with httpx.AsyncClient(base_url=BASE_URL, timeout=30.0) as client:
+        import asyncio
+        spacecrafts, launchers, satellites, centres = await asyncio.gather(
+            client.get("/api/spacecrafts"),
+            client.get("/api/launchers"),
+            client.get("/api/customer_satellites"),
+            client.get("/api/centres"),
+        )
+        return {
+            "spacecrafts": spacecrafts.json(),
+            "launchers": launchers.json(),
+            "customer_satellites": satellites.json(),
+            "centres": centres.json(),
+        }
+```
+
+## Error Handling
+
+```python
+import httpx
+
+try:
+    response = await client.get(f"{BASE_URL}/api/spacecrafts")
+    response.raise_for_status()
+    data = response.json()
+except httpx.HTTPStatusError as e:
+    if e.response.status_code == 404:
+        print("Endpoint not found -- check the path")
+    elif e.response.status_code == 429:
+        print("Too many requests -- slow down")
+    elif e.response.status_code >= 500:
+        print("Server error -- Vercel hosting may be temporarily down")
+    else:
+        print(f"ISRO API error {e.response.status_code}: {e.response.text}")
+except httpx.RequestError as e:
+    print(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+- **Community-maintained, not official ISRO**: This API is an open-source project hosted on Vercel, not an official ISRO government service
+- **No authentication needed**: Do not send API keys or auth headers
+- **All endpoints are GET**: There are no POST/PUT/DELETE operations (read-only data)
+- **Vercel free tier hosting**: May have cold starts (first request can be slow) and implicit rate limits
+- **Data is static/curated**: Not real-time telemetry; data is manually curated from public ISRO records
+- **Response structure varies**: Each endpoint wraps data in a different key (`spacecrafts`, `launchers`, `customer_satellites`, `centres`)
+- **No pagination**: All data is returned in a single response
+- **No filtering parameters on the server**: Filtering must be done client-side after fetching full datasets
+- **CORS is not enabled**: May not work from browser-based JavaScript; works fine from server-side Python
+- **HTTPS only**: All requests must use HTTPS
+- For official ISRO satellite imagery data, use the separate Bhoonidhi API at https://bhoonidhi.nrsc.gov.in/ (requires registration)

--- a/content/jina-reader/docs/rest-api/python/DOC.md
+++ b/content/jina-reader/docs/rest-api/python/DOC.md
@@ -1,0 +1,200 @@
+---
+name: rest-api
+description: "Jina AI Reader, Search & Grounding APIs"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-13"
+  source: community
+  tags: "jina,reader,search,grounding,web-scraping,markdown,llm,rag,api,integration"
+---
+
+# Jina AI Reader & Search API
+
+> **Golden Rule:** Jina Reader has no dedicated Python SDK for its REST APIs. Use `httpx` (async) or `requests` (sync) for direct HTTP access. The APIs convert web content into LLM-friendly Markdown. Free tier includes 10M tokens per new API key.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URLs
+
+| Endpoint | URL | Purpose |
+|---|---|---|
+| Reader | `https://r.jina.ai/` | Extract content from a URL as Markdown |
+| Search | `https://s.jina.ai/` | Web search returning LLM-friendly results |
+| Grounding | `https://g.jina.ai/` | Fact-check statements against web sources |
+
+EU region variants available: `https://eu.r.jina.ai/`, `https://eu.s.jina.ai/`
+
+## Authentication
+
+**Type:** Bearer Token (optional but recommended)
+
+```python
+import httpx
+
+JINA_API_KEY = "your-jina-api-key"  # Get free key at https://jina.ai/?sui=apikey
+
+headers = {
+    "Authorization": f"Bearer {JINA_API_KEY}",
+    "Accept": "application/json"
+}
+client = httpx.AsyncClient(headers=headers, timeout=30.0)
+```
+
+Without a key: 20 RPM limit (IP-based). With a free key: 500 RPM Reader, 100 RPM Search. Every new key gets 10M free tokens.
+
+## Rate Limiting
+
+| Tier | Reader RPM | Search RPM |
+|---|---|---|
+| No Key | 20 | N/A |
+| Free/Paid Key | 500 | 100 |
+| Premium | 5,000 | 1,000 |
+
+## Methods
+
+### `read_url` (Reader API)
+
+**Endpoint:** `GET https://r.jina.ai/{target_url}` or `POST https://r.jina.ai/`
+
+Extract content from any URL as clean Markdown. Supports HTML pages, PDFs, and dynamic JS-rendered content.
+
+**Returns:** Markdown text (default) or JSON with `data.content`, `data.links`, `data.images`
+
+```python
+# Simple GET -- append URL to path
+url = "https://r.jina.ai/https://example.com"
+response = await client.get(url)
+response.raise_for_status()
+data = response.json()
+markdown = data["data"]["content"]
+title = data["data"]["title"]
+```
+
+```python
+# POST -- required for URLs with hash fragments (#)
+response = await client.post(
+    "https://r.jina.ai/",
+    json={"url": "https://example.com/#/some-route"},
+    headers={**headers, "Content-Type": "application/json"}
+)
+response.raise_for_status()
+data = response.json()
+```
+
+**Key request headers for controlling output:**
+
+| Header | Values | Purpose |
+|---|---|---|
+| `X-Return-Format` | `markdown`, `html`, `text`, `screenshot` | Output format (default: markdown) |
+| `X-Target-Selector` | CSS selector | Extract only matching elements |
+| `X-Wait-For-Selector` | CSS selector | Wait for element before extracting |
+| `X-Remove-Selector` | CSS selector | Remove elements from output |
+| `X-No-Cache` | `true` | Bypass cache (default TTL: 3600s) |
+| `X-With-Links-Summary` | `true` | Include all page links in response |
+| `X-With-Images-Summary` | `true` | Include all images in response |
+| `X-Engine` | `browser`, `direct` | `direct` is fastest; `browser` renders JS |
+
+### `search_web` (Search API)
+
+**Endpoint:** `GET https://s.jina.ai/{query}` or `POST https://s.jina.ai/`
+
+Live web search returning results in LLM-friendly format. Each request consumes minimum 10,000 tokens.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `q` | `str` | **required** |
+| `num` | `int` | `5` |
+| `gl` | `str` | `None` (country code, e.g., `us`) |
+| `hl` | `str` | `None` (language code, e.g., `en`) |
+| `page` | `int` | `1` |
+
+**Returns:** JSON with array of results, each containing `title`, `url`, `content` (Markdown)
+
+```python
+# POST search
+response = await client.post(
+    "https://s.jina.ai/",
+    json={"q": "best practices for RAG pipelines", "num": 5},
+    headers={**headers, "Content-Type": "application/json"}
+)
+response.raise_for_status()
+data = response.json()
+results = data["data"]  # list of {title, url, content}
+```
+
+```python
+# Search within a specific site
+response = await client.get(
+    "https://s.jina.ai/asyncio tutorial",
+    headers={**headers, "X-Site": "https://docs.python.org"}
+)
+```
+
+### `fact_check` (Grounding API)
+
+**Endpoint:** `POST https://g.jina.ai/`
+
+Fact-check a statement against live web sources. Uses multi-hop reasoning. ~30s per request, ~300K tokens consumed.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `statement` | `str` | **required** |
+| `references` | `list` | `None` (restrict to specific source URLs) |
+
+**Returns:** JSON with `factuality` (0-1 score), `result` (bool), `reason`, `references`
+
+```python
+response = await client.post(
+    "https://g.jina.ai/",
+    json={
+        "statement": "Python 3.12 was released in October 2023.",
+        "references": ["https://en.wikipedia.org/wiki/Python_(programming_language)"]
+    },
+    headers={**headers, "Content-Type": "application/json"}
+)
+response.raise_for_status()
+data = response.json()
+is_true = data["result"]         # True/False
+confidence = data["factuality"]  # 0.0 to 1.0
+reasoning = data["reason"]       # Detailed explanation
+```
+
+## Error Handling
+
+```python
+import httpx
+
+try:
+    response = await client.get(f"https://r.jina.ai/https://example.com")
+    response.raise_for_status()
+    data = response.json()
+except httpx.HTTPStatusError as e:
+    if e.response.status_code == 401:
+        print("Authentication failed -- check your API key")
+    elif e.response.status_code == 429:
+        print("Rate limited -- reduce request frequency")
+    elif e.response.status_code == 402:
+        print("Insufficient tokens -- top up your account")
+    else:
+        print(f"Jina API error {e.response.status_code}: {e.response.text}")
+except httpx.RequestError as e:
+    print(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+- Use `Accept: application/json` to get structured JSON; without it, raw Markdown text is returned
+- POST is **required** for URLs containing `#` fragments (GET strips fragments)
+- Reader averages ~7.9s latency; set `timeout=30.0` on your client
+- Search consumes a fixed minimum of 10,000 tokens per request regardless of result count
+- Grounding API takes ~30s and ~300K tokens per request -- use selectively
+- Use `X-Target-Selector` to extract specific page sections and reduce token usage
+- `X-Engine: direct` is fastest but won't render JavaScript-heavy pages; use `browser` for SPAs
+- Tokens are NOT deducted for failed requests
+- Cache is enabled by default (3600s TTL); use `X-No-Cache: true` for fresh content

--- a/content/justgiving/docs/rest-api/python/DOC.md
+++ b/content/justgiving/docs/rest-api/python/DOC.md
@@ -1,0 +1,412 @@
+---
+name: rest-api
+description: "JustGiving - UK charity fundraising platform API for managing fundraising pages, donations, charities, events, and campaigns."
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "justgiving,charity,fundraising,uk,donations,api"
+---
+
+# JustGiving REST API - Python Reference (httpx)
+
+## Golden Rule
+
+Authentication requires an **App ID** (obtained from the developer portal) passed either in the URL path as `/{appId}/v1/...` or as an `x-api-key` header. User-level operations (creating pages, donating) additionally require **Basic Authentication** with Base64-encoded credentials. Always use the staging environment (`api.staging.justgiving.com`) for testing before switching to production (`api.justgiving.com`). Register at https://developer.justgiving.com/ to get your App ID.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+All examples use `httpx` with async/await. For scripts that need a synchronous entrypoint:
+
+```python
+import asyncio
+import httpx
+
+async def main():
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{BASE_URL}/v1/charity/search",
+            params={"q": "cancer research"},
+            headers=HEADERS,
+        )
+        print(resp.json())
+
+asyncio.run(main())
+```
+
+## Base URL
+
+```
+# Production
+https://api.justgiving.com
+
+# Staging (testing)
+https://api.staging.justgiving.com
+```
+
+```python
+import os
+import base64
+
+APP_ID = os.environ["JUSTGIVING_APP_ID"]
+BASE_URL = "https://api.justgiving.com"  # Switch to staging for testing
+HEADERS = {
+    "x-api-key": APP_ID,
+    "Accept": "application/json",
+    "Content-Type": "application/json",
+}
+```
+
+## Authentication
+
+JustGiving uses two layers of authentication:
+
+**1. App-level (required for all requests):**
+Pass your App ID via the `x-api-key` header or embed it in the URL path:
+
+```python
+# Option A: Header (preferred)
+headers = {"x-api-key": APP_ID, "Accept": "application/json"}
+
+# Option B: URL path
+url = f"{BASE_URL}/{APP_ID}/v1/charity/search"
+```
+
+**2. User-level (required for account operations):**
+Basic Authentication with Base64-encoded email:password over HTTPS:
+
+```python
+def get_auth_headers(email: str, password: str) -> dict:
+    credentials = base64.b64encode(f"{email}:{password}".encode()).decode()
+    return {
+        **HEADERS,
+        "Authorization": f"Basic {credentials}",
+    }
+```
+
+## Rate Limiting
+
+JustGiving does not publicly document specific rate limits. Implement reasonable throttling for batch operations.
+
+```python
+import asyncio
+
+async def jg_request(
+    client: httpx.AsyncClient,
+    method: str,
+    path: str,
+    params: dict = None,
+    json_body: dict = None,
+    auth_headers: dict = None,
+    max_retries: int = 3,
+) -> dict:
+    url = f"{BASE_URL}/v1{path}"
+    headers = auth_headers or HEADERS
+
+    for attempt in range(max_retries):
+        try:
+            resp = await client.request(
+                method, url, params=params, json=json_body, headers=headers,
+            )
+        except httpx.RequestError:
+            await asyncio.sleep(2 ** attempt)
+            continue
+
+        if resp.status_code in (200, 201):
+            return resp.json() if resp.content else {}
+
+        if resp.status_code == 429:
+            await asyncio.sleep(min(2 ** attempt, 30))
+            continue
+
+        resp.raise_for_status()
+
+    raise Exception("Max retries exceeded")
+```
+
+## Methods
+
+### Search Charities
+
+Search over 13,000 registered charities on JustGiving.
+
+**Parameters:**
+- `q` (str) -- Search query
+
+```python
+async def search_charities(client: httpx.AsyncClient, query: str) -> dict:
+    return await jg_request(client, "GET", "/charity/search", params={"q": query})
+
+# Usage
+results = await search_charities(client, "cancer research")
+for charity in results.get("charitySearchResults", []):
+    print(f"{charity['charityId']}: {charity['name']}")
+```
+
+### Get Charity Details
+
+Retrieve detailed information about a specific charity.
+
+```python
+async def get_charity(client: httpx.AsyncClient, charity_id: int) -> dict:
+    return await jg_request(client, "GET", f"/charity/{charity_id}")
+
+# Usage
+charity = await get_charity(client, 2357)
+print(charity["name"])
+print(charity["description"])
+print(charity["websiteUrl"])
+```
+
+### Get Fundraising Page
+
+Retrieve details for a fundraising page by its short name.
+
+```python
+async def get_fundraising_page(client: httpx.AsyncClient, page_short_name: str) -> dict:
+    return await jg_request(client, "GET", f"/fundraising/pages/{page_short_name}")
+
+# Usage
+page = await get_fundraising_page(client, "my-marathon-run")
+print(f"Target: {page['targetAmount']}, Raised: {page['grandTotalRaisedExcludingGiftAid']}")
+```
+
+### Get Fundraising Page Donations
+
+Retrieve donations for a specific fundraising page.
+
+**Parameters:**
+- `pageSize` (int) -- Results per page
+- `pageNum` (int) -- Page number
+
+```python
+async def get_page_donations(
+    client: httpx.AsyncClient,
+    page_short_name: str,
+    page_size: int = 25,
+    page_num: int = 1,
+) -> dict:
+    return await jg_request(
+        client, "GET",
+        f"/fundraising/pages/{page_short_name}/donations",
+        params={"pageSize": page_size, "pageNum": page_num},
+    )
+
+# Usage
+donations = await get_page_donations(client, "my-marathon-run")
+for d in donations.get("donations", []):
+    print(f"{d['donorDisplayName']}: {d['amount']} {d['currencyCode']}")
+```
+
+### Search Events
+
+Search for charity events.
+
+```python
+async def search_events(client: httpx.AsyncClient, query: str) -> dict:
+    return await jg_request(client, "GET", "/event/search", params={"q": query})
+
+# Usage
+events = await search_events(client, "marathon 2026")
+```
+
+### Get Event Details
+
+Retrieve details for a specific event.
+
+```python
+async def get_event(client: httpx.AsyncClient, event_id: int) -> dict:
+    return await jg_request(client, "GET", f"/event/{event_id}")
+```
+
+### Get Event Pages
+
+Retrieve fundraising pages associated with an event.
+
+```python
+async def get_event_pages(
+    client: httpx.AsyncClient,
+    event_id: int,
+    page_size: int = 25,
+    page_num: int = 1,
+) -> dict:
+    return await jg_request(
+        client, "GET",
+        f"/event/{event_id}/pages",
+        params={"pageSize": page_size, "pageNum": page_num},
+    )
+```
+
+### OneSearch
+
+Unified search across charities, fundraising pages, events, and users.
+
+```python
+async def one_search(client: httpx.AsyncClient, query: str, index: str = None) -> dict:
+    params = {"q": query}
+    if index:
+        params["i"] = index  # "Charity", "Fundraiser", "Event", "User"
+    return await jg_request(client, "GET", "/onesearch", params=params)
+
+# Usage
+results = await one_search(client, "london marathon", index="Event")
+```
+
+### Validate Account
+
+Check if an email address is already registered.
+
+```python
+async def validate_account(client: httpx.AsyncClient, email: str) -> dict:
+    return await jg_request(client, "GET", f"/account/{email}")
+```
+
+### Get Account Donations
+
+Retrieve donation history for an authenticated account.
+
+```python
+async def get_account_donations(
+    client: httpx.AsyncClient,
+    email: str,
+    password: str,
+) -> dict:
+    auth = get_auth_headers(email, password)
+    return await jg_request(client, "GET", "/account/donations", auth_headers=auth)
+```
+
+### Get Countries
+
+Retrieve list of countries supported by JustGiving.
+
+```python
+async def get_countries(client: httpx.AsyncClient) -> list:
+    return await jg_request(client, "GET", "/countries")
+```
+
+### Get Fundraising Leaderboard
+
+Retrieve top fundraisers for a charity or event.
+
+```python
+async def get_charity_leaderboard(client: httpx.AsyncClient, charity_id: int) -> dict:
+    return await jg_request(client, "GET", f"/charity/{charity_id}/leaderboard")
+```
+
+### Donate to a Fundraising Page
+
+Submit a donation to a fundraising page (requires user auth).
+
+```python
+async def donate_to_page(
+    client: httpx.AsyncClient,
+    page_short_name: str,
+    amount: float,
+    currency_code: str = "GBP",
+    email: str = None,
+    password: str = None,
+) -> dict:
+    auth = get_auth_headers(email, password) if email else HEADERS
+    body = {
+        "amount": str(amount),
+        "currencyCode": currency_code,
+    }
+    return await jg_request(
+        client, "POST",
+        f"/fundraising/pages/{page_short_name}/donate",
+        json_body=body,
+        auth_headers=auth,
+    )
+```
+
+## Error Handling
+
+Successful responses return HTTP 200 or 201 with JSON body.
+
+**Common status codes:**
+
+| Code | Meaning |
+|---|---|
+| 200 | Success |
+| 201 | Created (e.g., new fundraising page) |
+| 400 | Bad Request -- invalid parameters |
+| 401 | Unauthorized -- missing or invalid App ID or credentials |
+| 403 | Forbidden -- insufficient permissions |
+| 404 | Not Found -- charity/page/event not found |
+| 409 | Conflict -- resource already exists (e.g., duplicate page name) |
+| 500 | Internal Server Error |
+
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+
+class JustGivingError(Exception):
+    def __init__(self, status_code: int, message: str):
+        self.status_code = status_code
+        self.message = message
+        super().__init__(f"[{status_code}] {message}")
+
+async def jg_request_safe(
+    client: httpx.AsyncClient,
+    method: str,
+    path: str,
+    params: dict = None,
+    json_body: dict = None,
+    auth_headers: dict = None,
+    max_retries: int = 3,
+) -> dict:
+    url = f"{BASE_URL}/v1{path}"
+    headers = auth_headers or HEADERS
+
+    for attempt in range(max_retries):
+        try:
+            resp = await client.request(
+                method, url, params=params, json=json_body, headers=headers,
+            )
+        except httpx.RequestError as e:
+            logger.warning(f"Network error (attempt {attempt+1}): {e}")
+            await asyncio.sleep(2 ** attempt)
+            continue
+
+        if resp.status_code in (200, 201):
+            return resp.json() if resp.content else {}
+
+        if resp.status_code == 429:
+            wait = min(2 ** attempt, 30)
+            logger.warning(f"Rate limited, retrying in {wait}s")
+            await asyncio.sleep(wait)
+            continue
+
+        raise JustGivingError(resp.status_code, resp.text)
+
+    raise JustGivingError(429, "Max retries exceeded")
+```
+
+## Common Pitfalls
+
+1. **App ID can go in URL or header, not both.** Use `x-api-key` header (preferred) or URL path `/{appId}/v1/...`, but be consistent. Mixing both can cause issues.
+
+2. **Staging and production are separate environments.** Test data on staging does not carry over to production. Switch `BASE_URL` for deployment.
+
+3. **Page short names are URL slugs.** The `pageShortName` is the URL-friendly identifier (e.g., `my-marathon-run`), not the page title.
+
+4. **Currency defaults to GBP.** JustGiving is UK-based. Always specify `currencyCode` for non-GBP donations.
+
+5. **Basic Auth credentials travel over HTTPS.** Always use HTTPS endpoints. Never transmit credentials over plain HTTP.
+
+6. **Donation endpoints require user authentication.** Public endpoints (search, read) only need the App ID. Write operations (create page, donate) require Basic Auth.
+
+7. **Page names must be unique.** Creating a fundraising page with a name already in use returns 409 Conflict.
+
+8. **Search results are paginated.** Use `pageSize` and `pageNum` parameters. Default page size varies by endpoint.
+
+9. **The staging environment uses test payment credentials.** Use the provided test card numbers from the developer documentation for staging donations.
+
+10. **Response format depends on Accept header.** The API supports JSON and XML. Always set `Accept: application/json` to avoid XML responses.

--- a/content/kaleyra/docs/rest-api/python/DOC.md
+++ b/content/kaleyra/docs/rest-api/python/DOC.md
@@ -1,0 +1,248 @@
+---
+name: rest-api
+description: "Kaleyra - Cloud Communications Platform (SMS, Voice, WhatsApp)"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "kaleyra,sms,voice,whatsapp,cpaas,communications,india,api"
+---
+
+# Kaleyra REST API Reference (Python / httpx)
+
+Kaleyra is a cloud communications platform (CPaaS) offering SMS, Voice, WhatsApp, Email, and OTP verification APIs. It has a strong presence in India and serves global markets. All APIs are RESTful with JSON responses.
+
+## Golden Rule
+
+Always use async `httpx` for all HTTP calls. Never use `requests` or any third-party Kaleyra SDK. All endpoints require the `api-key` header. The account SID is part of the URL path for every request.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+The base URL varies by region. Your SID (account identifier) is part of the URL path.
+
+| Region | Base URL |
+|--------|----------|
+| India (IN) | `https://api.in.kaleyra.io/v1/<SID>` |
+| Singapore (SG) | `https://api.kaleyra.io/v1/<SID>` |
+| Europe (EU) | `https://api.eu.kaleyra.io/v1/<SID>` |
+| North America (NA) | `https://api.na.kaleyra.io/v1/<SID>` |
+
+Replace `<SID>` with your account SID (e.g. `HXXXXXXX071IN`).
+
+## Authentication
+
+Every request requires the `api-key` header. Obtain your API key from **Kaleyra Customer Portal > API Settings**.
+
+```python
+import os
+import httpx
+
+KALEYRA_SID = os.environ["KALEYRA_SID"]
+KALEYRA_API_KEY = os.environ["KALEYRA_API_KEY"]
+KALEYRA_BASE = f"https://api.in.kaleyra.io/v1/{KALEYRA_SID}"
+
+HEADERS = {"api-key": KALEYRA_API_KEY, "content-type": "application/json"}
+```
+
+## Rate Limiting
+
+Kaleyra does not publish explicit rate limits. Throughput depends on your account tier and channel. Use `callback_profile_id` (SMS) or `callback_url` (WhatsApp) for async delivery status instead of polling.
+
+## Methods
+
+### Send SMS
+
+`POST /messages` -- Send a transactional or marketing SMS message.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `to` | string | Yes | Recipient phone number with country code |
+| `sender` | string | Yes | Alphanumeric Sender ID |
+| `body` | string | Yes | SMS message body |
+| `type` | string | Yes | Route: `OTP`, `TXN`, `MKT`, `SI` |
+| `callback_profile_id` | string | Yes | Webhook profile ID for delivery status |
+| `template_id` | string | Conditional | DLT template ID (required for India) |
+
+```python
+async def send_sms(
+    to: str, sender: str, body: str, msg_type: str = "TXN",
+    callback_profile_id: str = "", template_id: str | None = None,
+) -> dict:
+    payload = {
+        "to": to, "sender": sender, "body": body,
+        "type": msg_type, "callback_profile_id": callback_profile_id,
+    }
+    if template_id:
+        payload["template_id"] = template_id
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(f"{KALEYRA_BASE}/messages", json=payload, headers=HEADERS)
+        resp.raise_for_status()
+        return resp.json()
+```
+
+Response includes `id`, `data[].message_id`, and `data[].recipient`.
+
+---
+
+### Send WhatsApp Message
+
+`POST /messages` -- Send a text or template message via WhatsApp Business API.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `to` | string | Yes | Recipient WhatsApp number (E.164) |
+| `from` | string | Yes | Registered WhatsApp Business number (E.164) |
+| `type` | string | Yes | `text`, `template`, `image`, `document`, `video`, `audio` |
+| `channel` | string | Yes | Must be `"whatsapp"` |
+| `body` | string | Yes | Message content |
+| `template` | object | Conditional | Required when `type` is `template` |
+
+```python
+async def send_whatsapp(
+    to: str, from_number: str, body: str,
+    msg_type: str = "text", template: dict | None = None,
+    callback_url: str | None = None,
+) -> dict:
+    payload = {
+        "to": to, "from": from_number, "type": msg_type,
+        "channel": "whatsapp", "body": body,
+    }
+    if template:
+        payload["template"] = template
+    if callback_url:
+        payload["callback_url"] = callback_url
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(f"{KALEYRA_BASE}/messages", json=payload, headers=HEADERS)
+        resp.raise_for_status()
+        return resp.json()
+
+# Text message:
+# await send_whatsapp(to="+919876543210", from_number="+919123456789", body="Hello!")
+
+# Template message (required for initiating conversations):
+# await send_whatsapp(
+#     to="+919876543210", from_number="+919123456789",
+#     body="", msg_type="template",
+#     template={"template_name": "order_confirmation", "language": "en",
+#               "body_params": ["Rahul", "ORD-98765"]},
+# )
+```
+
+---
+
+### Make Outbound Voice Call
+
+`POST /voice/outbound` -- Initiate an outbound voice call. Uses `application/x-www-form-urlencoded`.
+
+**Note:** Not available in the NA region.
+
+```python
+async def make_call(to: str, target: str, bridge: str | None = None) -> dict:
+    """target: flow ID, sound ID, or TTS string like 'tts:en-IN:Your code is 1234'"""
+    data = {"to": to, "target": target}
+    if bridge:
+        data["bridge"] = bridge
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{KALEYRA_BASE}/voice/outbound", data=data,
+            headers={"api-key": KALEYRA_API_KEY, "content-type": "application/x-www-form-urlencoded"},
+        )
+        resp.raise_for_status()
+        return resp.json()
+```
+
+---
+
+### Generate OTP (Verify API)
+
+`POST /verify` -- Generate and send an OTP to a mobile number.
+
+```python
+async def generate_otp(mobile: str, flow_id: str | None = None) -> dict:
+    payload: dict = {"to": {"mobile": mobile}}
+    if flow_id:
+        payload["flow_id"] = flow_id
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(f"{KALEYRA_BASE}/verify", json=payload, headers=HEADERS)
+        resp.raise_for_status()
+        return resp.json()
+    # Save result["data"]["verify_id"] for validation
+```
+
+---
+
+### Validate OTP (Verify API)
+
+`POST /verify/validate` -- Validate a previously sent OTP.
+
+```python
+async def validate_otp(verify_id: str, otp: str) -> dict:
+    payload = {"verify_id": verify_id, "otp": otp}
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(f"{KALEYRA_BASE}/verify/validate", json=payload, headers=HEADERS)
+        resp.raise_for_status()
+        return resp.json()
+```
+
+## Error Handling
+
+Kaleyra returns errors with a code and message:
+
+```json
+{"code": "RBC1001", "message": "Error description", "data": [], "error": {"detail": "..."}}
+```
+
+### Reusable Error-Handling Client
+
+```python
+class KaleyraError(Exception):
+    def __init__(self, code: str, message: str):
+        super().__init__(f"[{code}] {message}")
+        self.code = code
+
+async def safe_kaleyra_call(method: str, path: str, **kwargs) -> dict:
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.request(
+            method, f"{KALEYRA_BASE}{path}", headers=HEADERS, **kwargs,
+        )
+        data = resp.json()
+        if resp.status_code >= 400 or data.get("error"):
+            raise KaleyraError(data.get("code", "UNKNOWN"), data.get("message", str(data.get("error"))))
+        return data
+```
+
+### Common Verify API Error Codes
+
+| Code | Description |
+|------|-------------|
+| `E804` | Missing mobile number |
+| `E805` | Invalid mobile number format |
+| `E802` | Invalid email address |
+| `E905` | Invalid or unapproved flow ID |
+| `E600` | Missing `to` field |
+
+## Common Pitfalls
+
+1. **SID is always in the URL path** -- Every endpoint requires `https://api.<region>.kaleyra.io/v1/<SID>/...`.
+
+2. **India SMS requires DLT template_id** -- All India-bound SMS must include a pre-registered DLT `template_id`. Without it, messages are rejected.
+
+3. **SMS route types** -- `OTP` (one-time passwords), `TXN` (transactional), `MKT` (marketing), `SI` (service implicit). Wrong type may cause delivery failure.
+
+4. **WhatsApp opt-in required** -- Messages to users who have not opted-in require an approved template message.
+
+5. **Voice outbound uses form-data** -- Unlike SMS and WhatsApp (JSON), voice calls use `application/x-www-form-urlencoded`.
+
+6. **OTP is a two-step flow** -- Generate (`/verify`) then validate (`/verify/validate`), linked by `verify_id`.
+
+7. **E.164 phone format** -- Phone numbers must include `+` prefix and country code (e.g., `+919876543210`).
+
+8. **NA region voice restriction** -- Outbound voice calls are not available for North America region accounts.

--- a/content/klarna/docs/rest-api/python/DOC.md
+++ b/content/klarna/docs/rest-api/python/DOC.md
@@ -1,0 +1,344 @@
+---
+name: rest-api
+description: "Klarna REST API Coding Guidelines for Python using httpx async HTTP client"
+metadata:
+  languages: "python"
+  versions: "v1"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "klarna,bnpl,checkout,payments,europe,sweden,api"
+---
+
+# Klarna REST API Coding Guidelines (Python)
+
+You are a Klarna API coding expert. Help me with writing code using the Klarna REST API with httpx async HTTP client.
+
+## Golden Rule: Use httpx Async for All API Calls
+
+Always use `httpx.AsyncClient` for all Klarna API interactions. Never use `requests` or synchronous HTTP clients.
+
+- **Library Name:** httpx
+- **PyPI Package:** `httpx`
+
+Klarna provides Buy Now Pay Later (BNPL), checkout, and payment processing APIs. The main APIs are: **Klarna Payments** (create sessions and authorize), **Order Management** (capture, refund, cancel), and **Hosted Payment Page** (Klarna-hosted checkout).
+
+## Installation
+
+```bash
+pip install httpx python-dotenv
+```
+
+## Base URL
+
+### Production
+
+| Region   | Base URL |
+|----------|----------|
+| Europe   | `https://api.klarna.com` |
+| North America | `https://api-na.klarna.com` |
+| Oceania  | `https://api-oc.klarna.com` |
+
+### Playground (Sandbox)
+
+| Region   | Base URL |
+|----------|----------|
+| Europe   | `https://api.playground.klarna.com` |
+| North America | `https://api-na.playground.klarna.com` |
+| Oceania  | `https://api-oc.playground.klarna.com` |
+
+URL structure is the same for both environments -- the domain determines the target environment.
+
+## Authentication
+
+Klarna uses HTTP Basic Authentication. Credentials consist of a **username** (linked to your Merchant ID) and a **password** (API key) obtained from the Klarna Merchant Portal.
+
+```python
+import os
+import httpx
+from dotenv import load_dotenv
+
+load_dotenv()
+
+KLARNA_BASE_URL = os.environ.get(
+    "KLARNA_BASE_URL", "https://api.playground.klarna.com"
+)
+KLARNA_USERNAME = os.environ["KLARNA_USERNAME"]  # e.g., "K123456_abcdef"
+KLARNA_PASSWORD = os.environ["KLARNA_PASSWORD"]  # API key
+
+def get_auth() -> tuple[str, str]:
+    return (KLARNA_USERNAME, KLARNA_PASSWORD)
+
+def get_headers() -> dict:
+    return {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+```
+
+## Rate Limiting
+
+Klarna does not publicly document specific rate limits. Monitor for HTTP 429 responses and implement exponential backoff:
+
+```python
+import asyncio
+
+async def request_with_retry(
+    client: httpx.AsyncClient,
+    method: str,
+    url: str,
+    max_retries: int = 3,
+    **kwargs,
+) -> httpx.Response:
+    for attempt in range(max_retries):
+        response = await client.request(method, url, **kwargs)
+        if response.status_code == 429:
+            delay = 2 ** (attempt + 1)
+            await asyncio.sleep(delay)
+            continue
+        response.raise_for_status()
+        return response
+    raise httpx.HTTPStatusError(
+        "Rate limit exceeded after retries",
+        request=response.request,
+        response=response,
+    )
+```
+
+## Methods
+
+### Klarna Payments -- Create Session
+
+```python
+async def create_payment_session(
+    purchase_country: str,
+    purchase_currency: str,
+    locale: str,
+    order_amount: int,
+    order_tax_amount: int,
+    order_lines: list[dict],
+) -> dict:
+    """
+    Create a Klarna Payment session. Amounts in minor units (cents/pence).
+    order_lines: [{"name": "Widget", "quantity": 1, "unit_price": 1000,
+                   "tax_rate": 2000, "total_amount": 1000, "total_tax_amount": 167}]
+    Session lifetime: 48 hours.
+    """
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{KLARNA_BASE_URL}/payments/v1/sessions",
+            auth=get_auth(),
+            headers=get_headers(),
+            json={
+                "purchase_country": purchase_country,
+                "purchase_currency": purchase_currency,
+                "locale": locale,
+                "order_amount": order_amount,
+                "order_tax_amount": order_tax_amount,
+                "order_lines": order_lines,
+            },
+        )
+        response.raise_for_status()
+        return response.json()
+        # {"session_id": "...", "client_token": "...", "payment_method_categories": [...]}
+```
+
+### Create Order (from Authorization Token)
+
+```python
+async def create_order(
+    authorization_token: str,
+    purchase_country: str,
+    purchase_currency: str,
+    locale: str,
+    order_amount: int,
+    order_tax_amount: int,
+    order_lines: list[dict],
+    merchant_reference1: str | None = None,
+    auto_capture: bool = False,
+) -> dict:
+    """
+    Create an order from an authorization token.
+    Authorization token is valid for 60 minutes after customer approval.
+    Set auto_capture=True to skip manual capture step.
+    """
+    body = {
+        "purchase_country": purchase_country,
+        "purchase_currency": purchase_currency,
+        "locale": locale,
+        "order_amount": order_amount,
+        "order_tax_amount": order_tax_amount,
+        "order_lines": order_lines,
+        "auto_capture": auto_capture,
+    }
+    if merchant_reference1:
+        body["merchant_reference1"] = merchant_reference1
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{KLARNA_BASE_URL}/payments/v1/authorizations/{authorization_token}/order",
+            auth=get_auth(),
+            headers=get_headers(),
+            json=body,
+        )
+        response.raise_for_status()
+        return response.json()
+        # {"order_id": "...", "fraud_status": "ACCEPTED", ...}
+```
+
+### Capture Order
+
+```python
+async def capture_order(
+    order_id: str,
+    captured_amount: int,
+    description: str = "",
+    order_lines: list[dict] | None = None,
+    shipping_info: list[dict] | None = None,
+) -> None:
+    """
+    Capture (part of) an order. captured_amount in minor units.
+    shipping_info: [{"tracking_number": "...", "shipping_company": "..."}]
+    """
+    body: dict = {"captured_amount": captured_amount}
+    if description:
+        body["description"] = description
+    if order_lines:
+        body["order_lines"] = order_lines
+    if shipping_info:
+        body["shipping_info"] = shipping_info
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{KLARNA_BASE_URL}/ordermanagement/v1/orders/{order_id}/captures",
+            auth=get_auth(),
+            headers=get_headers(),
+            json=body,
+        )
+        response.raise_for_status()
+```
+
+### Refund Order
+
+```python
+async def refund_order(
+    order_id: str,
+    refunded_amount: int,
+    description: str = "",
+    order_lines: list[dict] | None = None,
+) -> None:
+    """Refund (part of) an order. refunded_amount in minor units."""
+    body: dict = {"refunded_amount": refunded_amount}
+    if description:
+        body["description"] = description
+    if order_lines:
+        body["order_lines"] = order_lines
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{KLARNA_BASE_URL}/ordermanagement/v1/orders/{order_id}/refunds",
+            auth=get_auth(),
+            headers=get_headers(),
+            json=body,
+        )
+        response.raise_for_status()
+```
+
+Additional endpoints: Cancel Authorization (`DELETE /payments/v1/authorizations/{token}`), Get Order (`GET /ordermanagement/v1/orders/{id}`), Cancel Order (`POST .../cancel`), Release Remaining Authorization, Extend Authorization Time, Update Merchant References, Hosted Payment Page (`POST /hpp/v1/sessions`), Customer Tokens. All follow the same `auth=get_auth(), headers=get_headers()` pattern.
+
+## Error Handling
+
+```python
+async def safe_klarna_request(
+    method: str,
+    path: str,
+    **kwargs,
+) -> dict | None:
+    async with httpx.AsyncClient(base_url=KLARNA_BASE_URL) as client:
+        try:
+            response = await client.request(
+                method,
+                path,
+                auth=get_auth(),
+                headers=get_headers(),
+                **kwargs,
+            )
+            response.raise_for_status()
+            if response.content:
+                return response.json()
+            return None
+        except httpx.HTTPStatusError as e:
+            status = e.response.status_code
+            try:
+                error_body = e.response.json()
+            except Exception:
+                error_body = {"error_message": e.response.text}
+
+            correlation_id = error_body.get("correlation_id", "unknown")
+            error_messages = error_body.get("error_messages", [])
+
+            if status == 400:
+                raise ValueError(
+                    f"Bad request (correlation: {correlation_id}): {error_messages}"
+                )
+            elif status == 401:
+                raise PermissionError("Invalid API credentials.")
+            elif status == 403:
+                raise PermissionError(f"Forbidden: {error_body}")
+            elif status == 404:
+                raise LookupError(f"Not found: {path}")
+            elif status == 409:
+                raise RuntimeError(f"Conflict: {error_body}")
+            elif status == 429:
+                raise RuntimeError("Rate limited. Implement backoff.")
+            elif status >= 500:
+                raise ConnectionError(
+                    f"Klarna server error ({status}, correlation: {correlation_id}): {error_body}"
+                )
+            raise
+        except httpx.RequestError as e:
+            raise ConnectionError(f"Network error: {e}")
+```
+
+### Klarna Error Response Format
+
+```json
+{
+  "correlation_id": "abc-123-def",
+  "error_code": "BAD_VALUE",
+  "error_messages": ["'order_amount' is required."],
+  "error_type": "validation_error"
+}
+```
+
+### HTTP Status Codes
+
+| Code | Meaning |
+|------|---------|
+| 200  | Success |
+| 201  | Created |
+| 204  | No Content (success, no response body) |
+| 400  | Bad Request -- validation errors |
+| 401  | Unauthorized -- invalid credentials |
+| 403  | Forbidden -- insufficient permissions |
+| 404  | Not Found |
+| 409  | Conflict -- order state prevents action |
+| 429  | Too Many Requests |
+| 500  | Internal Server Error |
+
+## Common Pitfalls
+
+1. **Amounts in Minor Units:** All amounts are in the smallest currency unit (cents for EUR/USD, pence for GBP). 1000 = 10.00.
+2. **Tax Calculations:** Order lines must include `tax_rate` (in hundredths of a percent, e.g., 2000 = 20%), `total_amount`, and `total_tax_amount`. These must be mathematically consistent.
+3. **Regional Base URLs:** Use the correct regional URL for your merchant account. EU merchants must use `api.klarna.com`, not the NA or OC endpoints.
+4. **Authorization Token Expiry:** The KP Authorization Token is valid for only 60 minutes. Create the order promptly after customer approval.
+5. **Session Lifetime:** Payment sessions expire after 48 hours. Create a new session if expired.
+6. **Basic Auth, Not Bearer:** Klarna uses HTTP Basic Auth (username:password), not Bearer tokens. Use `auth=(username, password)` with httpx.
+7. **Auto-Capture:** Set `auto_capture: true` when creating orders to skip the separate capture step. Otherwise, you must call the capture endpoint before the authorization expires.
+8. **Order Line Requirements:** Every order line needs: `name`, `quantity`, `unit_price`, `tax_rate`, `total_amount`, `total_tax_amount`. Missing fields cause validation errors.
+9. **Playground vs Production:** The playground environment uses separate credentials from production. URL structure is identical -- only the domain differs.
+10. **Correlation ID:** Always log the `correlation_id` from error responses for debugging with Klarna support.
+11. **Capture Before Refund:** You can only refund captured amounts. Uncaptured orders should be cancelled, not refunded.
+12. **Partial Captures/Refunds:** Both captures and refunds support partial amounts. Track cumulative totals to avoid exceeding the order amount.
+
+**Docs:** https://docs.klarna.com/ | **Payments API:** https://docs.klarna.com/api/payments/ | **Order Management:** https://docs.klarna.com/api/ordermanagement/

--- a/content/kraken/docs/rest-api/python/DOC.md
+++ b/content/kraken/docs/rest-api/python/DOC.md
@@ -1,0 +1,475 @@
+---
+name: rest-api
+description: "Kraken Exchange REST API Python coding guidelines using httpx async"
+metadata:
+  languages: "python"
+  versions: "3.12.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "kraken,crypto,trading,exchange,bitcoin,api"
+---
+
+# Kraken Exchange REST API Python Coding Guidelines
+
+You are a Kraken Exchange REST API coding expert. Help me with writing code using the Kraken REST API with httpx async in Python.
+
+You can find the official documentation here:
+https://docs.kraken.com/api/
+
+## Golden Rule: Use httpx Async with HMAC-SHA512 Signed Requests
+
+Always use `httpx` with async/await for all Kraken REST API interactions. Authenticate private endpoints using HMAC-SHA512 signatures with nonce. Never send your API secret in plaintext. Always use increasing nonces to avoid replay attacks.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+**Environment Variables:**
+
+```bash
+export KRAKEN_API_KEY='your_api_key_here'
+export KRAKEN_API_SECRET='your_base64_encoded_secret_here'
+```
+
+Load environment variables in Python:
+
+```python
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+api_key = os.getenv("KRAKEN_API_KEY")
+api_secret = os.getenv("KRAKEN_API_SECRET")
+```
+
+## Base URL
+
+```
+https://api.kraken.com
+```
+
+- Public endpoints: `/0/public/{method}`
+- Private endpoints: `/0/private/{method}`
+
+## Authentication
+
+Kraken uses HMAC-SHA512 signatures for private endpoint authentication.
+
+```python
+import base64
+import hashlib
+import hmac
+import time
+import urllib.parse
+
+
+def generate_kraken_signature(
+    url_path: str, data: dict, secret: str
+) -> str:
+    """Generate Kraken API signature.
+
+    Signature = HMAC-SHA512(url_path + SHA256(nonce + POST_data), base64_decode(secret))
+    """
+    post_data = urllib.parse.urlencode(data)
+    encoded = (str(data["nonce"]) + post_data).encode()
+    message = url_path.encode() + hashlib.sha256(encoded).digest()
+    mac = hmac.new(base64.b64decode(secret), message, hashlib.sha512)
+    return base64.b64encode(mac.digest()).decode()
+
+
+def get_nonce() -> int:
+    """Return a nonce as millisecond timestamp."""
+    return int(time.time() * 1000)
+```
+
+### Authenticated Client Helper
+
+```python
+import httpx
+
+
+class KrakenClient:
+    BASE_URL = "https://api.kraken.com"
+
+    def __init__(self, api_key: str, api_secret: str):
+        self.api_key = api_key
+        self.api_secret = api_secret
+
+    async def public(self, method: str, params: dict | None = None) -> dict:
+        """Call a public endpoint."""
+        url = f"{self.BASE_URL}/0/public/{method}"
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(url, params=params or {})
+            resp.raise_for_status()
+            return resp.json()
+
+    async def private(self, method: str, data: dict | None = None) -> dict:
+        """Call a private endpoint with authentication."""
+        url_path = f"/0/private/{method}"
+        url = f"{self.BASE_URL}{url_path}"
+        post_data = data or {}
+        post_data["nonce"] = get_nonce()
+
+        signature = generate_kraken_signature(url_path, post_data, self.api_secret)
+
+        headers = {
+            "API-Key": self.api_key,
+            "API-Sign": signature,
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(url, headers=headers, data=post_data)
+            resp.raise_for_status()
+            return resp.json()
+```
+
+## Rate Limiting
+
+Kraken uses a call counter system per API key that increases per request and decays over time.
+
+| Verification Tier | Max Counter | Decay Rate |
+|---|---|---|
+| Starter | 15 | -0.33/sec |
+| Intermediate | 20 | -0.5/sec |
+| Pro | 20 | -1/sec |
+
+Counter costs:
+- Most calls: +1
+- Ledger/trade history: +2
+- AddOrder/CancelOrder: separate matching engine limiter
+
+```python
+import asyncio
+
+class RateLimiter:
+    def __init__(self, max_counter: int = 15, decay_rate: float = 0.33):
+        self.counter = 0.0
+        self.max_counter = max_counter
+        self.decay_rate = decay_rate
+        self.last_time = time.time()
+        self._lock = asyncio.Lock()
+
+    async def acquire(self, cost: int = 1):
+        async with self._lock:
+            now = time.time()
+            elapsed = now - self.last_time
+            self.counter = max(0, self.counter - elapsed * self.decay_rate)
+            self.last_time = now
+
+            while self.counter + cost > self.max_counter:
+                wait = (self.counter + cost - self.max_counter) / self.decay_rate
+                await asyncio.sleep(wait)
+                now = time.time()
+                elapsed = now - self.last_time
+                self.counter = max(0, self.counter - elapsed * self.decay_rate)
+                self.last_time = now
+
+            self.counter += cost
+```
+
+## Methods
+
+### Get Server Time
+
+```python
+async def get_server_time(client: KrakenClient) -> dict:
+    """Get server time (useful for checking connectivity)."""
+    return await client.public("Time")
+
+# Usage
+import asyncio
+
+async def main():
+    kraken = KrakenClient(api_key, api_secret)
+    result = await get_server_time(kraken)
+    print(result["result"]["unixtime"])
+
+asyncio.run(main())
+```
+
+### Get Asset Info
+
+```python
+async def get_assets(client: KrakenClient, assets: str | None = None) -> dict:
+    """Get info about specific or all assets.
+
+    Args:
+        assets: Comma-delimited list like "XBT,ETH" or None for all.
+    """
+    params = {}
+    if assets:
+        params["asset"] = assets
+    return await client.public("Assets", params=params)
+```
+
+### Get Tradable Asset Pairs
+
+```python
+async def get_asset_pairs(client: KrakenClient, pair: str | None = None) -> dict:
+    """Get tradable asset pairs.
+
+    Args:
+        pair: Comma-delimited list like "XXBTZUSD,XETHZUSD" or None for all.
+    """
+    params = {}
+    if pair:
+        params["pair"] = pair
+    return await client.public("AssetPairs", params=params)
+```
+
+### Get Ticker Information
+
+```python
+async def get_ticker(client: KrakenClient, pair: str) -> dict:
+    """Get ticker information for one or more pairs.
+
+    Args:
+        pair: Comma-delimited pair list, e.g., "XBTUSD" or "XBTUSD,ETHUSD".
+    """
+    return await client.public("Ticker", params={"pair": pair})
+
+# Usage
+# result = await get_ticker(kraken, "XBTUSD")
+# ticker = result["result"]["XXBTZUSD"]
+# print(f"Last price: {ticker['c'][0]}, Volume: {ticker['v'][1]}")
+```
+
+### Get OHLC Data
+
+```python
+async def get_ohlc(
+    client: KrakenClient,
+    pair: str,
+    interval: int = 60,
+    since: int | None = None,
+) -> dict:
+    """Get OHLC (candlestick) data.
+
+    Args:
+        pair: Asset pair, e.g., "XBTUSD".
+        interval: Time frame in minutes (1, 5, 15, 30, 60, 240, 1440, 10080, 21600).
+        since: Return data since given Unix timestamp.
+    """
+    params = {"pair": pair, "interval": interval}
+    if since:
+        params["since"] = since
+    return await client.public("OHLC", params=params)
+```
+
+### Get Order Book
+
+```python
+async def get_order_book(client: KrakenClient, pair: str, count: int = 100) -> dict:
+    """Get order book for a pair.
+
+    Args:
+        pair: Asset pair, e.g., "XBTUSD".
+        count: Maximum number of asks/bids (1-500).
+    """
+    return await client.public("Depth", params={"pair": pair, "count": count})
+```
+
+### Get Recent Trades
+
+```python
+async def get_recent_trades(
+    client: KrakenClient, pair: str, since: str | None = None, count: int = 1000
+) -> dict:
+    """Get recent trades.
+
+    Args:
+        pair: Asset pair.
+        since: Timestamp for trades since (nanosecond timestamp as string).
+        count: Number of trades to return (max 1000).
+    """
+    params = {"pair": pair, "count": count}
+    if since:
+        params["since"] = since
+    return await client.public("Trades", params=params)
+```
+
+### Get Account Balance
+
+```python
+async def get_balance(client: KrakenClient) -> dict:
+    """Get account balances for all assets."""
+    return await client.private("Balance")
+
+# Usage
+# result = await get_balance(kraken)
+# for asset, balance in result["result"].items():
+#     print(f"{asset}: {balance}")
+```
+
+### Get Trade Balance
+
+```python
+async def get_trade_balance(client: KrakenClient, asset: str = "ZUSD") -> dict:
+    """Get trade balance info.
+
+    Args:
+        asset: Base asset to determine balance (default ZUSD).
+    """
+    return await client.private("TradeBalance", data={"asset": asset})
+```
+
+### Get Open Orders
+
+```python
+async def get_open_orders(client: KrakenClient, trades: bool = False) -> dict:
+    """Get open orders.
+
+    Args:
+        trades: Whether to include trades in output.
+    """
+    data = {}
+    if trades:
+        data["trades"] = True
+    return await client.private("OpenOrders", data=data)
+```
+
+### Add Order
+
+```python
+async def add_order(
+    client: KrakenClient,
+    pair: str,
+    type: str,
+    ordertype: str,
+    volume: str,
+    price: str | None = None,
+    leverage: str | None = None,
+    validate: bool = False,
+) -> dict:
+    """Place a new order.
+
+    Args:
+        pair: Asset pair, e.g., "XBTUSD".
+        type: "buy" or "sell".
+        ordertype: "market", "limit", "stop-loss", "take-profit",
+                   "stop-loss-limit", "take-profit-limit".
+        volume: Order volume in base currency (as string).
+        price: Limit price (required for limit orders, as string).
+        leverage: Leverage amount (e.g., "2:1").
+        validate: If True, validate only without placing order.
+    """
+    data = {
+        "pair": pair,
+        "type": type,
+        "ordertype": ordertype,
+        "volume": volume,
+    }
+    if price:
+        data["price"] = price
+    if leverage:
+        data["leverage"] = leverage
+    if validate:
+        data["validate"] = True
+    return await client.private("AddOrder", data=data)
+
+# Market buy 0.01 BTC
+# await add_order(kraken, "XBTUSD", "buy", "market", "0.01")
+
+# Limit sell 0.5 ETH at $4000
+# await add_order(kraken, "ETHUSD", "sell", "limit", "0.5", price="4000")
+```
+
+### Cancel Order
+
+```python
+async def cancel_order(client: KrakenClient, txid: str) -> dict:
+    """Cancel an open order.
+
+    Args:
+        txid: Transaction ID of the order to cancel.
+    """
+    return await client.private("CancelOrder", data={"txid": txid})
+```
+
+### Cancel All Orders
+
+```python
+async def cancel_all_orders(client: KrakenClient) -> dict:
+    """Cancel all open orders."""
+    return await client.private("CancelAll")
+```
+
+## Error Handling
+
+```python
+async def safe_request(client: KrakenClient, method: str, data: dict | None = None) -> dict | None:
+    """Make a private request with error handling."""
+    try:
+        result = await client.private(method, data=data)
+
+        # Kraken returns errors in the response body, not HTTP status
+        if result.get("error") and len(result["error"]) > 0:
+            for err in result["error"]:
+                if err.startswith("EAPI:Rate limit"):
+                    print("Rate limited - waiting before retry")
+                    await asyncio.sleep(5)
+                elif err.startswith("EAPI:Invalid nonce"):
+                    print("Invalid nonce - ensure nonces are always increasing")
+                elif err.startswith("EOrder:"):
+                    print(f"Order error: {err}")
+                elif err.startswith("EGeneral:"):
+                    print(f"General error: {err}")
+                elif err.startswith("EService:"):
+                    print(f"Service error: {err}")
+                else:
+                    print(f"Kraken error: {err}")
+            return None
+
+        return result
+    except httpx.HTTPStatusError as e:
+        print(f"HTTP error {e.response.status_code}: {e}")
+        return None
+    except httpx.RequestError as e:
+        print(f"Network error: {e}")
+        return None
+```
+
+### Common Kraken Error Prefixes
+
+| Prefix | Description |
+|---|---|
+| EAPI:Rate limit exceeded | REST API call counter exceeded tier maximum |
+| EAPI:Invalid nonce | Nonce is not greater than previous nonce |
+| EAPI:Invalid key | API key is invalid or inactive |
+| EGeneral:Invalid arguments | Missing or malformed parameters |
+| EGeneral:Permission denied | API key lacks required permissions |
+| EOrder:Insufficient funds | Not enough balance to place order |
+| EOrder:Order minimum not met | Order size below minimum for pair |
+| EService:Unavailable | Kraken service temporarily unavailable |
+| EService:Throttled | Too many concurrent requests |
+
+## Common Pitfalls
+
+1. **Nonce Must Always Increase** - Use millisecond timestamps. Never reuse or decrement nonces. Too many invalid nonce requests can result in temporary IP bans.
+
+2. **Errors in Response Body** - Kraken returns HTTP 200 even for errors. Always check the `error` array in the response JSON before accessing `result`.
+
+3. **Asset Naming Conventions** - Kraken uses X-prefixed names for crypto (e.g., `XXBT` for Bitcoin, `XETH` for Ethereum) and Z-prefixed for fiat (e.g., `ZUSD`). Pairs combine these: `XXBTZUSD`. Some endpoints also accept `XBT/USD` or `XBTUSD`.
+
+4. **POST for Private Endpoints** - All private endpoints use POST with `application/x-www-form-urlencoded` content type, not JSON.
+
+5. **Volume as String** - Always pass order volumes and prices as strings, not numbers.
+
+6. **Signature Encoding** - The API secret is base64-encoded. You must base64-decode it before using it for HMAC signing. The resulting signature must be base64-encoded.
+
+7. **Pair Names in Responses** - Response pair keys may differ from request keys (e.g., request `XBTUSD`, response key `XXBTZUSD`). Handle both formats.
+
+8. **OTP for 2FA** - If two-factor authentication is enabled on the API key, include the `otp` parameter in private requests.
+
+## Useful Links
+
+- Official API Documentation: https://docs.kraken.com/api/
+- Spot REST API Guide: https://docs.kraken.com/api/docs/guides/spot-rest-intro
+- Authentication Guide: https://docs.kraken.com/api/docs/guides/spot-rest-auth
+- Rate Limits: https://docs.kraken.com/api/docs/guides/spot-rest-ratelimits
+- API Key Management: https://www.kraken.com/u/security/api
+- Kraken Status: https://status.kraken.com/

--- a/content/krutrim-cloud/docs/rest-api/python/DOC.md
+++ b/content/krutrim-cloud/docs/rest-api/python/DOC.md
@@ -1,0 +1,222 @@
+---
+name: rest-api
+description: "Krutrim Cloud - Ola's Indian AI LLM Inference API (OpenAI-compatible)"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "krutrim,ola,indian-ai,llm,inference,chat-completions,openai-compatible,multilingual,indic,cloud,api"
+---
+
+# Krutrim Cloud API
+
+> **Golden Rule:** Krutrim Cloud (by Ola) provides an **OpenAI-compatible** REST API for LLM inference. You can use `httpx` directly or the `openai` Python client pointed at Krutrim's base URL. The API supports chat completions, image generation, and TTS. Auth is via API key from the Krutrim Cloud console. Models include Krutrim-2 (12B, 128K context, 22 Indian languages + English).
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+Alternatively, since the API is OpenAI-compatible:
+
+```bash
+pip install openai
+```
+
+## Base URL
+
+```
+https://cloud.olakrutrim.com/v1
+```
+
+Environment variable override: `KRUTRIM_CLOUD_BASE_URL`
+
+## Authentication
+
+**Type:** API Key (Bearer token)
+
+```python
+import httpx
+
+API_KEY = "your-krutrim-api-key"  # From https://cloud.olakrutrim.com console
+BASE_URL = "https://cloud.olakrutrim.com/v1"
+
+headers = {
+    "Authorization": f"Bearer {API_KEY}",
+    "Content-Type": "application/json"
+}
+
+client = httpx.AsyncClient(
+    base_url=BASE_URL,
+    headers=headers,
+    timeout=60.0
+)
+```
+
+Sign up at: https://cloud.olakrutrim.com (redirects to https://www.olakrutrim.com/cloud)
+
+API keys are managed in the Krutrim Cloud console under your account settings.
+
+## Available Models
+
+| Model | Parameters | Context | Languages |
+|---|---|---|---|
+| `Krutrim-spectre-v2` | — | 4K tokens | English + Indic |
+| `Meta-Llama-3-8B-Instruct` | 8B | 8K tokens | English |
+| `Mistral-7B-Instruct` | 7B | 8K tokens | English |
+| `Krutrim-2-12B` | 12B | 128K tokens | English + 22 Indian languages |
+
+Krutrim-2 is natively multilingual, trained on web data, code, math, and Indic language corpora.
+
+## Rate Limiting
+
+Not publicly documented. Expect HTTP 429 responses when limits are exceeded. Contact Krutrim support for plan-specific limits.
+
+## Methods
+
+### `chat_completions` (OpenAI-compatible)
+
+**Endpoint:** `POST /chat/completions`
+
+Generate text completions using chat-style messaging. Follows the OpenAI Chat Completions API format.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `model` | `str` | **required** (e.g., `"Krutrim-spectre-v2"`) |
+| `messages` | `list` | **required** (array of `{"role": ..., "content": ...}`) |
+| `max_tokens` | `int` | model default |
+| `temperature` | `float` | `1.0` |
+| `top_p` | `float` | `1.0` |
+| `stream` | `bool` | `false` |
+
+```python
+import httpx
+
+API_KEY = "your-krutrim-api-key"
+BASE_URL = "https://cloud.olakrutrim.com/v1"
+
+async def chat_completion():
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        response = await client.post(
+            f"{BASE_URL}/chat/completions",
+            headers={
+                "Authorization": f"Bearer {API_KEY}",
+                "Content-Type": "application/json"
+            },
+            json={
+                "model": "Krutrim-spectre-v2",
+                "messages": [
+                    {"role": "system", "content": "You are a helpful assistant fluent in Indian languages."},
+                    {"role": "user", "content": "Translate 'Good morning' to Hindi, Tamil, and Telugu."}
+                ],
+                "max_tokens": 256,
+                "temperature": 0.7
+            }
+        )
+        response.raise_for_status()
+        data = response.json()
+        return data["choices"][0]["message"]["content"]
+```
+
+### `chat_completions_streaming`
+
+**Endpoint:** `POST /chat/completions` (with `stream: true`)
+
+Stream responses token-by-token using Server-Sent Events (SSE).
+
+```python
+import httpx
+
+async def stream_chat():
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        async with client.stream(
+            "POST",
+            f"{BASE_URL}/chat/completions",
+            headers={
+                "Authorization": f"Bearer {API_KEY}",
+                "Content-Type": "application/json"
+            },
+            json={
+                "model": "Krutrim-spectre-v2",
+                "messages": [
+                    {"role": "user", "content": "Write a short poem in Hindi about monsoon."}
+                ],
+                "max_tokens": 512,
+                "stream": True
+            }
+        ) as response:
+            response.raise_for_status()
+            async for line in response.aiter_lines():
+                if line.startswith("data: ") and line != "data: [DONE]":
+                    import json
+                    chunk = json.loads(line[6:])
+                    delta = chunk["choices"][0].get("delta", {})
+                    if "content" in delta:
+                        print(delta["content"], end="", flush=True)
+```
+
+### Using OpenAI Client (Alternative)
+
+Since Krutrim is OpenAI-compatible, you can use the `openai` library directly:
+
+```python
+from openai import AsyncOpenAI
+
+client = AsyncOpenAI(
+    api_key="your-krutrim-api-key",
+    base_url="https://cloud.olakrutrim.com/v1"
+)
+
+response = await client.chat.completions.create(
+    model="Krutrim-spectre-v2",
+    messages=[
+        {"role": "user", "content": "What are the major festivals of India?"}
+    ],
+    max_tokens=512
+)
+print(response.choices[0].message.content)
+```
+
+## Error Handling
+
+```python
+import httpx
+
+try:
+    response = await client.post(
+        f"{BASE_URL}/chat/completions",
+        headers=headers,
+        json=payload
+    )
+    response.raise_for_status()
+    data = response.json()
+except httpx.HTTPStatusError as e:
+    if e.response.status_code == 401:
+        print("Invalid API key -- check KRUTRIM_CLOUD_API_KEY")
+    elif e.response.status_code == 429:
+        print("Rate limited -- back off and retry")
+    elif e.response.status_code == 400:
+        print(f"Bad request (invalid model or params): {e.response.text}")
+    elif e.response.status_code == 404:
+        print("Model not found -- check available models")
+    else:
+        print(f"Krutrim API error {e.response.status_code}: {e.response.text}")
+except httpx.RequestError as e:
+    print(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+- **OpenAI-compatible format**: Use standard OpenAI chat completion request structure (`messages` array with `role`/`content`)
+- **Model names are case-sensitive**: Use exact model names (e.g., `"Krutrim-spectre-v2"`, not `"krutrim-spectre-v2"`)
+- **Python version requirement**: Official SDK requires Python 3.10-3.12; httpx works on any Python 3.7+
+- **Base URL**: The cloud console URL `cloud.olakrutrim.com` redirects to `olakrutrim.com/cloud` for the web UI, but the API base URL is `https://cloud.olakrutrim.com/v1`
+- **Set generous timeouts**: LLM inference can be slow, use `timeout=60.0` or higher
+- **Krutrim-2 context window**: 128K tokens, but respect the model-specific max token limits
+- **Indian language support**: Krutrim-2 natively supports 22 scheduled Indian languages; other hosted models (Llama, Mistral) are primarily English
+- **No public rate limit docs**: Monitor for 429 responses and implement exponential backoff
+- **Official Python SDK exists** (`pip install krutrim-cloud`) but is less documented than using httpx/openai directly
+- Sign up at https://www.olakrutrim.com/cloud to get API credentials

--- a/content/leadsquared/docs/rest-api/python/DOC.md
+++ b/content/leadsquared/docs/rest-api/python/DOC.md
@@ -1,0 +1,494 @@
+---
+name: rest-api
+description: "LeadSquared - Sales Execution & Marketing Automation REST API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "leadsquared,crm,sales,marketing,leads,automation,india,api"
+---
+
+# LeadSquared REST API - Python Guide
+
+## Overview
+
+LeadSquared is a sales execution and marketing automation CRM platform. Its REST API provides access to leads, activities, tasks, opportunities, and users. All endpoints use JSON over HTTPS.
+
+- **Base URL**: `https://{host}/v2/` (host varies by account, found in Settings)
+- **Authentication**: Access Key + Secret Key as query parameters or headers
+- **HTTP Methods**: GET (read) and POST (create/update)
+- **Rate Limit**: 25 requests per 5 seconds
+- **Date Format**: UTC `YYYY-MM-DD HH:MM:SS`
+- **Official docs**: https://apidocs.leadsquared.com/
+
+## Authentication
+
+LeadSquared authenticates via `accessKey` and `secretKey` passed as query string parameters on every request. Obtain these from **My Account > Settings > API and Webhooks**.
+
+All requests must use HTTPS. Plain HTTP calls will fail.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Python Client
+
+```python
+import httpx
+from typing import Any
+from urllib.parse import urlencode
+
+
+class LeadSquaredClient:
+    """Async client for LeadSquared REST API."""
+
+    def __init__(
+        self,
+        host: str,
+        access_key: str,
+        secret_key: str,
+    ):
+        """Initialize the client.
+
+        Args:
+            host: Your LeadSquared API host (e.g., 'api.leadsquared.com').
+            access_key: API access key from Settings.
+            secret_key: API secret key from Settings.
+        """
+        self.base_url = f"https://{host}/v2"
+        self.auth_params = {
+            "accessKey": access_key,
+            "secretKey": secret_key,
+        }
+        self.headers = {"Content-Type": "application/json"}
+
+    def _url(self, path: str, extra_params: dict | None = None) -> str:
+        params = {**self.auth_params, **(extra_params or {})}
+        return f"{self.base_url}/{path}?{urlencode(params)}"
+
+    async def _get(self, path: str, params: dict | None = None) -> Any:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.get(
+                self._url(path, params),
+                headers=self.headers,
+            )
+            response.raise_for_status()
+            return response.json()
+
+    async def _post(
+        self, path: str, body: Any, params: dict | None = None
+    ) -> Any:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(
+                self._url(path, params),
+                headers=self.headers,
+                json=body,
+            )
+            response.raise_for_status()
+            return response.json()
+
+    # --- Lead Management ---
+
+    async def capture_lead(
+        self,
+        attributes: dict[str, str],
+        search_by: str = "EmailAddress",
+        update_behavior: str | None = None,
+    ) -> dict:
+        """Create or update a lead.
+
+        Args:
+            attributes: Dict of field name to value (e.g., {"FirstName": "Raj"}).
+            search_by: Field to match existing leads: EmailAddress, Phone, etc.
+            update_behavior: One of DoNotUpdate, UpdateOnlyEmptyFields,
+                             DoNotUpdateUniqueFields, or None (default update all).
+        """
+        body = [
+            {"Attribute": k, "Value": v} for k, v in attributes.items()
+        ]
+        body.append({"Attribute": "SearchBy", "Value": search_by})
+
+        extra = {}
+        if update_behavior:
+            extra["LeadUpdateBehavior"] = update_behavior
+
+        return await self._post(
+            "LeadManagement.svc/Lead.Capture", body, extra
+        )
+
+    async def get_lead_by_id(self, lead_id: str) -> list[dict]:
+        """Get a lead by its ProspectID."""
+        return await self._get(
+            "LeadManagement.svc/Leads.GetById",
+            {"id": lead_id},
+        )
+
+    async def get_lead_by_email(self, email: str) -> list[dict]:
+        """Get a lead by email address."""
+        return await self._get(
+            "LeadManagement.svc/Leads.GetByEmailaddress",
+            {"emailaddress": email},
+        )
+
+    async def search_leads(
+        self,
+        lookup_name: str,
+        lookup_value: str,
+        operator: str = "=",
+        columns: list[str] | None = None,
+        page_index: int = 1,
+        page_size: int = 100,
+        sort_by: str | None = None,
+        sort_desc: bool = True,
+    ) -> list[dict]:
+        """Search leads by criteria.
+
+        Args:
+            lookup_name: Field schema name to filter on.
+            lookup_value: Value to match.
+            operator: SQL operator: =, LIKE, >, <, <=, >=, <>.
+            columns: Fields to include in results.
+            page_index: Page number (starts at 1).
+            page_size: Results per page (max 1000).
+            sort_by: Field to sort by.
+            sort_desc: True for descending, False for ascending.
+        """
+        body: dict[str, Any] = {
+            "Parameter": {
+                "LookupName": lookup_name,
+                "LookupValue": lookup_value,
+                "SqlOperator": operator,
+            },
+            "Paging": {
+                "PageIndex": page_index,
+                "PageSize": page_size,
+            },
+        }
+        if columns:
+            body["Columns"] = {"Include_CSV": ", ".join(columns)}
+        if sort_by:
+            body["Sorting"] = {
+                "ColumnName": sort_by,
+                "Direction": "1" if sort_desc else "0",
+            }
+
+        return await self._post("LeadManagement.svc/Leads.Get", body)
+
+    async def update_lead(
+        self, lead_id: str, attributes: dict[str, str]
+    ) -> dict:
+        """Update an existing lead by ProspectID."""
+        body = [
+            {"Attribute": k, "Value": v} for k, v in attributes.items()
+        ]
+        return await self._post(
+            "LeadManagement.svc/Lead.Update",
+            body,
+            {"leadId": lead_id},
+        )
+
+    # --- Activity Management ---
+
+    async def get_lead_activities(
+        self, lead_id: str, activity_event: int | None = None
+    ) -> list[dict]:
+        """Get activities for a lead.
+
+        Args:
+            lead_id: The ProspectID.
+            activity_event: Specific activity type code, or None for all.
+        """
+        body = {}
+        if activity_event is not None:
+            body = {"Parameter": {"ActivityEvent": activity_event}}
+
+        return await self._post(
+            "ProspectActivity.svc/Retrieve",
+            body,
+            {"leadId": lead_id},
+        )
+
+    async def create_activity(
+        self,
+        lead_id: str,
+        activity_event: int,
+        activity_note: str = "",
+        fields: dict[str, str] | None = None,
+    ) -> dict:
+        """Post a new activity on a lead."""
+        body: dict[str, Any] = {
+            "RelatedProspectId": lead_id,
+            "ActivityEvent": activity_event,
+            "ActivityNote": activity_note,
+        }
+        if fields:
+            body["Fields"] = [
+                {"SchemaName": k, "Value": v} for k, v in fields.items()
+            ]
+        return await self._post(
+            "ProspectActivity.svc/Create", body
+        )
+
+    # --- Quick Search ---
+
+    async def quick_search(
+        self,
+        key: str,
+        value: str,
+    ) -> list[dict]:
+        """Search leads by a single key-value pair."""
+        return await self._get(
+            "LeadManagement.svc/Leads.GetByQuickSearch",
+            {"key": key, "value": value},
+        )
+```
+
+## Usage Examples
+
+### Capture a New Lead
+
+```python
+import asyncio
+
+
+async def main():
+    lsq = LeadSquaredClient(
+        host="api.leadsquared.com",
+        access_key="YOUR_ACCESS_KEY",
+        secret_key="YOUR_SECRET_KEY",
+    )
+
+    result = await lsq.capture_lead(
+        attributes={
+            "FirstName": "Rahul",
+            "LastName": "Verma",
+            "EmailAddress": "rahul.verma@example.com",
+            "Phone": "+919876543210",
+            "Company": "TechCorp India",
+            "mx_City": "Bangalore",
+            "Source": "Website",
+        },
+        search_by="EmailAddress",
+    )
+    print(f"Lead ID: {result['Message']['Id']}")
+    print(f"New lead created: {result['Message']['IsCreated']}")
+
+
+asyncio.run(main())
+```
+
+### Get a Lead by ID
+
+```python
+async def get_lead():
+    lsq = LeadSquaredClient(
+        host="api.leadsquared.com",
+        access_key="YOUR_ACCESS_KEY",
+        secret_key="YOUR_SECRET_KEY",
+    )
+
+    lead = await lsq.get_lead_by_id("abc12345-def6-7890-ghij-klmnopqrstuv")
+    if lead:
+        for field in lead:
+            print(f"  {field.get('Attribute')}: {field.get('Value')}")
+    else:
+        print("Lead not found")
+
+
+asyncio.run(get_lead())
+```
+
+### Search Leads by Criteria
+
+```python
+async def search_recent_leads():
+    lsq = LeadSquaredClient(
+        host="api.leadsquared.com",
+        access_key="YOUR_ACCESS_KEY",
+        secret_key="YOUR_SECRET_KEY",
+    )
+
+    leads = await lsq.search_leads(
+        lookup_name="CreatedOn",
+        lookup_value="2026-03-01 00:00:00",
+        operator=">",
+        columns=[
+            "ProspectID",
+            "FirstName",
+            "LastName",
+            "EmailAddress",
+            "Phone",
+            "ProspectStage",
+        ],
+        sort_by="CreatedOn",
+        sort_desc=True,
+        page_size=50,
+    )
+
+    for lead in leads:
+        name = f"{lead.get('FirstName', '')} {lead.get('LastName', '')}"
+        print(f"  {name} - {lead.get('EmailAddress', '')}")
+
+    return leads
+
+
+asyncio.run(search_recent_leads())
+```
+
+### Update a Lead
+
+```python
+async def update_lead_stage():
+    lsq = LeadSquaredClient(
+        host="api.leadsquared.com",
+        access_key="YOUR_ACCESS_KEY",
+        secret_key="YOUR_SECRET_KEY",
+    )
+
+    result = await lsq.update_lead(
+        lead_id="abc12345-def6-7890-ghij-klmnopqrstuv",
+        attributes={
+            "ProspectStage": "Qualified",
+            "mx_Score": "85",
+            "mx_LastContactedOn": "2026-03-17 10:30:00",
+        },
+    )
+    print(f"Update result: {result}")
+
+
+asyncio.run(update_lead_stage())
+```
+
+### Log an Activity on a Lead
+
+```python
+async def log_call_activity():
+    lsq = LeadSquaredClient(
+        host="api.leadsquared.com",
+        access_key="YOUR_ACCESS_KEY",
+        secret_key="YOUR_SECRET_KEY",
+    )
+
+    result = await lsq.create_activity(
+        lead_id="abc12345-def6-7890-ghij-klmnopqrstuv",
+        activity_event=208,  # Phone call activity type
+        activity_note="Discussed pricing. Client interested in enterprise plan.",
+        fields={
+            "mx_CallDuration": "15",
+            "mx_CallOutcome": "Interested",
+        },
+    )
+    print(f"Activity created: {result}")
+
+
+asyncio.run(log_call_activity())
+```
+
+### Paginated Lead Export
+
+```python
+async def export_all_leads():
+    """Retrieve all leads with pagination."""
+    lsq = LeadSquaredClient(
+        host="api.leadsquared.com",
+        access_key="YOUR_ACCESS_KEY",
+        secret_key="YOUR_SECRET_KEY",
+    )
+
+    all_leads = []
+    page = 1
+    page_size = 1000
+
+    while True:
+        batch = await lsq.search_leads(
+            lookup_name="CreatedOn",
+            lookup_value="2020-01-01 00:00:00",
+            operator=">",
+            columns=["ProspectID", "FirstName", "LastName", "EmailAddress"],
+            page_index=page,
+            page_size=page_size,
+        )
+        if not batch:
+            break
+        all_leads.extend(batch)
+        print(f"  Page {page}: fetched {len(batch)} leads")
+        if len(batch) < page_size:
+            break
+        page += 1
+
+    print(f"Total leads exported: {len(all_leads)}")
+    return all_leads
+
+
+asyncio.run(export_all_leads())
+```
+
+## Key API Endpoints Summary
+
+| Operation | Method | Endpoint Path |
+|-----------|--------|---------------|
+| Capture Lead | POST | `LeadManagement.svc/Lead.Capture` |
+| Get Lead by ID | GET | `LeadManagement.svc/Leads.GetById` |
+| Get Lead by Email | GET | `LeadManagement.svc/Leads.GetByEmailaddress` |
+| Search Leads | POST | `LeadManagement.svc/Leads.Get` |
+| Quick Search | GET | `LeadManagement.svc/Leads.GetByQuickSearch` |
+| Update Lead | POST | `LeadManagement.svc/Lead.Update` |
+| Get Activities | POST | `ProspectActivity.svc/Retrieve` |
+| Create Activity | POST | `ProspectActivity.svc/Create` |
+| Create Lead + Activity | POST | `LeadManagement.svc/Lead.CreateOrUpdateLeadAndActivity` |
+
+## Error Handling
+
+```python
+import httpx
+
+
+async def safe_leadsquared_request(lsq: LeadSquaredClient):
+    try:
+        result = await lsq.get_lead_by_id("some-id")
+        return result
+    except httpx.HTTPStatusError as e:
+        status = e.response.status_code
+        if status == 401:
+            print("Authentication failed. Check accessKey and secretKey.")
+        elif status == 404:
+            print("Endpoint not found. Verify your API host URL.")
+        elif status == 429:
+            print("Rate limited (25 req/5sec). Back off and retry.")
+        elif status == 400:
+            print(f"Bad request: {e.response.text}")
+        else:
+            print(f"HTTP error {status}: {e.response.text}")
+        return None
+    except httpx.ConnectError:
+        print("Cannot connect. Check host URL and network.")
+        return None
+    except httpx.TimeoutException:
+        print("Request timed out.")
+        return None
+```
+
+## HTTP Status Codes
+
+| Code | Meaning |
+|------|---------|
+| 200 | Success |
+| 400 | Invalid request body or format |
+| 401 | Invalid access credentials |
+| 404 | API endpoint not found |
+| 429 | Rate limit exceeded (25 calls per 5 seconds) |
+| 500 | Server error |
+
+## References
+
+- API Overview: https://apidocs.leadsquared.com/overview/
+- Authentication: https://apidocs.leadsquared.com/authentication/
+- Lead Management: https://apidocs.leadsquared.com/lead-management/
+- Capture Lead: https://apidocs.leadsquared.com/capture-lead/
+- Search by Criteria: https://apidocs.leadsquared.com/search-by-lead-criteria/
+- Activity Management: https://apidocs.leadsquared.com/activity-management/
+- Get Lead by ID: https://apidocs.leadsquared.com/get-lead-by-id/

--- a/content/line/docs/rest-api/python/DOC.md
+++ b/content/line/docs/rest-api/python/DOC.md
@@ -1,0 +1,344 @@
+---
+name: rest-api
+description: "LINE Messaging API - Chat Bot Platform for Japan/Asia"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "line,messaging,japan,asia,bot,chat,api"
+---
+
+# LINE Messaging API - Python Reference (httpx)
+
+## Golden Rule
+
+Authentication uses a **channel access token** in the `Authorization: Bearer` header. Never embed your channel access token in client-side code or commit it to version control. Create your channel through the LINE Official Account Manager (direct creation from LINE Developers Console is no longer supported as of September 2024).
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+All examples use `httpx` with async/await. For scripts that need a synchronous entrypoint:
+
+```python
+import asyncio
+import httpx
+
+async def main():
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{BASE_URL}/v2/bot/info",
+            headers=HEADERS,
+        )
+        print(resp.json())
+
+asyncio.run(main())
+```
+
+## Base URL
+
+```
+https://api.line.me
+```
+
+For large data transfers (content retrieval, file uploads, rich menu images):
+
+```
+https://api-data.line.me
+```
+
+```python
+import os
+
+CHANNEL_ACCESS_TOKEN = os.environ["LINE_CHANNEL_ACCESS_TOKEN"]
+BASE_URL = "https://api.line.me"
+DATA_URL = "https://api-data.line.me"
+HEADERS = {"Authorization": f"Bearer {CHANNEL_ACCESS_TOKEN}"}
+```
+
+## Authentication
+
+LINE Messaging API uses **Bearer token** authentication via the `Authorization` header on every request:
+
+```
+Authorization: Bearer {channel access token}
+```
+
+Channel access tokens come in two types:
+- **Short-lived** (expires in 30 days) -- issued via the LINE Developers Console or the token endpoint
+- **Stateless channel access tokens** (v2.1) -- issued programmatically via JWT assertion
+
+```python
+async def issue_stateless_token(client: httpx.AsyncClient, client_id: str, client_secret: str) -> str:
+    """Issue a short-lived channel access token v2.1."""
+    resp = await client.post(
+        "https://api.line.me/oauth2/v3/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": client_id,
+            "client_secret": client_secret,
+        },
+    )
+    resp.raise_for_status()
+    return resp.json()["access_token"]
+```
+
+## Rate Limiting
+
+Rate limits are **per-channel** and vary by endpoint:
+
+| Endpoint Category | Limit |
+|---|---|
+| Most API endpoints | 2,000 requests/second |
+| Multicast, membership, coupons | 200 requests/second |
+| Webhook configuration | 1,000 requests/minute |
+| Rich menu operations | 100 requests/hour |
+| Narrowcast, broadcast, statistics | 60 requests/hour |
+| Audience management | 60 requests/minute |
+
+When you exceed limits, the API returns HTTP `429 Too Many Requests`.
+
+```python
+import asyncio
+
+async def request_with_retry(client: httpx.AsyncClient, method: str, url: str, max_retries: int = 3, **kwargs):
+    for attempt in range(max_retries):
+        resp = await client.request(method, url, headers=HEADERS, **kwargs)
+        if resp.status_code == 429:
+            wait = min(2 ** attempt, 30)
+            await asyncio.sleep(wait)
+            continue
+        return resp
+    raise Exception("Max retries exceeded due to rate limiting")
+```
+
+## Methods
+
+### Reply Message
+
+Reply to a user event (message, follow, postback, etc.) using the `replyToken` from the webhook event. The reply token expires after 1 minute.
+
+**Required parameters:**
+- `replyToken` (str) -- Token from the webhook event
+- `messages` (list[dict]) -- Up to 5 message objects
+
+```python
+async def reply_message(client: httpx.AsyncClient, reply_token: str, messages: list[dict]) -> dict:
+    resp = await client.post(
+        f"{BASE_URL}/v2/bot/message/reply",
+        headers={**HEADERS, "Content-Type": "application/json"},
+        json={"replyToken": reply_token, "messages": messages},
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+# Usage
+await reply_message(client, reply_token, [
+    {"type": "text", "text": "Hello! How can I help you?"}
+])
+```
+
+### Push Message
+
+Send a message to a user, group, or room at any time (not in response to an event).
+
+**Required parameters:**
+- `to` (str) -- User ID, group ID, or room ID
+- `messages` (list[dict]) -- Up to 5 message objects
+
+```python
+async def push_message(client: httpx.AsyncClient, to: str, messages: list[dict]) -> dict:
+    resp = await client.post(
+        f"{BASE_URL}/v2/bot/message/push",
+        headers={**HEADERS, "Content-Type": "application/json"},
+        json={"to": to, "messages": messages},
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+# Usage -- send a text message to a specific user
+await push_message(client, user_id, [
+    {"type": "text", "text": "Your order has been shipped!"}
+])
+```
+
+### Multicast Message
+
+Send a message to multiple users at once (up to 500 user IDs per request).
+
+```python
+async def multicast_message(client: httpx.AsyncClient, to: list[str], messages: list[dict]) -> dict:
+    resp = await client.post(
+        f"{BASE_URL}/v2/bot/message/multicast",
+        headers={**HEADERS, "Content-Type": "application/json"},
+        json={"to": to, "messages": messages},
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Broadcast Message
+
+Send a message to all users who have added the bot as a friend.
+
+```python
+async def broadcast_message(client: httpx.AsyncClient, messages: list[dict]) -> dict:
+    resp = await client.post(
+        f"{BASE_URL}/v2/bot/message/broadcast",
+        headers={**HEADERS, "Content-Type": "application/json"},
+        json={"messages": messages},
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Get User Profile
+
+Retrieve a user's display name, profile picture, and status message.
+
+```python
+async def get_profile(client: httpx.AsyncClient, user_id: str) -> dict:
+    resp = await client.get(
+        f"{BASE_URL}/v2/bot/profile/{user_id}",
+        headers=HEADERS,
+    )
+    resp.raise_for_status()
+    return resp.json()
+    # Returns: {"displayName": "Taro", "userId": "U...", "pictureUrl": "https://...", "statusMessage": "..."}
+```
+
+### Get Message Content
+
+Download image, video, audio, or file content sent by a user.
+
+```python
+async def get_content(client: httpx.AsyncClient, message_id: str) -> bytes:
+    resp = await client.get(
+        f"{DATA_URL}/v2/bot/message/{message_id}/content",
+        headers=HEADERS,
+    )
+    resp.raise_for_status()
+    return resp.content
+```
+
+### Set Webhook URL
+
+Configure the webhook endpoint that LINE sends events to.
+
+```python
+async def set_webhook(client: httpx.AsyncClient, endpoint: str) -> dict:
+    resp = await client.put(
+        f"{BASE_URL}/v2/bot/channel/webhook/endpoint",
+        headers={**HEADERS, "Content-Type": "application/json"},
+        json={"endpoint": endpoint},
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+## Error Handling
+
+Successful responses return HTTP 200 with a JSON body (often `{}`).
+
+On failure, the API returns an error JSON:
+
+```json
+{
+    "message": "The request body has 1 error(s)",
+    "details": [
+        {
+            "message": "May not be empty",
+            "property": "messages[0].text"
+        }
+    ]
+}
+```
+
+**Common status codes:**
+
+| Code | Meaning |
+|---|---|
+| 200 | Success |
+| 400 | Bad Request -- invalid parameters or message format |
+| 401 | Unauthorized -- missing or invalid channel access token |
+| 403 | Forbidden -- bot lacks permission for this action |
+| 404 | Not Found -- resource does not exist |
+| 429 | Too Many Requests -- rate limit exceeded |
+| 500 | Internal Server Error |
+
+**Robust error handling pattern:**
+
+```python
+import asyncio
+import httpx
+import logging
+
+logger = logging.getLogger(__name__)
+
+class LineAPIError(Exception):
+    def __init__(self, status_code: int, message: str, details: list = None):
+        self.status_code = status_code
+        self.message = message
+        self.details = details or []
+        super().__init__(f"[{status_code}] {message}")
+
+async def line_request(
+    client: httpx.AsyncClient,
+    method: str,
+    path: str,
+    max_retries: int = 3,
+    **kwargs,
+) -> dict:
+    url = f"{BASE_URL}{path}"
+    for attempt in range(max_retries):
+        try:
+            resp = await client.request(method, url, headers=HEADERS, **kwargs)
+        except httpx.RequestError as e:
+            logger.warning(f"Network error on {path} (attempt {attempt+1}): {e}")
+            await asyncio.sleep(2 ** attempt)
+            continue
+
+        if resp.status_code == 200:
+            return resp.json() if resp.content else {}
+
+        if resp.status_code == 429:
+            wait = min(2 ** attempt, 30)
+            logger.warning(f"Rate limited on {path}, retrying in {wait}s")
+            await asyncio.sleep(wait)
+            continue
+
+        data = resp.json() if resp.content else {}
+        raise LineAPIError(
+            resp.status_code,
+            data.get("message", "Unknown error"),
+            data.get("details", []),
+        )
+
+    raise LineAPIError(429, f"Max retries exceeded for {path}")
+```
+
+## Common Pitfalls
+
+1. **Reply tokens expire in 1 minute.** You must call the reply endpoint promptly after receiving a webhook event. If the token expires, use `push` instead (which counts toward your monthly message quota).
+
+2. **Webhook signature verification is essential.** Always verify the `X-Line-Signature` header using HMAC-SHA256 with your channel secret. Skipping this allows anyone to forge webhook events to your server.
+
+3. **Push messages count toward monthly quotas.** The free plan includes a limited number of push messages per month. Reply messages are free. Design your bot to use reply messages whenever possible.
+
+4. **User IDs are channel-scoped.** A user's ID is different for each channel (provider). You cannot use a user ID obtained from one channel with another channel's access token.
+
+5. **Message types are strict.** Each message object must include `type` (text, image, video, audio, file, location, sticker, template, flex, imagemap). Sending an invalid type returns a 400 error with no useful description.
+
+6. **Rich menu images have exact size requirements.** Rich menu images must be 2500x1686 or 2500x843 pixels, JPEG or PNG, and under 1 MB. Use the `api-data.line.me` domain for uploading.
+
+7. **Flex Messages JSON is deeply nested.** Flex Message containers have strict schema validation. Test your Flex Message JSON in the LINE Bot Designer or Flex Message Simulator before deploying.
+
+8. **Narrowcast requires audience.** Narrowcast messages target a specific audience segment. You must create an audience first using the audience management endpoints.
+
+9. **Webhook events are not retried.** If your server returns a non-200 status for a webhook delivery, LINE does not retry. Implement a fallback polling mechanism if reliability is critical.
+
+10. **Content download URLs are temporary.** Message content (images, videos, files) must be downloaded soon after receipt. The content may become unavailable after some time.

--- a/content/make/docs/rest-api/python/DOC.md
+++ b/content/make/docs/rest-api/python/DOC.md
@@ -1,0 +1,247 @@
+---
+name: rest-api
+description: "Make.com (Integromat) Workflow Automation API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-13"
+  source: community
+  tags: "make,integromat,automation,workflows,scenarios,webhooks,api,integration"
+---
+
+# Make.com API
+
+> **Golden Rule:** Make.com has no official Python SDK. Use `httpx` (async) or `requests` (sync) for direct REST API access. Authentication uses `Token` (not Bearer). Base URL is zone-specific. Always handle rate limits explicitly.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+`https://{zone}.make.com/api/v2`
+
+Zones: `eu1`, `eu2`, `us1`, `us2` (check your account settings for your zone).
+
+## Authentication
+
+**Type:** API Token
+
+```python
+import httpx
+
+API_TOKEN = "your-make-api-token"  # UUID format
+ZONE = "us1"  # or eu1, eu2, us2
+BASE_URL = f"https://{ZONE}.make.com/api/v2"
+
+headers = {
+    "Authorization": f"Token {API_TOKEN}",
+    "Content-Type": "application/json"
+}
+client = httpx.AsyncClient(headers=headers)
+```
+
+**Important:** Make uses `Token` prefix (not `Bearer`). Tokens are UUID format.
+
+## Rate Limiting
+
+| Plan | Requests/minute |
+|---|---|
+| Core | 60 |
+| Pro | 120 |
+| Teams | 240 |
+| Enterprise | 1,000 |
+
+Returns HTTP 429 when exceeded. Pagination uses `pg[offset]` query parameter.
+
+## Methods
+
+### `list_scenarios`
+
+**Endpoint:** `GET /scenarios`
+
+List all scenarios for a team.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `teamId` | `int` | **required** (query param) |
+| `pg[offset]` | `int` | `0` |
+
+**Returns:** JSON with `scenarios` array
+
+```python
+params = {"teamId": 12345}
+response = await client.get(f"{BASE_URL}/scenarios", params=params)
+response.raise_for_status()
+data = response.json()
+scenarios = data.get("scenarios", [])
+```
+
+### `run_scenario`
+
+**Endpoint:** `POST /scenarios/{scenarioId}/run`
+
+Trigger a scenario to run immediately. Scenario must be active.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `scenarioId` | `int` | **required** (path param) |
+
+**Returns:** JSON with execution details
+
+```python
+scenario_id = 12345
+response = await client.post(f"{BASE_URL}/scenarios/{scenario_id}/run")
+response.raise_for_status()
+data = response.json()
+```
+
+### `start_scenario`
+
+**Endpoint:** `POST /scenarios/{scenarioId}/start`
+
+Activate a scenario (enables scheduling and triggers).
+
+```python
+response = await client.post(f"{BASE_URL}/scenarios/{scenario_id}/start")
+response.raise_for_status()
+```
+
+### `stop_scenario`
+
+**Endpoint:** `POST /scenarios/{scenarioId}/stop`
+
+Deactivate a scenario.
+
+```python
+response = await client.post(f"{BASE_URL}/scenarios/{scenario_id}/stop")
+response.raise_for_status()
+```
+
+### `get_scenario`
+
+**Endpoint:** `GET /scenarios/{scenarioId}`
+
+Get scenario details including blueprint, scheduling, and status.
+
+```python
+response = await client.get(f"{BASE_URL}/scenarios/{scenario_id}")
+response.raise_for_status()
+scenario = response.json().get("scenario", {})
+```
+
+### `create_hook`
+
+**Endpoint:** `POST /hooks`
+
+Create a webhook that can receive external data and trigger scenarios.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `name` | `str` | **required** |
+| `teamId` | `int` | **required** |
+| `typeName` | `str` | **required** (e.g., `"web"`) |
+
+**Returns:** JSON with hook details including webhook URL
+
+```python
+payload = {
+    "name": "My Webhook",
+    "teamId": 12345,
+    "typeName": "web"
+}
+response = await client.post(f"{BASE_URL}/hooks", json=payload)
+response.raise_for_status()
+hook = response.json().get("hook", {})
+webhook_url = hook.get("url")
+```
+
+### `list_hooks`
+
+**Endpoint:** `GET /hooks`
+
+List all webhooks for a team.
+
+```python
+params = {"teamId": 12345}
+response = await client.get(f"{BASE_URL}/hooks", params=params)
+response.raise_for_status()
+hooks = response.json().get("hooks", [])
+```
+
+### `list_data_store_records`
+
+**Endpoint:** `GET /data-stores/{dataStoreId}/data`
+
+List all records in a data store.
+
+```python
+data_store_id = 67890
+response = await client.get(f"{BASE_URL}/data-stores/{data_store_id}/data")
+response.raise_for_status()
+records = response.json().get("records", [])
+```
+
+### `create_data_store_record`
+
+**Endpoint:** `POST /data-stores/{dataStoreId}/data`
+
+Create a record in a data store.
+
+```python
+payload = {"key": "user_123", "data": {"name": "Jane", "score": 95}}
+response = await client.post(
+    f"{BASE_URL}/data-stores/{data_store_id}/data", json=payload
+)
+response.raise_for_status()
+```
+
+### Other Endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| `POST /scenarios` | Create a new scenario |
+| `PATCH /scenarios/{id}` | Update scenario properties |
+| `DELETE /scenarios/{id}` | Delete a scenario |
+| `POST /scenarios/{id}/clone` | Clone a scenario |
+| `GET /scenarios/{id}/blueprint` | Get scenario blueprint |
+| `GET /connections` | List connections |
+| `POST /connections/{id}/test` | Test a connection |
+| `GET /dlqs` | List incomplete executions |
+| `POST /dlqs/{id}/retry` | Retry failed execution |
+
+## Error Handling
+
+```python
+import httpx
+
+try:
+    response = await client.post(f"{BASE_URL}/scenarios/{scenario_id}/run")
+    response.raise_for_status()
+    data = response.json()
+except httpx.HTTPStatusError as e:
+    if e.response.status_code == 401:
+        print("Authentication failed -- check your API token")
+    elif e.response.status_code == 429:
+        print("Rate limited -- back off and retry")
+    elif e.response.status_code == 403:
+        print("Forbidden -- check token permissions/scopes")
+    else:
+        print(f"Make API error {e.response.status_code}: {e.response.text}")
+except httpx.RequestError as e:
+    print(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+- Auth header is `Token` (not `Bearer`) -- format: `Authorization: Token {uuid}`
+- Base URL is zone-specific -- use the zone matching your account (`eu1`, `eu2`, `us1`, `us2`)
+- Scenarios must be activated (`/start`) before they can be run (`/run`)
+- Pagination uses `pg[offset]` query parameter (not `page` or `cursor`)
+- Data store records use a `key` field as the primary identifier
+- Rate limits vary significantly by plan (60-1000 RPM)
+- Always call `response.raise_for_status()` to catch HTTP errors
+- Set a reasonable timeout: `httpx.AsyncClient(timeout=30.0)`

--- a/content/mappls/docs/rest-api/python/DOC.md
+++ b/content/mappls/docs/rest-api/python/DOC.md
@@ -1,0 +1,440 @@
+---
+name: rest-api
+description: "Mappls (MapMyIndia) - Indian Maps, Geocoding & Navigation REST API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "mappls,mapmyindia,maps,geocoding,directions,india,navigation,api"
+---
+
+# Mappls (MapMyIndia) REST API - Python Reference
+
+Mappls is India's leading mapping and location platform, offering geocoding, routing, search, and navigation APIs with coverage across India and 238 countries. It serves as a regional alternative to Google Maps with deep address-level coverage in India.
+
+## Golden Rule
+
+Always obtain an OAuth 2.0 access token before making API calls. The token endpoint uses `client_credentials` grant type and returns a bearer token valid for 24 hours. Search/places APIs use `search.mappls.com`, routing/distance APIs use `route.mappls.com`, and tile/static map APIs use `tile.mappls.com`. Coordinates are `latitude,longitude` for search APIs but `longitude,latitude` for routing APIs. The `eLoc` is Mappls' proprietary 6-character place identifier and can be used interchangeably with coordinates in many endpoints.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URLs
+
+| Service | Base URL |
+|---------|----------|
+| Token/Auth | `https://outpost.mappls.com/api/security/oauth/token` |
+| Search/Geocoding/Places | `https://search.mappls.com/search/` |
+| Routing/Directions | `https://route.mappls.com/route/` |
+| Static Map Tiles | `https://tile.mappls.com/map/raster_tile/` |
+| Atlas (Legacy/Alternate) | `https://atlas.mappls.com/api/` |
+
+## Authentication
+
+Mappls uses OAuth 2.0 client credentials flow. Obtain `client_id` and `client_secret` from the Mappls Console at `https://apis.mappls.com/console/`.
+
+Some endpoints also accept a static `access_token` query parameter (API key from the console) without requiring the OAuth flow. The OAuth bearer token approach is recommended for production use.
+
+```python
+import httpx
+
+TOKEN_URL = "https://outpost.mappls.com/api/security/oauth/token"
+
+async def get_access_token(client_id: str, client_secret: str) -> dict:
+    """Obtain OAuth 2.0 bearer token. Valid for 24 hours by default."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            TOKEN_URL,
+            data={
+                "grant_type": "client_credentials",
+                "client_id": client_id,
+                "client_secret": client_secret,
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        # Returns: access_token, token_type ("bearer"), expires_in
+        return data
+
+def auth_headers(token_type: str, access_token: str) -> dict:
+    """Build Authorization header from token response."""
+    return {"Authorization": f"{token_type} {access_token}"}
+```
+
+For endpoints that accept the static API key approach (query parameter):
+
+```python
+# Static key auth - pass as query parameter
+params = {"access_token": "YOUR_STATIC_API_KEY", ...}
+```
+
+## Rate Limiting
+
+Rate limits depend on your plan tier. When rate-limited, the API returns HTTP 403. Implement exponential backoff. Free-tier accounts have lower limits; check your console for specifics. Each static map request counts as one transaction.
+
+## Methods
+
+### Forward Geocoding
+
+Convert a text address to geographic coordinates.
+
+**Endpoint:** `GET https://search.mappls.com/search/address/geocode`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `address` | string | Yes | Address to geocode, e.g. "237 Okhla Industrial Estate Phase 3 New Delhi" |
+| `access_token` | string | Yes | API key or OAuth token |
+| `itemCount` | int | No | Max results (default: 1) |
+| `bias` | int | No | 0 = default, -1 = rural, 1 = urban |
+| `podFilter` | string | No | Restrict to admin level: hno, poi, street, village, city, dist, pincode, state |
+| `bound` | string | No | Admin boundary eLoc (mutually exclusive with podFilter) |
+| `region` | string | No | Country code; mandatory for non-India queries |
+
+```python
+import httpx
+
+GEOCODE_URL = "https://search.mappls.com/search/address/geocode"
+
+async def forward_geocode(
+    access_token: str,
+    address: str,
+    item_count: int = 1,
+    region: str = "IND",
+) -> dict:
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            GEOCODE_URL,
+            params={
+                "access_token": access_token,
+                "address": address,
+                "itemCount": item_count,
+                "region": region,
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+        # Response includes: copResults.houseNumber, .locality, .city,
+        # .state, .pincode, .formattedAddress, .eLoc,
+        # .geocodeLevel, .confidenceScore, lat/lng
+```
+
+### Reverse Geocoding
+
+Convert latitude/longitude to a human-readable address.
+
+**Endpoint:** `GET https://search.mappls.com/search/address/rev-geocode`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `lat` | float | Yes | Latitude |
+| `lng` | float | Yes | Longitude |
+| `access_token` | string | Yes | API key |
+| `region` | string | No | Country code (default: IND) |
+| `lang` | string | No | Language code, e.g. "hi" for Hindi |
+
+```python
+REV_GEOCODE_URL = "https://search.mappls.com/search/address/rev-geocode"
+
+async def reverse_geocode(
+    access_token: str,
+    lat: float,
+    lng: float,
+    region: str = "IND",
+) -> dict:
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            REV_GEOCODE_URL,
+            params={
+                "access_token": access_token,
+                "lat": lat,
+                "lng": lng,
+                "region": region,
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+        # Response: results[].houseNumber, .houseName, .poi, .poi_dist,
+        # .street, .village, .district, .subDistrict, .city, .state,
+        # .pincode, .lat, .lng, .formatted_address
+```
+
+### Autosuggest (Autocomplete)
+
+Type-ahead search returning location suggestions as the user types.
+
+**Endpoint:** `GET https://search.mappls.com/search/places/autosuggest/json`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query` | string | Yes | Search term (POI name, address, keyword) |
+| `access_token` | string | Yes | API key |
+| `location` | string | No | Bias center as "lat,lng" |
+| `zoom` | float | No | Map zoom level 4-18 (India only) |
+| `region` | string | No | Country code (default: IND) |
+| `tokenizeAddress` | valueless | No | Include structured address fields |
+| `pod` | string | No | Place type filter: SLC, LC, CITY, VLG, SDIST, DIST, STATE |
+| `filter` | string | No | Bounds/PIN/eLoc filter |
+| `bridge` | valueless | No | Enable nearby API suggestions |
+| `hyperLocal` | valueless | No | Strong location bias (requires location param) |
+
+```python
+AUTOSUGGEST_URL = "https://search.mappls.com/search/places/autosuggest/json"
+
+async def autosuggest(
+    access_token: str,
+    query: str,
+    location: str | None = None,
+    region: str = "IND",
+) -> dict:
+    params = {
+        "access_token": access_token,
+        "query": query,
+        "region": region,
+    }
+    if location:
+        params["location"] = location  # "28.631460,77.217423"
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(AUTOSUGGEST_URL, params=params)
+        resp.raise_for_status()
+        return resp.json()
+        # Response: suggestedLocations[].type, .placeName, .placeAddress,
+        # .eLoc, .keywords[], .orderIndex, .distance
+        # Also: suggestedSearches[], userAddedLocations[]
+```
+
+### Nearby Search (POI)
+
+Search for places near a reference location by category or keyword.
+
+**Endpoint:** `GET https://search.mappls.com/search/places/nearby/json`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `keywords` | string | Yes | Category name or code (e.g. "coffee", "FODCOF") |
+| `refLocation` | string | Yes | Center point as "lat,lng" or eLoc code |
+| `access_token` | string | Yes | API key |
+| `page` | int | No | Result page number |
+| `region` | string | No | Country code (IND, LKA, BTN, BGD, NPL) |
+| `radius` | int | No | Search radius in meters (500-10000, default: 1000) |
+| `bounds` | string | No | Rectangular bounds "x1,y1;x2,y2" |
+| `filter` | string | No | Key-value filter, e.g. "categoryCode:FODCOF" |
+| `sortBy` | string | No | Sort: "dist:asc", "dist:desc", or "imp" |
+| `pod` | string | No | Place type: SLC, LC, CITY, STATE |
+
+```python
+NEARBY_URL = "https://search.mappls.com/search/places/nearby/json"
+
+async def nearby_search(
+    access_token: str,
+    keywords: str,
+    ref_location: str,
+    radius: int = 1000,
+    sort_by: str = "dist:asc",
+    page: int = 1,
+) -> dict:
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            NEARBY_URL,
+            params={
+                "access_token": access_token,
+                "keywords": keywords,
+                "refLocation": ref_location,  # "28.631460,77.217423" or "MMI000"
+                "radius": radius,
+                "sortBy": sort_by,
+                "page": page,
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+        # Response: suggestedLocations[].distance, .eLoc, .placeName,
+        # .placeAddress, .type, .keywords[], .orderIndex
+        # Also: pageInfo.pageCount, .totalHits, .totalPages, .pageSize
+```
+
+### Directions / Routing
+
+Calculate driving, biking, walking, or trucking routes between waypoints.
+
+**Endpoint:** `GET https://route.mappls.com/route/direction/{resource}/{profile}/{coordinates}`
+
+**URL path segments:**
+
+| Segment | Values | Description |
+|---------|--------|-------------|
+| `resource` | `route_adv`, `route_eta`, `route_traffic` | route_adv = no traffic; route_eta = live traffic durations (India); route_traffic = live traffic routing (India) |
+| `profile` | `driving`, `biking`, `walking`, `trucking` | Transport mode |
+| `coordinates` | `lng1,lat1;lng2,lat2` | Semicolon-separated waypoints; can mix coords and eLoc codes |
+
+**Query parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `access_token` | string | Yes | API key |
+| `geometries` | string | No | "polyline" (default), "polyline6", "geojson" |
+| `steps` | bool | No | Include turn-by-turn steps (default: false) |
+| `exclude` | string | No | Avoid road types: "toll", "motorway", "ferry" (period-separated) |
+| `rtype` | int | No | 0 = optimal (default), 1 = shortest |
+| `region` | string | No | Country code (mandatory outside India) |
+| `alternatives` | int | No | Number of alternative routes |
+| `overview` | string | No | "simplified" (default), "full", "false" |
+
+**IMPORTANT:** Routing coordinates are `longitude,latitude` (not lat,lng like search APIs).
+
+```python
+DIRECTIONS_URL = "https://route.mappls.com/route/direction"
+
+async def get_directions(
+    access_token: str,
+    start: tuple[float, float],  # (lng, lat)
+    end: tuple[float, float],    # (lng, lat)
+    profile: str = "driving",
+    resource: str = "route_adv",
+    steps: bool = False,
+    alternatives: int = 0,
+    rtype: int = 0,
+    exclude: str | None = None,
+    region: str = "ind",
+) -> dict:
+    coords = f"{start[0]},{start[1]};{end[0]},{end[1]}"
+    url = f"{DIRECTIONS_URL}/{resource}/{profile}/{coords}"
+    params = {
+        "access_token": access_token,
+        "steps": str(steps).lower(),
+        "rtype": rtype,
+        "region": region,
+    }
+    if alternatives:
+        params["alternatives"] = alternatives
+    if exclude:
+        params["exclude"] = exclude  # "toll.motorway"
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(url, params=params)
+        resp.raise_for_status()
+        return resp.json()
+        # Response: code ("Ok"), routes[].distance (meters),
+        # .duration (seconds), .geometry (encoded polyline),
+        # .legs[].steps[], waypoints[].name, .location
+```
+
+### Distance Matrix
+
+Compute distance and duration between multiple origins and destinations.
+
+**Endpoint:** `GET https://route.mappls.com/route/dm/{resource}/{profile}/{coordinates}`
+
+**URL path segments:**
+
+| Segment | Values | Description |
+|---------|--------|-------------|
+| `resource` | `distance_matrix`, `distance_matrix_eta`, `distance_matrix_traffic` | Standard, with ETA, or with traffic (ETA/traffic India only) |
+| `profile` | `driving`, `biking`, `trucking` | Transport mode |
+| `coordinates` | `lng1,lat1;lng2,lat2;...` | All points semicolon-separated (max 100 total) |
+
+**Query parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `access_token` | string | Yes | API key |
+| `sources` | string | No | Index numbers of source points, e.g. "0;1" |
+| `destinations` | string | No | Index numbers of destination points, e.g. "2;3" |
+| `rtype` | int | No | 0 = optimal (default), 1 = shortest |
+| `region` | string | No | Country code (mandatory outside India) |
+
+**IMPORTANT:** Coordinates are `longitude,latitude` (same as routing).
+
+```python
+DM_URL = "https://route.mappls.com/route/dm"
+
+async def distance_matrix(
+    access_token: str,
+    coordinates: list[tuple[float, float]],  # [(lng, lat), ...]
+    profile: str = "driving",
+    resource: str = "distance_matrix",
+    sources: list[int] | None = None,
+    destinations: list[int] | None = None,
+    rtype: int = 0,
+    region: str = "ind",
+) -> dict:
+    coords_str = ";".join(f"{lng},{lat}" for lng, lat in coordinates)
+    url = f"{DM_URL}/{resource}/{profile}/{coords_str}"
+    params = {
+        "access_token": access_token,
+        "rtype": rtype,
+        "region": region,
+    }
+    if sources is not None:
+        params["sources"] = ";".join(str(s) for s in sources)
+    if destinations is not None:
+        params["destinations"] = ";".join(str(d) for d in destinations)
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(url, params=params)
+        resp.raise_for_status()
+        return resp.json()
+        # Response: responseCode, results.code ("Ok"),
+        # results.distances[][] (meters), results.durations[][] (seconds)
+```
+
+Additional endpoints: Text Search (`GET .../textsearch/json`), Static Map Image (`GET https://tile.mappls.com/map/raster_tile/still_image` -- returns PNG bytes, not JSON). Both follow the same `access_token` query parameter pattern.
+
+## Error Handling
+
+All JSON endpoints return standard HTTP status codes:
+
+| Code | Meaning |
+|------|---------|
+| 200 | Success |
+| 204 | Success but no results found |
+| 400 | Bad request (invalid parameters) |
+| 401 | Unauthorized (invalid or expired token/key) |
+| 403 | Forbidden (rate limit exceeded or IP/domain not whitelisted) |
+| 412 | Precondition failed (missing mandatory parameter) |
+| 500 | Internal server error |
+| 503 | Service unavailable |
+
+```python
+import httpx
+
+class MapplsAPIError(Exception):
+    def __init__(self, status_code: int, detail: str):
+        self.status_code = status_code
+        self.detail = detail
+        super().__init__(f"Mappls API error {status_code}: {detail}")
+
+async def handle_response(resp: httpx.Response) -> dict:
+    if resp.status_code == 204:
+        return {"results": []}
+    if resp.status_code == 401:
+        raise MapplsAPIError(401, "Invalid or expired access token. Re-authenticate.")
+    if resp.status_code == 403:
+        raise MapplsAPIError(403, "Rate limit exceeded or IP/domain not whitelisted.")
+    resp.raise_for_status()
+    return resp.json()
+```
+
+## Common Pitfalls
+
+1. **Coordinate order varies by endpoint.** Search/geocoding APIs use `latitude,longitude` while routing/distance APIs use `longitude,latitude`. Mixing them up produces results in the wrong location or errors.
+
+2. **Token expiry.** OAuth tokens expire after 24 hours. Cache and refresh proactively. Static API keys do not expire but have IP/domain whitelisting restrictions.
+
+3. **Region parameter.** For queries outside India, the `region` parameter is mandatory. Omitting it defaults to `IND` and returns no results for international queries.
+
+4. **eLoc codes.** Mappls uses proprietary 6-character eLoc identifiers (e.g. "MMI000") as place IDs. These can be used in place of coordinates in many endpoints. They are not interchangeable with Google Place IDs or OSM IDs.
+
+5. **Routing exclude syntax.** Multiple road exclusions are separated by periods (not commas): `exclude=toll.motorway.ferry`.
+
+6. **Search vs Atlas base URLs.** The current production search endpoints use `search.mappls.com`. Some older documentation references `atlas.mappls.com/api/places/` which also works but may point to legacy endpoints. Use the `search.mappls.com` URLs documented above.
+
+7. **Static map coordinates.** The static map API uses `lat,lng` format (matching search APIs), not `lng,lat` like routing.
+
+8. **Distance matrix limit.** Maximum 100 total points (sources + destinations combined) per request.
+
+9. **Live traffic endpoints.** The `route_eta`, `route_traffic`, `distance_matrix_eta`, and `distance_matrix_traffic` resources only work for India (`region=ind`). Using them for other regions returns errors.
+
+10. **OAuth Content-Type.** The token endpoint requires `application/x-www-form-urlencoded` content type. Sending JSON will fail silently or return an error.

--- a/content/mercadopago/docs/rest-api/python/DOC.md
+++ b/content/mercadopago/docs/rest-api/python/DOC.md
@@ -1,0 +1,315 @@
+---
+name: rest-api
+description: "MercadoPago - Latin America Payment Platform REST API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "mercadopago,payments,latam,brazil,argentina,mexico,checkout,api"
+---
+
+# MercadoPago REST API — Python (httpx)
+
+## Golden Rule
+
+Always include the `X-Idempotency-Key` header on POST requests — MercadoPago will reject duplicate keys with HTTP 422. Amounts use **major currency units** with up to 2 decimal places (e.g., 100.50 = BRL 100.50). Every payment request must include a unique `external_reference` for reconciliation. Access tokens are per-country — a Brazilian token cannot process Argentine payments.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+```
+https://api.mercadopago.com
+```
+
+All endpoints are versioned in the path (e.g., `/v1/payments`).
+
+## Authentication
+
+MercadoPago uses an **Access Token** (OAuth 2.0 Bearer) passed in the `Authorization` header.
+
+```python
+import httpx
+import os
+import uuid
+
+ACCESS_TOKEN = os.environ["MERCADOPAGO_ACCESS_TOKEN"]
+
+headers = {
+    "Authorization": f"Bearer {ACCESS_TOKEN}",
+    "Content-Type": "application/json",
+}
+
+async def get_client() -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        base_url="https://api.mercadopago.com",
+        headers=headers,
+        timeout=30.0,
+    )
+
+def idempotency_key() -> str:
+    return str(uuid.uuid4())
+```
+
+**Token types:**
+- `APP_USR-...` — Production access token
+- `TEST-...` — Test/sandbox access token
+
+Tokens are obtained from the MercadoPago dashboard or via OAuth flow for marketplace integrations.
+
+### OAuth Token Exchange (Marketplace)
+
+```python
+async def exchange_oauth_code(client: httpx.AsyncClient, auth_code: str,
+                               client_id: str, client_secret: str,
+                               redirect_uri: str):
+    payload = {
+        "grant_type": "authorization_code",
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "code": auth_code,
+        "redirect_uri": redirect_uri,
+    }
+    resp = await client.post("/oauth/token", json=payload)
+    resp.raise_for_status()
+    return resp.json()  # {"access_token": "...", "refresh_token": "...", "expires_in": ...}
+```
+
+## Rate Limiting
+
+MercadoPago does not publish exact rate limits but returns HTTP **429** when exceeded. General guidance:
+- Avoid bursts above ~50 requests/second.
+- Use idempotency keys to safely retry without creating duplicates.
+- Implement exponential backoff on 429 responses.
+
+```python
+import asyncio
+
+async def request_with_retry(client: httpx.AsyncClient, method: str, url: str, **kwargs):
+    for attempt in range(5):
+        resp = await client.request(method, url, **kwargs)
+        if resp.status_code == 429:
+            wait = 2 ** attempt
+            await asyncio.sleep(wait)
+            continue
+        resp.raise_for_status()
+        return resp.json()
+    raise Exception("Rate limit exceeded after retries")
+```
+
+## Methods
+
+### Create Payment
+
+Process a card payment (requires a card token from the frontend SDK).
+
+```python
+async def create_payment(client: httpx.AsyncClient, amount: float,
+                          token: str, description: str, email: str,
+                          payment_method_id: str, installments: int = 1,
+                          external_reference: str | None = None):
+    payload = {
+        "transaction_amount": amount,
+        "token": token,
+        "description": description,
+        "payment_method_id": payment_method_id,
+        "installments": installments,
+        "payer": {"email": email},
+    }
+    if external_reference:
+        payload["external_reference"] = external_reference
+
+    resp = await client.post(
+        "/v1/payments",
+        json=payload,
+        headers={"X-Idempotency-Key": idempotency_key()},
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Get Payment
+
+```python
+async def get_payment(client: httpx.AsyncClient, payment_id: int):
+    resp = await client.get(f"/v1/payments/{payment_id}")
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Search Payments
+
+```python
+async def search_payments(client: httpx.AsyncClient, external_reference: str | None = None,
+                           status: str | None = None, offset: int = 0, limit: int = 30):
+    params = {"offset": offset, "limit": limit}
+    if external_reference:
+        params["external_reference"] = external_reference
+    if status:
+        params["status"] = status  # "approved", "pending", "rejected"
+    resp = await client.get("/v1/payments/search", params=params)
+    resp.raise_for_status()
+    return resp.json()["results"]
+```
+
+### Create Checkout Preference
+
+Generate a hosted checkout (Checkout Pro) link.
+
+```python
+async def create_preference(client: httpx.AsyncClient, title: str,
+                              unit_price: float, quantity: int = 1,
+                              currency_id: str = "BRL",
+                              back_urls: dict | None = None,
+                              external_reference: str | None = None):
+    payload = {
+        "items": [
+            {
+                "title": title,
+                "unit_price": unit_price,
+                "quantity": quantity,
+                "currency_id": currency_id,
+            }
+        ],
+    }
+    if back_urls:
+        payload["back_urls"] = back_urls  # {"success": "...", "failure": "...", "pending": "..."}
+    if external_reference:
+        payload["external_reference"] = external_reference
+
+    resp = await client.post(
+        "/checkout/preferences",
+        json=payload,
+        headers={"X-Idempotency-Key": idempotency_key()},
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    return data  # data["init_point"] = checkout URL, data["sandbox_init_point"] for testing
+```
+
+### Refund Payment
+
+```python
+async def refund_payment(client: httpx.AsyncClient, payment_id: int,
+                          amount: float | None = None):
+    """Full refund if amount is None, partial refund otherwise."""
+    payload = {}
+    if amount is not None:
+        payload["amount"] = amount
+
+    resp = await client.post(
+        f"/v1/payments/{payment_id}/refunds",
+        json=payload,
+        headers={"X-Idempotency-Key": idempotency_key()},
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Create Customer
+
+```python
+async def create_customer(client: httpx.AsyncClient, email: str,
+                           first_name: str = "", last_name: str = ""):
+    payload = {"email": email, "first_name": first_name, "last_name": last_name}
+    resp = await client.post("/v1/customers", json=payload,
+                              headers={"X-Idempotency-Key": idempotency_key()})
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Create Order (newer API)
+
+```python
+async def create_order(client: httpx.AsyncClient, amount: float,
+                        currency: str, description: str,
+                        external_reference: str):
+    payload = {
+        "total_amount": amount,
+        "currency_id": currency,
+        "description": description,
+        "external_reference": external_reference,
+    }
+    resp = await client.post(
+        "/v1/orders",
+        json=payload,
+        headers={"X-Idempotency-Key": idempotency_key()},
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Refund Order (Full)
+
+```python
+async def refund_order(client: httpx.AsyncClient, order_id: str):
+    resp = await client.post(
+        f"/v1/orders/{order_id}/refund",
+        headers={"X-Idempotency-Key": idempotency_key()},
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+## Error Handling
+
+MercadoPago returns structured error responses:
+
+```json
+{
+  "message": "Invalid card number",
+  "error": "bad_request",
+  "status": 400,
+  "cause": [
+    {"code": "325", "description": "Invalid card number"}
+  ]
+}
+```
+
+HTTP status codes:
+- **200/201** — Success
+- **400** — Bad request / validation error
+- **401** — Invalid or expired access token
+- **403** — Forbidden (wrong country token, insufficient permissions)
+- **404** — Resource not found
+- **422** — Idempotency key already used (code 422001), or unprocessable entity
+- **429** — Rate limited
+- **5xx** — MercadoPago server error
+
+```python
+class MercadoPagoError(Exception):
+    def __init__(self, status_code: int, message: str, causes: list | None = None):
+        self.status_code = status_code
+        self.message = message
+        self.causes = causes or []
+        super().__init__(f"[{status_code}] {message}")
+
+async def safe_request(client: httpx.AsyncClient, method: str, url: str, **kwargs):
+    resp = await client.request(method, url, **kwargs)
+    if resp.status_code >= 400:
+        body = resp.json()
+        raise MercadoPagoError(
+            resp.status_code,
+            body.get("message", "Unknown error"),
+            body.get("cause", []),
+        )
+    return resp.json()
+```
+
+## Common Pitfalls
+
+1. **Missing X-Idempotency-Key** — POST requests without this header risk creating duplicates on retries. Always generate a UUID per unique operation.
+2. **Country-specific access tokens** — A Brazilian access token cannot process payments in Argentina. Each country integration needs its own credentials.
+3. **Installments (parcelas)** — In Brazil and Argentina, installment payments are standard. Omitting `installments` defaults to 1. The `payment_method_id` must support installments.
+4. **Currency precision** — Use 2 decimal places max. Amounts like `10.999` cause 400 errors.
+5. **Payment status flow** — Payments can be `approved`, `pending`, `in_process`, `rejected`, or `refunded`. Webhook notifications (`payment.created`, `payment.updated`) are essential for async methods like Boleto or Pix.
+6. **Pix payments** — For Pix (Brazil), create a payment with `payment_method_id: "pix"` and no card token. The response includes a `point_of_interaction.transaction_data.qr_code` for display.
+7. **Sandbox vs. production URLs** — Both use the same base URL (`api.mercadopago.com`). The token type determines the environment.
+8. **Webhook verification** — Validate webhooks by fetching the payment/order by ID from the API rather than trusting the webhook payload directly.
+9. **Preference expiration** — Checkout Pro preferences expire after 30 days by default. Set `expires` and `expiration_date_to` for shorter windows.

--- a/content/mercury/docs/rest-api/python/DOC.md
+++ b/content/mercury/docs/rest-api/python/DOC.md
@@ -1,0 +1,335 @@
+---
+name: rest-api
+description: "Mercury Banking REST API Python coding guidelines using httpx async"
+metadata:
+  languages: "python"
+  versions: "3.12.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "mercury,banking,startup,fintech,usa,api"
+---
+
+# Mercury REST API Python Coding Guidelines
+
+You are a Mercury Banking API coding expert. Help me with writing code that calls the Mercury REST API using httpx async in Python.
+
+Official documentation: https://docs.mercury.com/
+
+## Golden Rule: Use httpx Async for All REST Calls
+
+Always use `httpx.AsyncClient` for all Mercury REST API interactions. Do not use `requests` or synchronous HTTP libraries. All code must be async-first using `httpx`.
+
+- **HTTP Library:** httpx (async)
+- **Correct:** `async with httpx.AsyncClient() as client:`
+- **Incorrect:** Using `requests` or synchronous httpx
+
+## Installation
+
+```bash
+pip install httpx python-dotenv
+```
+
+**Environment Variables:**
+
+```bash
+export MERCURY_API_TOKEN='your_api_token_here'
+```
+
+Or create a `.env` file:
+
+```bash
+MERCURY_API_TOKEN=your_api_token_here
+```
+
+Load in Python:
+
+```python
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+api_token = os.getenv("MERCURY_API_TOKEN")
+```
+
+**Generating a token:** Log into Mercury dashboard, navigate to Settings, and generate an API token. Tokens are only shown once at creation time. Store securely.
+
+## Base URL
+
+```
+https://api.mercury.com/api/v1
+```
+
+A v2 beta also exists but v1 is the stable version.
+
+## Authentication
+
+Mercury supports two authentication methods:
+
+1. **Bearer Token (recommended):** `Authorization: Bearer {token}`
+2. **HTTP Basic Auth:** Username = API token, Password = empty string
+
+```python
+import httpx
+
+BASE_URL = "https://api.mercury.com/api/v1"
+
+HEADERS = {
+    "Authorization": f"Bearer {api_token}",
+    "Content-Type": "application/json",
+}
+
+async def get_accounts():
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get("/accounts")
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Token Permission Tiers
+
+| Tier              | Capabilities                                    | IP Whitelist Required |
+|-------------------|------------------------------------------------|-----------------------|
+| **Read Only**     | Fetch accounts, transactions, recipients        | No                    |
+| **Read and Write**| All reads + initiate payments, manage recipients | Yes                   |
+| **Custom**        | Scoped to specific operations (e.g. `RequestSendMoney`) | Depends on scope |
+
+## Rate Limiting
+
+Mercury does not publicly document specific rate limits. However:
+
+- Tokens expire after prolonged inactivity (making any API call resets the timer)
+- Implement reasonable backoff on 429 responses
+- Avoid polling more frequently than once per minute for transaction updates
+
+```python
+import asyncio
+import httpx
+
+async def request_with_retry(client: httpx.AsyncClient, method: str, url: str, **kwargs):
+    for attempt in range(5):
+        resp = await client.request(method, url, **kwargs)
+        if resp.status_code == 429:
+            wait = 2 ** attempt
+            await asyncio.sleep(wait)
+            continue
+        resp.raise_for_status()
+        return resp.json()
+    raise Exception("Rate limit exceeded after retries")
+```
+
+## Methods
+
+### Accounts
+
+```python
+async def list_accounts():
+    """GET /accounts - List all accounts in the organization."""
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get("/accounts")
+        resp.raise_for_status()
+        return resp.json()
+
+async def get_account(account_id: str):
+    """GET /account/{id} - Get a specific account (balance, routing number, etc.)."""
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get(f"/account/{account_id}")
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Transactions
+
+```python
+async def list_all_transactions(limit: int = 50, offset: int = 0, status: str | None = None, search: str | None = None):
+    """GET /transactions - List all transactions across all accounts.
+
+    Supports filtering, pagination, and search.
+    """
+    params: dict = {"limit": limit, "offset": offset}
+    if status:
+        params["status"] = status  # "pending", "sent", "cancelled", "failed"
+    if search:
+        params["search"] = search
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get("/transactions", params=params)
+        resp.raise_for_status()
+        return resp.json()
+
+async def list_account_transactions(account_id: str, limit: int = 50, offset: int = 0):
+    """GET /account/{id}/transactions - List transactions for a specific account."""
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get(f"/account/{account_id}/transactions", params={
+            "limit": limit,
+            "offset": offset,
+        })
+        resp.raise_for_status()
+        return resp.json()
+
+async def get_transaction(transaction_id: str):
+    """GET /transactions/{id} - Get a single transaction by ID."""
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get(f"/transactions/{transaction_id}")
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Recipients
+
+```python
+async def list_recipients():
+    """GET /recipients - List all payment recipients."""
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get("/recipients")
+        resp.raise_for_status()
+        return resp.json()
+
+async def create_recipient(name: str, emails: list[str], payment_method: str = "ach"):
+    """POST /recipients - Create a new payment recipient."""
+    payload = {
+        "name": name,
+        "emails": emails,
+        "paymentMethod": payment_method,  # "ach", "domesticWire", "internationalWire", "check"
+    }
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.post("/recipients", json=payload)
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Payments (Send Money)
+
+```python
+async def send_payment(account_id: str, recipient_id: str, amount: float, payment_method: str = "ach", note: str | None = None, idempotency_key: str | None = None):
+    """POST /account/{id}/transactions - Send money to a recipient.
+
+    Requires Read and Write token tier with IP whitelist.
+    Custom tokens need RequestSendMoney scope (payment requires admin approval).
+    """
+    payload = {
+        "recipientId": recipient_id,
+        "amount": amount,
+        "paymentMethod": payment_method,  # "ach", "domesticWire", "internationalWire", "check"
+    }
+    if note:
+        payload["note"] = note
+    if idempotency_key:
+        payload["idempotencyKey"] = idempotency_key
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.post(f"/account/{account_id}/transactions", json=payload)
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Internal Transfers
+
+```python
+async def transfer_between_accounts(from_account_id: str, to_account_id: str, amount: float, note: str | None = None):
+    """POST /transfer - Move money between your own Mercury accounts.
+
+    Requires SendMoney write scope.
+    """
+    payload = {
+        "fromAccountId": from_account_id,
+        "toAccountId": to_account_id,
+        "amount": amount,
+    }
+    if note:
+        payload["note"] = note
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.post("/transfer", json=payload)
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Organization and Users
+
+```python
+async def get_organization():
+    """GET /organization - Get org info (EIN, legal name, DBAs)."""
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get("/organization")
+        resp.raise_for_status()
+        return resp.json()
+
+async def list_users():
+    """GET /users - List users in the organization."""
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get("/users")
+        resp.raise_for_status()
+        return resp.json()
+```
+
+## Error Handling
+
+Mercury returns standard HTTP status codes with JSON error bodies.
+
+| Status | Meaning                                         |
+|--------|------------------------------------------------|
+| 200    | Success                                         |
+| 400    | Bad request / validation error                  |
+| 401    | Unauthorized (invalid or expired token)         |
+| 403    | Forbidden (insufficient token permissions)      |
+| 404    | Resource not found                              |
+| 409    | Conflict (duplicate idempotency key)            |
+| 429    | Rate limit exceeded                             |
+| 500    | Internal server error                           |
+
+```python
+import httpx
+
+async def safe_request(client: httpx.AsyncClient, method: str, url: str, **kwargs):
+    try:
+        resp = await client.request(method, url, **kwargs)
+        resp.raise_for_status()
+        return resp.json()
+    except httpx.HTTPStatusError as e:
+        error_body = {}
+        try:
+            error_body = e.response.json()
+        except Exception:
+            pass
+        msg = error_body.get("errors", error_body.get("message", e.response.text))
+        if e.response.status_code == 401:
+            raise Exception("Unauthorized: check your MERCURY_API_TOKEN or regenerate it")
+        elif e.response.status_code == 403:
+            raise Exception(f"Forbidden: token lacks required permissions. {msg}")
+        elif e.response.status_code == 429:
+            raise Exception(f"Rate limited: {msg}")
+        else:
+            raise Exception(f"Mercury API error {e.response.status_code}: {msg}")
+    except httpx.RequestError as e:
+        raise Exception(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+1. **Token shown only once.** When you create an API token in Mercury's dashboard, it is displayed only at creation time. Store it immediately in a secure location.
+
+2. **Write operations require IP whitelist.** Read and Write tokens require IP whitelisting in the Mercury dashboard. Calls from non-whitelisted IPs get 403.
+
+3. **Token inactivity expiration.** Tokens may be deleted after prolonged inactivity. Making any API call resets the inactivity timer.
+
+4. **ACH payment limits.** Mercury provides 100 free programmatic ACH payments per month. Additional payments may incur fees.
+
+5. **Payments may require approval.** Using a Custom token with `RequestSendMoney` scope creates transactions that require admin approval in the Mercury dashboard before they are processed.
+
+6. **Idempotency keys for payments.** Always include an `idempotencyKey` when creating payments to prevent duplicate transactions on retries.
+
+7. **Account vs accounts endpoint.** List all accounts: `GET /accounts` (plural). Get single account: `GET /account/{id}` (singular). This inconsistency is in Mercury's API design.
+
+8. **Amounts are floats, not cents.** Mercury uses dollar amounts as floats (e.g., `100.50`), not integer cents like Stripe.
+
+9. **Recipient attachments use pre-signed URLs.** Attachment URLs in recipient responses are ephemeral pre-signed URLs that expire. Download them promptly.
+
+10. **Sandbox for testing.** Mercury provides a sandbox environment for testing. Check the docs for sandbox-specific base URLs and test credentials.
+
+## Useful Links
+
+- Official Documentation: https://docs.mercury.com/
+- API Reference: https://docs.mercury.com/reference/getting-started-with-your-api
+- Getting Started: https://docs.mercury.com/docs/getting-started
+- OAuth2 Integration: https://docs.mercury.com/docs/oauth2
+- Mercury Dashboard: https://app.mercury.com/
+- API Features Page: https://mercury.com/api

--- a/content/moengage/docs/rest-api/python/DOC.md
+++ b/content/moengage/docs/rest-api/python/DOC.md
@@ -1,0 +1,419 @@
+---
+name: rest-api
+description: "MoEngage - Customer Engagement & Analytics REST API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "moengage,engagement,analytics,push-notifications,campaigns,segmentation,api"
+---
+
+# MoEngage REST API - Python Guide
+
+## Overview
+
+MoEngage is a customer engagement platform providing APIs for user tracking, push notifications, campaign management, event tracking, and analytics. All APIs are REST-based using JSON over HTTPS.
+
+- **Authentication**: HTTP Basic Auth (Workspace ID as username, API Key as password)
+- **Format**: JSON request/response bodies
+- **Base URL pattern**: `https://api-0X.moengage.com` where `X` is your data center number
+- **Official docs**: https://developers.moengage.com/hc/en-us/categories/4404541620756-API
+
+## Data Centers
+
+MoEngage hosts customers in different data centers. Replace `0X` in all endpoint URLs with your DC number.
+
+| Data Center | API Base URL |
+|-------------|-------------|
+| DC-01 | `https://api-01.moengage.com` |
+| DC-02 | `https://api-02.moengage.com` |
+| DC-03 | `https://api-03.moengage.com` |
+| DC-04 | `https://api-04.moengage.com` |
+| DC-05 | `https://api-05.moengage.com` |
+
+Find your DC number in the MoEngage Dashboard under **Settings > Account > APIs**.
+
+## Authentication
+
+All requests use HTTP Basic Authentication:
+- **Username**: Workspace ID (formerly App ID)
+- **Password**: API Key (from the Data tile)
+
+Both values are found in **Settings > Account > APIs** in the MoEngage Dashboard.
+
+```python
+import base64
+
+WORKSPACE_ID = "YOUR_WORKSPACE_ID"
+API_KEY = "YOUR_API_KEY"
+
+credentials = base64.b64encode(f"{WORKSPACE_ID}:{API_KEY}".encode()).decode()
+auth_header = f"Basic {credentials}"
+```
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Python Client
+
+```python
+import httpx
+import base64
+from typing import Any
+
+
+class MoEngageClient:
+    """Async client for MoEngage REST API."""
+
+    def __init__(
+        self,
+        workspace_id: str,
+        api_key: str,
+        data_center: int = 1,
+    ):
+        self.workspace_id = workspace_id
+        self.data_center = f"{data_center:02d}"
+        self.base_url = f"https://api-{self.data_center}.moengage.com"
+        credentials = base64.b64encode(
+            f"{workspace_id}:{api_key}".encode()
+        ).decode()
+        self.headers = {
+            "Authorization": f"Basic {credentials}",
+            "Content-Type": "application/json",
+            "MOE-APPKEY": workspace_id,
+        }
+
+    async def _request(
+        self,
+        method: str,
+        url: str,
+        json_body: dict | None = None,
+    ) -> dict:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.request(
+                method,
+                url,
+                headers=self.headers,
+                json=json_body,
+            )
+            response.raise_for_status()
+            return response.json()
+
+    # --- Track User ---
+
+    async def track_user(
+        self,
+        customer_id: str,
+        attributes: dict[str, Any],
+        platform: str = "web",
+    ) -> dict:
+        """Create or update a user profile with attributes."""
+        url = f"{self.base_url}/v1/customer/{self.workspace_id}"
+        payload = {
+            "type": "customer",
+            "customer_id": customer_id,
+            "attributes": attributes,
+            "platforms": [{"platform": platform}],
+        }
+        return await self._request("POST", url, payload)
+
+    # --- Create Event ---
+
+    async def create_event(
+        self,
+        customer_id: str,
+        event_name: str,
+        event_attributes: dict[str, Any] | None = None,
+    ) -> dict:
+        """Track a custom event for a user."""
+        url = f"{self.base_url}/v1/event/{self.workspace_id}"
+        payload = {
+            "type": "event",
+            "customer_id": customer_id,
+            "actions": [
+                {
+                    "action": event_name,
+                    "attributes": event_attributes or {},
+                }
+            ],
+        }
+        return await self._request("POST", url, payload)
+
+    # --- Send Transactional Push ---
+
+    async def send_push(
+        self,
+        target_user_id: str,
+        title: str,
+        message: str,
+        payload_data: dict | None = None,
+        platform: str = "android",
+    ) -> dict:
+        """Send a transactional push notification to a single user."""
+        push_url = (
+            f"https://pushapi-{self.data_center}.moengage.com"
+            f"/v2/transaction/sendpush"
+        )
+        payload = {
+            "appId": self.workspace_id,
+            "target_user_id": target_user_id,
+            "title": title,
+            "message": message,
+            "platform": platform,
+        }
+        if payload_data:
+            payload["payload"] = payload_data
+        return await self._request("POST", push_url, payload)
+
+    # --- Inform API (Multi-Channel Notifications) ---
+
+    async def send_inform(
+        self,
+        template_id: str,
+        recipient_id: str,
+        personalization: dict[str, str] | None = None,
+    ) -> dict:
+        """Send a notification via the Inform API (supports push, email, SMS)."""
+        inform_url = (
+            f"https://inform-api-{self.data_center}.moengage.com"
+            f"/v1/send"
+        )
+        payload = {
+            "template_id": template_id,
+            "recipients": [
+                {
+                    "customer_id": recipient_id,
+                    "personalization": personalization or {},
+                }
+            ],
+        }
+        return await self._request("POST", inform_url, payload)
+
+    # --- Campaign Reports ---
+
+    async def get_campaign_report(
+        self,
+        campaign_id: str,
+        start_date: str,
+        end_date: str,
+    ) -> dict:
+        """Get campaign delivery and engagement stats.
+
+        Date format: YYYY-MM-DD
+        """
+        url = (
+            f"{self.base_url}/v2/report/campaign"
+            f"?campaign_id={campaign_id}"
+        )
+        payload = {
+            "start_date": start_date,
+            "end_date": end_date,
+        }
+        return await self._request("POST", url, payload)
+```
+
+## Usage Examples
+
+### Track a User
+
+```python
+import asyncio
+
+
+async def main():
+    moe = MoEngageClient(
+        workspace_id="YOUR_WORKSPACE_ID",
+        api_key="YOUR_API_KEY",
+        data_center=1,
+    )
+
+    result = await moe.track_user(
+        customer_id="user_12345",
+        attributes={
+            "name": "Priya Sharma",
+            "email": "priya@example.com",
+            "phone": "+919876543210",
+            "city": "Mumbai",
+            "signup_date": "2026-03-17",
+            "plan": "premium",
+        },
+    )
+    print(f"Track user response: {result}")
+
+
+asyncio.run(main())
+```
+
+### Track Custom Events
+
+```python
+async def track_purchase():
+    moe = MoEngageClient(
+        workspace_id="YOUR_WORKSPACE_ID",
+        api_key="YOUR_API_KEY",
+        data_center=1,
+    )
+
+    result = await moe.create_event(
+        customer_id="user_12345",
+        event_name="purchase_completed",
+        event_attributes={
+            "product_name": "Premium Plan",
+            "amount": 999.00,
+            "currency": "INR",
+            "payment_method": "UPI",
+            "order_id": "ORD-2026-001",
+        },
+    )
+    print(f"Event tracked: {result}")
+
+
+asyncio.run(track_purchase())
+```
+
+### Send a Push Notification
+
+```python
+async def send_notification():
+    moe = MoEngageClient(
+        workspace_id="YOUR_WORKSPACE_ID",
+        api_key="YOUR_API_KEY",
+        data_center=1,
+    )
+
+    result = await moe.send_push(
+        target_user_id="user_12345",
+        title="Order Shipped!",
+        message="Your order ORD-2026-001 has been dispatched.",
+        payload_data={"order_id": "ORD-2026-001", "deep_link": "/orders"},
+        platform="android",
+    )
+    print(f"Push sent: {result}")
+
+
+asyncio.run(send_notification())
+```
+
+### Send Multi-Channel Notification via Inform API
+
+```python
+async def send_inform_notification():
+    moe = MoEngageClient(
+        workspace_id="YOUR_WORKSPACE_ID",
+        api_key="YOUR_API_KEY",
+        data_center=1,
+    )
+
+    result = await moe.send_inform(
+        template_id="your_template_id",
+        recipient_id="user_12345",
+        personalization={
+            "name": "Priya",
+            "order_id": "ORD-2026-001",
+        },
+    )
+    print(f"Inform sent: {result}")
+
+
+asyncio.run(send_inform_notification())
+```
+
+### Batch User Tracking
+
+```python
+async def track_users_batch(users: list[dict]):
+    """Track multiple users concurrently."""
+    moe = MoEngageClient(
+        workspace_id="YOUR_WORKSPACE_ID",
+        api_key="YOUR_API_KEY",
+        data_center=1,
+    )
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        tasks = []
+        for user in users:
+            tasks.append(
+                moe.track_user(
+                    customer_id=user["id"],
+                    attributes=user["attributes"],
+                )
+            )
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    for i, result in enumerate(results):
+        if isinstance(result, Exception):
+            print(f"Failed for user {users[i]['id']}: {result}")
+        else:
+            print(f"Tracked user {users[i]['id']}")
+
+    return results
+
+
+users = [
+    {
+        "id": "u001",
+        "attributes": {"name": "Amit", "email": "amit@example.com"},
+    },
+    {
+        "id": "u002",
+        "attributes": {"name": "Neha", "email": "neha@example.com"},
+    },
+]
+asyncio.run(track_users_batch(users))
+```
+
+## Key API Endpoints Summary
+
+| API | Method | Endpoint Pattern |
+|-----|--------|-----------------|
+| Track User | POST | `https://api-0X.moengage.com/v1/customer/{appId}` |
+| Create Event | POST | `https://api-0X.moengage.com/v1/event/{appId}` |
+| Get User | GET | `https://api-0X.moengage.com/v1/customer/{appId}?customer_id=...` |
+| Push API | POST | `https://pushapi-0X.moengage.com/v2/transaction/sendpush` |
+| Inform API | POST | `https://inform-api-0X.moengage.com/v1/send` |
+| Campaign Report | POST | `https://api-0X.moengage.com/v2/report/campaign` |
+| Personalize | GET | `https://sdk-0X.moengage.com/v1/experiences/...` |
+
+## Error Handling
+
+```python
+import httpx
+
+
+async def safe_moengage_request(moe: MoEngageClient):
+    try:
+        result = await moe.track_user("test_user", {"name": "Test"})
+        return result
+    except httpx.HTTPStatusError as e:
+        status = e.response.status_code
+        if status == 401:
+            print("Authentication failed. Check Workspace ID and API Key.")
+        elif status == 400:
+            print(f"Bad request: {e.response.text}")
+        elif status == 429:
+            print("Rate limited. Back off and retry.")
+        else:
+            print(f"HTTP error {status}: {e.response.text}")
+        return None
+    except httpx.ConnectError:
+        print("Cannot connect. Check data center number and network.")
+        return None
+    except httpx.TimeoutException:
+        print("Request timed out.")
+        return None
+```
+
+## References
+
+- Developer Guide: https://developers.moengage.com/hc/en-us
+- API Overview: https://developers.moengage.com/hc/en-us/articles/4404674776724-Overview
+- Track User API: https://developers.moengage.com/hc/en-us/articles/4413167462804-Track-User
+- Create Event API: https://developers.moengage.com/hc/en-us/articles/4413174104852-Create-Event
+- Push API: https://developers.moengage.com/hc/en-us/articles/4404548252820-Push-API
+- Inform API: https://developers.moengage.com/hc/en-us/articles/10699624590868-Inform-API
+- Data Centers: https://help.moengage.com/hc/en-us/articles/360057030512-Data-Centers-in-MoEngage

--- a/content/mollie/docs/rest-api/python/DOC.md
+++ b/content/mollie/docs/rest-api/python/DOC.md
@@ -1,0 +1,305 @@
+---
+name: rest-api
+description: "Mollie - European payment service provider for iDEAL, Bancontact, cards, and more"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "mollie,payments,europe,ideal,bancontact,checkout,api"
+---
+
+# Mollie REST API - Python (`httpx`)
+
+## Golden Rule
+
+Always use Bearer token authentication with your API key. Mollie uses HAL+JSON for responses -- follow `_links` for pagination and related resources. All amounts are strings with two decimal places (e.g., `"10.00"`), not numbers. Use test API keys (prefixed `test_`) during development and live keys (prefixed `live_`) in production. Support idempotency via the `Idempotency-Key` header to avoid duplicate operations.
+
+## Installation
+
+```bash
+pip install httpx python-dotenv
+```
+
+## Base URL
+
+| Environment | URL |
+|-------------|-----|
+| Production  | `https://api.mollie.com/v2` |
+| Test        | `https://api.mollie.com/v2` (same URL, use `test_` API key) |
+
+Mollie uses the same base URL for both environments. The API key prefix (`test_` vs `live_`) determines the mode.
+
+## Authentication
+
+```python
+import httpx
+import os
+
+MOLLIE_API_KEY = os.environ["MOLLIE_API_KEY"]  # test_xxxx or live_xxxx
+BASE_URL = "https://api.mollie.com/v2"
+
+headers = {
+    "Authorization": f"Bearer {MOLLIE_API_KEY}",
+    "Content-Type": "application/json",
+}
+```
+
+Mollie also supports OAuth2 for partner/marketplace integrations (Mollie Connect).
+
+## Rate Limiting
+
+Mollie returns HTTP 429 when rate limits are exceeded. The response may include a `Retry-After` header.
+
+```python
+import asyncio
+
+async def mollie_request(
+    client: httpx.AsyncClient, method: str, url: str, **kwargs
+) -> dict:
+    for attempt in range(5):
+        resp = await client.request(method, url, headers=headers, **kwargs)
+        if resp.status_code == 429:
+            retry_after = int(resp.headers.get("Retry-After", 2 ** attempt))
+            await asyncio.sleep(retry_after)
+            continue
+        resp.raise_for_status()
+        return resp.json()
+    raise Exception("Rate limit exceeded after retries")
+```
+
+## Methods
+
+### Create Payment
+
+Create a payment with a specified method or let the customer choose.
+
+```python
+async def create_payment(
+    client: httpx.AsyncClient,
+    amount: str,
+    currency: str,
+    description: str,
+    redirect_url: str,
+    webhook_url: str,
+    method: str | list[str] | None = None,
+    idempotency_key: str | None = None,
+) -> dict:
+    payload = {
+        "amount": {"currency": currency, "value": amount},  # e.g., "10.00"
+        "description": description,
+        "redirectUrl": redirect_url,
+        "webhookUrl": webhook_url,
+    }
+    if method:
+        payload["method"] = method  # "ideal", "bancontact", "creditcard", etc.
+
+    req_headers = {**headers}
+    if idempotency_key:
+        req_headers["Idempotency-Key"] = idempotency_key
+
+    resp = await client.post(
+        f"{BASE_URL}/payments", headers=req_headers, json=payload
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Get Payment
+
+```python
+async def get_payment(client: httpx.AsyncClient, payment_id: str) -> dict:
+    resp = await client.get(f"{BASE_URL}/payments/{payment_id}", headers=headers)
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### List Payments
+
+```python
+async def list_payments(
+    client: httpx.AsyncClient, limit: int = 50, cursor: str | None = None
+) -> dict:
+    params = {"limit": limit}
+    if cursor:
+        params["from"] = cursor
+    resp = await client.get(
+        f"{BASE_URL}/payments", headers=headers, params=params
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Create Refund
+
+```python
+async def create_refund(
+    client: httpx.AsyncClient,
+    payment_id: str,
+    amount: str,
+    currency: str,
+    description: str | None = None,
+) -> dict:
+    payload = {"amount": {"currency": currency, "value": amount}}
+    if description:
+        payload["description"] = description
+    resp = await client.post(
+        f"{BASE_URL}/payments/{payment_id}/refunds",
+        headers=headers,
+        json=payload,
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Create Customer
+
+```python
+async def create_customer(
+    client: httpx.AsyncClient,
+    name: str,
+    email: str,
+    locale: str | None = None,
+) -> dict:
+    payload = {"name": name, "email": email}
+    if locale:
+        payload["locale"] = locale
+    resp = await client.post(
+        f"{BASE_URL}/customers", headers=headers, json=payload
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Create Subscription (Recurring)
+
+Requires a customer with a valid mandate (first payment completed).
+
+```python
+async def create_subscription(
+    client: httpx.AsyncClient,
+    customer_id: str,
+    amount: str,
+    currency: str,
+    interval: str,
+    description: str,
+    webhook_url: str,
+) -> dict:
+    payload = {
+        "amount": {"currency": currency, "value": amount},
+        "interval": interval,  # "1 month", "2 weeks", "1 year", etc.
+        "description": description,
+        "webhookUrl": webhook_url,
+    }
+    resp = await client.post(
+        f"{BASE_URL}/customers/{customer_id}/subscriptions",
+        headers=headers,
+        json=payload,
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### List Payment Methods
+
+```python
+async def list_methods(
+    client: httpx.AsyncClient,
+    amount: str | None = None,
+    currency: str | None = None,
+) -> dict:
+    params = {}
+    if amount and currency:
+        params["amount[value]"] = amount
+        params["amount[currency]"] = currency
+    resp = await client.get(
+        f"{BASE_URL}/methods", headers=headers, params=params
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Create Order
+
+For order-based payments (required for Klarna, pay-later methods).
+
+```python
+async def create_order(
+    client: httpx.AsyncClient,
+    amount: str,
+    currency: str,
+    order_number: str,
+    lines: list[dict],
+    billing_address: dict,
+    redirect_url: str,
+    webhook_url: str,
+    locale: str = "en_US",
+) -> dict:
+    payload = {
+        "amount": {"currency": currency, "value": amount},
+        "orderNumber": order_number,
+        "lines": lines,
+        "billingAddress": billing_address,
+        "redirectUrl": redirect_url,
+        "webhookUrl": webhook_url,
+        "locale": locale,
+    }
+    resp = await client.post(
+        f"{BASE_URL}/orders", headers=headers, json=payload
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+## Error Handling
+
+Mollie returns HAL-formatted JSON errors:
+
+```json
+{
+  "status": 422,
+  "title": "Unprocessable Entity",
+  "detail": "The amount is higher than the maximum",
+  "field": "amount",
+  "_links": {
+    "documentation": {
+      "href": "https://docs.mollie.com/errors",
+      "type": "text/html"
+    }
+  }
+}
+```
+
+```python
+class MollieAPIError(Exception):
+    def __init__(self, status: int, body: dict):
+        self.status = status
+        self.title = body.get("title", "Unknown")
+        self.detail = body.get("detail", str(body))
+        self.field = body.get("field")
+        super().__init__(f"HTTP {status} [{self.title}]: {self.detail}")
+        if self.field:
+            self.args = (f"{self.args[0]} (field: {self.field})",)
+
+
+async def mollie_request_safe(
+    client: httpx.AsyncClient, method: str, url: str, **kwargs
+) -> dict:
+    resp = await client.request(method, url, headers=headers, **kwargs)
+    if resp.status_code >= 400:
+        raise MollieAPIError(resp.status_code, resp.json())
+    return resp.json()
+```
+
+Key status codes: 200 (OK), 201 (created), 204 (deleted), 400 (bad request), 401 (unauthorized), 403 (forbidden), 404 (not found), 409 (conflict/duplicate), 422 (validation), 429 (rate limit), 500/502/503/504 (server errors).
+
+## Common Pitfalls
+
+1. **Amounts are strings** -- Always pass amounts as `"10.00"` (string), never as a number. The API rejects numeric amounts.
+2. **Test vs Live keys** -- Same base URL for both. The key prefix (`test_` / `live_`) determines the mode. Do not mix keys across environments.
+3. **Webhook required** -- Most payment flows require a `webhookUrl`. Mollie sends POST requests to notify you of status changes. Always verify the payment status server-side after receiving a webhook.
+4. **HAL pagination** -- Use `_links.next.href` to paginate. Do not construct pagination URLs manually.
+5. **Recurring payments setup** -- Before creating subscriptions, you must: (a) create a customer, (b) create a "first" payment with `sequenceType: "first"` to establish a mandate, (c) then create subscriptions against that customer.
+6. **Idempotency** -- Use the `Idempotency-Key` header on create operations to prevent duplicate payments/orders on retries.
+7. **Order vs Payment API** -- Use the Orders API for Klarna and other pay-later methods that require order line details. Use the Payments API for simple card/iDEAL/Bancontact flows.

--- a/content/monzo/docs/rest-api/python/DOC.md
+++ b/content/monzo/docs/rest-api/python/DOC.md
@@ -1,0 +1,445 @@
+---
+name: rest-api
+description: "Monzo Bank REST API Coding Guidelines for Python using httpx async HTTP client"
+metadata:
+  languages: "python"
+  versions: "v1"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "monzo,banking,uk,neobank,accounts,transactions,api"
+---
+
+# Monzo REST API Coding Guidelines (Python)
+
+You are a Monzo Bank API coding expert. Help me with writing code using the Monzo REST API with httpx async HTTP client.
+
+## Golden Rule: Use httpx Async for All API Calls
+
+Always use `httpx.AsyncClient` for all Monzo API interactions. Never use `requests` or synchronous HTTP clients.
+
+- **Library Name:** httpx
+- **PyPI Package:** `httpx`
+
+**IMPORTANT ACCESS RESTRICTION:** The Monzo Developer API is not suitable for building public applications. API access is limited to personal use or explicitly authorized OAuth clients. Strong Customer Authentication (SCA) is required -- users must approve access via a push notification in the Monzo app. After 5 minutes of initial authentication, transaction history access is limited to the last 90 days.
+
+## Installation
+
+```bash
+pip install httpx python-dotenv
+```
+
+## Base URL
+
+```
+https://api.monzo.com
+```
+
+There is no separate sandbox environment. Testing is done against real accounts with the developer API.
+
+## Authentication
+
+Monzo uses OAuth 2.0 with Bearer token authentication. All requests require an `Authorization: Bearer {access_token}` header.
+
+### OAuth 2.0 Flow
+
+1. Register an OAuth client at https://developers.monzo.com/
+2. Redirect user to Monzo authorization URL
+3. Exchange authorization code for access token
+4. User approves via push notification in the Monzo app (SCA)
+5. Access token expires after several hours; refresh tokens are available only for confidential clients
+
+```python
+import os
+import httpx
+from dotenv import load_dotenv
+
+load_dotenv()
+
+MONZO_BASE_URL = "https://api.monzo.com"
+MONZO_ACCESS_TOKEN = os.environ["MONZO_ACCESS_TOKEN"]
+
+def get_headers() -> dict:
+    return {
+        "Authorization": f"Bearer {MONZO_ACCESS_TOKEN}",
+        "Content-Type": "application/x-www-form-urlencoded",
+    }
+```
+
+### Token Exchange
+
+```python
+async def exchange_auth_code(
+    client_id: str,
+    client_secret: str,
+    redirect_uri: str,
+    auth_code: str,
+) -> dict:
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{MONZO_BASE_URL}/oauth2/token",
+            data={
+                "grant_type": "authorization_code",
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "redirect_uri": redirect_uri,
+                "code": auth_code,
+            },
+        )
+        response.raise_for_status()
+        return response.json()  # {"access_token": "...", "refresh_token": "...", ...}
+```
+
+### Token Refresh
+
+```python
+async def refresh_access_token(
+    client_id: str,
+    client_secret: str,
+    refresh_token: str,
+) -> dict:
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{MONZO_BASE_URL}/oauth2/token",
+            data={
+                "grant_type": "refresh_token",
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "refresh_token": refresh_token,
+            },
+        )
+        response.raise_for_status()
+        return response.json()
+```
+
+### Verify Token
+
+```python
+async def whoami() -> dict:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{MONZO_BASE_URL}/ping/whoami",
+            headers=get_headers(),
+        )
+        response.raise_for_status()
+        return response.json()  # {"authenticated": true, "client_id": "...", "user_id": "..."}
+```
+
+## Rate Limiting
+
+Monzo does not publicly document specific rate limits. However, HTTP 429 responses indicate rate limiting. Implement exponential backoff:
+
+```python
+import asyncio
+
+async def request_with_retry(
+    client: httpx.AsyncClient,
+    method: str,
+    url: str,
+    max_retries: int = 3,
+    **kwargs,
+) -> httpx.Response:
+    for attempt in range(max_retries):
+        response = await client.request(method, url, **kwargs)
+        if response.status_code == 429:
+            delay = 2 ** (attempt + 1)
+            await asyncio.sleep(delay)
+            continue
+        response.raise_for_status()
+        return response
+    raise httpx.HTTPStatusError(
+        "Rate limit exceeded after retries",
+        request=response.request,
+        response=response,
+    )
+```
+
+## Methods
+
+### List Accounts
+
+```python
+async def list_accounts(account_type: str | None = None) -> list[dict]:
+    """List user accounts. account_type: 'uk_retail', 'uk_retail_joint', etc."""
+    params = {}
+    if account_type:
+        params["account_type"] = account_type
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{MONZO_BASE_URL}/accounts",
+            headers=get_headers(),
+            params=params,
+        )
+        response.raise_for_status()
+        return response.json()["accounts"]
+```
+
+### Get Balance
+
+```python
+async def get_balance(account_id: str) -> dict:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{MONZO_BASE_URL}/balance",
+            headers=get_headers(),
+            params={"account_id": account_id},
+        )
+        response.raise_for_status()
+        return response.json()
+        # {"balance": 5000, "total_balance": 6000, "currency": "GBP", "spend_today": -200}
+```
+
+### List Transactions
+
+```python
+async def list_transactions(
+    account_id: str,
+    since: str | None = None,
+    before: str | None = None,
+    limit: int = 100,
+    expand_merchant: bool = False,
+) -> list[dict]:
+    """
+    List transactions. Pagination uses time-based cursors.
+    since/before: ISO 8601 timestamps or transaction IDs.
+    NOTE: After 5 min of auth, only last 90 days available.
+    """
+    params = {"account_id": account_id, "limit": limit}
+    if since:
+        params["since"] = since
+    if before:
+        params["before"] = before
+    if expand_merchant:
+        params["expand[]"] = "merchant"
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{MONZO_BASE_URL}/transactions",
+            headers=get_headers(),
+            params=params,
+        )
+        response.raise_for_status()
+        return response.json()["transactions"]
+```
+
+### Get Single Transaction
+
+```python
+async def get_transaction(
+    transaction_id: str,
+    expand_merchant: bool = True,
+) -> dict:
+    params = {}
+    if expand_merchant:
+        params["expand[]"] = "merchant"
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{MONZO_BASE_URL}/transactions/{transaction_id}",
+            headers=get_headers(),
+            params=params,
+        )
+        response.raise_for_status()
+        return response.json()["transaction"]
+```
+
+### Annotate Transaction (Metadata)
+
+```python
+async def annotate_transaction(
+    transaction_id: str,
+    metadata: dict[str, str],
+) -> dict:
+    """Add key-value metadata to a transaction."""
+    data = {f"metadata[{k}]": v for k, v in metadata.items()}
+    async with httpx.AsyncClient() as client:
+        response = await client.patch(
+            f"{MONZO_BASE_URL}/transactions/{transaction_id}",
+            headers=get_headers(),
+            data=data,
+        )
+        response.raise_for_status()
+        return response.json()["transaction"]
+```
+
+### List Pots
+
+```python
+async def list_pots(current_account_id: str) -> list[dict]:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{MONZO_BASE_URL}/pots",
+            headers=get_headers(),
+            params={"current_account_id": current_account_id},
+        )
+        response.raise_for_status()
+        return response.json()["pots"]
+```
+
+### Deposit Into Pot
+
+```python
+import uuid
+
+async def deposit_into_pot(
+    pot_id: str,
+    source_account_id: str,
+    amount_pence: int,
+) -> dict:
+    """Move money into a pot. Amount is in pence (e.g., 1000 = 10.00 GBP)."""
+    async with httpx.AsyncClient() as client:
+        response = await client.put(
+            f"{MONZO_BASE_URL}/pots/{pot_id}/deposit",
+            headers=get_headers(),
+            data={
+                "source_account_id": source_account_id,
+                "amount": amount_pence,
+                "dedupe_id": str(uuid.uuid4()),
+            },
+        )
+        response.raise_for_status()
+        return response.json()
+```
+
+### Withdraw From Pot
+
+```python
+async def withdraw_from_pot(
+    pot_id: str,
+    destination_account_id: str,
+    amount_pence: int,
+) -> dict:
+    async with httpx.AsyncClient() as client:
+        response = await client.put(
+            f"{MONZO_BASE_URL}/pots/{pot_id}/withdraw",
+            headers=get_headers(),
+            data={
+                "destination_account_id": destination_account_id,
+                "amount": amount_pence,
+                "dedupe_id": str(uuid.uuid4()),
+            },
+        )
+        response.raise_for_status()
+        return response.json()
+```
+
+### Create Feed Item
+
+```python
+async def create_feed_item(
+    account_id: str,
+    title: str,
+    body: str,
+    image_url: str = "",
+) -> None:
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{MONZO_BASE_URL}/feed",
+            headers=get_headers(),
+            data={
+                "account_id": account_id,
+                "type": "basic",
+                "params[title]": title,
+                "params[body]": body,
+                "params[image_url]": image_url or "https://monzo.com/static/images/favicon.png",
+            },
+        )
+        response.raise_for_status()
+```
+
+### Webhooks
+
+```python
+async def register_webhook(account_id: str, url: str) -> dict:
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{MONZO_BASE_URL}/webhooks",
+            headers=get_headers(),
+            data={"account_id": account_id, "url": url},
+        )
+        response.raise_for_status()
+        return response.json()["webhook"]
+
+async def list_webhooks(account_id: str) -> list[dict]:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{MONZO_BASE_URL}/webhooks",
+            headers=get_headers(),
+            params={"account_id": account_id},
+        )
+        response.raise_for_status()
+        return response.json()["webhooks"]
+
+async def delete_webhook(webhook_id: str) -> None:
+    async with httpx.AsyncClient() as client:
+        response = await client.delete(
+            f"{MONZO_BASE_URL}/webhooks/{webhook_id}",
+            headers=get_headers(),
+        )
+        response.raise_for_status()
+```
+
+## Error Handling
+
+```python
+async def safe_monzo_request(
+    method: str,
+    path: str,
+    **kwargs,
+) -> dict | None:
+    async with httpx.AsyncClient(base_url=MONZO_BASE_URL) as client:
+        try:
+            response = await client.request(
+                method, path, headers=get_headers(), **kwargs
+            )
+            response.raise_for_status()
+            return response.json() if response.content else None
+        except httpx.HTTPStatusError as e:
+            status = e.response.status_code
+            if status == 400:
+                raise ValueError(f"Bad request: {e.response.text}")
+            elif status == 401:
+                raise PermissionError("Token expired or invalid. Re-authenticate.")
+            elif status == 403:
+                raise PermissionError("Insufficient permissions or SCA required.")
+            elif status == 404:
+                raise LookupError(f"Resource not found: {path}")
+            elif status == 429:
+                raise RuntimeError("Rate limited. Implement backoff.")
+            elif status >= 500:
+                raise ConnectionError(f"Monzo server error ({status}): {e.response.text}")
+            raise
+        except httpx.RequestError as e:
+            raise ConnectionError(f"Network error: {e}")
+```
+
+### HTTP Status Codes
+
+| Code | Meaning |
+|------|---------|
+| 200  | Success |
+| 400  | Bad Request -- missing or malformed arguments |
+| 401  | Unauthorized -- invalid or expired token |
+| 403  | Forbidden -- insufficient permissions or SCA needed |
+| 404  | Not Found |
+| 405  | Method Not Allowed |
+| 429  | Rate Limited -- back off and retry |
+| 500  | Internal Server Error |
+| 504  | Gateway Timeout |
+
+## Common Pitfalls
+
+1. **SCA Timeout:** After 5 minutes of initial authentication, transaction history is limited to the last 90 days. Plan data fetches accordingly.
+2. **Not a Public API:** Monzo explicitly states the developer API is not for building public apps. Access is restricted to personal use or pre-approved OAuth clients.
+3. **Form-Encoded Bodies:** Most POST/PUT/PATCH endpoints expect `application/x-www-form-urlencoded`, NOT JSON. Use `data=` not `json=` with httpx.
+4. **Amounts in Pence:** All monetary values are in the smallest currency unit (pence for GBP). 1000 = 10.00 GBP.
+5. **Idempotency:** Use `dedupe_id` for pot deposit/withdraw operations to prevent duplicate transactions.
+6. **Object Expansion:** Use `expand[]=merchant` query parameter to inline merchant details in transaction responses.
+7. **Pagination:** Uses `since`, `before`, and `limit` parameters. `since` can be a timestamp or transaction ID.
+8. **Token Expiry:** Access tokens expire after several hours. Only confidential clients get refresh tokens.
+9. **Webhook Events:** Only `transaction.created` event is currently supported.
+10. **Pot Withdrawals:** May be blocked if the user has enabled additional security on the pot.
+
+## Useful Links
+
+- **API Documentation:** https://docs.monzo.com/
+- **Developer Portal:** https://developers.monzo.com/
+- **OAuth Playground:** https://developers.monzo.com/api/playground

--- a/content/moralis/docs/rest-api/python/DOC.md
+++ b/content/moralis/docs/rest-api/python/DOC.md
@@ -1,0 +1,473 @@
+---
+name: rest-api
+description: "Moralis Web3 Data REST API Python coding guidelines using httpx async"
+metadata:
+  languages: "python"
+  versions: "3.12.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "moralis,web3,nft,defi,wallet,blockchain,ethereum,api"
+---
+
+# Moralis Web3 Data REST API Python Coding Guidelines
+
+You are a Moralis Web3 Data API coding expert. Help me with writing code using the Moralis REST API with httpx async in Python.
+
+You can find the official documentation here:
+https://docs.moralis.com/
+
+## Golden Rule: Use httpx Async with X-API-Key Authentication
+
+Always use `httpx` with async/await for all Moralis API interactions. Authenticate using the `X-API-Key` header. Moralis provides Web3 data across multiple EVM chains (Ethereum, Polygon, BSC, Arbitrum, Optimism, Avalanche, Base, etc.) and Solana. Never hardcode API keys in source code.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+**Environment Variables:**
+
+```bash
+export MORALIS_API_KEY='your_moralis_api_key_here'
+```
+
+Load environment variables in Python:
+
+```python
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+api_key = os.getenv("MORALIS_API_KEY")
+```
+
+## Base URL
+
+```
+https://deep-index.moralis.io/api/v2.2
+```
+
+Swagger documentation: https://deep-index.moralis.io/api-docs-2.2/
+
+## Authentication
+
+Moralis uses a simple API key passed in the `X-API-Key` header.
+
+```python
+import httpx
+
+
+class MoralisClient:
+    BASE_URL = "https://deep-index.moralis.io/api/v2.2"
+
+    def __init__(self, api_key: str):
+        self.headers = {
+            "X-API-Key": api_key,
+            "accept": "application/json",
+        }
+
+    async def get(self, path: str, params: dict | None = None) -> dict | list:
+        url = f"{self.BASE_URL}{path}"
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(url, headers=self.headers, params=params or {})
+            resp.raise_for_status()
+            return resp.json()
+
+    async def post(self, path: str, json_data: dict | None = None) -> dict | list:
+        url = f"{self.BASE_URL}{path}"
+        headers = {**self.headers, "Content-Type": "application/json"}
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(url, headers=headers, json=json_data)
+            resp.raise_for_status()
+            return resp.json()
+```
+
+## Rate Limiting
+
+Moralis uses a Compute Units (CU) system. Each endpoint has a CU weight, and your plan determines throughput.
+
+| Plan | Throughput |
+|---|---|
+| Free | 150 CU/s |
+| Pro | 150 CU/s |
+| Business | 300 CU/s |
+| Enterprise | Custom |
+
+Common endpoint weights:
+- Most wallet/token endpoints: 1-5 CU
+- NFT endpoints: 5-10 CU
+- Complex/premium endpoints: 10-25 CU
+
+```python
+import asyncio
+
+semaphore = asyncio.Semaphore(10)  # Limit concurrent requests
+
+async def rate_limited_get(client: MoralisClient, path: str, params: dict | None = None):
+    async with semaphore:
+        result = await client.get(path, params=params)
+        await asyncio.sleep(0.1)  # Basic pacing
+        return result
+```
+
+You can check endpoint weights at:
+```
+GET https://deep-index.moralis.io/api/v2/info/endpointWeights
+```
+
+## Methods
+
+### Get Native Balance by Wallet
+
+```python
+async def get_native_balance(
+    client: MoralisClient, address: str, chain: str = "eth"
+) -> dict:
+    """Get native token balance (ETH, MATIC, BNB, etc.) for a wallet.
+
+    Args:
+        address: Wallet address (0x...).
+        chain: Chain identifier - eth, polygon, bsc, arbitrum, optimism, avalanche, base, linea, etc.
+    """
+    return await client.get(f"/{address}/balance", params={"chain": chain})
+
+# Usage
+import asyncio
+
+async def main():
+    moralis = MoralisClient(api_key)
+    result = await get_native_balance(moralis, "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+    print(f"Balance: {int(result['balance']) / 1e18} ETH")
+
+asyncio.run(main())
+```
+
+### Get ERC20 Token Balances
+
+```python
+async def get_token_balances(
+    client: MoralisClient,
+    address: str,
+    chain: str = "eth",
+    token_addresses: list[str] | None = None,
+) -> list:
+    """Get all ERC20 token balances for a wallet.
+
+    Args:
+        address: Wallet address.
+        chain: Chain identifier.
+        token_addresses: Optional list of specific token contract addresses to filter.
+    """
+    params = {"chain": chain}
+    if token_addresses:
+        params["token_addresses"] = token_addresses
+    return await client.get(f"/wallets/{address}/tokens", params=params)
+```
+
+### Get Token Price
+
+```python
+async def get_token_price(
+    client: MoralisClient,
+    address: str,
+    chain: str = "eth",
+    include: str = "percent_change",
+) -> dict:
+    """Get the price of a token by contract address.
+
+    Args:
+        address: Token contract address.
+        chain: Chain identifier.
+        include: Additional data - "percent_change" for 24hr change.
+    """
+    params = {"chain": chain, "include": include}
+    return await client.get(f"/erc20/{address}/price", params=params)
+```
+
+### Get Wallet Transactions
+
+```python
+async def get_wallet_transactions(
+    client: MoralisClient,
+    address: str,
+    chain: str = "eth",
+    limit: int = 100,
+    cursor: str | None = None,
+    order: str = "DESC",
+) -> dict:
+    """Get native transactions for a wallet.
+
+    Args:
+        address: Wallet address.
+        chain: Chain identifier.
+        limit: Number of results (max 100).
+        cursor: Pagination cursor from previous response.
+        order: Sort order - "DESC" or "ASC".
+    """
+    params = {"chain": chain, "limit": limit, "order": order}
+    if cursor:
+        params["cursor"] = cursor
+    return await client.get(f"/{address}", params=params)
+```
+
+### Get Wallet History (Categorized)
+
+```python
+async def get_wallet_history(
+    client: MoralisClient,
+    address: str,
+    chain: str = "eth",
+    limit: int = 100,
+    cursor: str | None = None,
+    order: str = "DESC",
+) -> dict:
+    """Get full transaction history with automatic categorization.
+
+    Categories: Send, Receive, NFT Send, NFT Receive, Token Send, Token Receive,
+    Token Swap, Deposit, Withdraw, Airdrop, Mint, Burn, NFT Purchase, NFT Sale,
+    Borrow, Contract Interaction.
+    """
+    params = {"chain": chain, "limit": limit, "order": order}
+    if cursor:
+        params["cursor"] = cursor
+    return await client.get(f"/wallets/{address}/history", params=params)
+```
+
+### Get NFTs by Wallet
+
+```python
+async def get_nfts_by_wallet(
+    client: MoralisClient,
+    address: str,
+    chain: str = "eth",
+    limit: int = 100,
+    cursor: str | None = None,
+    normalise_metadata: bool = True,
+) -> dict:
+    """Get all NFTs owned by a wallet with metadata.
+
+    Args:
+        address: Wallet address.
+        chain: Chain identifier.
+        normalise_metadata: If True, returns parsed metadata.
+    """
+    params = {
+        "chain": chain,
+        "limit": limit,
+        "normalise_metadata": str(normalise_metadata).lower(),
+    }
+    if cursor:
+        params["cursor"] = cursor
+    return await client.get(f"/{address}/nft", params=params)
+```
+
+### Get NFT Metadata
+
+```python
+async def get_nft_metadata(
+    client: MoralisClient,
+    address: str,
+    token_id: str,
+    chain: str = "eth",
+    normalise_metadata: bool = True,
+) -> dict:
+    """Get metadata for a specific NFT.
+
+    Args:
+        address: NFT contract address.
+        token_id: Token ID.
+        chain: Chain identifier.
+    """
+    params = {
+        "chain": chain,
+        "normalise_metadata": str(normalise_metadata).lower(),
+    }
+    return await client.get(f"/nft/{address}/{token_id}", params=params)
+```
+
+### Get NFT Collection Metadata
+
+```python
+async def get_nft_collection(
+    client: MoralisClient, address: str, chain: str = "eth"
+) -> dict:
+    """Get metadata for an NFT collection/contract."""
+    return await client.get(f"/nft/{address}/metadata", params={"chain": chain})
+```
+
+### Get Block by Number or Hash
+
+```python
+async def get_block(
+    client: MoralisClient, block_number_or_hash: str, chain: str = "eth"
+) -> dict:
+    """Get block details including transactions.
+
+    Args:
+        block_number_or_hash: Block number (as string) or block hash.
+        chain: Chain identifier.
+    """
+    return await client.get(f"/block/{block_number_or_hash}", params={"chain": chain})
+```
+
+### Resolve ENS Domain
+
+```python
+async def resolve_ens_domain(client: MoralisClient, domain: str) -> dict:
+    """Resolve an ENS domain to an address.
+
+    Args:
+        domain: ENS domain name (e.g., "vitalik.eth").
+    """
+    return await client.get(f"/resolve/ens/{domain}")
+```
+
+### Resolve Address to ENS
+
+```python
+async def resolve_address(client: MoralisClient, address: str) -> dict:
+    """Reverse resolve an address to its ENS domain."""
+    return await client.get(f"/resolve/{address}/reverse")
+```
+
+### Get DeFi Positions
+
+```python
+async def get_defi_positions(
+    client: MoralisClient, address: str, chain: str = "eth"
+) -> dict:
+    """Get DeFi protocol positions for a wallet (premium endpoint)."""
+    return await client.get(
+        f"/wallets/{address}/defi/positions", params={"chain": chain}
+    )
+```
+
+### Get Token Metadata
+
+```python
+async def get_token_metadata(
+    client: MoralisClient, addresses: list[str], chain: str = "eth"
+) -> list:
+    """Get metadata for ERC20 tokens by contract address.
+
+    Args:
+        addresses: List of token contract addresses.
+        chain: Chain identifier.
+    """
+    return await client.get(
+        "/erc20/metadata", params={"chain": chain, "addresses": addresses}
+    )
+```
+
+### Paginate Through All Results
+
+```python
+async def paginate_all(
+    client: MoralisClient,
+    path: str,
+    params: dict,
+    max_pages: int = 10,
+) -> list:
+    """Paginate through all results using cursor-based pagination.
+
+    Args:
+        path: API endpoint path.
+        params: Query parameters.
+        max_pages: Maximum number of pages to fetch.
+    """
+    all_results = []
+    cursor = None
+
+    for _ in range(max_pages):
+        if cursor:
+            params["cursor"] = cursor
+        result = await client.get(path, params=params)
+        all_results.extend(result.get("result", []))
+
+        cursor = result.get("cursor")
+        if not cursor:
+            break
+
+    return all_results
+
+# Get all NFTs for a wallet (up to 10 pages)
+# all_nfts = await paginate_all(moralis, "/0xABC.../nft", {"chain": "eth", "limit": 100})
+```
+
+## Error Handling
+
+```python
+async def safe_request(
+    client: MoralisClient, path: str, params: dict | None = None
+) -> dict | list | None:
+    """Make a request with error handling."""
+    try:
+        return await client.get(path, params=params)
+    except httpx.HTTPStatusError as e:
+        status = e.response.status_code
+        try:
+            body = e.response.json()
+            message = body.get("message", "")
+        except Exception:
+            message = e.response.text
+
+        if status == 400:
+            print(f"Bad request: {message}")
+        elif status == 401:
+            print("Unauthorized - check your API key")
+        elif status == 429:
+            print("Rate limited - reduce request frequency")
+            await asyncio.sleep(1)
+        elif status == 404:
+            print(f"Not found: {message}")
+        elif status >= 500:
+            print(f"Moralis server error ({status}): {message}")
+        else:
+            print(f"HTTP {status}: {message}")
+        return None
+    except httpx.RequestError as e:
+        print(f"Network error: {e}")
+        return None
+```
+
+### Common HTTP Error Codes
+
+| Status | Description |
+|---|---|
+| 400 | Bad request - invalid address, chain, or parameters |
+| 401 | Unauthorized - missing or invalid API key |
+| 404 | Not found - address or resource does not exist |
+| 429 | Rate limit exceeded - too many compute units consumed |
+| 500 | Internal server error |
+
+## Common Pitfalls
+
+1. **Chain Parameter** - Always pass the `chain` parameter. It defaults to `eth` but must be explicit for other chains. Valid values: `eth`, `polygon`, `bsc`, `arbitrum`, `optimism`, `avalanche`, `base`, `linea`, `fantom`, `cronos`, `palm`, `gnosis`.
+
+2. **Checksum Addresses** - Moralis accepts both checksummed and non-checksummed Ethereum addresses, but always validate addresses before sending.
+
+3. **Cursor Pagination** - Most list endpoints return paginated results with a `cursor` field. Use `cursor` for the next page, not `page` or `offset` numbers.
+
+4. **Balance Precision** - Native balances and token balances are returned in wei (or smallest unit). Divide by `10**decimals` to get human-readable values. Always get `decimals` from token metadata.
+
+5. **Premium Endpoints** - Some endpoints (DeFi positions, wallet history categorization) are premium and cost more CUs. Check your plan tier before relying on them.
+
+6. **Supported Chains** - Not all endpoints support all chains. NFT and DeFi endpoints may have limited chain support compared to wallet/token endpoints.
+
+7. **Rate Limit by CU, Not Requests** - Rate limiting is based on total compute units per second, not raw request count. Heavy endpoints consume more CUs. Use the endpoint weights API to plan your request budget.
+
+8. **Address Casing** - While Ethereum addresses are case-insensitive, always lowercase addresses when constructing URLs to avoid unexpected 404s on some endpoints.
+
+## Useful Links
+
+- Official Documentation: https://docs.moralis.com/
+- EVM API Reference: https://docs.moralis.com/web3-data-api/evm/reference
+- Wallet API: https://docs.moralis.com/web3-data-api/evm/reference/wallet-api
+- Rate Limits: https://docs.moralis.com/web3-data-api/evm/reference/rate-limits
+- Endpoint Weights: https://docs.moralis.com/web3-data-api/evm/reference/endpoint-weights
+- Swagger Docs: https://deep-index.moralis.io/api-docs-2.2/
+- Get API Key: https://docs.moralis.com/web3-data-api/evm/get-your-api-key
+- Supported Chains: https://docs.moralis.com/supported-chains

--- a/content/mpesa/docs/rest-api/python/DOC.md
+++ b/content/mpesa/docs/rest-api/python/DOC.md
@@ -1,0 +1,330 @@
+---
+name: rest-api
+description: "M-Pesa Daraja - Mobile Money API (Safaricom Kenya)"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "mpesa,mobile-money,safaricom,kenya,africa,payments,api"
+---
+
+# M-Pesa Daraja API — Python (httpx)
+
+## Golden Rule
+
+Always generate a **fresh OAuth token** before each batch of requests — tokens expire in 3600 seconds. The **Password** field for STK Push is a Base64 encoding of `BusinessShortCode + Passkey + Timestamp`. All callbacks are POST requests to your `CallbackURL` — you must expose a publicly accessible HTTPS endpoint. Amounts are in whole **KES** (no decimals). Phone numbers must be in format `2547XXXXXXXX` (country code, no leading zero or plus).
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+| Environment | Base URL |
+|---|---|
+| **Sandbox** | `https://sandbox.safaricom.co.ke` |
+| **Production** | `https://api.safaricom.co.ke` |
+
+All endpoint paths are identical between sandbox and production — only the domain changes.
+
+## Authentication
+
+Daraja uses **OAuth 2.0 Client Credentials** flow. Send your Consumer Key and Consumer Secret via HTTP Basic Auth to get a time-limited access token.
+
+```python
+import httpx
+import os
+import base64
+from datetime import datetime
+
+CONSUMER_KEY = os.environ["MPESA_CONSUMER_KEY"]
+CONSUMER_SECRET = os.environ["MPESA_CONSUMER_SECRET"]
+BASE_URL = os.environ.get("MPESA_BASE_URL", "https://sandbox.safaricom.co.ke")
+
+async def get_access_token() -> str:
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{BASE_URL}/oauth/v1/generate",
+            params={"grant_type": "client_credentials"},
+            auth=(CONSUMER_KEY, CONSUMER_SECRET),
+            timeout=15.0,
+        )
+        resp.raise_for_status()
+        return resp.json()["access_token"]
+
+async def get_client() -> httpx.AsyncClient:
+    token = await get_access_token()
+    return httpx.AsyncClient(
+        base_url=BASE_URL,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        timeout=30.0,
+    )
+```
+
+**Credentials:**
+- **Consumer Key / Consumer Secret** — obtained from the Daraja portal (developer.safaricom.co.ke)
+- **Passkey** — provided by Safaricom for Lipa Na M-Pesa Online (STK Push)
+- **Initiator Name / Security Credential** — required for B2C, B2B, and query APIs
+
+## Rate Limiting
+
+Safaricom enforces rate limits per app. Sandbox is more restrictive than production. Typical production limits:
+- ~50 transactions/second for STK Push
+- Exact limits depend on your approved throughput tier
+
+HTTP **500** or **503** often indicates throttling on Daraja. Implement retry with backoff:
+
+```python
+import asyncio
+
+async def request_with_retry(client: httpx.AsyncClient, method: str, url: str, **kwargs):
+    for attempt in range(5):
+        resp = await client.request(method, url, **kwargs)
+        if resp.status_code in (429, 500, 503):
+            wait = 2 ** attempt
+            await asyncio.sleep(wait)
+            continue
+        resp.raise_for_status()
+        return resp.json()
+    raise Exception("M-Pesa API request failed after retries")
+```
+
+## Methods
+
+### STK Push (Lipa Na M-Pesa Online)
+
+Trigger a payment prompt on the customer's phone.
+
+```python
+BUSINESS_SHORTCODE = os.environ["MPESA_SHORTCODE"]
+PASSKEY = os.environ["MPESA_PASSKEY"]
+
+def generate_password() -> tuple[str, str]:
+    """Returns (password, timestamp) for STK Push."""
+    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+    raw = f"{BUSINESS_SHORTCODE}{PASSKEY}{timestamp}"
+    password = base64.b64encode(raw.encode()).decode()
+    return password, timestamp
+
+async def stk_push(client: httpx.AsyncClient, phone: str, amount: int,
+                    account_ref: str, description: str, callback_url: str):
+    """
+    phone: 2547XXXXXXXX format
+    amount: whole KES (no decimals)
+    """
+    password, timestamp = generate_password()
+    payload = {
+        "BusinessShortCode": BUSINESS_SHORTCODE,
+        "Password": password,
+        "Timestamp": timestamp,
+        "TransactionType": "CustomerPayBillOnline",  # or "CustomerBuyGoodsOnline"
+        "Amount": amount,
+        "PartyA": phone,
+        "PartyB": BUSINESS_SHORTCODE,
+        "PhoneNumber": phone,
+        "CallBackURL": callback_url,
+        "AccountReference": account_ref,
+        "TransactionDesc": description,
+    }
+    resp = await client.post("/mpesa/stkpush/v1/processrequest", json=payload)
+    resp.raise_for_status()
+    return resp.json()
+    # Returns: {"MerchantRequestID": "...", "CheckoutRequestID": "...", "ResponseCode": "0", ...}
+```
+
+### STK Push Query
+
+Check the status of an STK Push request.
+
+```python
+async def stk_query(client: httpx.AsyncClient, checkout_request_id: str):
+    password, timestamp = generate_password()
+    payload = {
+        "BusinessShortCode": BUSINESS_SHORTCODE,
+        "Password": password,
+        "Timestamp": timestamp,
+        "CheckoutRequestID": checkout_request_id,
+    }
+    resp = await client.post("/mpesa/stkpushquery/v1/query", json=payload)
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### C2B Register URL
+
+Register your confirmation and validation URLs for C2B payments.
+
+```python
+async def c2b_register(client: httpx.AsyncClient, shortcode: str,
+                        confirmation_url: str, validation_url: str):
+    payload = {
+        "ShortCode": shortcode,
+        "ResponseType": "Completed",  # or "Cancelled"
+        "ConfirmationURL": confirmation_url,
+        "ValidationURL": validation_url,
+    }
+    resp = await client.post("/mpesa/c2b/v1/registerurl", json=payload)
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### C2B Simulate (Sandbox Only)
+
+```python
+async def c2b_simulate(client: httpx.AsyncClient, shortcode: str,
+                        amount: int, phone: str, bill_ref: str):
+    payload = {
+        "ShortCode": shortcode,
+        "CommandID": "CustomerPayBillOnline",
+        "Amount": amount,
+        "Msisdn": phone,
+        "BillRefNumber": bill_ref,
+    }
+    resp = await client.post("/mpesa/c2b/v1/simulate", json=payload)
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### B2C Payment (Business to Customer)
+
+Send money to a customer (salaries, refunds, promotions).
+
+```python
+async def b2c_payment(client: httpx.AsyncClient, initiator_name: str,
+                       security_credential: str, amount: int,
+                       phone: str, shortcode: str,
+                       result_url: str, timeout_url: str,
+                       command_id: str = "BusinessPayment",
+                       remarks: str = "", occasion: str = ""):
+    """
+    command_id: BusinessPayment, SalaryPayment, or PromotionPayment
+    security_credential: encrypted initiator password (RSA with Safaricom cert)
+    """
+    payload = {
+        "InitiatorName": initiator_name,
+        "SecurityCredential": security_credential,
+        "CommandID": command_id,
+        "Amount": amount,
+        "PartyA": shortcode,
+        "PartyB": phone,
+        "Remarks": remarks,
+        "QueueTimeOutURL": timeout_url,
+        "ResultURL": result_url,
+        "Occasion": occasion,
+    }
+    resp = await client.post("/mpesa/b2c/v1/paymentrequest", json=payload)
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Account Balance Query
+
+```python
+async def account_balance(client: httpx.AsyncClient, initiator_name: str,
+                           security_credential: str, shortcode: str,
+                           result_url: str, timeout_url: str):
+    payload = {
+        "Initiator": initiator_name,
+        "SecurityCredential": security_credential,
+        "CommandID": "AccountBalance",
+        "PartyA": shortcode,
+        "IdentifierType": "4",  # 4 = Shortcode
+        "Remarks": "Balance query",
+        "QueueTimeOutURL": timeout_url,
+        "ResultURL": result_url,
+    }
+    resp = await client.post("/mpesa/accountbalance/v1/query", json=payload)
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Transaction Status Query
+
+```python
+async def transaction_status(client: httpx.AsyncClient, initiator_name: str,
+                              security_credential: str, transaction_id: str,
+                              shortcode: str, result_url: str, timeout_url: str):
+    payload = {
+        "Initiator": initiator_name,
+        "SecurityCredential": security_credential,
+        "CommandID": "TransactionStatusQuery",
+        "TransactionID": transaction_id,
+        "PartyA": shortcode,
+        "IdentifierType": "4",
+        "Remarks": "Status check",
+        "QueueTimeOutURL": timeout_url,
+        "ResultURL": result_url,
+    }
+    resp = await client.post("/mpesa/transactionstatus/v1/query", json=payload)
+    resp.raise_for_status()
+    return resp.json()
+```
+
+## Error Handling
+
+Daraja returns a `ResponseCode` in the JSON body. HTTP status may be 200 even on logical errors.
+
+**STK Push Result Codes (callback):**
+
+| ResultCode | Meaning |
+|---|---|
+| 0 | Success |
+| 1 | Insufficient balance |
+| 1025 | Push request issue (system error) |
+| 1032 | Request cancelled by user |
+| 1037 | DS timeout (user did not respond) |
+| 2001 | Invalid credentials / wrong initiator |
+
+**HTTP-level errors:**
+
+| Status | Meaning |
+|---|---|
+| 400 | Bad request (malformed JSON, missing fields) |
+| 401 | Invalid or expired access token |
+| 403 | Forbidden (IP not whitelisted in production) |
+| 404 | Endpoint not found |
+| 500 | Safaricom internal error (often transient) |
+| 503 | Service unavailable (throttled or maintenance) |
+
+```python
+class MpesaError(Exception):
+    def __init__(self, response_code: str, response_desc: str, http_status: int = 200):
+        self.response_code = response_code
+        self.response_desc = response_desc
+        self.http_status = http_status
+        super().__init__(f"[{response_code}] {response_desc}")
+
+async def safe_request(client: httpx.AsyncClient, method: str, url: str, **kwargs):
+    resp = await client.request(method, url, **kwargs)
+    body = resp.json()
+    if resp.status_code >= 400:
+        raise MpesaError(
+            str(resp.status_code),
+            body.get("errorMessage", body.get("ResponseDescription", "Unknown error")),
+            resp.status_code,
+        )
+    response_code = body.get("ResponseCode", body.get("errorCode", ""))
+    if response_code and response_code != "0":
+        raise MpesaError(response_code, body.get("ResponseDescription", "Request failed"))
+    return body
+```
+
+## Common Pitfalls
+
+1. **Expired OAuth tokens** — Tokens last 3600 seconds. Always fetch a fresh token or cache with a TTL slightly under 1 hour.
+2. **Phone number format** — Must be `2547XXXXXXXX`. Leading `+`, `07`, or `7` formats cause 400 errors. Strip and normalize.
+3. **Password generation** — The Password is `base64(ShortCode + Passkey + Timestamp)`. A wrong Passkey or mismatched Timestamp causes "Invalid credentials."
+4. **Callback URL must be HTTPS** — Daraja rejects HTTP callback URLs. In development, use ngrok or similar tunneling.
+5. **Sandbox vs. production domain** — Forgetting to switch from `sandbox.safaricom.co.ke` to `api.safaricom.co.ke` is the most common go-live failure.
+6. **IP whitelisting** — Production apps require your server IP to be whitelisted via the Daraja portal. Requests from non-whitelisted IPs get 403.
+7. **Security Credential for B2C** — The initiator password must be encrypted with Safaricom's public certificate (different cert for sandbox vs. production). Use OpenSSL or Python's `cryptography` library.
+8. **Callback response** — Your callback endpoint must respond with HTTP 200 and a JSON body `{"ResultCode": 0, "ResultDesc": "Success"}`. Otherwise, Daraja retries and may mark the transaction as failed.
+9. **Amount as integer** — M-Pesa does not support decimal amounts. Passing `10.5` causes errors. Always use whole numbers.
+10. **TransactionType confusion** — STK Push uses `CustomerPayBillOnline` for Paybill and `CustomerBuyGoodsOnline` for Till. Using the wrong type causes the push to fail silently.

--- a/content/msg91/docs/rest-api/python/DOC.md
+++ b/content/msg91/docs/rest-api/python/DOC.md
@@ -1,0 +1,426 @@
+---
+name: rest-api
+description: "MSG91 - Transactional SMS, Email & WhatsApp API (India)"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "msg91,sms,email,whatsapp,otp,india,messaging,api"
+---
+
+# MSG91 REST API Reference (Python / httpx)
+
+MSG91 is India's leading cloud communication platform for transactional SMS, email, WhatsApp messaging, and OTP verification. All API requests authenticate via the `authkey` header.
+
+**Base URL:** `https://control.msg91.com/api/v5`
+
+## Authentication
+
+Every request requires your MSG91 authkey in the header:
+
+```
+authkey: <your_authkey>
+```
+
+Obtain your authkey from the MSG91 dashboard under **API Keys**.
+
+---
+
+## 1. Send SMS
+
+Send transactional SMS using a pre-approved template.
+
+| Field | Value |
+|-------|-------|
+| **Endpoint** | `POST /flow` |
+| **Full URL** | `https://control.msg91.com/api/v5/flow` |
+| **Content-Type** | `application/json` |
+
+### Request Body
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `template_id` | string | Yes | SMS template ID from MSG91 dashboard |
+| `recipients` | array | Yes | List of recipient objects |
+| `recipients[].mobiles` | string | Yes | Phone number with country code (e.g. `919876543210`) |
+| `recipients[].VAR1` | string | No | Template variable (case-sensitive, matches template) |
+| `recipients[].VAR2` | string | No | Additional template variable |
+| `short_url` | string | No | `"1"` to enable URL shortening, `"0"` to disable |
+| `short_url_expiry` | string | No | Short URL expiry in seconds |
+| `realTimeResponse` | string | No | `"1"` for real-time error response |
+
+### Example
+
+```python
+import httpx
+
+async def send_sms(authkey: str, template_id: str, mobile: str, variables: dict) -> dict:
+    """Send transactional SMS via MSG91 Flow API."""
+    url = "https://control.msg91.com/api/v5/flow"
+    headers = {
+        "accept": "application/json",
+        "authkey": authkey,
+        "content-type": "application/json",
+    }
+    recipient = {"mobiles": mobile}
+    recipient.update(variables)
+
+    payload = {
+        "template_id": template_id,
+        "recipients": [recipient],
+    }
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(url, json=payload, headers=headers)
+        resp.raise_for_status()
+        return resp.json()
+
+# Usage:
+# result = await send_sms(
+#     authkey="your_authkey",
+#     template_id="6123abcdef01234567890abc",
+#     mobile="919876543210",
+#     variables={"VAR1": "John", "VAR2": "12345"},
+# )
+```
+
+### Response
+
+```json
+{
+  "type": "success",
+  "message": "5e1e93cad6fc054d8e759a5b"
+}
+```
+
+The `message` field contains the request ID for tracking.
+
+---
+
+## 2. Send OTP
+
+Send a one-time password to a mobile number.
+
+| Field | Value |
+|-------|-------|
+| **Endpoint** | `POST /otp` |
+| **Full URL** | `https://control.msg91.com/api/v5/otp` |
+| **Content-Type** | `application/json` |
+
+### Request Body / Query Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `authkey` | string | Yes | Your MSG91 authkey |
+| `mobile` | string | Yes | Phone with country code (e.g. `919876543210`) |
+| `template_id` | string | Yes | OTP template ID (template must contain `##OTP##` placeholder) |
+| `otp` | string | No | Specify a custom OTP value |
+| `otp_expiry` | integer | No | Expiry in minutes (default 15, max 10080) |
+| `otp_length` | integer | No | Number of digits (4-9, default 4) |
+| `unicode` | string | No | `"1"` for non-English languages |
+| `invisible` | string | No | `"1"` for mobile app silent verification |
+| `userip` | string | No | End-user IP address |
+| `realTimeResponse` | string | No | `"1"` for real-time error codes |
+
+### Example
+
+```python
+import httpx
+
+async def send_otp(
+    authkey: str,
+    mobile: str,
+    template_id: str,
+    otp_length: int = 6,
+    otp_expiry: int = 10,
+) -> dict:
+    """Send OTP to a mobile number via MSG91."""
+    url = "https://control.msg91.com/api/v5/otp"
+    headers = {
+        "accept": "application/json",
+        "content-type": "application/json",
+    }
+    payload = {
+        "authkey": authkey,
+        "mobile": mobile,
+        "template_id": template_id,
+        "otp_length": otp_length,
+        "otp_expiry": otp_expiry,
+    }
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(url, json=payload, headers=headers)
+        resp.raise_for_status()
+        return resp.json()
+
+# Usage:
+# result = await send_otp(
+#     authkey="your_authkey",
+#     mobile="919876543210",
+#     template_id="6123abcdef01234567890abc",
+# )
+```
+
+### Response
+
+```json
+{
+  "type": "success",
+  "request_id": "34676b6d426b303131363537"
+}
+```
+
+---
+
+## 3. Verify OTP
+
+Verify an OTP previously sent to a mobile number.
+
+| Field | Value |
+|-------|-------|
+| **Endpoint** | `GET /otp/verify` |
+| **Full URL** | `https://control.msg91.com/api/v5/otp/verify` |
+
+### Query Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `authkey` | string | Yes | Your MSG91 authkey |
+| `mobile` | string | Yes | Phone with country code |
+| `otp` | string | Yes | OTP entered by the user |
+
+### Example
+
+```python
+import httpx
+
+async def verify_otp(authkey: str, mobile: str, otp: str) -> dict:
+    """Verify an OTP sent via MSG91."""
+    url = "https://control.msg91.com/api/v5/otp/verify"
+    params = {
+        "authkey": authkey,
+        "mobile": mobile,
+        "otp": otp,
+    }
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(url, params=params)
+        resp.raise_for_status()
+        return resp.json()
+
+# Usage:
+# result = await verify_otp(
+#     authkey="your_authkey",
+#     mobile="919876543210",
+#     otp="482901",
+# )
+```
+
+### Response
+
+```json
+{
+  "type": "success",
+  "message": "OTP verified successfully"
+}
+```
+
+---
+
+## 4. Resend OTP
+
+Resend OTP to the same mobile number via SMS or voice.
+
+| Field | Value |
+|-------|-------|
+| **Endpoint** | `GET /otp/retry` |
+| **Full URL** | `https://control.msg91.com/api/v5/otp/retry` |
+
+### Query Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `authkey` | string | Yes | Your MSG91 authkey |
+| `mobile` | string | Yes | Phone with country code |
+| `retrytype` | string | No | `"text"` for SMS (default), `"voice"` for voice call |
+
+### Example
+
+```python
+import httpx
+
+async def resend_otp(authkey: str, mobile: str, retrytype: str = "text") -> dict:
+    """Resend OTP via SMS or voice call."""
+    url = "https://control.msg91.com/api/v5/otp/retry"
+    params = {
+        "authkey": authkey,
+        "mobile": mobile,
+        "retrytype": retrytype,
+    }
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(url, params=params)
+        resp.raise_for_status()
+        return resp.json()
+```
+
+---
+
+## 5. Send Email
+
+Send transactional email using a pre-approved template.
+
+| Field | Value |
+|-------|-------|
+| **Endpoint** | `POST /email/send` |
+| **Full URL** | `https://control.msg91.com/api/v5/email/send` |
+| **Content-Type** | `application/json` |
+
+### Request Body
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `domain` | string | Yes | Verified sending domain |
+| `template_id` | string | Yes | Email template ID from MSG91 dashboard |
+| `recipients` | array | Yes | List of recipient objects |
+| `recipients[].to` | array | Yes | Array of `{"email": "...", "name": "..."}` objects |
+| `recipients[].variables` | object | No | Template variable key-value pairs |
+| `from` | object | Yes | `{"email": "sender@domain.com", "name": "Sender Name"}` |
+
+### Example
+
+```python
+import httpx
+
+async def send_email(
+    authkey: str,
+    domain: str,
+    template_id: str,
+    to_email: str,
+    to_name: str,
+    from_email: str,
+    from_name: str,
+    variables: dict | None = None,
+) -> dict:
+    """Send transactional email via MSG91."""
+    url = "https://control.msg91.com/api/v5/email/send"
+    headers = {
+        "accept": "application/json",
+        "authkey": authkey,
+        "content-type": "application/json",
+    }
+    payload = {
+        "domain": domain,
+        "template_id": template_id,
+        "recipients": [
+            {
+                "to": [{"email": to_email, "name": to_name}],
+                "variables": variables or {},
+            }
+        ],
+        "from": {"email": from_email, "name": from_name},
+    }
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(url, json=payload, headers=headers)
+        resp.raise_for_status()
+        return resp.json()
+
+# Usage:
+# result = await send_email(
+#     authkey="your_authkey",
+#     domain="mail.example.com",
+#     template_id="global_otp_01",
+#     to_email="user@example.com",
+#     to_name="Priya Sharma",
+#     from_email="noreply@mail.example.com",
+#     from_name="MyApp",
+#     variables={"company_name": "MyApp", "otp": "482901"},
+# )
+```
+
+### Response
+
+```json
+{
+  "type": "success",
+  "message": "Request accepted"
+}
+```
+
+---
+
+## Error Handling
+
+MSG91 returns errors in a consistent format:
+
+```json
+{
+  "type": "error",
+  "message": "Description of the error"
+}
+```
+
+Common error messages:
+
+| Error | Cause |
+|-------|-------|
+| `Auth Key missing` | Missing `authkey` header or parameter |
+| `Please enter atleast one number` | No mobile number provided |
+| `The provided flow ID or template ID is invalid` | Invalid template/flow ID |
+| `Invalid OTP` | OTP verification failed |
+| `OTP expired` | OTP has passed its expiry window |
+
+### Reusable Error Handler
+
+```python
+import httpx
+
+class MSG91Error(Exception):
+    """Custom exception for MSG91 API errors."""
+    def __init__(self, message: str, response: httpx.Response):
+        super().__init__(message)
+        self.response = response
+
+async def msg91_request(
+    method: str,
+    url: str,
+    authkey: str,
+    **kwargs,
+) -> dict:
+    """Generic MSG91 API request with error handling."""
+    headers = kwargs.pop("headers", {})
+    headers.update({
+        "accept": "application/json",
+        "authkey": authkey,
+    })
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.request(method, url, headers=headers, **kwargs)
+        data = resp.json()
+
+        if resp.status_code >= 400 or data.get("type") == "error":
+            raise MSG91Error(data.get("message", "Unknown error"), resp)
+
+        return data
+```
+
+---
+
+## Rate Limits and Notes
+
+- Templates must be pre-approved via the MSG91 dashboard before use.
+- OTP templates must include the `##OTP##` placeholder.
+- SMS sending uses the Flow API (`/flow`), which requires a template-based approach.
+- The `authkey` is your primary credential; keep it secret.
+- Phone numbers must include the country code without `+` (e.g. `919876543210` for India).
+- Email domains must be verified with DNS (TXT + MX records) before sending.
+
+## References
+
+- MSG91 API Docs: https://docs.msg91.com/
+- SMS: https://docs.msg91.com/sms/send-sms
+- OTP: https://docs.msg91.com/otp/sendotp
+- Email: https://docs.msg91.com/email/send-email

--- a/content/nextcloud/docs/rest-api/python/DOC.md
+++ b/content/nextcloud/docs/rest-api/python/DOC.md
@@ -1,0 +1,309 @@
+---
+name: rest-api
+description: "Nextcloud OCS and WebDAV REST API for file management, sharing, user provisioning, calendars, and self-hosted personal organization"
+metadata:
+  languages: "python"
+  versions: "29+"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "nextcloud,calendar,contacts,files,self-hosted,privacy,organization,api"
+---
+
+# Nextcloud REST API Coding Guidelines (Python)
+
+You are a Nextcloud API coding expert. Help me with writing code using httpx async to interact with the Nextcloud OCS API and WebDAV endpoints for file management, sharing, user administration, and personal organization.
+
+You can find the official documentation here: https://docs.nextcloud.com/server/stable/developer_manual/client_apis/
+
+## Golden Rule: Use httpx Async for All API Calls
+
+Always use `httpx` with async/await for all Nextcloud REST API interactions.
+
+- **Correct:** `import httpx` / `async with httpx.AsyncClient() as client:` / `response = await client.request("PROPFIND", url, headers=headers)`
+- **Incorrect:** Using `requests`, `webdavclient3`, or `caldav` libraries for REST calls
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URLs
+
+Nextcloud provides two main API types: OCS API and WebDAV.
+
+- **OCS API Base:** `https://<nextcloud>/ocs/v2.php/`
+- **WebDAV Base:** `https://<nextcloud>/remote.php/dav/`
+
+## Authentication
+
+Basic Auth with username + app password. Required OCS header: `OCS-APIRequest: true`.
+
+For security, use app passwords (Settings > Security > Devices & sessions) instead of your main password.
+
+```bash
+export NEXTCLOUD_URL="https://cloud.example.com"
+export NEXTCLOUD_USER="your_username"
+export NEXTCLOUD_PASS="your_app_password"
+```
+
+```python
+import os
+import httpx
+
+NC_URL = os.environ["NEXTCLOUD_URL"]
+NC_USER = os.environ["NEXTCLOUD_USER"]
+NC_PASS = os.environ["NEXTCLOUD_PASS"]
+NC_AUTH = httpx.BasicAuth(NC_USER, NC_PASS)
+
+OCS_HEADERS = {"OCS-APIRequest": "true", "Accept": "application/json"}
+WEBDAV_BASE = f"{NC_URL}/remote.php/dav"
+OCS_BASE = f"{NC_URL}/ocs/v2.php"
+```
+
+## Rate Limiting
+
+Nextcloud does not impose strict API rate limits, but performance depends on your server's resources. Use pagination parameters (`limit`, `offset`) for large result sets.
+
+## Methods
+
+### List Folder Contents (WebDAV PROPFIND)
+
+```python
+import xml.etree.ElementTree as ET
+
+async def list_folder(path: str = "/"):
+    url = f"{WEBDAV_BASE}/files/{NC_USER}{path}"
+    body = """<?xml version="1.0" encoding="UTF-8"?>
+    <d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+        <d:prop>
+            <d:getlastmodified/><d:getcontentlength/>
+            <d:getcontenttype/><d:resourcetype/><oc:fileid/><oc:size/>
+        </d:prop>
+    </d:propfind>"""
+    async with httpx.AsyncClient(auth=NC_AUTH) as client:
+        response = await client.request("PROPFIND", url, headers={"Depth": "1"}, content=body)
+        response.raise_for_status()
+    ns = {"d": "DAV:", "oc": "http://owncloud.org/ns"}
+    root = ET.fromstring(response.text)
+    items = []
+    for resp in root.findall("d:response", ns):
+        href = resp.find("d:href", ns).text
+        props = resp.find("d:propstat/d:prop", ns)
+        is_dir = props.find("d:resourcetype/d:collection", ns) is not None
+        size = props.find("d:getcontentlength", ns)
+        items.append({
+            "href": href, "is_directory": is_dir,
+            "size": int(size.text) if size is not None and size.text else 0,
+        })
+    return items
+```
+
+---
+
+### Download a File
+
+```python
+async def download_file(remote_path: str, local_path: str):
+    url = f"{WEBDAV_BASE}/files/{NC_USER}{remote_path}"
+    async with httpx.AsyncClient(auth=NC_AUTH) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+        with open(local_path, "wb") as f:
+            f.write(response.content)
+```
+
+---
+
+### Upload a File
+
+```python
+async def upload_file(local_path: str, remote_path: str):
+    url = f"{WEBDAV_BASE}/files/{NC_USER}{remote_path}"
+    with open(local_path, "rb") as f:
+        content = f.read()
+    async with httpx.AsyncClient(auth=NC_AUTH) as client:
+        response = await client.put(url, content=content)
+        response.raise_for_status()
+```
+
+---
+
+### Create Folder / Delete / Move / Copy (WebDAV)
+
+```python
+async def create_folder(path: str):
+    url = f"{WEBDAV_BASE}/files/{NC_USER}{path}"
+    async with httpx.AsyncClient(auth=NC_AUTH) as client:
+        response = await client.request("MKCOL", url, headers={"X-NC-WebDAV-AutoMkcol": "1"})
+        response.raise_for_status()
+
+async def delete_item(path: str):
+    url = f"{WEBDAV_BASE}/files/{NC_USER}{path}"
+    async with httpx.AsyncClient(auth=NC_AUTH) as client:
+        response = await client.delete(url)
+        response.raise_for_status()
+
+async def move_item(source_path: str, dest_path: str, overwrite: bool = False):
+    async with httpx.AsyncClient(auth=NC_AUTH) as client:
+        response = await client.request(
+            "MOVE", f"{WEBDAV_BASE}/files/{NC_USER}{source_path}",
+            headers={
+                "Destination": f"{WEBDAV_BASE}/files/{NC_USER}{dest_path}",
+                "Overwrite": "T" if overwrite else "F",
+            },
+        )
+        response.raise_for_status()
+```
+
+---
+
+### Create a Share (OCS)
+
+```python
+async def create_share(
+    path: str, share_type: int = 3, permissions: int = 1,
+    password: str = None, expire_date: str = None,
+):
+    """share_type: 0=user, 1=group, 3=public link, 4=email, 6=federated.
+    permissions: 1=read, 2=update, 4=create, 8=delete, 16=share (bitmask)."""
+    data = {"path": path, "shareType": share_type, "permissions": permissions}
+    if password:
+        data["password"] = password
+    if expire_date:
+        data["expireDate"] = expire_date
+    async with httpx.AsyncClient(auth=NC_AUTH) as client:
+        response = await client.post(
+            f"{OCS_BASE}/apps/files_sharing/api/v1/shares",
+            headers=OCS_HEADERS, data=data,
+        )
+        response.raise_for_status()
+        return response.json()["ocs"]["data"]
+```
+
+---
+
+### Create a Calendar Event (CalDAV)
+
+```python
+import uuid
+
+async def create_event(
+    calendar_name: str, summary: str, start: str, end: str,
+    description: str = None, location: str = None,
+):
+    """start/end format: '20260315T090000Z'"""
+    event_uid = str(uuid.uuid4())
+    url = f"{WEBDAV_BASE}/calendars/{NC_USER}/{calendar_name}/{event_uid}.ics"
+    vcal = f"""BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Python//httpx//EN
+BEGIN:VEVENT
+UID:{event_uid}
+DTSTART:{start}
+DTEND:{end}
+SUMMARY:{summary}"""
+    if description:
+        vcal += f"\nDESCRIPTION:{description}"
+    if location:
+        vcal += f"\nLOCATION:{location}"
+    vcal += "\nEND:VEVENT\nEND:VCALENDAR"
+    async with httpx.AsyncClient(auth=NC_AUTH) as client:
+        response = await client.put(
+            url, content=vcal,
+            headers={"Content-Type": "text/calendar; charset=utf-8"},
+        )
+        response.raise_for_status()
+        return event_uid
+```
+
+---
+
+### Get Calendar Events (CalDAV REPORT)
+
+```python
+async def get_events(calendar_name: str, start: str, end: str):
+    """start/end format: '20260101T000000Z'"""
+    url = f"{WEBDAV_BASE}/calendars/{NC_USER}/{calendar_name}/"
+    body = f"""<?xml version="1.0" encoding="UTF-8"?>
+    <c:calendar-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+        <d:prop><d:getetag/><c:calendar-data/></d:prop>
+        <c:filter><c:comp-filter name="VCALENDAR"><c:comp-filter name="VEVENT">
+            <c:time-range start="{start}" end="{end}"/>
+        </c:comp-filter></c:comp-filter></c:filter>
+    </c:calendar-query>"""
+    async with httpx.AsyncClient(auth=NC_AUTH) as client:
+        response = await client.request("REPORT", url, content=body, headers={"Depth": "1"})
+        response.raise_for_status()
+        return response.text
+```
+
+## Error Handling
+
+```python
+async def safe_ocs_call(method: str, path: str, **kwargs):
+    async with httpx.AsyncClient(auth=NC_AUTH) as client:
+        try:
+            response = await getattr(client, method)(
+                f"{OCS_BASE}{path}", headers=OCS_HEADERS, **kwargs,
+            )
+            response.raise_for_status()
+            data = response.json()
+            status_code = data["ocs"]["meta"]["statuscode"]
+            if status_code >= 400:
+                print(f"OCS error {status_code}: {data['ocs']['meta'].get('message')}")
+                return None
+            return data["ocs"]["data"]
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 401:
+                print("Authentication failed -- check credentials or app password")
+            elif e.response.status_code == 404:
+                print(f"Resource not found: {path}")
+            else:
+                print(f"HTTP error {e.response.status_code}")
+            raise
+        except httpx.ConnectError:
+            print(f"Cannot connect to Nextcloud at {NC_URL}")
+            raise
+```
+
+### OCS Status Codes
+
+| Code | Meaning |
+|------|---------|
+| 200 | Success (OCS v2) |
+| 400 | Bad request / invalid parameter |
+| 403 | Forbidden / insufficient permissions |
+| 404 | Resource not found |
+| 997 | Unauthorized |
+
+### WebDAV Status Codes
+
+| Code | Meaning |
+|------|---------|
+| 201 | Created |
+| 204 | No content (successful delete/move) |
+| 207 | Multi-status (PROPFIND response) |
+| 401 | Unauthorized |
+| 404 | Not found |
+| 409 | Conflict (missing parent folder) |
+| 507 | Insufficient storage |
+
+## Common Pitfalls
+
+1. **`OCS-APIRequest: true` header is mandatory** -- All OCS requests require it. Without it, requests are rejected.
+
+2. **Use `Accept: application/json`** -- Default OCS response format is XML. Add this header for JSON.
+
+3. **OCS v2 vs v1** -- Use `/ocs/v2.php/` (returns standard HTTP status codes). v1 always returns 200 with status in body.
+
+4. **App passwords required with 2FA** -- When two-factor authentication is enabled, API calls must use app passwords.
+
+5. **WebDAV uses HTTP methods** -- `PROPFIND`, `MKCOL`, `MOVE`, `COPY`, `PROPPATCH` are standard WebDAV methods. httpx supports them via `client.request("METHOD", url)`.
+
+6. **`X-NC-WebDAV-AutoMkcol: 1`** -- Auto-creates parent directories on upload (NC 29+).
+
+7. **CalDAV/CardDAV endpoints** -- Calendars: `/remote.php/dav/calendars/<user>/<calendar>/`. Contacts: `/remote.php/dav/addressbooks/users/<user>/<addressbook>/`.
+
+8. **Chunked uploads** -- For large files, use `/remote.php/dav/uploads/` endpoint.

--- a/content/nhs/docs/rest-api/python/DOC.md
+++ b/content/nhs/docs/rest-api/python/DOC.md
@@ -1,0 +1,220 @@
+---
+name: rest-api
+description: "NHS Service Search API for UK healthcare organisation and service data"
+metadata:
+  languages: "python"
+  versions: "3.0.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "nhs,health,uk,gp,prescriptions,organizations,api"
+---
+
+# NHS Service Search API
+
+> **Golden Rule:** The NHS API has no official Python SDK. Use `httpx` (async) for direct REST API access. All endpoints are GET or POST returning JSON. Authentication requires a `subscription-key` header obtained from the NHS developer portal. Use v3 endpoints -- v1/v2 were deprecated on 2 February 2026.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+`https://api.nhs.uk/service-search`
+
+Documentation and key registration: https://digital.nhs.uk/developer
+
+## Authentication
+
+**Type:** Subscription Key (custom header)
+
+Register at the NHS developer portal to get a subscription key.
+
+```python
+import httpx
+
+SUBSCRIPTION_KEY = "your-nhs-subscription-key"
+BASE_URL = "https://api.nhs.uk/service-search"
+
+headers = {
+    "subscription-key": SUBSCRIPTION_KEY,
+    "Content-Type": "application/json"
+}
+client = httpx.AsyncClient(headers=headers, timeout=30.0)
+```
+
+**Important:** The `subscription-key` header is required for all requests. There is no anonymous/keyless access.
+
+## Rate Limiting
+
+| Tier | Rate Limit |
+|---|---|
+| Trial | 10 requests/minute, 1,000/month |
+| Full subscription | 4,000 requests/hour |
+
+## Methods
+
+### Search Organisations
+
+**Endpoint:** `GET /search`
+
+Search for NHS organisations (GP practices, hospitals, pharmacies, dentists, etc.) by name or postcode.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `search` | `str` | **required** (name or postcode) |
+| `$filter` | `str` | `None` (OData filter expression) |
+| `$top` | `int` | `25` (max results per page) |
+| `$skip` | `int` | `0` |
+| `$orderby` | `str` | `None` |
+| `api-version` | `str` | `3` |
+
+```python
+# Search for GP practices near a postcode
+params = {
+    "search": "SW1A 1AA",
+    "$filter": "OrganisationTypeId eq 'GPB'",
+    "$top": 10,
+    "api-version": "3"
+}
+response = await client.get(f"{BASE_URL}/search", params=params)
+response.raise_for_status()
+data = response.json()
+for org in data.get("value", []):
+    print(f"{org['OrganisationName']} - {org.get('Address1', 'N/A')}")
+```
+
+### Get Organisation Types
+
+**Endpoint:** `GET /search/organisationtypes`
+
+List all available organisation type codes.
+
+```python
+params = {"api-version": "3"}
+response = await client.get(f"{BASE_URL}/search/organisationtypes", params=params)
+response.raise_for_status()
+data = response.json()
+for org_type in data.get("value", []):
+    print(f"{org_type['OrganisationTypeId']}: {org_type['OrganisationTypeName']}")
+```
+
+Common organisation type codes:
+- `GPB` -- GP practices
+- `HOS` -- Hospitals
+- `PHA` -- Pharmacies
+- `DEN` -- Dentists
+- `OPT` -- Opticians
+- `CLI` -- Clinics
+
+### Search by Postcode
+
+**Endpoint:** `GET /search`
+
+Find nearby services by postcode with distance ordering.
+
+```python
+params = {
+    "search": "EC1A 1BB",
+    "$filter": "OrganisationTypeId eq 'PHA'",
+    "$top": 5,
+    "$orderby": "Geocode/distance",
+    "api-version": "3"
+}
+response = await client.get(f"{BASE_URL}/search", params=params)
+response.raise_for_status()
+data = response.json()
+for pharmacy in data.get("value", []):
+    name = pharmacy.get("OrganisationName", "Unknown")
+    postcode = pharmacy.get("Postcode", "N/A")
+    print(f"{name} ({postcode})")
+```
+
+### Search by Service
+
+**Endpoint:** `POST /search`
+
+Search with complex filters using POST body.
+
+```python
+body = {
+    "search": "mental health",
+    "filter": "OrganisationTypeId eq 'CLI'",
+    "top": 10,
+    "api-version": "3"
+}
+response = await client.post(f"{BASE_URL}/search", json=body)
+response.raise_for_status()
+data = response.json()
+```
+
+### Organisation Data Service (ODS) - Open Access
+
+**Base URL:** `https://directory.spineservices.nhs.uk/ORD/2-0-0`
+
+The ODS ORD API is **open access** and requires no authentication or subscription key.
+
+```python
+# Look up a specific organisation by ODS code
+ods_client = httpx.AsyncClient(timeout=30.0)
+response = await ods_client.get(
+    "https://directory.spineservices.nhs.uk/ORD/2-0-0/organisations/RJY"
+)
+response.raise_for_status()
+data = response.json()
+org = data.get("Organisation", {})
+print(f"Name: {org.get('Name', 'N/A')}")
+```
+
+```python
+# Search ODS organisations by name
+response = await ods_client.get(
+    "https://directory.spineservices.nhs.uk/ORD/2-0-0/organisations",
+    params={"Name": "Royal", "Limit": 10}
+)
+response.raise_for_status()
+data = response.json()
+for org in data.get("Organisations", []):
+    print(f"{org['Name']} ({org['OrgId']})")
+```
+
+## Error Handling
+
+```python
+import httpx
+
+try:
+    response = await client.get(f"{BASE_URL}/search", params={"search": "test", "api-version": "3"})
+    response.raise_for_status()
+    data = response.json()
+except httpx.HTTPStatusError as e:
+    if e.response.status_code == 401:
+        print("Invalid or missing subscription-key header")
+    elif e.response.status_code == 403:
+        print("Subscription key not authorized for this API")
+    elif e.response.status_code == 429:
+        print("Rate limited -- reduce request frequency or upgrade subscription")
+    elif e.response.status_code == 400:
+        print(f"Bad request (invalid filter syntax): {e.response.text}")
+    elif e.response.status_code == 404:
+        print("Endpoint not found -- check API version parameter")
+    else:
+        print(f"NHS API error {e.response.status_code}: {e.response.text}")
+except httpx.RequestError as e:
+    print(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+- Auth header is `subscription-key` (not `Authorization: Bearer`)
+- Always include `api-version=3` parameter -- v1/v2 were deprecated February 2026
+- OData filter expressions use single quotes for strings: `OrganisationTypeId eq 'GPB'`
+- The `$filter`, `$top`, `$skip`, `$orderby` parameters use OData syntax with `$` prefix
+- Postcode searches work best with spaces (e.g., `SW1A 1AA` not `SW1A1AA`)
+- Results are paginated; use `$skip` to get subsequent pages
+- The ODS ORD API at `directory.spineservices.nhs.uk` is separate and needs no auth
+- Trial subscriptions are severely limited (10/min, 1000/month)
+- Response structure uses `value` array (OData convention), not `results`
+- Set a reasonable timeout: `httpx.AsyncClient(timeout=30.0)`

--- a/content/nominatim/docs/rest-api/python/DOC.md
+++ b/content/nominatim/docs/rest-api/python/DOC.md
@@ -1,0 +1,343 @@
+---
+name: rest-api
+description: "Nominatim / OpenStreetMap API - Free geocoding, reverse geocoding, and address lookup"
+metadata:
+  languages: "python"
+  versions: "v1"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "nominatim,openstreetmap,geocoding,mapping,accessibility,open-data,api"
+---
+
+# Nominatim API - Python Reference (httpx)
+
+## Golden Rule
+
+Nominatim is the **free geocoding service** for OpenStreetMap. The public instance at `https://nominatim.openstreetmap.org` requires: (1) a **descriptive User-Agent** header identifying your application, (2) a maximum of **1 request per second**, and (3) **no autocomplete/typeahead** usage (this will get you banned). There is no API key -- just follow the usage policy. For higher throughput, self-host Nominatim or use a commercial OSM provider.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+All examples use `httpx` with async/await. For scripts that need a synchronous entrypoint:
+
+```python
+import asyncio
+import httpx
+
+async def main():
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{BASE_URL}/search",
+            headers=HEADERS,
+            params={"q": "Seattle, WA", "format": "jsonv2", "limit": 1},
+        )
+        print(resp.json())
+
+asyncio.run(main())
+```
+
+## Base URL
+
+```
+https://nominatim.openstreetmap.org
+```
+
+```python
+import os
+
+BASE_URL = os.environ.get("NOMINATIM_BASE_URL", "https://nominatim.openstreetmap.org")
+HEADERS = {
+    "User-Agent": "MyGeoApp/1.0 (contact@example.com)",
+}
+```
+
+## Authentication
+
+Nominatim requires **no authentication**. The only mandatory requirement is a descriptive `User-Agent` header:
+
+```
+User-Agent: MyAppName/Version (contact@email.com)
+```
+
+Generic or library-default User-Agent strings (e.g., `python-httpx/0.27`) will be blocked. Your User-Agent must identify your specific application.
+
+For high-volume usage, include an `email` query parameter as well:
+
+```python
+params["email"] = "your@email.com"
+```
+
+## Rate Limiting
+
+| Rule | Limit |
+|---|---|
+| Requests per second | 1 (absolute max for public instance) |
+| Autocomplete/typeahead | Strictly forbidden (results in ban) |
+| Bulk geocoding | Strongly discouraged (use database dump instead) |
+| Caching | Expected -- cache results for repeated queries |
+
+The public server runs on **donated hardware with limited capacity**. Respect these limits or self-host.
+
+```python
+import asyncio
+import time
+
+_last_request_time = 0.0
+
+async def nominatim_request(
+    client: httpx.AsyncClient,
+    path: str,
+    params: dict = None,
+) -> httpx.Response:
+    global _last_request_time
+
+    # Enforce 1 request per second
+    now = time.monotonic()
+    elapsed = now - _last_request_time
+    if elapsed < 1.0:
+        await asyncio.sleep(1.0 - elapsed)
+
+    _last_request_time = time.monotonic()
+
+    resp = await client.get(
+        f"{BASE_URL}{path}",
+        headers=HEADERS,
+        params=params,
+    )
+    resp.raise_for_status()
+    return resp
+```
+
+## Methods
+
+### Search (Forward Geocoding)
+
+Convert a place name or address to coordinates.
+
+**Free-form query parameters:**
+- `q` (str) -- Free-form search string (e.g., `"Seattle, WA"`, `"Eiffel Tower"`)
+
+**Structured query parameters (alternative to `q`):**
+- `amenity` (str) -- Name of POI
+- `street` (str) -- House number and street
+- `city` (str) -- City name
+- `county` (str) -- County name
+- `state` (str) -- State name
+- `country` (str) -- Country name
+- `postalcode` (str) -- Postal code
+
+**Common parameters:**
+- `format` (str) -- Response format: `jsonv2` (recommended), `json`, `geojson`, `geocodejson`, `xml`
+- `limit` (int) -- Max results (default 10, max 40)
+- `addressdetails` (int) -- Include address breakdown (0 or 1)
+- `extratags` (int) -- Include extra tags like Wikipedia links (0 or 1)
+- `namedetails` (int) -- Include all name variants (0 or 1)
+- `countrycodes` (str) -- Restrict to countries (comma-separated ISO 3166-1 codes)
+- `viewbox` (str) -- Focus area: `lon1,lat1,lon2,lat2`
+- `bounded` (int) -- Restrict to viewbox (0 or 1)
+- `layer` (str) -- Filter by type: `address`, `poi`, `railway`, `natural`, `manmade`
+- `featuretype` (str) -- Narrow by: `country`, `state`, `city`, `settlement`
+- `accept-language` (str) -- Preferred result language
+
+```python
+async def search(
+    client: httpx.AsyncClient,
+    query: str = None,
+    limit: int = 5,
+    addressdetails: bool = True,
+    countrycodes: str = None,
+    **structured_params,
+) -> list:
+    params = {
+        "format": "jsonv2",
+        "limit": limit,
+        "addressdetails": 1 if addressdetails else 0,
+    }
+    if query:
+        params["q"] = query
+    else:
+        params.update(structured_params)
+    if countrycodes:
+        params["countrycodes"] = countrycodes
+    resp = await nominatim_request(client, "/search", params)
+    return resp.json()
+
+# Usage -- free-form search
+results = await search(client, "Central Park, New York")
+if results:
+    r = results[0]
+    print(f"{r['display_name']}")
+    print(f"Lat: {r['lat']}, Lon: {r['lon']}")
+```
+
+### Structured Search
+
+```python
+# Usage -- structured search for a specific address
+results = await search(
+    client,
+    street="1600 Pennsylvania Avenue NW",
+    city="Washington",
+    state="DC",
+    country="United States",
+)
+```
+
+### Reverse Geocoding
+
+Convert coordinates to an address.
+
+**Parameters:**
+- `lat` (float) -- Latitude (required)
+- `lon` (float) -- Longitude (required)
+- `zoom` (int) -- Detail level 0-18 (3=country, 5=state, 8=county, 10=city, 14=suburb, 18=building)
+- `format` (str) -- Response format (default `xml`, use `jsonv2`)
+- `addressdetails` (int) -- Include address breakdown (default 1)
+- `layer` (str) -- Filter: `address`, `poi`, `railway`, `natural`, `manmade`
+- `accept-language` (str) -- Preferred language
+
+```python
+async def reverse_geocode(
+    client: httpx.AsyncClient,
+    lat: float,
+    lon: float,
+    zoom: int = 18,
+    addressdetails: bool = True,
+) -> dict:
+    params = {
+        "lat": lat,
+        "lon": lon,
+        "zoom": zoom,
+        "format": "jsonv2",
+        "addressdetails": 1 if addressdetails else 0,
+    }
+    resp = await nominatim_request(client, "/reverse", params)
+    return resp.json()
+
+# Usage
+location = await reverse_geocode(client, lat=40.7484, lon=-73.9857)
+print(f"Address: {location['display_name']}")
+address = location.get("address", {})
+print(f"City: {address.get('city')}, State: {address.get('state')}")
+```
+
+### Lookup (OSM IDs to Addresses)
+
+Look up address details for one or more OSM objects by their IDs.
+
+**Parameters:**
+- `osm_ids` (str) -- Comma-separated list of OSM IDs with type prefix: `N` (node), `W` (way), `R` (relation)
+
+```python
+async def lookup(
+    client: httpx.AsyncClient,
+    osm_ids: list[str],
+    addressdetails: bool = True,
+) -> list:
+    params = {
+        "osm_ids": ",".join(osm_ids),  # e.g., ["R146656", "W104393803", "N240109189"]
+        "format": "jsonv2",
+        "addressdetails": 1 if addressdetails else 0,
+    }
+    resp = await nominatim_request(client, "/lookup", params)
+    return resp.json()
+
+# Usage -- look up multiple places by OSM ID
+places = await lookup(client, ["R146656", "N240109189"])
+for p in places:
+    print(f"{p['display_name']} (OSM {p['osm_type']} {p['osm_id']})")
+```
+
+### Status Check
+
+```python
+async def check_status(client: httpx.AsyncClient) -> dict:
+    resp = await nominatim_request(client, "/status", params={"format": "json"})
+    return resp.json()
+
+# Returns: {"status": 0, "message": "OK", "data_updated": "2026-03-17T..."}
+```
+
+### Batch Geocoding Helper
+
+Since rate limit is 1/second, batch operations need throttling:
+
+```python
+async def batch_geocode(
+    client: httpx.AsyncClient,
+    addresses: list[str],
+) -> list[dict | None]:
+    results = []
+    for addr in addresses:
+        try:
+            matches = await search(client, addr, limit=1)
+            results.append(matches[0] if matches else None)
+        except httpx.HTTPStatusError:
+            results.append(None)
+    return results
+
+# Usage -- geocode a list of school addresses (respects 1/sec limit)
+schools = ["PS 234, New York", "Lincoln Elementary, Seattle", "Central High School, Philadelphia"]
+coords = await batch_geocode(client, schools)
+for addr, result in zip(schools, coords):
+    if result:
+        print(f"{addr}: ({result['lat']}, {result['lon']})")
+    else:
+        print(f"{addr}: not found")
+```
+
+## Error Handling
+
+| Code | Meaning |
+|---|---|
+| 200 | Success |
+| 400 | Bad Request -- missing or invalid parameters |
+| 403 | Forbidden -- blocked due to usage policy violation |
+| 404 | Not Found -- invalid endpoint |
+| 429 | Too Many Requests -- rate limit exceeded |
+| 503 | Service Unavailable -- server overloaded |
+
+```python
+class NominatimError(Exception):
+    def __init__(self, status_code: int, message: str):
+        self.status_code = status_code
+        self.message = message
+        super().__init__(f"[{status_code}] {message}")
+
+async def safe_nominatim_request(
+    client: httpx.AsyncClient,
+    path: str,
+    params: dict = None,
+) -> dict | list:
+    try:
+        resp = await nominatim_request(client, path, params)
+        return resp.json()
+    except httpx.HTTPStatusError as e:
+        raise NominatimError(e.response.status_code, str(e)) from e
+```
+
+## Common Pitfalls
+
+1. **1 request per second is enforced.** Exceeding this on the public server will get your IP blocked. The rate limiter in the examples above handles this, but be careful with concurrent code.
+
+2. **Autocomplete is banned.** Do not send requests on every keystroke. Wait until the user has finished typing and explicitly triggers a search. Violating this results in a permanent ban.
+
+3. **User-Agent is mandatory and must be specific.** Generic User-Agent strings are rejected. Use `AppName/Version (email@example.com)` format.
+
+4. **Default format is XML, not JSON.** Always pass `format=jsonv2` (recommended) or `format=json`. Without this, you get XML which is harder to parse.
+
+5. **Coordinates are returned as strings.** The `lat` and `lon` fields in JSON responses are strings, not floats. Cast them: `float(result["lat"])`.
+
+6. **Structured search cannot be combined with `q`.** Use either `q` for free-form or the structured parameters (`street`, `city`, etc.) -- not both.
+
+7. **`viewbox` uses lon,lat order.** The viewbox parameter is `lon1,lat1,lon2,lat2` (longitude first), which is opposite to the `lat,lon` convention used elsewhere in the API.
+
+8. **Reverse geocoding zoom controls detail level.** Zoom 3 returns country, zoom 10 returns city, zoom 18 returns building. Use an appropriate zoom for your use case.
+
+9. **Cache aggressively.** Nominatim data changes slowly. Cache geocoding results for at least 24 hours. For static addresses, cache indefinitely.
+
+10. **For bulk geocoding, use a local instance.** If you need to geocode more than a few hundred addresses, download the OSM data and run your own Nominatim instance. The public server is not designed for bulk use.

--- a/content/ntfy/docs/rest-api/python/DOC.md
+++ b/content/ntfy/docs/rest-api/python/DOC.md
@@ -1,0 +1,270 @@
+---
+name: rest-api
+description: "ntfy open-source push notification API for sending alerts, reminders, and notifications to phones and desktops with no account required"
+metadata:
+  languages: "python"
+  versions: "2.x"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "ntfy,notifications,push,open-source,alerts,reminders,free,api"
+---
+
+# ntfy REST API Coding Guidelines (Python)
+
+You are an ntfy API coding expert. Help me with writing code using httpx async to send and subscribe to push notifications via the ntfy REST API for personal alerts, reminders, and accessibility-focused notifications.
+
+You can find the official documentation here: https://docs.ntfy.sh/
+
+## Golden Rule: Use httpx Async for All API Calls
+
+Always use `httpx` with async/await for all ntfy REST API interactions.
+
+- **Library Name:** httpx
+- **Python Package:** `httpx`
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL and Authentication
+
+ntfy requires no account for the public server. Authentication is optional for self-hosted instances.
+
+- **Public Server:** `https://ntfy.sh`
+- **Self-Hosted:** `https://your-ntfy-server.example.com`
+- **No signup required** for the public server
+- **Topics act as channels** -- pick an unpredictable topic name as your "password"
+
+### Authentication (Optional, for self-hosted or protected topics)
+
+```python
+import httpx
+import os
+
+NTFY_URL = os.environ.get("NTFY_URL", "https://ntfy.sh")
+NTFY_TOPIC = os.environ["NTFY_TOPIC"]
+
+# Option 1: Bearer token
+NTFY_TOKEN = os.environ.get("NTFY_TOKEN")
+HEADERS_TOKEN = {"Authorization": f"Bearer {NTFY_TOKEN}"} if NTFY_TOKEN else {}
+
+# Option 2: Basic auth
+from base64 import b64encode
+NTFY_USER = os.environ.get("NTFY_USER")
+NTFY_PASS = os.environ.get("NTFY_PASS")
+if NTFY_USER and NTFY_PASS:
+    credentials = b64encode(f"{NTFY_USER}:{NTFY_PASS}".encode()).decode()
+    HEADERS_BASIC = {"Authorization": f"Basic {credentials}"}
+else:
+    HEADERS_BASIC = {}
+```
+
+## Rate Limiting
+
+| Resource | Limit |
+|----------|-------|
+| Message body | 4,096 bytes (excess becomes attachment) |
+| Attachment size | 15 MB per file |
+| Attachment expiry | 3 hours |
+| Action buttons | 3 per notification |
+| Scheduled delivery | 10 seconds to 3 days in the future |
+| Cache duration (default) | 12 hours |
+| Default rate limit burst | 60 requests |
+
+## Methods
+
+### Simple Text Message
+
+```python
+async def send_notification(message: str):
+    async with httpx.AsyncClient() as client:
+        response = await client.post(f"{NTFY_URL}/{NTFY_TOPIC}", content=message)
+        response.raise_for_status()
+        return response.json()
+```
+
+### Notification with Title, Priority, and Tags
+
+All options can be set via HTTP headers:
+
+```python
+async def send_rich_notification(
+    message: str, title: str = None, priority: int = None,
+    tags: list[str] = None, click_url: str = None,
+    attach_url: str = None, delay: str = None, markdown: bool = False,
+):
+    """Send a notification with full options via headers.
+
+    Args:
+        message: Message body (max 4096 bytes)
+        title: Notification title
+        priority: 1=min, 2=low, 3=default, 4=high, 5=urgent
+        tags: List of tags (can include emoji shortcodes like "warning")
+        click_url: URL to open when notification is tapped
+        attach_url: URL of file to attach
+        delay: Schedule delivery ("30m", "2h", "tomorrow 9am", Unix timestamp)
+        markdown: Enable markdown formatting
+    """
+    headers = {}
+    if title: headers["X-Title"] = title
+    if priority: headers["X-Priority"] = str(priority)
+    if tags: headers["X-Tags"] = ",".join(tags)
+    if click_url: headers["X-Click"] = click_url
+    if attach_url: headers["X-Attach"] = attach_url
+    if delay: headers["X-Delay"] = delay
+    if markdown: headers["Content-Type"] = "text/markdown"
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(f"{NTFY_URL}/{NTFY_TOPIC}", content=message, headers=headers)
+        response.raise_for_status()
+        return response.json()
+```
+
+### JSON Publishing (Action Buttons)
+
+For notifications with interactive action buttons, use the JSON endpoint:
+
+```python
+async def send_json_notification(
+    message: str, title: str = None, priority: int = None,
+    tags: list[str] = None, actions: list[dict] = None,
+    click: str = None, delay: str = None, markdown: bool = False,
+):
+    payload = {"topic": NTFY_TOPIC, "message": message}
+    if title: payload["title"] = title
+    if priority: payload["priority"] = priority
+    if tags: payload["tags"] = tags
+    if actions: payload["actions"] = actions  # max 3 action buttons
+    if click: payload["click"] = click
+    if delay: payload["delay"] = delay
+    if markdown: payload["markdown"] = True
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(f"{NTFY_URL}/", json=payload)
+        response.raise_for_status()
+        return response.json()
+```
+
+### Scheduled / Delayed Delivery
+
+```python
+# Delay by duration
+await send_rich_notification("Time to stretch!", title="Break Reminder", delay="30m")
+# Delay until specific time
+await send_rich_notification("Take evening medication", title="Medication", delay="8:30pm")
+# Delay until date and time
+await send_rich_notification("Appointment tomorrow", delay="tomorrow, 9am")
+```
+
+### Cancel a Scheduled Message
+
+```python
+async def cancel_scheduled(message_id: str):
+    async with httpx.AsyncClient() as client:
+        response = await client.delete(f"{NTFY_URL}/{NTFY_TOPIC}/{message_id}")
+        response.raise_for_status()
+        return response.json()
+```
+
+### Upload File Attachment
+
+```python
+async def send_with_file(filepath: str, message: str = None, title: str = None):
+    """Upload a local file as attachment (max 15MB)."""
+    filename = filepath.split("/")[-1]
+    headers = {"X-Filename": filename}
+    if message: headers["X-Message"] = message
+    if title: headers["X-Title"] = title
+    with open(filepath, "rb") as f:
+        async with httpx.AsyncClient() as client:
+            response = await client.put(f"{NTFY_URL}/{NTFY_TOPIC}", content=f.read(), headers=headers)
+            response.raise_for_status()
+            return response.json()
+```
+
+## Subscribing / Polling
+
+### Poll for Cached Messages
+
+```python
+import json
+
+async def poll_messages(since: str = "10m"):
+    """Retrieve cached messages. since: duration ("10m", "1h"), message ID, or "all"."""
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{NTFY_URL}/{NTFY_TOPIC}/json", params={"poll": "1", "since": since},
+        )
+        response.raise_for_status()
+        return [json.loads(line) for line in response.text.strip().split("\n")
+                if line and json.loads(line).get("event") == "message"]
+```
+
+### Subscribe with Streaming (Long-lived connection)
+
+```python
+async def subscribe_stream(callback, since: str = "all"):
+    """Subscribe to topic with streaming JSON response."""
+    async with httpx.AsyncClient(timeout=None) as client:
+        async with client.stream("GET", f"{NTFY_URL}/{NTFY_TOPIC}/json", params={"since": since}) as response:
+            async for line in response.aiter_lines():
+                if line.strip():
+                    data = json.loads(line)
+                    if data.get("event") == "message":
+                        await callback(data)
+```
+
+### Server Health Check
+
+```python
+async def health_check():
+    async with httpx.AsyncClient() as client:
+        response = await client.get(f"{NTFY_URL}/v1/health")
+        response.raise_for_status()
+        return response.json()
+```
+
+## Error Handling
+
+```python
+async def safe_send(message: str, **kwargs):
+    try:
+        headers = {}
+        for key, value in kwargs.items():
+            headers[f"X-{key.replace('_', '-').title()}"] = str(value)
+        async with httpx.AsyncClient() as client:
+            response = await client.post(f"{NTFY_URL}/{NTFY_TOPIC}", content=message, headers=headers)
+            response.raise_for_status()
+            return response.json()
+    except httpx.HTTPStatusError as e:
+        status_map = {401: "Authentication required", 403: "Access denied",
+                      413: "Message or attachment too large", 429: "Rate limit exceeded"}
+        print(status_map.get(e.response.status_code, f"HTTP error {e.response.status_code}: {e.response.text}"))
+        raise
+    except httpx.ConnectError:
+        print(f"Cannot connect to ntfy server at {NTFY_URL}")
+        raise
+```
+
+## Common Pitfalls
+
+1. **Topic names are public** -- On the public ntfy.sh server, anyone who knows your topic name can read/write. Use long, random strings as topic names.
+2. **Message size limit** -- Messages over 4,096 bytes are automatically converted to file attachments.
+3. **Scheduled delivery window** -- Delays must be between 10 seconds and 3 days in the future.
+4. **Priority levels** -- Priority 5 (urgent) bypasses Do Not Disturb on most devices. Use sparingly.
+5. **Action button limit** -- Maximum 3 action buttons per notification. HTTP actions can include custom headers and body.
+6. **Subscription formats** -- ntfy supports JSON stream, SSE, raw stream, and WebSocket. Use `/json` for structured data.
+7. **Cache duration** -- Messages are cached for 12 hours by default. Use `since` parameter to fetch cached messages.
+8. **Self-hosted auth** -- The public server needs no auth, but self-hosted instances can require bearer tokens or basic auth.
+
+## Useful Links
+
+- **Official Documentation:** https://docs.ntfy.sh/
+- **Publishing API:** https://docs.ntfy.sh/publish/
+- **Subscribe API:** https://docs.ntfy.sh/subscribe/api/
+- **Self-Hosting:** https://docs.ntfy.sh/install/
+- **Web App:** https://ntfy.sh/app
+- **GitHub Repository:** https://github.com/binwiederhier/ntfy

--- a/content/ola-maps/docs/rest-api/python/DOC.md
+++ b/content/ola-maps/docs/rest-api/python/DOC.md
@@ -1,0 +1,278 @@
+---
+name: rest-api
+description: "Ola Maps - India-Optimized Mapping, Geocoding & Routing API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-13"
+  source: community
+  tags: "ola-maps,maps,geocoding,routing,directions,places,india,distance-matrix,autocomplete,api,integration"
+---
+
+# Ola Maps API
+
+> **Golden Rule:** Ola Maps has no official Python SDK (unofficial `py_olamaps` exists). Use `httpx` for direct REST access. Auth supports either `api_key` query parameter or OAuth 2.0 Bearer token. All coordinates use `lat,lng` format. Multiple points use pipe (`|`) separator. Free tier: 500K calls/month for the first year.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+```
+https://api.olamaps.io
+```
+
+## Authentication
+
+**Type:** API Key (query param) or OAuth 2.0 Bearer Token
+
+```python
+import httpx
+
+API_KEY = "your-ola-maps-api-key"
+BASE_URL = "https://api.olamaps.io"
+
+# Option 1: API Key (simplest)
+client = httpx.AsyncClient(params={"api_key": API_KEY}, timeout=30.0)
+
+# Option 2: OAuth 2.0 Bearer Token
+token_response = await httpx.AsyncClient().post(
+    "https://account.olamaps.io/realms/olamaps/protocol/openid-connect/token",
+    data={
+        "grant_type": "client_credentials",
+        "scope": "openid",
+        "client_id": "your-client-id",
+        "client_secret": "your-client-secret"
+    }
+)
+token_response.raise_for_status()
+access_token = token_response.json()["access_token"]
+client = httpx.AsyncClient(
+    headers={"Authorization": f"Bearer {access_token}"},
+    timeout=30.0
+)
+```
+
+**Important:** Sign up at https://cloud.olakrutrim.com to get credentials. Domains must be whitelisted for OAuth.
+
+## Rate Limiting
+
+Per-minute and monthly limits (tier-specific, not publicly documented). HTTP 429 returned when exceeded.
+
+## Methods
+
+### `geocode`
+
+**Endpoint:** `GET /places/v1/geocode`
+
+Convert an address to geographic coordinates.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `address` | `str` | **required** |
+| `bounds` | `str` | `None` (pipe-separated lat,lng pairs) |
+| `language` | `str` | `None` |
+
+**Returns:** JSON with geocoded results including coordinates
+
+```python
+params = {"address": "Connaught Place, New Delhi"}
+response = await client.get(f"{BASE_URL}/places/v1/geocode", params=params)
+response.raise_for_status()
+results = response.json()
+```
+
+### `reverse_geocode`
+
+**Endpoint:** `GET /places/v1/reverse-geocode`
+
+Convert coordinates to a human-readable address.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `latlng` | `str` | **required** (`lat,lng` format) |
+
+```python
+params = {"latlng": "28.6315,77.2167"}
+response = await client.get(f"{BASE_URL}/places/v1/reverse-geocode", params=params)
+response.raise_for_status()
+address = response.json()
+```
+
+### `autocomplete`
+
+**Endpoint:** `GET /places/v1/autocomplete`
+
+Get real-time location search suggestions.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `input` | `str` | **required** (search text) |
+| `location` | `str` | `None` (bias near `lat,lng`) |
+| `radius` | `int` | `None` (meters) |
+| `strictbounds` | `bool` | `None` |
+
+```python
+params = {"input": "Indiranagar Bangalore", "location": "12.9716,77.5946"}
+response = await client.get(f"{BASE_URL}/places/v1/autocomplete", params=params)
+response.raise_for_status()
+suggestions = response.json()
+```
+
+### `place_details`
+
+**Endpoint:** `GET /places/v1/details`
+
+Get detailed information about a place by its ID.
+
+```python
+params = {"place_id": "ola-place-id-here"}
+response = await client.get(f"{BASE_URL}/places/v1/details", params=params)
+response.raise_for_status()
+place = response.json()
+```
+
+### `nearby_search`
+
+**Endpoint:** `GET /places/v1/nearbysearch`
+
+Search for places near a location.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `layers` | `str` | **required** |
+| `location` | `str` | **required** (`lat,lng`) |
+| `types` | `str` | `None` |
+| `radius` | `int` | `None` (meters) |
+| `limit` | `int` | `None` (5-50) |
+
+```python
+params = {
+    "layers": "venue",
+    "location": "12.9716,77.5946",
+    "types": "restaurant",
+    "radius": 1000,
+    "limit": 10
+}
+response = await client.get(f"{BASE_URL}/places/v1/nearbysearch", params=params)
+response.raise_for_status()
+places = response.json()
+```
+
+### `text_search`
+
+**Endpoint:** `GET /places/v1/textsearch`
+
+Search for places using a text query.
+
+```python
+params = {"input": "coffee shops in Koramangala", "location": "12.9352,77.6245"}
+response = await client.get(f"{BASE_URL}/places/v1/textsearch", params=params)
+response.raise_for_status()
+results = response.json()
+```
+
+### `directions`
+
+**Endpoint:** `POST /routing/v1/directions`
+
+Get optimized routes with turn-by-turn directions.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `origin` | `str` | **required** (`lat,lng`) |
+| `destination` | `str` | **required** (`lat,lng`) |
+| `waypoints` | `str` | `None` (pipe-separated `lat,lng` pairs) |
+| `mode` | `str` | `driving` (`driving` or `walking`) |
+| `alternatives` | `bool` | `None` |
+| `steps` | `bool` | `None` |
+| `language` | `str` | `en` (`en`, `hi`, `kn`) |
+| `traffic_metadata` | `bool` | `None` |
+
+```python
+params = {
+    "origin": "12.9352,77.6245",
+    "destination": "12.9716,77.5946",
+    "alternatives": "true",
+    "steps": "true",
+    "traffic_metadata": "true"
+}
+response = await client.post(f"{BASE_URL}/routing/v1/directions", params=params)
+response.raise_for_status()
+route = response.json()
+```
+
+### `distance_matrix`
+
+**Endpoint:** `GET /routing/v1/distanceMatrix`
+
+Calculate travel distance and time between multiple origins and destinations.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `origins` | `str` | **required** (pipe-separated `lat,lng` pairs) |
+| `destinations` | `str` | **required** (pipe-separated `lat,lng` pairs) |
+
+```python
+params = {
+    "origins": "12.9352,77.6245|12.9716,77.5946",
+    "destinations": "13.0827,80.2707|12.2958,76.6394"
+}
+response = await client.get(f"{BASE_URL}/routing/v1/distanceMatrix", params=params)
+response.raise_for_status()
+matrix = response.json()
+```
+
+### `snap_to_road`
+
+**Endpoint:** `GET /routing/v1/snapToRoad`
+
+Snap GPS coordinates to nearest road segments.
+
+```python
+params = {
+    "points": "12.9352,77.6245|12.9360,77.6250|12.9370,77.6260",
+    "enhancePath": "true"
+}
+response = await client.get(f"{BASE_URL}/routing/v1/snapToRoad", params=params)
+response.raise_for_status()
+snapped = response.json()
+```
+
+## Error Handling
+
+```python
+import httpx
+
+try:
+    response = await client.get(f"{BASE_URL}/places/v1/geocode", params=params)
+    response.raise_for_status()
+    data = response.json()
+except httpx.HTTPStatusError as e:
+    if e.response.status_code == 401:
+        print("Auth failed -- check API key or refresh OAuth token")
+    elif e.response.status_code == 429:
+        print("Rate limited -- monthly or per-minute limit exceeded")
+    else:
+        print(f"Ola Maps error {e.response.status_code}: {e.response.text}")
+except httpx.RequestError as e:
+    print(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+- Coordinates use **`lat,lng` format** consistently (not `lng,lat`)
+- Multiple points are separated by **pipe (`|`)** character (not comma)
+- API key is passed as a **query parameter** (`?api_key=...`), not a header
+- Directions endpoint is **POST** (not GET)
+- Distance matrix endpoint is **GET** (not POST)
+- Directions support `driving` and `walking` modes only (no transit/cycling)
+- Direction instructions available in `en` (English), `hi` (Hindi), `kn` (Kannada)
+- Free tier: **500K API calls/month** for the first year
+- OAuth tokens require domain whitelisting
+- Use debounce on autocomplete to avoid excessive API calls during typing
+- An MCP server is available: https://maps.olakrutrim.com/docs/ola-maps-mcp/ola-maps-mcp-server

--- a/content/ondc/docs/rest-api/python/DOC.md
+++ b/content/ondc/docs/rest-api/python/DOC.md
@@ -1,0 +1,418 @@
+---
+name: rest-api
+description: "ONDC (Open Network for Digital Commerce) - India's open e-commerce protocol built on Beckn for buyer/seller node integration"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "india,ondc,beckn,e-commerce,digital-commerce,open-protocol,retail,logistics"
+---
+
+# ONDC (Open Network for Digital Commerce) REST API
+
+## Golden Rule
+
+ONDC is an **open protocol**, not a traditional API. It is built on top of the **Beckn Protocol** and uses an asynchronous request-callback model over HTTP POST with JSON payloads. Every participant (buyer app or seller app) is a **Network Participant (NP)** that must be registered in the ONDC Registry. All API calls are **digitally signed** using Ed25519 keys. The protocol flow is: your app sends a request (e.g., `/search`), receives an immediate ACK, and then the counterparty calls back to your endpoint (e.g., `/on_search`) with the actual response. You must host publicly accessible callback endpoints. ONDC is **not a SaaS API** you simply call -- you become a node in a decentralized network.
+
+## Installation
+
+```bash
+pip install httpx cryptography PyNaCl
+```
+
+- `httpx` for async HTTP
+- `cryptography` for X25519 key exchange
+- `PyNaCl` for Ed25519 digital signatures
+
+## Base URL
+
+ONDC operates across three environments. Your app communicates with the **Gateway** (for search broadcast) and directly with other **Network Participants** (for select/init/confirm).
+
+### Gateway URLs
+
+| Environment | Gateway URL |
+|-------------|-------------|
+| Staging | `https://staging.gateway.proteantech.in` |
+| Pre-production | `https://preprod.gateway.ondc.org` |
+| Production | `https://prod.gateway.ondc.org` |
+
+### Registry URLs
+
+| Environment | Registry URL |
+|-------------|--------------|
+| Staging | `https://staging.registry.ondc.org` |
+| Pre-production | `https://preprod.registry.ondc.org` |
+| Production | `https://prod.registry.ondc.org` |
+
+### Reference Apps (White-label)
+
+| App | Staging URL |
+|-----|-------------|
+| Buyer App | `https://ref-app-buyer-staging-v2.ondc.org` |
+| Seller App | `https://ref-app-seller-staging-v2.ondc.org` |
+| Logistics App | `https://ref-logistics-app-stage.ondc.org` |
+
+### Your App's Base URL
+
+You must host your own endpoints (e.g., `https://your-buyer-app.com`) and register them with the ONDC Registry. The registry tells other NPs where to send callbacks.
+
+## Authentication
+
+ONDC uses **Ed25519 digital signatures** for authentication. Every request and callback must be signed.
+
+### Signature Format
+
+The `Authorization` header follows this format:
+
+```
+Signature keyId="{subscriber_id}|{unique_key_id}|ed25519",algorithm="ed25519",created="1606970629",expires="1607030629",headers="(created) (expires) digest",signature="Base64(signed_string)"
+```
+
+### Generating Signatures
+
+```python
+import base64
+import hashlib
+import time
+import json
+from nacl.signing import SigningKey
+
+
+def create_signing_string(
+    body: dict, created: int, expires: int,
+) -> str:
+    """Create the string to be signed per Beckn auth spec."""
+    body_bytes = json.dumps(body, separators=(",", ":")).encode()
+    digest = f"BLAKE-512={base64.b64encode(hashlib.blake2b(body_bytes).digest()).decode()}"
+    signing_string = f"(created): {created}\n(expires): {expires}\ndigest: {digest}"
+    return signing_string
+
+
+def sign_request(
+    body: dict,
+    private_key_b64: str,
+    subscriber_id: str,
+    unique_key_id: str,
+) -> str:
+    """Sign a request body and return the Authorization header value."""
+    created = int(time.time())
+    expires = created + 3600  # 1 hour validity
+
+    signing_string = create_signing_string(body, created, expires)
+
+    # Ed25519 sign
+    private_key_bytes = base64.b64decode(private_key_b64)
+    signing_key = SigningKey(private_key_bytes)
+    signed = signing_key.sign(signing_string.encode())
+    signature = base64.b64encode(signed.signature).decode()
+
+    auth_header = (
+        f'Signature keyId="{subscriber_id}|{unique_key_id}|ed25519",'
+        f'algorithm="ed25519",'
+        f'created="{created}",'
+        f'expires="{expires}",'
+        f'headers="(created) (expires) digest",'
+        f'signature="{signature}"'
+    )
+    return auth_header
+```
+
+### Verifying Incoming Signatures
+
+```python
+from nacl.signing import VerifyKey
+
+
+async def verify_signature(
+    body: dict,
+    auth_header: str,
+    sender_public_key_b64: str,
+) -> bool:
+    """Verify an incoming request's digital signature."""
+    # Parse auth_header to extract created, expires, signature
+    # (parsing logic omitted for brevity -- extract from header string)
+    parts = dict(
+        item.split("=", 1) for item in auth_header.replace("Signature ", "").split(",")
+    )
+    created = int(parts["created"].strip('"'))
+    expires = int(parts["expires"].strip('"'))
+    signature_b64 = parts["signature"].strip('"')
+
+    signing_string = create_signing_string(body, created, expires)
+
+    public_key_bytes = base64.b64decode(sender_public_key_b64)
+    verify_key = VerifyKey(public_key_bytes)
+
+    try:
+        verify_key.verify(
+            signing_string.encode(),
+            base64.b64decode(signature_b64),
+        )
+        return True
+    except Exception:
+        return False
+```
+
+### Gateway Forwarding
+
+When a Gateway forwards a search request, it adds its own signature in the `X-Gateway-Authorization` header using the same format.
+
+## Rate Limiting
+
+ONDC does not publish explicit rate limits. However, the Gateway and individual NPs may impose their own limits. The ONDC network is designed for real commerce traffic. Implement:
+
+- Exponential backoff on NACK responses
+- Respect `ttl` (time-to-live) values in context objects
+- Do not flood the gateway with repeated identical searches
+
+## Methods
+
+All ONDC API calls use **HTTP POST** with JSON bodies. Every request contains a `context` object and a `message` object.
+
+### Context Object (required in every call)
+
+```python
+import uuid
+from datetime import datetime
+
+
+def build_context(
+    action: str,
+    domain: str = "ONDC:RET10",  # Grocery retail
+    city: str = "std:080",        # Bangalore
+    bap_id: str = "your-buyer-app.com",
+    bap_uri: str = "https://your-buyer-app.com",
+    bpp_id: str | None = None,
+    bpp_uri: str | None = None,
+    transaction_id: str | None = None,
+    message_id: str | None = None,
+) -> dict:
+    """Build the ONDC context object."""
+    ctx = {
+        "domain": domain,
+        "action": action,
+        "core_version": "1.2.0",
+        "bap_id": bap_id,
+        "bap_uri": bap_uri,
+        "transaction_id": transaction_id or str(uuid.uuid4()),
+        "message_id": message_id or str(uuid.uuid4()),
+        "city": city,
+        "country": "IND",
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+        "ttl": "PT30S",  # 30-second TTL
+    }
+    if bpp_id:
+        ctx["bpp_id"] = bpp_id
+        ctx["bpp_uri"] = bpp_uri
+    return ctx
+```
+
+### Search (Buyer App -> Gateway)
+
+`POST /search` to the Gateway URL
+
+Broadcasts a search query to all seller apps in the network.
+
+```python
+GATEWAY_URL = "https://staging.gateway.proteantech.in"
+
+
+async def search_products(query: str, category: str = "Grocery") -> dict:
+    """Search for products on the ONDC network."""
+    body = {
+        "context": build_context(action="search"),
+        "message": {
+            "intent": {
+                "item": {
+                    "descriptor": {
+                        "name": query,
+                    }
+                },
+                "fulfillment": {
+                    "type": "Delivery",
+                },
+                "payment": {
+                    "@ondc/org/buyer_app_finder_fee_type": "percent",
+                    "@ondc/org/buyer_app_finder_fee_amount": "3",
+                },
+            }
+        },
+    }
+
+    auth_header = sign_request(
+        body, PRIVATE_KEY_B64, SUBSCRIBER_ID, UNIQUE_KEY_ID,
+    )
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{GATEWAY_URL}/search",
+            json=body,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": auth_header,
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+        # Returns: { "message": { "ack": { "status": "ACK" } } }
+        # Actual results arrive via callback to your /on_search endpoint
+```
+
+### Select (Buyer App -> Seller App)
+
+`POST /select` directly to the seller's `bpp_uri`
+
+After receiving search results, select specific items from a seller.
+
+```python
+async def select_items(
+    bpp_uri: str, bpp_id: str, provider_id: str, items: list[dict],
+    transaction_id: str,
+) -> dict:
+    """Select items from a specific seller."""
+    body = {
+        "context": build_context(
+            action="select",
+            bpp_id=bpp_id,
+            bpp_uri=bpp_uri,
+            transaction_id=transaction_id,
+        ),
+        "message": {
+            "order": {
+                "provider": {"id": provider_id},
+                "items": items,  # [{"id": "item-1", "quantity": {"count": 2}}]
+            }
+        },
+    }
+
+    auth_header = sign_request(
+        body, PRIVATE_KEY_B64, SUBSCRIBER_ID, UNIQUE_KEY_ID,
+    )
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{bpp_uri}/select",
+            json=body,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": auth_header,
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+        # ACK response; actual quote arrives at /on_select
+```
+
+### Init / Confirm (and other actions)
+
+`POST /init` and `POST /confirm` to the seller's `bpp_uri` follow the same pattern as `/select` -- build context with the appropriate `action`, wrap the `order` object in `message`, sign, and POST directly to `bpp_uri`. Init returns payment details via `/on_init`; confirm returns order confirmation via `/on_confirm`.
+
+Additional actions (`status`, `track`, `cancel`, `update`, `rating`, `support`) all follow the same signed POST pattern. Each has a corresponding `on_{action}` callback endpoint.
+
+### Registry Lookup
+
+`POST /lookup` to the Registry URL
+
+Look up a Network Participant's details (public key, endpoints).
+
+```python
+REGISTRY_URL = "https://staging.registry.ondc.org"
+
+
+async def registry_lookup(subscriber_id: str, domain: str = "ONDC:RET10") -> dict:
+    """Look up a subscriber in the ONDC registry."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{REGISTRY_URL}/lookup",
+            json={
+                "subscriber_id": subscriber_id,
+                "domain": domain,
+                "type": "sellerApp",  # or "buyerApp", "gateway"
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+        # Returns: signing_public_key, subscriber_url, valid_from, valid_until, etc.
+```
+
+### Hosting Callback Endpoints
+
+As a buyer app, you must host POST endpoints at: `/on_search`, `/on_select`, `/on_init`, `/on_confirm`, `/on_status`, `/on_track`, `/on_cancel`, `/on_update`, `/on_rating`, `/on_support`. Each must: (1) verify the Authorization header signature, (2) process the response data, (3) return `{"message": {"ack": {"status": "ACK"}}}`.
+
+## Error Handling
+
+```python
+async def safe_ondc_call(url: str, body: dict) -> dict:
+    auth_header = sign_request(
+        body, PRIVATE_KEY_B64, SUBSCRIBER_ID, UNIQUE_KEY_ID,
+    )
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        try:
+            resp = await client.post(
+                url,
+                json=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "Authorization": auth_header,
+                },
+            )
+            resp.raise_for_status()
+            data = resp.json()
+
+            # Check for NACK (negative acknowledgment)
+            ack_status = data.get("message", {}).get("ack", {}).get("status")
+            if ack_status == "NACK":
+                error = data.get("error", {})
+                raise ValueError(
+                    f"ONDC NACK: {error.get('code')} - {error.get('message')}"
+                )
+
+            return data
+
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 401:
+                print("Signature verification failed")
+            elif e.response.status_code == 422:
+                print("Schema validation error")
+            raise
+```
+
+### ONDC Error Codes
+
+| Code | Type | Description |
+|------|------|-------------|
+| 20000 | Invalid request | Schema validation failure |
+| 20001 | Invalid request | Invalid signature |
+| 20002 | Invalid request | Subscriber not found in registry |
+| 20006 | Invalid request | Stale request (TTL expired) |
+| 30000 | Provider error | Provider not found |
+| 30001 | Provider error | Item not found |
+| 40000 | Business error | Item out of stock |
+| 40001 | Business error | Order not found |
+| 40002 | Business error | Cancellation not possible |
+| 50000 | Policy error | Action not applicable |
+
+## Common Pitfalls
+
+1. **This is a protocol, not a typical API** - You do not get synchronous responses. You send a request, get an ACK, and then the counterparty calls YOUR endpoint with the response. You must host publicly accessible callback endpoints.
+
+2. **Every request must be signed** - All HTTP requests require Ed25519 digital signatures in the `Authorization` header. Unsigned or incorrectly signed requests are rejected.
+
+3. **Registry onboarding is required** - Before you can transact, you must register your subscriber ID, public key, and callback URLs in the ONDC Registry. Staging allows self-registration; production requires ONDC approval.
+
+4. **Transaction ID is the session** - A single transaction (from search to order completion) uses the same `transaction_id` across all calls. Each individual API call gets a unique `message_id`.
+
+5. **Search goes through the Gateway** - The `/search` call is the ONLY one that goes through the ONDC Gateway (which broadcasts it to all seller apps). All subsequent calls (`/select`, `/init`, `/confirm`) go directly to the seller's `bpp_uri`.
+
+6. **TTL matters** - The `ttl` field in the context defines how long the counterparty has to respond. If they miss the window, the request expires. Common values: `PT30S` (30 seconds) for search, `PT30S` for select.
+
+7. **Specification version alignment** - ONDC specification version 1.2 is the current standard. Ensure your implementation matches the version expected by the network. Mismatches cause schema validation failures.
+
+8. **City codes use STD format** - Cities are identified by STD codes (e.g., `std:080` for Bangalore, `std:011` for Delhi), not city names or PIN codes.
+
+9. **Domain codes are specific** - Use the correct domain code: `ONDC:RET10` (grocery), `ONDC:RET11` (F&B), `ONDC:RET12` (fashion), `ONDC:RET13` (BPC), `ONDC:RET14` (electronics), `ONDC:RET15` (appliances), etc.
+
+10. **Use the reference apps for testing** - ONDC provides white-label buyer and seller reference apps with staging environments. Start by running these before building custom implementations. GitHub: `github.com/ONDC-Official`.

--- a/content/open-project/docs/rest-api/python/DOC.md
+++ b/content/open-project/docs/rest-api/python/DOC.md
@@ -1,0 +1,122 @@
+---
+name: rest-api
+description: "OpenProject Integration"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-13"
+  source: community
+  tags: "openproject,developer-tools,project-management,issues,api,integration"
+---
+
+# OpenProject API
+
+> **Golden Rule:** OpenProject has no official Python SDK. Use `httpx` (async) or `requests` (sync) for direct REST API access. Always handle rate limits, retries, and error responses explicitly.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+`https://<domain>/api/v3`
+
+## Authentication
+
+**Type:** Basic
+
+```python
+import httpx
+
+API_KEY = "your-api-key"
+DOMAIN = "your-domain"
+BASE_URL = f"https://{DOMAIN}/api/v3"
+
+# Basic auth: API key as username, "X" as password
+auth = httpx.BasicAuth(API_KEY, "X")
+client = httpx.AsyncClient(auth=auth)
+```
+
+## Rate Limiting
+
+**Limit:** 100 requests/minute
+
+The API enforces rate limits. Check `X-RateLimit-Remaining` and `Retry-After` response headers. Implement exponential backoff on 429 responses.
+
+## Methods
+
+### `list_projects`
+
+**Endpoint:** `GET /projects`
+
+
+
+| Parameter | Type | Default |
+|---|---|---|
+| `limit` | `int` | `50` |
+
+**Returns:** JSON response
+
+```python
+params = {
+    "limit": 50
+}
+response = await client.get(f"{BASE_URL}/projects", params=params)
+response.raise_for_status()
+data = response.json()
+```
+
+### `list_work_packages`
+
+**Endpoint:** `GET /work_packages`
+
+List work packages (issues/tasks)
+
+| Parameter | Type | Default |
+|---|---|---|
+| `project_id` | `str` | `None` |
+| `limit` | `int` | `50` |
+
+**Returns:** JSON response
+
+```python
+params = {
+    "project_id": None,
+    "limit": 50
+}
+response = await client.get(f"{BASE_URL}/work_packages", params=params)
+response.raise_for_status()
+data = response.json()
+```
+
+## Error Handling
+
+```python
+import httpx
+
+try:
+    response = await client.get(f"{BASE_URL}/projects")
+    response.raise_for_status()
+    data = response.json()
+except httpx.HTTPStatusError as e:
+    if e.response.status_code == 401:
+        print("Authentication failed -- check your API key")
+    elif e.response.status_code == 429:
+        retry_after = e.response.headers.get("Retry-After", "60")
+        print(f"Rate limited -- retry after {retry_after}s")
+    else:
+        print(f"OpenProject API error {e.response.status_code}: {e.response.text}")
+except httpx.RequestError as e:
+    print(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+- Always call `response.raise_for_status()` to catch HTTP errors
+- Use `async with httpx.AsyncClient() as client:` to auto-close connections
+- Handle 429 (rate limit) responses with exponential backoff
+- Set a reasonable timeout: `httpx.AsyncClient(timeout=30.0)`
+- The `limit` / `per_page` parameter controls page size, not total results -- paginate to get all data

--- a/content/open-router/docs/rest-api/python/DOC.md
+++ b/content/open-router/docs/rest-api/python/DOC.md
@@ -1,0 +1,114 @@
+---
+name: rest-api
+description: "OpenRouter API integration with 2 methods"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-13"
+  source: community
+  tags: "openrouter,ai,llm,machine-learning,api,integration"
+---
+
+# OpenRouter API
+
+> **Golden Rule:** OpenRouter has no official Python SDK. Use `httpx` (async) or `requests` (sync) for direct REST API access. Always handle rate limits, retries, and error responses explicitly.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+`https://openrouter.ai/api/v1`
+
+## Authentication
+
+**Type:** Bearer
+
+```python
+import httpx
+
+API_KEY = "your-token"
+BASE_URL = "https://openrouter.ai/api/v1"
+
+headers = {"Authorization": f"Bearer {API_KEY}"}
+client = httpx.AsyncClient(headers=headers)
+```
+
+## Rate Limiting
+
+**Limit:** 100 requests/minute
+
+The API enforces rate limits. Check `X-RateLimit-Remaining` and `Retry-After` response headers. Implement exponential backoff on 429 responses.
+
+## Methods
+
+### `list_models`
+
+**Endpoint:** `GET /models`
+
+
+
+
+**Returns:** JSON response
+
+```python
+response = await client.get(f"{BASE_URL}/models")
+response.raise_for_status()
+data = response.json()
+```
+
+### `create_chat_completion`
+
+**Endpoint:** `POST /chat/completions`
+
+Create chat completion
+
+| Parameter | Type | Default |
+|---|---|---|
+| `model` | `str` | **required** |
+| `messages` | `List[Dict]` | **required** |
+
+**Returns:** JSON response
+
+```python
+payload = {
+    "model": "...",
+    "messages": [...]
+}
+response = await client.post(f"{BASE_URL}/chat/completions", json=payload)
+response.raise_for_status()
+data = response.json()
+```
+
+## Error Handling
+
+```python
+import httpx
+
+try:
+    response = await client.get(f"{BASE_URL}/models")
+    response.raise_for_status()
+    data = response.json()
+except httpx.HTTPStatusError as e:
+    if e.response.status_code == 401:
+        print("Authentication failed -- check your API key")
+    elif e.response.status_code == 429:
+        retry_after = e.response.headers.get("Retry-After", "60")
+        print(f"Rate limited -- retry after {retry_after}s")
+    else:
+        print(f"OpenRouter API error {e.response.status_code}: {e.response.text}")
+except httpx.RequestError as e:
+    print(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+- Always call `response.raise_for_status()` to catch HTTP errors
+- Use `async with httpx.AsyncClient() as client:` to auto-close connections
+- Handle 429 (rate limit) responses with exponential backoff
+- Set a reasonable timeout: `httpx.AsyncClient(timeout=30.0)`
+- For POST/PUT requests, pass data via `json=` parameter (not `data=`) to auto-set Content-Type

--- a/content/open311/docs/rest-api/python/DOC.md
+++ b/content/open311/docs/rest-api/python/DOC.md
@@ -1,0 +1,429 @@
+---
+name: rest-api
+description: "Open311 GeoReport v2 - Civic issue reporting standard for potholes, graffiti, broken lights, and other non-emergency municipal issues."
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "open311,civic,community,issue-reporting,government,municipal,api"
+---
+
+# Open311 GeoReport v2 API - Python Reference (httpx)
+
+## Golden Rule
+
+Open311 is an **open standard**, not a single API. Each city/municipality runs its own server with its own base URL. GET endpoints (reading services and requests) require no API key. POST endpoints (creating service requests) require an API key obtained from the specific city's portal. Responses support JSON and XML -- always request JSON via the `.json` extension in the URL path. Location is required when submitting requests: provide `lat`/`long`, `address_string`, or `address_id`. See http://wiki.open311.org/GeoReport_v2/Servers for a list of cities implementing the spec.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+All examples use `httpx` with async/await. For scripts that need a synchronous entrypoint:
+
+```python
+import asyncio
+import httpx
+
+async def main():
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{BASE_URL}/services.json")
+        print(resp.json())
+
+asyncio.run(main())
+```
+
+## Base URL
+
+Each city has its own endpoint. Common examples:
+
+```
+# Chicago
+https://311api.cityofchicago.org/open311/v2
+
+# San Francisco
+https://mobile311.sfgov.org/open311/v2
+
+# Toronto
+https://secure.toronto.ca/webwizard/ws
+
+# Washington D.C.
+https://311.dc.gov/open311/v2
+
+# Helsinki
+https://asiointi.hel.fi/palautews/rest/v1
+```
+
+```python
+import os
+
+# Configure for your target city
+BASE_URL = os.environ.get("OPEN311_BASE_URL", "https://311api.cityofchicago.org/open311/v2")
+API_KEY = os.environ.get("OPEN311_API_KEY", "")  # Required only for POST
+JURISDICTION_ID = os.environ.get("OPEN311_JURISDICTION_ID", "")  # Optional for single-jurisdiction
+```
+
+## Authentication
+
+- **GET requests:** No API key required.
+- **POST requests:** API key required, passed as `api_key` query parameter or form field.
+
+Each city has its own API key registration process. Check the specific city's developer portal.
+
+```python
+def post_params(**extra) -> dict:
+    params = {**extra}
+    if API_KEY:
+        params["api_key"] = API_KEY
+    if JURISDICTION_ID:
+        params["jurisdiction_id"] = JURISDICTION_ID
+    return params
+```
+
+## Rate Limiting
+
+Rate limits vary by city implementation. The Open311 standard does not specify rate limits. Implement reasonable throttling.
+
+```python
+import asyncio
+
+async def open311_get(
+    client: httpx.AsyncClient,
+    path: str,
+    params: dict = None,
+    max_retries: int = 3,
+) -> list | dict:
+    url = f"{BASE_URL}/{path}.json"
+    request_params = {**(params or {})}
+    if JURISDICTION_ID:
+        request_params["jurisdiction_id"] = JURISDICTION_ID
+
+    for attempt in range(max_retries):
+        try:
+            resp = await client.get(url, params=request_params)
+        except httpx.RequestError:
+            await asyncio.sleep(2 ** attempt)
+            continue
+
+        if resp.status_code == 200:
+            return resp.json()
+
+        if resp.status_code == 429:
+            await asyncio.sleep(min(2 ** attempt, 30))
+            continue
+
+        resp.raise_for_status()
+
+    raise Exception("Max retries exceeded")
+```
+
+## Methods
+
+### Get Service List
+
+Retrieve available service request types for the city. No API key required.
+
+**Response fields:**
+- `service_code` -- Unique identifier for the service type
+- `service_name` -- Human-readable name
+- `description` -- Description of the service
+- `type` -- `realtime` (instant ID), `batch` (returns token), or `blackbox` (no ID returned)
+- `keywords` -- Comma-separated tags
+- `group` -- Category grouping
+
+```python
+async def get_services(client: httpx.AsyncClient) -> list:
+    return await open311_get(client, "services")
+
+# Usage
+services = await get_services(client)
+for svc in services:
+    print(f"{svc['service_code']}: {svc['service_name']} ({svc['type']})")
+    # e.g., "001": "Clogged Drain" (realtime)
+```
+
+### Get Service Definition
+
+Retrieve extended attributes (form fields) required when submitting a request for a specific service.
+
+```python
+async def get_service_definition(client: httpx.AsyncClient, service_code: str) -> dict:
+    return await open311_get(client, f"services/{service_code}")
+
+# Usage
+definition = await get_service_definition(client, "001")
+for attr in definition.get("attributes", []):
+    print(f"  {attr['code']}: {attr['description']} (required={attr['required']})")
+    if attr.get("values"):
+        for val in attr["values"]:
+            print(f"    - {val['key']}: {val['name']}")
+```
+
+### Create Service Request (POST)
+
+Submit a new civic issue report. **Requires API key.** Must include location via lat/long, address string, or address ID.
+
+**Required parameters:**
+- `service_code` (str) -- Service type code from service list
+- Location: `lat` + `long` (WGS84), OR `address_string`, OR `address_id`
+
+**Optional parameters:**
+- `description` (str) -- Issue description (max 4,000 chars)
+- `email` (str) -- Reporter's email
+- `first_name` (str) -- Reporter's first name
+- `last_name` (str) -- Reporter's last name
+- `phone` (str) -- Reporter's phone number
+- `media_url` (str) -- URL to a photo of the issue
+- `device_id` (str) -- Device identifier
+- `account_id` (str) -- User account ID
+- `attribute[CODE]` (str) -- Dynamic attributes from service definition
+
+```python
+async def create_service_request(
+    client: httpx.AsyncClient,
+    service_code: str,
+    lat: float = None,
+    long: float = None,
+    address_string: str = None,
+    description: str = None,
+    email: str = None,
+    first_name: str = None,
+    last_name: str = None,
+    phone: str = None,
+    media_url: str = None,
+    attributes: dict = None,
+) -> list:
+    url = f"{BASE_URL}/requests.json"
+    data = post_params(service_code=service_code)
+
+    if lat is not None and long is not None:
+        data["lat"] = lat
+        data["long"] = long
+    elif address_string:
+        data["address_string"] = address_string
+
+    if description:
+        data["description"] = description
+    if email:
+        data["email"] = email
+    if first_name:
+        data["first_name"] = first_name
+    if last_name:
+        data["last_name"] = last_name
+    if phone:
+        data["phone"] = phone
+    if media_url:
+        data["media_url"] = media_url
+
+    if attributes:
+        for code, value in attributes.items():
+            if isinstance(value, list):
+                for v in value:
+                    data[f"attribute[{code}][]"] = v
+            else:
+                data[f"attribute[{code}]"] = value
+
+    resp = await client.post(
+        url,
+        data=data,
+        headers={"Content-Type": "application/x-www-form-urlencoded; charset=utf-8"},
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+# Usage
+result = await create_service_request(
+    client,
+    service_code="001",
+    lat=41.8781,
+    long=-87.6298,
+    description="Large pothole on Main Street near the intersection with Oak Ave",
+    email="reporter@example.com",
+)
+# Returns: [{"service_request_id": "293944", "service_notice": "..."}]
+# OR for batch systems: [{"token": "abc123"}]
+```
+
+### Get Service Request ID from Token
+
+For batch-processing systems that return a token instead of an immediate ID.
+
+```python
+async def get_request_id_from_token(client: httpx.AsyncClient, token: str) -> list:
+    return await open311_get(client, f"tokens/{token}")
+
+# Usage
+result = await get_request_id_from_token(client, "abc123")
+service_request_id = result[0]["service_request_id"]
+```
+
+### Get Service Requests (Multiple)
+
+Retrieve multiple service requests with filtering. No API key required.
+
+**Parameters:**
+- `service_request_id` (str) -- Comma-delimited IDs (overrides other filters)
+- `service_code` (str) -- Filter by service type (comma-delimited)
+- `start_date` (str) -- ISO 8601 start date (max 90-day span)
+- `end_date` (str) -- ISO 8601 end date
+- `status` (str) -- `open`, `closed`, or comma-delimited
+
+```python
+async def get_service_requests(
+    client: httpx.AsyncClient,
+    service_code: str = None,
+    start_date: str = None,
+    end_date: str = None,
+    status: str = None,
+    service_request_ids: str = None,
+) -> list:
+    params = {}
+    if service_request_ids:
+        params["service_request_id"] = service_request_ids
+    if service_code:
+        params["service_code"] = service_code
+    if start_date:
+        params["start_date"] = start_date
+    if end_date:
+        params["end_date"] = end_date
+    if status:
+        params["status"] = status
+    return await open311_get(client, "requests", params)
+
+# Usage -- get open pothole reports from last week
+requests = await get_service_requests(
+    client,
+    service_code="001",
+    status="open",
+    start_date="2026-03-10T00:00:00Z",
+    end_date="2026-03-17T00:00:00Z",
+)
+for req in requests:
+    print(f"{req['service_request_id']}: {req['description']} - {req['status']}")
+    print(f"  Location: {req.get('address', 'N/A')} ({req.get('lat')}, {req.get('long')})")
+```
+
+### Get Single Service Request
+
+Retrieve a specific service request by ID.
+
+```python
+async def get_service_request(client: httpx.AsyncClient, request_id: str) -> list:
+    return await open311_get(client, f"requests/{request_id}")
+
+# Usage
+request = (await get_service_request(client, "293944"))[0]
+print(f"Status: {request['status']}")
+print(f"Service: {request['service_name']}")
+print(f"Submitted: {request['requested_datetime']}")
+print(f"Updated: {request['updated_datetime']}")
+print(f"Agency: {request.get('agency_responsible', 'N/A')}")
+```
+
+## Error Handling
+
+Successful responses return HTTP 200 with a JSON array.
+
+Errors return a JSON array of error objects:
+
+```json
+[
+    {
+        "code": 400,
+        "description": "jurisdiction_id was not provided"
+    }
+]
+```
+
+**Common status codes:**
+
+| Code | Meaning |
+|---|---|
+| 200 | Success |
+| 400 | Bad Request -- missing or invalid parameters |
+| 403 | Forbidden -- missing or invalid API key (POST only) |
+| 404 | Not Found -- jurisdiction or resource not found |
+| 500 | Internal Server Error |
+
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+
+class Open311Error(Exception):
+    def __init__(self, status_code: int, errors: list):
+        self.status_code = status_code
+        self.errors = errors
+        desc = "; ".join(e.get("description", "Unknown") for e in errors)
+        super().__init__(f"[{status_code}] {desc}")
+
+async def open311_request_safe(
+    client: httpx.AsyncClient,
+    method: str,
+    path: str,
+    params: dict = None,
+    data: dict = None,
+    max_retries: int = 3,
+) -> list | dict:
+    url = f"{BASE_URL}/{path}.json"
+    request_params = {**(params or {})}
+    if JURISDICTION_ID:
+        request_params["jurisdiction_id"] = JURISDICTION_ID
+
+    for attempt in range(max_retries):
+        try:
+            if method == "GET":
+                resp = await client.get(url, params=request_params)
+            else:
+                resp = await client.post(url, data={**request_params, **(data or {})})
+        except httpx.RequestError as e:
+            logger.warning(f"Network error (attempt {attempt+1}): {e}")
+            await asyncio.sleep(2 ** attempt)
+            continue
+
+        if resp.status_code == 200:
+            return resp.json()
+
+        if resp.status_code == 429:
+            wait = min(2 ** attempt, 30)
+            logger.warning(f"Rate limited, retrying in {wait}s")
+            await asyncio.sleep(wait)
+            continue
+
+        try:
+            errors = resp.json()
+        except Exception:
+            errors = [{"code": resp.status_code, "description": resp.text}]
+        raise Open311Error(resp.status_code, errors)
+
+    raise Open311Error(429, [{"code": 429, "description": "Max retries exceeded"}])
+```
+
+## Common Pitfalls
+
+1. **Each city has a different base URL.** There is no central Open311 server. You must configure the endpoint for each city. Check http://wiki.open311.org/GeoReport_v2/Servers for the list.
+
+2. **API keys are city-specific.** An API key for Chicago will not work for San Francisco. Register separately with each city.
+
+3. **GET requests do not need API keys.** Only POST (creating requests) requires authentication. Do not send API keys on GET requests unnecessarily.
+
+4. **Use `.json` extension for JSON responses.** Append `.json` to the path (e.g., `/services.json`). Without it, many servers default to XML.
+
+5. **Default result set is 1,000 requests or 90 days.** The API returns whichever limit is reached first. For older data, narrow your date range.
+
+6. **Dates must be ISO 8601 with timezone.** Use the format `2026-03-17T00:00:00-05:00` or `2026-03-17T05:00:00Z`. Missing timezone can cause unexpected results.
+
+7. **Location is required for POST.** You must provide at least one of: `lat`+`long`, `address_string`, or `address_id`. The request will fail without location data.
+
+8. **Batch systems return tokens, not IDs.** If the service `type` is `batch`, the POST returns a `token` instead of `service_request_id`. Poll the token endpoint to get the ID.
+
+9. **`jurisdiction_id` is optional for single-jurisdiction endpoints.** Most city endpoints serve a single jurisdiction. Only multi-jurisdiction servers require this parameter.
+
+10. **Multivaluelist attributes use array syntax.** For service definition attributes that accept multiple values, use `attribute[code][]=value1&attribute[code][]=value2` format.
+
+11. **Not all fields are returned by all cities.** The spec defines optional fields. Some cities return minimal data. Always check for `None`/missing keys.
+
+12. **Coordinates use WGS84 (GPS standard).** Latitude/longitude values should be standard GPS coordinates in decimal degrees.

--- a/content/openaq/docs/rest-api/python/DOC.md
+++ b/content/openaq/docs/rest-api/python/DOC.md
@@ -1,0 +1,494 @@
+---
+name: rest-api
+description: "OpenAQ - Open air quality data API providing worldwide pollution measurements, locations, sensors, and environmental monitoring data."
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "openaq,air-quality,environment,health,pollution,community,api"
+---
+
+# OpenAQ REST API v3 - Python Reference (httpx)
+
+## Golden Rule
+
+Authentication uses an `X-API-Key` **request header** on every request. Register at https://explore.openaq.org/register to obtain a free API key. The free tier allows **60 requests/minute** and **2,000 requests/hour**. Rate limit headers (`x-ratelimit-remaining`, `x-ratelimit-reset`) are returned on every response. Data is organized hierarchically: Providers -> Locations -> Sensors -> Measurements. Always start by finding locations, then drill into their sensors for measurement data.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+All examples use `httpx` with async/await. For scripts that need a synchronous entrypoint:
+
+```python
+import asyncio
+import httpx
+
+async def main():
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{BASE_URL}/locations",
+            params={"iso": "US", "limit": 10},
+            headers=HEADERS,
+        )
+        print(resp.json())
+
+asyncio.run(main())
+```
+
+## Base URL
+
+```
+https://api.openaq.org/v3
+```
+
+```python
+import os
+
+API_KEY = os.environ["OPENAQ_API_KEY"]
+BASE_URL = "https://api.openaq.org/v3"
+HEADERS = {
+    "X-API-Key": API_KEY,
+    "Accept": "application/json",
+}
+```
+
+## Authentication
+
+OpenAQ uses an **API key in the request header**:
+
+```
+X-API-Key: YOUR_OPENAQ_API_KEY
+```
+
+Register at https://explore.openaq.org/register. Manage and rotate your key at https://explore.openaq.org/account.
+
+## Rate Limiting
+
+| Plan | Requests/Minute | Requests/Hour |
+|---|---|---|
+| Free | 60 | 2,000 |
+| Custom | Higher | Contact platform@openaq.org |
+
+**Response headers:**
+- `x-ratelimit-used` -- Requests made in current period
+- `x-ratelimit-remaining` -- Requests remaining before limit
+- `x-ratelimit-limit` -- Maximum requests per period
+- `x-ratelimit-reset` -- Unix timestamp when period resets
+
+When exceeded, the API returns HTTP `429 Too Many Requests`. Repeatedly exceeding limits may result in suspension.
+
+```python
+import asyncio
+
+async def oaq_request(
+    client: httpx.AsyncClient,
+    path: str,
+    params: dict = None,
+    max_retries: int = 3,
+) -> dict:
+    url = f"{BASE_URL}{path}"
+
+    for attempt in range(max_retries):
+        try:
+            resp = await client.get(url, params=params, headers=HEADERS)
+        except httpx.RequestError:
+            await asyncio.sleep(2 ** attempt)
+            continue
+
+        if resp.status_code == 200:
+            return resp.json()
+
+        if resp.status_code == 429:
+            reset = resp.headers.get("x-ratelimit-reset")
+            if reset:
+                import time
+                wait = max(int(reset) - int(time.time()), 1)
+            else:
+                wait = min(2 ** attempt, 60)
+            await asyncio.sleep(wait)
+            continue
+
+        resp.raise_for_status()
+
+    raise Exception("Max retries exceeded")
+```
+
+## Methods
+
+### List Locations
+
+Retrieve air quality monitoring locations with extensive filtering.
+
+**Parameters:**
+- `iso` (str) -- ISO 3166-1 alpha-2 country code (e.g., `US`, `GB`, `IN`)
+- `countries_id` (int) -- Country ID
+- `coordinates` (str) -- Center point as `lat,lon`
+- `radius` (int) -- Radius in meters from coordinates
+- `bbox` (str) -- Bounding box as `min_lon,min_lat,max_lon,max_lat`
+- `parameters_id` (int) -- Filter by measured parameter
+- `providers_id` (int) -- Filter by data provider
+- `monitor` (bool) -- Filter to reference-grade monitors
+- `mobile` (bool) -- Filter to mobile/stationary
+- `limit` (int) -- Results per page (default: 100)
+- `page` (int) -- Page number
+- `order_by` (str) -- Sort field
+- `sort_order` (str) -- `asc` or `desc`
+
+```python
+async def list_locations(
+    client: httpx.AsyncClient,
+    iso: str = None,
+    coordinates: str = None,
+    radius: int = None,
+    parameters_id: int = None,
+    monitor: bool = None,
+    limit: int = 100,
+    page: int = 1,
+) -> dict:
+    params = {"limit": limit, "page": page}
+    if iso:
+        params["iso"] = iso
+    if coordinates:
+        params["coordinates"] = coordinates
+    if radius:
+        params["radius"] = radius
+    if parameters_id:
+        params["parameters_id"] = parameters_id
+    if monitor is not None:
+        params["monitor"] = str(monitor).lower()
+    return await oaq_request(client, "/locations", params)
+
+# Usage -- find PM2.5 monitors in London
+locations = await list_locations(
+    client,
+    coordinates="51.5074,-0.1278",
+    radius=25000,
+    parameters_id=2,  # PM2.5
+)
+for loc in locations["results"]:
+    print(f"{loc['id']}: {loc['name']} - {loc['locality']}")
+```
+
+### Get Location
+
+Retrieve details for a specific monitoring location.
+
+```python
+async def get_location(client: httpx.AsyncClient, location_id: int) -> dict:
+    return await oaq_request(client, f"/locations/{location_id}")
+
+# Usage
+location = await get_location(client, 2178)
+print(f"{location['results'][0]['name']}")
+print(f"Provider: {location['results'][0]['provider']['name']}")
+```
+
+### Get Location Sensors
+
+Retrieve sensors installed at a specific location.
+
+```python
+async def get_location_sensors(client: httpx.AsyncClient, location_id: int) -> dict:
+    return await oaq_request(client, f"/locations/{location_id}/sensors")
+
+# Usage
+sensors = await get_location_sensors(client, 2178)
+for sensor in sensors["results"]:
+    print(f"Sensor {sensor['id']}: {sensor['parameter']['name']} ({sensor['parameter']['units']})")
+```
+
+### Get Latest Measurements for Location
+
+Retrieve the most recent measurements at a location.
+
+```python
+async def get_location_latest(client: httpx.AsyncClient, location_id: int) -> dict:
+    return await oaq_request(client, f"/locations/{location_id}/latest")
+
+# Usage
+latest = await get_location_latest(client, 2178)
+for m in latest["results"]:
+    print(f"{m['parameter']['name']}: {m['value']} {m['parameter']['units']}")
+```
+
+### Get Sensor Measurements
+
+Retrieve raw measurements for a specific sensor with date filtering.
+
+**Parameters:**
+- `date_from` (str) -- ISO 8601 start date
+- `date_to` (str) -- ISO 8601 end date
+- `limit` (int) -- Results per page
+- `page` (int) -- Page number
+
+```python
+async def get_sensor_measurements(
+    client: httpx.AsyncClient,
+    sensor_id: int,
+    date_from: str = None,
+    date_to: str = None,
+    limit: int = 100,
+    page: int = 1,
+) -> dict:
+    params = {"limit": limit, "page": page}
+    if date_from:
+        params["date_from"] = date_from
+    if date_to:
+        params["date_to"] = date_to
+    return await oaq_request(client, f"/sensors/{sensor_id}/measurements", params)
+
+# Usage -- get last week's PM2.5 data
+measurements = await get_sensor_measurements(
+    client,
+    sensor_id=12345,
+    date_from="2026-03-10",
+    date_to="2026-03-17",
+)
+for m in measurements["results"]:
+    print(f"{m['period']['datetimeFrom']['utc']}: {m['value']}")
+```
+
+### Get Hourly Aggregated Measurements
+
+Retrieve hourly averaged measurement data for a sensor.
+
+```python
+async def get_sensor_hourly(
+    client: httpx.AsyncClient,
+    sensor_id: int,
+    date_from: str = None,
+    date_to: str = None,
+    limit: int = 100,
+    page: int = 1,
+) -> dict:
+    params = {"limit": limit, "page": page}
+    if date_from:
+        params["date_from"] = date_from
+    if date_to:
+        params["date_to"] = date_to
+    return await oaq_request(client, f"/sensors/{sensor_id}/measurements/hourly", params)
+```
+
+### Get Daily Aggregated Measurements
+
+Retrieve daily averaged measurement data for a sensor.
+
+```python
+async def get_sensor_daily(
+    client: httpx.AsyncClient,
+    sensor_id: int,
+    date_from: str = None,
+    date_to: str = None,
+    limit: int = 100,
+    page: int = 1,
+) -> dict:
+    params = {"limit": limit, "page": page}
+    if date_from:
+        params["date_from"] = date_from
+    if date_to:
+        params["date_to"] = date_to
+    return await oaq_request(client, f"/sensors/{sensor_id}/measurements/daily", params)
+```
+
+### Get Temporal Patterns
+
+Retrieve measurement patterns by hour-of-day, day-of-week, or month-of-year.
+
+```python
+async def get_sensor_pattern(
+    client: httpx.AsyncClient,
+    sensor_id: int,
+    aggregation: str = "hours",
+    pattern: str = "hourofday",
+) -> dict:
+    """
+    aggregation: 'hours' or 'days'
+    pattern: 'hourofday', 'dayofweek', 'monthofyear', 'monthly', 'yearly'
+    """
+    return await oaq_request(client, f"/sensors/{sensor_id}/{aggregation}/{pattern}")
+
+# Usage -- get hourly pollution patterns
+hourly_pattern = await get_sensor_pattern(client, 12345, "hours", "hourofday")
+for entry in hourly_pattern["results"]:
+    print(f"Hour {entry['label']}: {entry['value']} avg")
+```
+
+### List Parameters
+
+Retrieve available measurement parameters (PM2.5, PM10, O3, NO2, CO, SO2, etc.).
+
+```python
+async def list_parameters(
+    client: httpx.AsyncClient,
+    parameter_type: str = None,
+    iso: str = None,
+    limit: int = 100,
+) -> dict:
+    params = {"limit": limit}
+    if parameter_type:
+        params["parameter_type"] = parameter_type
+    if iso:
+        params["iso"] = iso
+    return await oaq_request(client, "/parameters", params)
+
+# Usage
+parameters = await list_parameters(client)
+for p in parameters["results"]:
+    print(f"{p['id']}: {p['name']} ({p['units']})")
+```
+
+### List Countries
+
+Retrieve countries with air quality data available.
+
+```python
+async def list_countries(client: httpx.AsyncClient, limit: int = 200) -> dict:
+    return await oaq_request(client, "/countries", {"limit": limit})
+
+# Usage
+countries = await list_countries(client)
+for c in countries["results"]:
+    print(f"{c['code']}: {c['name']} ({c['locationsCount']} locations)")
+```
+
+### List Providers
+
+Retrieve data providers contributing air quality data.
+
+```python
+async def list_providers(
+    client: httpx.AsyncClient,
+    iso: str = None,
+    limit: int = 100,
+) -> dict:
+    params = {"limit": limit}
+    if iso:
+        params["iso"] = iso
+    return await oaq_request(client, "/providers", params)
+```
+
+### List Manufacturers
+
+Retrieve instrument manufacturers.
+
+```python
+async def list_manufacturers(client: httpx.AsyncClient, limit: int = 100) -> dict:
+    return await oaq_request(client, "/manufacturers", {"limit": limit})
+```
+
+### List Instruments
+
+Retrieve monitoring instruments.
+
+```python
+async def list_instruments(client: httpx.AsyncClient, limit: int = 100) -> dict:
+    return await oaq_request(client, "/instruments", {"limit": limit})
+```
+
+### Get Manufacturer Instruments
+
+Retrieve instruments from a specific manufacturer.
+
+```python
+async def get_manufacturer_instruments(
+    client: httpx.AsyncClient,
+    manufacturer_id: int,
+) -> dict:
+    return await oaq_request(client, f"/manufacturers/{manufacturer_id}/instruments")
+```
+
+## Error Handling
+
+Successful responses return HTTP 200 with a JSON body containing `meta` and `results` fields.
+
+**Common status codes:**
+
+| Code | Meaning |
+|---|---|
+| 200 | Success |
+| 400 | Bad Request -- invalid parameters |
+| 401 | Unauthorized -- missing or invalid API key |
+| 404 | Not Found -- resource does not exist |
+| 422 | Validation Error -- parameter format issues |
+| 429 | Too Many Requests -- rate limit exceeded |
+| 500 | Internal Server Error |
+
+```python
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+class OpenAQError(Exception):
+    def __init__(self, status_code: int, message: str):
+        self.status_code = status_code
+        self.message = message
+        super().__init__(f"[{status_code}] {message}")
+
+async def oaq_request_safe(
+    client: httpx.AsyncClient,
+    path: str,
+    params: dict = None,
+    max_retries: int = 3,
+) -> dict:
+    url = f"{BASE_URL}{path}"
+
+    for attempt in range(max_retries):
+        try:
+            resp = await client.get(url, params=params, headers=HEADERS)
+        except httpx.RequestError as e:
+            logger.warning(f"Network error (attempt {attempt+1}): {e}")
+            await asyncio.sleep(2 ** attempt)
+            continue
+
+        if resp.status_code == 200:
+            remaining = resp.headers.get("x-ratelimit-remaining")
+            if remaining and int(remaining) < 5:
+                logger.warning(f"Rate limit nearly exhausted: {remaining} remaining")
+            return resp.json()
+
+        if resp.status_code == 429:
+            reset = resp.headers.get("x-ratelimit-reset")
+            if reset:
+                wait = max(int(reset) - int(time.time()), 1)
+            else:
+                wait = min(2 ** attempt, 60)
+            logger.warning(f"Rate limited, waiting {wait}s")
+            await asyncio.sleep(wait)
+            continue
+
+        raise OpenAQError(resp.status_code, resp.text)
+
+    raise OpenAQError(429, "Max retries exceeded")
+```
+
+## Common Pitfalls
+
+1. **API key goes in the header, not query parameters.** Use `X-API-Key` header. Unlike many APIs, the key is not a query parameter.
+
+2. **Free tier is 60 req/min and 2,000 req/hour.** This is strict. Use the `x-ratelimit-remaining` header to throttle proactively rather than waiting for 429 errors.
+
+3. **Data is hierarchical: Location -> Sensor -> Measurement.** You cannot query measurements directly by location. First get the location's sensors, then query measurements per sensor.
+
+4. **Parameter IDs are not obvious.** Common IDs: PM2.5 = 2, PM10 = 1, O3 = 3, NO2 = 5, CO = 7, SO2 = 9. Use the `/parameters` endpoint to get the full list.
+
+5. **Coordinates format is `lat,lon` as a single string.** Not separate parameters. Example: `coordinates=51.5074,-0.1278`.
+
+6. **Bounding box format is `min_lon,min_lat,max_lon,max_lat`.** Note the order: longitude first, then latitude. This follows GeoJSON convention.
+
+7. **Date parameters accept ISO 8601.** Use `2026-03-17` or `2026-03-17T00:00:00Z`. Missing timezone defaults to UTC.
+
+8. **Results are wrapped in a standard envelope.** All responses have `meta` (pagination info) and `results` (data array) fields. Access data via `response["results"]`.
+
+9. **Source attribution is required.** The Terms of Use require attributing data sources. Use the provider information from locations to credit data providers.
+
+10. **Not all locations have all parameters.** A PM2.5 sensor at one location does not mean all locations have PM2.5. Filter locations by `parameters_id` to find relevant stations.
+
+11. **Repeated rate limit violations can result in suspension.** Implement exponential backoff and respect the `x-ratelimit-reset` header to avoid account suspension.
+
+12. **Measurement aggregations are pre-computed.** Hourly, daily, and pattern endpoints return pre-aggregated data that is faster and more efficient than fetching raw measurements and computing yourself.

--- a/content/openfda/docs/rest-api/python/DOC.md
+++ b/content/openfda/docs/rest-api/python/DOC.md
@@ -1,0 +1,301 @@
+---
+name: rest-api
+description: "OpenFDA REST API for US FDA drug, device, and food safety data"
+metadata:
+  languages: "python"
+  versions: "2.0.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "openfda,health,drugs,medical-devices,food-safety,adverse-events,api"
+---
+
+# OpenFDA REST API
+
+> **Golden Rule:** OpenFDA has no official Python SDK. Use `httpx` (async) for direct REST API access. All endpoints are GET with query parameters. Authentication via optional API key (`api_key` query param) increases daily rate limits from 1,000 to 120,000. Returns JSON with `meta` and `results` sections.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+`https://api.fda.gov`
+
+## Authentication
+
+**Type:** API Key (query parameter, optional but recommended)
+
+Get a free API key at: https://open.fda.gov/apis/authentication/
+
+```python
+import httpx
+
+API_KEY = "your-openfda-api-key"  # Optional but recommended
+BASE_URL = "https://api.fda.gov"
+
+client = httpx.AsyncClient(
+    base_url=BASE_URL,
+    params={"api_key": API_KEY},
+    timeout=30.0
+)
+```
+
+Alternatively, pass as basic auth username in the Authorization header:
+
+```python
+client = httpx.AsyncClient(
+    base_url=BASE_URL,
+    auth=(API_KEY, ""),
+    timeout=30.0
+)
+```
+
+**Important:** The API works without a key but at severely reduced rate limits.
+
+## Rate Limiting
+
+| Authentication | Per Minute | Per Day |
+|---|---|---|
+| Without API key | 240 (per IP) | 1,000 (per IP) |
+| With API key | 240 (per key) | 120,000 (per key) |
+
+For higher limits, contact open@fda.hhs.gov.
+
+## Methods
+
+### Drug Adverse Events
+
+**Endpoint:** `GET /drug/event.json`
+
+Search FDA Adverse Event Reporting System (FAERS) for drug side effects.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `search` | `str` | `None` (field:term syntax) |
+| `count` | `str` | `None` (field to count unique values) |
+| `limit` | `int` | `1` (max 1000) |
+| `skip` | `int` | `0` |
+
+```python
+# Search adverse events for a specific drug
+params = {
+    "search": 'patient.drug.medicinalproduct:"ibuprofen"',
+    "limit": 5
+}
+response = await client.get("/drug/event.json", params=params)
+response.raise_for_status()
+data = response.json()
+for result in data.get("results", []):
+    reactions = [r["reactionmeddrapt"] for r in result.get("patient", {}).get("reaction", [])]
+    print(f"Reactions: {reactions}")
+```
+
+### Drug Labeling
+
+**Endpoint:** `GET /drug/label.json`
+
+Search structured product labeling (package inserts) for drugs.
+
+```python
+# Search drug labels for warnings about drowsiness
+params = {
+    "search": 'warnings:"drowsiness"',
+    "limit": 3
+}
+response = await client.get("/drug/label.json", params=params)
+response.raise_for_status()
+data = response.json()
+for label in data.get("results", []):
+    brand = label.get("openfda", {}).get("brand_name", ["Unknown"])
+    print(f"Brand: {brand[0]}")
+```
+
+### Drug Recalls (Enforcement)
+
+**Endpoint:** `GET /drug/enforcement.json`
+
+Search drug recall and enforcement reports.
+
+```python
+params = {
+    "search": 'classification:"Class I"+AND+status:"Ongoing"',
+    "limit": 5
+}
+response = await client.get("/drug/enforcement.json", params=params)
+response.raise_for_status()
+data = response.json()
+for recall in data.get("results", []):
+    print(f"Recall: {recall.get('reason_for_recall', 'N/A')}")
+```
+
+### Drug NDC Directory
+
+**Endpoint:** `GET /drug/ndc.json`
+
+Search the National Drug Code directory.
+
+```python
+params = {
+    "search": 'brand_name:"aspirin"',
+    "limit": 5
+}
+response = await client.get("/drug/ndc.json", params=params)
+response.raise_for_status()
+data = response.json()
+```
+
+### Medical Device Reports
+
+**Endpoint:** `GET /device/event.json`
+
+Search medical device adverse event reports (MDR).
+
+```python
+params = {
+    "search": 'device.generic_name:"wheelchair"',
+    "limit": 5
+}
+response = await client.get("/device/event.json", params=params)
+response.raise_for_status()
+data = response.json()
+for event in data.get("results", []):
+    print(f"Event type: {event.get('event_type', 'N/A')}")
+```
+
+### Device Recalls
+
+**Endpoint:** `GET /device/recall.json`
+
+```python
+params = {
+    "search": 'openfda.device_name:"hearing aid"',
+    "limit": 5
+}
+response = await client.get("/device/recall.json", params=params)
+response.raise_for_status()
+data = response.json()
+```
+
+### Device Classifications
+
+**Endpoint:** `GET /device/classification.json`
+
+```python
+params = {
+    "search": 'device_name:"glucose monitor"',
+    "limit": 5
+}
+response = await client.get("/device/classification.json", params=params)
+response.raise_for_status()
+data = response.json()
+```
+
+### Food Adverse Events
+
+**Endpoint:** `GET /food/event.json`
+
+Search food and dietary supplement adverse events.
+
+```python
+params = {
+    "search": 'products.name_brand:"supplement"',
+    "limit": 5
+}
+response = await client.get("/food/event.json", params=params)
+response.raise_for_status()
+data = response.json()
+```
+
+### Food Recalls (Enforcement)
+
+**Endpoint:** `GET /food/enforcement.json`
+
+```python
+params = {
+    "search": 'reason_for_recall:"allergen"',
+    "limit": 5
+}
+response = await client.get("/food/enforcement.json", params=params)
+response.raise_for_status()
+data = response.json()
+```
+
+### Count Queries
+
+Use `count` parameter to aggregate unique values across results.
+
+```python
+# Count top 10 drugs with most adverse events
+params = {
+    "search": 'patient.drug.medicinalproduct:"*"',
+    "count": "patient.drug.medicinalproduct.exact"
+}
+response = await client.get("/drug/event.json", params=params)
+response.raise_for_status()
+data = response.json()
+for item in data.get("results", [])[:10]:
+    print(f"{item['term']}: {item['count']}")
+```
+
+### Other Endpoints
+
+| Endpoint | Description |
+|---|---|
+| `GET /drug/drugsfda.json` | FDA-approved drug products |
+| `GET /drug/drugshortages.json` | Drug shortage data |
+| `GET /device/510k.json` | 510(k) premarket submissions |
+| `GET /device/pma.json` | Premarket approval (PMA) data |
+| `GET /device/udi.json` | Unique Device Identifiers |
+| `GET /device/enforcement.json` | Device enforcement reports |
+| `GET /food/enforcement.json` | Food enforcement reports |
+
+## Search Syntax
+
+- **Single field:** `search=field:term`
+- **AND logic:** `search=field1:term1+AND+field2:term2`
+- **OR logic:** `search=field1:term1+OR+field2:term2`
+- **Exact match:** `search=field.exact:"value"`
+- **Wildcard:** `search=field:val*`
+- **Date range:** `search=date:[20200101+TO+20231231]`
+
+## Error Handling
+
+```python
+import httpx
+
+try:
+    response = await client.get("/drug/event.json", params={"search": "test", "limit": 5})
+    response.raise_for_status()
+    data = response.json()
+except httpx.HTTPStatusError as e:
+    if e.response.status_code == 404:
+        error = e.response.json().get("error", {})
+        print(f"No matches found: {error.get('message', 'N/A')}")
+    elif e.response.status_code == 429:
+        print("Rate limited -- reduce request frequency or add API key")
+    elif e.response.status_code == 400:
+        print(f"Bad request (invalid search syntax): {e.response.text}")
+    elif e.response.status_code == 409:
+        print("Search timed out -- simplify your query")
+    else:
+        print(f"OpenFDA error {e.response.status_code}: {e.response.text}")
+except httpx.RequestError as e:
+    print(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+- All endpoints use **GET** (not POST) with query string parameters
+- A `404` means **no matching results**, not that the endpoint is invalid
+- The `limit` parameter max is **1000** per request; use `skip` for pagination
+- Search terms with spaces must be quoted: `search=field:"two words"`
+- Date fields use `YYYYMMDD` format without dashes: `[20200101+TO+20231231]`
+- The `count` parameter cannot be combined with `limit` or `skip`
+- Response `meta.results.total` gives total matches; use for pagination logic
+- Wildcard (`*`) searches cannot be combined with exact-match quoted strings
+- The `openfda` sub-object on results provides standardized drug/device identifiers
+- HTTPS is required; HTTP requests will fail
+- Set a reasonable timeout: `httpx.AsyncClient(timeout=30.0)` -- some queries are slow

--- a/content/openfoodfacts/docs/rest-api/python/DOC.md
+++ b/content/openfoodfacts/docs/rest-api/python/DOC.md
@@ -1,0 +1,351 @@
+---
+name: rest-api
+description: "Open Food Facts API - Free food and nutrition database with allergen and ingredient data"
+metadata:
+  languages: "python"
+  versions: "v2"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "openfoodfacts,food,nutrition,allergens,health,diet,open-data,api"
+---
+
+# Open Food Facts API - Python Reference (httpx)
+
+## Golden Rule
+
+Open Food Facts is a **free, open-source** food product database. Read operations require **no authentication** -- only a descriptive `User-Agent` header in the format `AppName/Version (contact@email.com)`. The production API is at `https://world.openfoodfacts.org` and the test/staging server is at `https://world.openfoodfacts.net`. Use the staging server for development and testing. Write operations (adding/editing products) require a free account. Always set a `User-Agent` -- requests without one may be blocked.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+All examples use `httpx` with async/await. For scripts that need a synchronous entrypoint:
+
+```python
+import asyncio
+import httpx
+
+async def main():
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{BASE_URL}/api/v2/product/3017624010701",
+            headers=HEADERS,
+            params={"fields": "product_name,nutrition_grades,allergens_tags"},
+        )
+        print(resp.json())
+
+asyncio.run(main())
+```
+
+## Base URL
+
+```
+https://world.openfoodfacts.org
+```
+
+For testing and development:
+```
+https://world.openfoodfacts.net
+```
+
+Country-specific subdomains are available (e.g., `https://us.openfoodfacts.org`, `https://fr.openfoodfacts.org`).
+
+```python
+import os
+
+BASE_URL = os.environ.get("OFF_BASE_URL", "https://world.openfoodfacts.org")
+HEADERS = {
+    "User-Agent": "MyFoodApp/1.0 (contact@example.com)",
+}
+```
+
+## Authentication
+
+- **Read operations:** No authentication required. Only the `User-Agent` header is needed.
+- **Write operations:** Requires `user_id` and `password` parameters (free account at openfoodfacts.org).
+
+```python
+# For write operations only
+OFF_USER = os.environ.get("OFF_USER_ID")
+OFF_PASS = os.environ.get("OFF_PASSWORD")
+```
+
+## Rate Limiting
+
+Open Food Facts does not publish strict rate limits, but as a community-run project with limited resources:
+- Be respectful and keep request rates moderate
+- Cache responses where possible
+- Use the `fields` parameter to reduce bandwidth
+- For bulk data needs, download the database dump instead of making thousands of API calls
+
+## Methods
+
+### Get Product by Barcode
+
+Fetch a single product using its barcode (EAN-13, UPC-A, etc.).
+
+**Parameters:**
+- `fields` (str) -- Comma-separated list of fields to return (reduces response size)
+
+```python
+async def get_product(
+    client: httpx.AsyncClient,
+    barcode: str,
+    fields: list[str] = None,
+) -> dict:
+    params = {}
+    if fields:
+        params["fields"] = ",".join(fields)
+    resp = await client.get(
+        f"{BASE_URL}/api/v2/product/{barcode}",
+        headers=HEADERS,
+        params=params,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    if data.get("status") == 0:
+        return None  # Product not found
+    return data["product"]
+
+# Usage -- get allergen and nutrition info for Nutella
+product = await get_product(client, "3017624010701", fields=[
+    "product_name", "brands", "allergens_tags", "allergens",
+    "nutrition_grades", "nutriscore_grade", "nutriments",
+    "ingredients_text", "image_url",
+])
+if product:
+    print(f"{product['product_name']} by {product.get('brands', 'unknown')}")
+    print(f"Nutri-Score: {product.get('nutriscore_grade', 'N/A')}")
+    print(f"Allergens: {product.get('allergens_tags', [])}")
+```
+
+### Search Products
+
+Search for products by various criteria.
+
+**Parameters:**
+- `categories_tags_en` (str) -- Category filter (e.g., `"breakfast-cereals"`)
+- `brands_tags` (str) -- Brand filter
+- `nutrition_grades_tags` (str) -- Nutri-Score grade (`a`, `b`, `c`, `d`, `e`)
+- `allergens_tags` (str) -- Filter by allergen (e.g., `"en:milk"`, `"en:gluten"`)
+- `labels_tags` (str) -- Filter by label (e.g., `"en:organic"`, `"en:no-gluten"`)
+- `countries_tags_en` (str) -- Filter by country
+- `sort_by` (str) -- Sort field (e.g., `"last_modified_t"`, `"popularity_key"`)
+- `fields` (str) -- Comma-separated fields to return
+- `page` (int) -- Page number (default 1)
+- `page_size` (int) -- Results per page (default 24, max 100)
+
+```python
+async def search_products(
+    client: httpx.AsyncClient,
+    fields: list[str] = None,
+    page: int = 1,
+    page_size: int = 24,
+    **filters,
+) -> dict:
+    params = {"page": page, "page_size": page_size}
+    if fields:
+        params["fields"] = ",".join(fields)
+    params.update(filters)
+    resp = await client.get(
+        f"{BASE_URL}/api/v2/search",
+        headers=HEADERS,
+        params=params,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+# Usage -- find gluten-free breakfast cereals
+results = await search_products(
+    client,
+    fields=["product_name", "brands", "allergens_tags", "nutrition_grades"],
+    categories_tags_en="breakfast-cereals",
+    labels_tags="en:no-gluten",
+    page_size=10,
+)
+print(f"Found {results['count']} products")
+for p in results["products"]:
+    print(f"  {p.get('product_name', 'unnamed')} -- {p.get('brands', 'unknown')}")
+```
+
+### Search by Text (Legacy v1 Endpoint)
+
+Free-text search using the v1 search endpoint.
+
+```python
+async def text_search(
+    client: httpx.AsyncClient,
+    query: str,
+    page: int = 1,
+    page_size: int = 24,
+    fields: list[str] = None,
+) -> dict:
+    params = {
+        "search_terms": query,
+        "search_simple": 1,
+        "action": "process",
+        "json": 1,
+        "page": page,
+        "page_size": page_size,
+    }
+    if fields:
+        params["fields"] = ",".join(fields)
+    resp = await client.get(
+        f"{BASE_URL}/cgi/search.pl",
+        headers=HEADERS,
+        params=params,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+# Usage
+results = await text_search(client, "organic peanut butter", page_size=5)
+```
+
+### Check Allergens for a Product
+
+Helper that extracts allergen data from a product.
+
+```python
+async def check_allergens(client: httpx.AsyncClient, barcode: str) -> dict:
+    product = await get_product(client, barcode, fields=[
+        "product_name", "allergens_tags", "traces_tags",
+        "allergens", "traces",
+    ])
+    if not product:
+        return {"found": False}
+    return {
+        "found": True,
+        "product_name": product.get("product_name", "Unknown"),
+        "allergens": product.get("allergens_tags", []),
+        "traces": product.get("traces_tags", []),  # "may contain" warnings
+        "allergens_text": product.get("allergens", ""),
+        "traces_text": product.get("traces", ""),
+    }
+
+# Usage -- check if product is safe for someone with milk allergy
+info = await check_allergens(client, "3017624010701")
+if info["found"]:
+    has_milk = any("milk" in a for a in info["allergens"])
+    may_contain_milk = any("milk" in t for t in info["traces"])
+    print(f"Contains milk: {has_milk}, May contain milk: {may_contain_milk}")
+```
+
+### Get Nutrition Data
+
+```python
+async def get_nutrition(client: httpx.AsyncClient, barcode: str) -> dict | None:
+    product = await get_product(client, barcode, fields=[
+        "product_name", "nutriments", "nutrition_grades",
+        "nutriscore_grade", "nutriscore_score",
+        "serving_size", "serving_quantity",
+    ])
+    if not product:
+        return None
+    return {
+        "product_name": product.get("product_name"),
+        "nutriscore": product.get("nutriscore_grade"),
+        "serving_size": product.get("serving_size"),
+        "nutrients": {
+            "energy_kcal_100g": product.get("nutriments", {}).get("energy-kcal_100g"),
+            "fat_100g": product.get("nutriments", {}).get("fat_100g"),
+            "saturated_fat_100g": product.get("nutriments", {}).get("saturated-fat_100g"),
+            "sugars_100g": product.get("nutriments", {}).get("sugars_100g"),
+            "salt_100g": product.get("nutriments", {}).get("salt_100g"),
+            "fiber_100g": product.get("nutriments", {}).get("fiber_100g"),
+            "proteins_100g": product.get("nutriments", {}).get("proteins_100g"),
+        },
+    }
+```
+
+### Add or Edit a Product (Write Operation)
+
+```python
+async def add_product(
+    client: httpx.AsyncClient,
+    barcode: str,
+    product_name: str = None,
+    brands: str = None,
+    categories: str = None,
+    labels: str = None,
+    **kwargs,
+) -> dict:
+    data = {
+        "code": barcode,
+        "user_id": OFF_USER,
+        "password": OFF_PASS,
+    }
+    if product_name:
+        data["product_name"] = product_name
+    if brands:
+        data["brands"] = brands
+    if categories:
+        data["categories"] = categories
+    if labels:
+        data["labels"] = labels
+    data.update(kwargs)
+    resp = await client.post(
+        f"{BASE_URL}/cgi/product_jqm2.pl",
+        headers=HEADERS,
+        data=data,
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+## Error Handling
+
+| Code | Meaning |
+|---|---|
+| 200 | Success |
+| 404 | Product not found (also check `status` field in response) |
+| 500 | Internal Server Error |
+
+The API often returns 200 even when a product is not found. Check the `status` field:
+- `status: 1` -- product found
+- `status: 0` -- product not found
+
+```python
+class OFFError(Exception):
+    def __init__(self, status_code: int, message: str):
+        self.status_code = status_code
+        self.message = message
+        super().__init__(f"[{status_code}] {message}")
+
+async def safe_off_request(
+    client: httpx.AsyncClient,
+    url: str,
+    params: dict = None,
+) -> dict:
+    try:
+        resp = await client.get(url, headers=HEADERS, params=params)
+        resp.raise_for_status()
+        return resp.json()
+    except httpx.HTTPStatusError as e:
+        raise OFFError(e.response.status_code, str(e)) from e
+```
+
+## Common Pitfalls
+
+1. **Always set a User-Agent header.** Requests without a descriptive User-Agent may be blocked. Use the format `AppName/Version (contact@email.com)`.
+
+2. **Use the `fields` parameter.** Product responses can be very large (hundreds of fields). Always request only the fields you need to reduce bandwidth and response time.
+
+3. **Check `status` field, not just HTTP status.** A 200 response with `status: 0` means the product was not found. Always check `data["status"]`.
+
+4. **Allergen tags use language prefixes.** Allergen values are like `"en:milk"`, `"en:gluten"`, `"en:nuts"`. Always parse with the prefix or strip it when displaying.
+
+5. **Data quality varies.** Open Food Facts is crowdsourced. Fields may be missing, incomplete, or in different languages. Always handle missing keys gracefully.
+
+6. **Use the test server for development.** `https://world.openfoodfacts.net` is the staging environment. Do not test write operations against the production database.
+
+7. **Nutri-Score is not available for all products.** Many products lack sufficient data for Nutri-Score calculation. Check for `None`/missing values.
+
+8. **Nutriment keys use hyphens.** Keys in the `nutriments` object use hyphens like `"energy-kcal_100g"`, `"saturated-fat_100g"`. Do not assume underscores.
+
+9. **Bulk data is available as dumps.** For large-scale analysis, download the CSV or MongoDB dump from `https://world.openfoodfacts.org/data` instead of making thousands of API calls.
+
+10. **Barcodes are strings.** Leading zeros matter in barcodes (e.g., EAN-13). Always store and pass barcodes as strings, never as integers.

--- a/content/openweather/docs/rest-api/python/DOC.md
+++ b/content/openweather/docs/rest-api/python/DOC.md
@@ -1,0 +1,335 @@
+---
+name: rest-api
+description: "OpenWeatherMap - Weather Data and Forecasts API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "openweather,weather,forecast,climate,geolocation,api"
+---
+
+# OpenWeatherMap API - Python Reference (httpx)
+
+## Golden Rule
+
+Authentication uses an `appid` **query parameter** on every request. The free tier allows 60 calls/minute and 1,000 calls/day. New API keys take up to 2 hours to activate after creation -- if you get a 401 immediately after signup, wait and try again. Always geocode city names to lat/lon first using the Geocoding API rather than passing city names directly.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+All examples use `httpx` with async/await. For scripts that need a synchronous entrypoint:
+
+```python
+import asyncio
+import httpx
+
+async def main():
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{BASE_URL}/weather",
+            params={"lat": 35.6762, "lon": 139.6503, "appid": API_KEY, "units": "metric"},
+        )
+        print(resp.json())
+
+asyncio.run(main())
+```
+
+## Base URL
+
+```
+https://api.openweathermap.org/data/2.5
+```
+
+For the One Call API 3.0 (all-in-one current + forecast + historical):
+
+```
+https://api.openweathermap.org/data/3.0
+```
+
+For the Geocoding API:
+
+```
+https://api.openweathermap.org/geo/1.0
+```
+
+```python
+import os
+
+API_KEY = os.environ["OPENWEATHER_API_KEY"]
+BASE_URL = "https://api.openweathermap.org/data/2.5"
+ONECALL_URL = "https://api.openweathermap.org/data/3.0"
+GEO_URL = "https://api.openweathermap.org/geo/1.0"
+```
+
+## Authentication
+
+OpenWeatherMap uses **API key as a query parameter** on every request:
+
+```
+https://api.openweathermap.org/data/2.5/weather?lat=35.68&lon=139.65&appid=YOUR_API_KEY
+```
+
+There are no authorization headers. The key is always the `appid` parameter.
+
+## Rate Limiting
+
+| Plan | Calls/Minute | Calls/Day |
+|---|---|---|
+| Free | 60 | 1,000 |
+| One Call 3.0 | 60 | 2,000 (default, configurable) |
+| Paid tiers | Higher limits | Configurable |
+
+When you exceed limits, the API returns HTTP `429 Too Many Requests`.
+
+```python
+import asyncio
+
+async def weather_request(client: httpx.AsyncClient, url: str, params: dict, max_retries: int = 3) -> dict:
+    for attempt in range(max_retries):
+        resp = await client.get(url, params={**params, "appid": API_KEY})
+        if resp.status_code == 429:
+            wait = min(2 ** attempt, 30)
+            await asyncio.sleep(wait)
+            continue
+        resp.raise_for_status()
+        return resp.json()
+    raise Exception("Max retries exceeded due to rate limiting")
+```
+
+## Methods
+
+### Geocoding (City Name to Coordinates)
+
+Convert city names to lat/lon coordinates. Use this before calling weather endpoints.
+
+**Parameters:**
+- `q` (str) -- City name, state code, and country code (e.g., `Tokyo,JP` or `London,GB`)
+- `limit` (int) -- Max results (default: 5)
+
+```python
+async def geocode(client: httpx.AsyncClient, city: str, limit: int = 5) -> list:
+    resp = await client.get(
+        f"{GEO_URL}/direct",
+        params={"q": city, "limit": limit, "appid": API_KEY},
+    )
+    resp.raise_for_status()
+    return resp.json()
+    # Returns: [{"name": "Tokyo", "lat": 35.6762, "lon": 139.6503, "country": "JP", ...}]
+
+# Usage
+locations = await geocode(client, "Tokyo,JP")
+lat, lon = locations[0]["lat"], locations[0]["lon"]
+```
+
+### Reverse Geocoding
+
+Convert coordinates to location names.
+
+```python
+async def reverse_geocode(client: httpx.AsyncClient, lat: float, lon: float, limit: int = 5) -> list:
+    resp = await client.get(
+        f"{GEO_URL}/reverse",
+        params={"lat": lat, "lon": lon, "limit": limit, "appid": API_KEY},
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Current Weather
+
+Get current weather for a location.
+
+**Required parameters:**
+- `lat` (float) -- Latitude
+- `lon` (float) -- Longitude
+
+**Optional parameters:**
+- `units` (str) -- `standard` (Kelvin), `metric` (Celsius), or `imperial` (Fahrenheit). Default: `standard`
+- `lang` (str) -- Language code for descriptions (e.g., `en`, `ja`, `zh_cn`)
+
+```python
+async def get_current_weather(
+    client: httpx.AsyncClient,
+    lat: float,
+    lon: float,
+    units: str = "metric",
+    lang: str = "en",
+) -> dict:
+    resp = await client.get(
+        f"{BASE_URL}/weather",
+        params={"lat": lat, "lon": lon, "units": units, "lang": lang, "appid": API_KEY},
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+# Usage
+weather = await get_current_weather(client, lat=35.6762, lon=139.6503)
+temp = weather["main"]["temp"]
+desc = weather["weather"][0]["description"]
+print(f"Tokyo: {temp}C, {desc}")
+```
+
+### 5-Day / 3-Hour Forecast
+
+Get weather forecast in 3-hour intervals for up to 5 days.
+
+```python
+async def get_forecast(
+    client: httpx.AsyncClient,
+    lat: float,
+    lon: float,
+    units: str = "metric",
+    cnt: int = None,
+) -> dict:
+    params = {"lat": lat, "lon": lon, "units": units, "appid": API_KEY}
+    if cnt:
+        params["cnt"] = cnt  # Number of 3-hour intervals to return
+    resp = await client.get(f"{BASE_URL}/forecast", params=params)
+    resp.raise_for_status()
+    return resp.json()
+
+# Usage -- next 24 hours (8 x 3-hour intervals)
+forecast = await get_forecast(client, lat=35.6762, lon=139.6503, cnt=8)
+for entry in forecast["list"]:
+    print(f"{entry['dt_txt']}: {entry['main']['temp']}C")
+```
+
+### Air Pollution
+
+Get current air quality data.
+
+```python
+async def get_air_pollution(client: httpx.AsyncClient, lat: float, lon: float) -> dict:
+    resp = await client.get(
+        f"{BASE_URL}/air_pollution",
+        params={"lat": lat, "lon": lon, "appid": API_KEY},
+    )
+    resp.raise_for_status()
+    return resp.json()
+    # Returns AQI (1-5 scale) and component concentrations (CO, NO2, O3, PM2.5, etc.)
+```
+
+### One Call API 3.0 (Paid)
+
+All-in-one endpoint for current, minutely (1h), hourly (48h), daily (8d) forecasts, and weather alerts.
+
+```python
+async def get_onecall(
+    client: httpx.AsyncClient,
+    lat: float,
+    lon: float,
+    units: str = "metric",
+    exclude: str = None,
+) -> dict:
+    params = {"lat": lat, "lon": lon, "units": units, "appid": API_KEY}
+    if exclude:
+        params["exclude"] = exclude  # e.g., "minutely,hourly"
+    resp = await client.get(f"{ONECALL_URL}/onecall", params=params)
+    resp.raise_for_status()
+    return resp.json()
+
+# Usage -- get daily forecast only
+data = await get_onecall(client, lat=35.6762, lon=139.6503, exclude="minutely,hourly,current,alerts")
+for day in data["daily"]:
+    print(f"{day['dt']}: {day['temp']['day']}C")
+```
+
+## Error Handling
+
+Successful responses return HTTP 200 with a JSON body.
+
+On failure:
+
+```json
+{
+    "cod": 401,
+    "message": "Invalid API key. Please see https://openweathermap.org/faq#error401 for more info."
+}
+```
+
+**Common status codes:**
+
+| Code | Meaning |
+|---|---|
+| 200 | Success |
+| 400 | Bad Request -- missing or invalid parameters (e.g., missing lat/lon) |
+| 401 | Unauthorized -- invalid API key, or key not yet activated (wait up to 2 hours) |
+| 404 | Not Found -- invalid endpoint or city not found |
+| 429 | Too Many Requests -- exceeded calls/minute or calls/day limit |
+| 500 | Internal Server Error |
+
+**Robust error handling pattern:**
+
+```python
+import asyncio
+import httpx
+import logging
+
+logger = logging.getLogger(__name__)
+
+class OpenWeatherError(Exception):
+    def __init__(self, status_code: int, message: str):
+        self.status_code = status_code
+        self.message = message
+        super().__init__(f"[{status_code}] {message}")
+
+async def owm_request(
+    client: httpx.AsyncClient,
+    url: str,
+    params: dict = None,
+    max_retries: int = 3,
+) -> dict:
+    request_params = {**(params or {}), "appid": API_KEY}
+
+    for attempt in range(max_retries):
+        try:
+            resp = await client.get(url, params=request_params)
+        except httpx.RequestError as e:
+            logger.warning(f"Network error (attempt {attempt+1}): {e}")
+            await asyncio.sleep(2 ** attempt)
+            continue
+
+        if resp.status_code == 200:
+            return resp.json()
+
+        if resp.status_code == 429:
+            wait = min(2 ** attempt, 30)
+            logger.warning(f"Rate limited, retrying in {wait}s")
+            await asyncio.sleep(wait)
+            continue
+
+        data = resp.json() if resp.content else {}
+        raise OpenWeatherError(
+            resp.status_code,
+            data.get("message", "Unknown error"),
+        )
+
+    raise OpenWeatherError(429, "Max retries exceeded")
+```
+
+## Common Pitfalls
+
+1. **New API keys take up to 2 hours to activate.** You will get 401 errors immediately after creating a key. This is normal -- wait and retry.
+
+2. **Default temperature is Kelvin.** Always pass `units=metric` (Celsius) or `units=imperial` (Fahrenheit) unless you specifically want Kelvin. Forgetting this is the most common mistake.
+
+3. **Use lat/lon, not city names.** The current weather endpoint accepts `lat` and `lon`. The old `q=CityName` parameter is deprecated for most endpoints. Use the Geocoding API to convert city names to coordinates first.
+
+4. **Free tier is 60 calls/minute.** This sounds generous but adds up quickly if you have multiple users or poll frequently. Implement caching with a 10-minute TTL for weather data.
+
+5. **One Call API 3.0 requires separate subscription.** Even with a paid plan for 2.5 endpoints, One Call 3.0 is a separate product requiring its own subscription in your account dashboard.
+
+6. **The `cod` field in error responses is sometimes a string.** The API inconsistently returns `"cod": "404"` (string) or `"cod": 404` (integer). Handle both types when parsing errors.
+
+7. **Weather icon URLs follow a pattern.** Icon codes from the response (e.g., `"10d"`) map to `https://openweathermap.org/img/wn/{icon}@2x.png`. Use `@2x` for retina-quality images.
+
+8. **Forecast timestamps are UTC.** The `dt` field in forecast responses is a Unix timestamp in UTC. Convert to local time using the `timezone` offset provided in the response.
+
+9. **Air pollution AQI scale is 1-5, not 0-500.** OpenWeather uses its own 1-5 scale (1=Good, 5=Very Poor), not the US EPA 0-500 AQI. Do not confuse these scales in your UI.
+
+10. **Geocoding returns multiple results.** Searching for "London" returns London GB, London CA, London US, etc. Always include the country code (e.g., `London,GB`) and verify the result matches your intent.

--- a/content/paystack/docs/rest-api/python/DOC.md
+++ b/content/paystack/docs/rest-api/python/DOC.md
@@ -1,0 +1,287 @@
+---
+name: rest-api
+description: "Paystack - African Payment Processor REST API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "paystack,payments,africa,nigeria,ghana,south-africa,api"
+---
+
+# Paystack REST API — Python (httpx)
+
+## Golden Rule
+
+All amounts are in the **smallest currency unit** — kobo for NGN (divide by 100 for naira), pesewas for GHS, cents for ZAR. Always **verify transactions server-side** using the transaction reference before fulfilling orders. Never expose your Secret Key in client-side code. All requests require HTTPS.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+```
+https://api.paystack.co
+```
+
+## Authentication
+
+Paystack uses a Secret Key passed as a Bearer token in the `Authorization` header.
+
+```python
+import httpx
+import os
+
+SECRET_KEY = os.environ["PAYSTACK_SECRET_KEY"]
+
+headers = {
+    "Authorization": f"Bearer {SECRET_KEY}",
+    "Content-Type": "application/json",
+}
+
+async def get_client() -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        base_url="https://api.paystack.co",
+        headers=headers,
+        timeout=30.0,
+    )
+```
+
+**Key prefixes:**
+- `sk_test_...` — Test secret key
+- `pk_test_...` — Test public key
+- `sk_live_...` — Live secret key
+- `pk_live_...` — Live public key
+
+## Rate Limiting
+
+Paystack does not publish a fixed rate-limit number, but aggressive request patterns trigger HTTP **429 Too Many Requests**. Guidelines:
+- Bulk charges: max 100 items per batch, 5-second interval between batches.
+- Bulk transfers: max 100 per batch.
+- General: avoid more than ~50 requests/second sustained.
+
+```python
+import asyncio
+
+async def request_with_retry(client: httpx.AsyncClient, method: str, url: str, **kwargs):
+    for attempt in range(5):
+        resp = await client.request(method, url, **kwargs)
+        if resp.status_code == 429:
+            wait = 2 ** attempt
+            await asyncio.sleep(wait)
+            continue
+        resp.raise_for_status()
+        return resp.json()
+    raise Exception("Rate limit exceeded after retries")
+```
+
+## Methods
+
+### Initialize Transaction
+
+Start a payment — returns an authorization URL to redirect the customer.
+
+```python
+async def initialize_transaction(client: httpx.AsyncClient, email: str,
+                                  amount_kobo: int, reference: str | None = None,
+                                  currency: str = "NGN",
+                                  callback_url: str | None = None):
+    """amount_kobo: amount in smallest unit (e.g., 50000 = NGN 500)"""
+    payload = {
+        "email": email,
+        "amount": amount_kobo,
+        "currency": currency,
+    }
+    if reference:
+        payload["reference"] = reference
+    if callback_url:
+        payload["callback_url"] = callback_url
+
+    resp = await client.post("/transaction/initialize", json=payload)
+    resp.raise_for_status()
+    data = resp.json()
+    return data["data"]  # {"authorization_url": "...", "access_code": "...", "reference": "..."}
+```
+
+### Verify Transaction
+
+Always verify after redirect or webhook. Match amount and currency.
+
+```python
+async def verify_transaction(client: httpx.AsyncClient, reference: str):
+    resp = await client.get(f"/transaction/verify/{reference}")
+    resp.raise_for_status()
+    data = resp.json()["data"]
+    assert data["status"] == "success"
+    # assert data["amount"] == expected_amount_kobo
+    # assert data["currency"] == "NGN"
+    return data
+```
+
+### List Transactions
+
+```python
+async def list_transactions(client: httpx.AsyncClient, page: int = 1,
+                             per_page: int = 50, status: str | None = None):
+    params = {"page": page, "perPage": per_page}
+    if status:
+        params["status"] = status  # "success", "failed", "abandoned"
+    resp = await client.get("/transaction", params=params)
+    resp.raise_for_status()
+    return resp.json()["data"]
+```
+
+### Charge Authorization (Recurring)
+
+Charge a previously authorized card (for subscriptions/recurring).
+
+```python
+async def charge_authorization(client: httpx.AsyncClient, email: str,
+                                amount_kobo: int, authorization_code: str,
+                                reference: str | None = None):
+    payload = {
+        "email": email,
+        "amount": amount_kobo,
+        "authorization_code": authorization_code,
+    }
+    if reference:
+        payload["reference"] = reference
+    resp = await client.post("/transaction/charge_authorization", json=payload)
+    resp.raise_for_status()
+    return resp.json()["data"]
+```
+
+### Create Transfer Recipient
+
+Register a bank account before sending money.
+
+```python
+async def create_transfer_recipient(client: httpx.AsyncClient, name: str,
+                                     account_number: str, bank_code: str,
+                                     currency: str = "NGN"):
+    payload = {
+        "type": "nuban",  # "ghipss" for Ghana, "basa" for South Africa
+        "name": name,
+        "account_number": account_number,
+        "bank_code": bank_code,
+        "currency": currency,
+    }
+    resp = await client.post("/transferrecipient", json=payload)
+    resp.raise_for_status()
+    return resp.json()["data"]
+```
+
+### Initiate Transfer (Payout)
+
+```python
+async def initiate_transfer(client: httpx.AsyncClient, amount_kobo: int,
+                              recipient_code: str, reason: str,
+                              reference: str | None = None):
+    payload = {
+        "source": "balance",
+        "amount": amount_kobo,
+        "recipient": recipient_code,
+        "reason": reason,
+    }
+    if reference:
+        payload["reference"] = reference
+    resp = await client.post("/transfer", json=payload)
+    resp.raise_for_status()
+    return resp.json()["data"]
+```
+
+### Create Customer
+
+```python
+async def create_customer(client: httpx.AsyncClient, email: str,
+                           first_name: str = "", last_name: str = ""):
+    payload = {"email": email, "first_name": first_name, "last_name": last_name}
+    resp = await client.post("/customer", json=payload)
+    resp.raise_for_status()
+    return resp.json()["data"]
+```
+
+### List Banks
+
+Useful for populating bank selection dropdowns.
+
+```python
+async def list_banks(client: httpx.AsyncClient, country: str = "nigeria"):
+    resp = await client.get("/bank", params={"country": country})
+    resp.raise_for_status()
+    return resp.json()["data"]
+```
+
+### Create Dedicated Virtual Account
+
+```python
+async def create_dedicated_virtual_account(client: httpx.AsyncClient,
+                                            customer_code: str,
+                                            preferred_bank: str = "wema-bank"):
+    payload = {
+        "customer": customer_code,
+        "preferred_bank": preferred_bank,
+    }
+    resp = await client.post("/dedicated_account", json=payload)
+    resp.raise_for_status()
+    return resp.json()["data"]
+```
+
+## Error Handling
+
+Paystack returns a consistent response envelope:
+
+```json
+{
+  "status": false,
+  "message": "Invalid key",
+  "data": null,
+  "meta": {
+    "next_step": "Check your API key and try again"
+  }
+}
+```
+
+HTTP status codes:
+- **200** — Success (`"status": true`)
+- **400** — Bad request / validation error
+- **401** — Invalid or missing authorization key
+- **404** — Resource not found
+- **429** — Rate limited
+- **5xx** — Paystack server error
+
+```python
+class PaystackError(Exception):
+    def __init__(self, status_code: int, message: str, meta=None):
+        self.status_code = status_code
+        self.message = message
+        self.meta = meta
+        super().__init__(f"[{status_code}] {message}")
+
+async def safe_request(client: httpx.AsyncClient, method: str, url: str, **kwargs):
+    resp = await client.request(method, url, **kwargs)
+    body = resp.json()
+    if not body.get("status"):
+        raise PaystackError(
+            resp.status_code,
+            body.get("message", "Unknown error"),
+            body.get("meta"),
+        )
+    return body
+```
+
+## Common Pitfalls
+
+1. **Amounts in major units instead of kobo** — `amount: 500` means NGN 5.00, not NGN 500. Multiply naira by 100.
+2. **Not verifying transactions** — Always call `/transaction/verify/{reference}` before fulfilling. Redirect params can be spoofed.
+3. **Wrong transfer recipient type** — Use `"nuban"` for Nigeria, `"ghipss"` for Ghana, `"basa"` for South Africa. Wrong type returns 400.
+4. **Test vs. live keys** — Test keys (prefixed `sk_test_`) simulate transactions. No real money moves. Ensure you switch for production.
+5. **Webhook IP whitelisting** — Paystack sends webhooks from specific IPs. Verify the `x-paystack-signature` header (HMAC SHA512 of body with your secret key).
+6. **Bulk charge pacing** — Sending batches too fast (< 5s apart) triggers 429. Use a 5-second delay between batch submissions.
+7. **Currency support** — Paystack supports NGN, GHS, ZAR, and USD. Passing an unsupported currency silently fails or errors.
+8. **Dedicated virtual accounts** — Only available for registered Nigerian businesses. Requires BVN validation of the customer.
+9. **Transfer OTP** — First-time transfers or large amounts may require OTP confirmation via the dashboard. Disable OTP for automated flows through Paystack dashboard settings.

--- a/content/perplexity/docs/rest-api/python/DOC.md
+++ b/content/perplexity/docs/rest-api/python/DOC.md
@@ -1,0 +1,470 @@
+---
+name: rest-api
+description: "Perplexity - Search-Grounded LLM API (Sonar)"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "perplexity,sonar,search,llm,citations,grounded-search,rag,api"
+---
+
+# Perplexity Sonar REST API (Python / httpx)
+
+## Golden Rule
+
+Every Sonar response is grounded in live web search results. **Always consume the `citations` array** returned alongside `choices` -- these URLs are the provenance chain for the generated text. If you discard citations you lose the primary value proposition of the API.
+
+---
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+All examples in this document use **`httpx`** with `async`/`await`. No SDK or `requests` library is needed.
+
+---
+
+## Base URL
+
+```
+https://api.perplexity.ai
+```
+
+---
+
+## Authentication
+
+All requests require a **Bearer token** in the `Authorization` header. Obtain an API key from the [Perplexity API Settings](https://www.perplexity.ai/settings/api).
+
+```python
+headers = {
+    "Authorization": "Bearer pplx-xxxxxxxxxxxxxxxxxxxx",
+    "Content-Type": "application/json",
+}
+```
+
+Store the key in an environment variable (`PERPLEXITY_API_KEY`) and load it at runtime:
+
+```python
+import os
+
+API_KEY = os.environ["PERPLEXITY_API_KEY"]
+headers = {
+    "Authorization": f"Bearer {API_KEY}",
+    "Content-Type": "application/json",
+}
+```
+
+---
+
+## Rate Limiting
+
+Perplexity uses a **leaky-bucket** algorithm allowing short bursts while enforcing a sustained rate.
+
+| Tier | Sonar RPM | Sonar Pro RPM |
+|------|-----------|---------------|
+| 0    | 50        | 50            |
+| 1    | 50        | 50            |
+| 2    | 100       | 100           |
+| 3+   | Higher    | Higher        |
+
+*RPM = requests per minute. Limits vary by model and tier. The Search API allows up to 50 req/s across all tiers.*
+
+When you hit a limit the API returns **HTTP 429**. Implement exponential backoff with jitter:
+
+```python
+import asyncio
+import random
+
+async def backoff_request(client, url, headers, payload, max_retries=5):
+    for attempt in range(max_retries):
+        resp = await client.post(url, headers=headers, json=payload)
+        if resp.status_code != 429:
+            return resp
+        wait = (2 ** attempt) + random.uniform(0, 1)
+        await asyncio.sleep(wait)
+    raise Exception("Max retries exceeded")
+```
+
+---
+
+## Models
+
+| Model ID                 | Context Window | Best For                                      |
+|--------------------------|----------------|-----------------------------------------------|
+| `sonar`                  | 128 000 tokens | Fast, lightweight Q&A with citations          |
+| `sonar-pro`              | 200 000 tokens | Complex multi-step queries, more citations     |
+| `sonar-reasoning-pro`    | 128 000 tokens | Chain-of-thought reasoning with web grounding  |
+| `sonar-deep-research`    | 128 000 tokens | Exhaustive multi-query research reports         |
+
+### Pricing (per 1M tokens / per 1K requests)
+
+| Model                 | Input Tokens | Output Tokens | Request Fee (medium context) |
+|-----------------------|--------------|---------------|------------------------------|
+| `sonar`               | $1           | $1            | $8                           |
+| `sonar-pro`           | $3           | $15           | $10                          |
+| `sonar-reasoning-pro` | $2           | $8            | $10                          |
+| `sonar-deep-research` | $2           | $8            | varies                       |
+
+*Request fees vary by `search_context_size` (low / medium / high). Citation tokens are no longer billed for standard Sonar and Sonar Pro.*
+
+---
+
+## Methods
+
+### POST `/v1/sonar` -- Chat Completions
+
+The primary endpoint. Sends a conversation to a Sonar model and receives a search-grounded completion with citations.
+
+#### Minimal Example
+
+```python
+import httpx
+import os
+import asyncio
+
+API_KEY = os.environ["PERPLEXITY_API_KEY"]
+BASE_URL = "https://api.perplexity.ai"
+
+async def chat():
+    payload = {
+        "model": "sonar",
+        "messages": [
+            {"role": "system", "content": "Be precise and cite sources."},
+            {"role": "user", "content": "What are the latest advances in solid-state batteries?"},
+        ],
+    }
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{BASE_URL}/v1/sonar",
+            headers={
+                "Authorization": f"Bearer {API_KEY}",
+                "Content-Type": "application/json",
+            },
+            json=payload,
+            timeout=30.0,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        # The generated answer
+        answer = data["choices"][0]["message"]["content"]
+        print(answer)
+
+        # Citations -- list of source URLs
+        citations = data.get("citations", [])
+        for i, url in enumerate(citations, 1):
+            print(f"[{i}] {url}")
+
+asyncio.run(chat())
+```
+
+#### Full Request Parameters
+
+```python
+payload = {
+    # Required
+    "model": "sonar-pro",                          # Model ID (see Models table)
+    "messages": [                                   # Conversation history
+        {"role": "system", "content": "..."},
+        {"role": "user", "content": "..."},
+    ],
+
+    # Generation control
+    "max_tokens": 4096,                             # 1 - 128000
+    "temperature": 0.2,                             # 0.0 - 2.0
+    "top_p": 0.9,                                   # 0.0 - 1.0
+    "stop": ["\n\n"],                               # Stop sequences (string or list)
+    "stream": False,                                # Enable streaming
+    "stream_mode": "full",                          # "full" | "concise"
+
+    # Search configuration
+    "search_domain_filter": ["arxiv.org", "nature.com"],  # Restrict to these domains
+    "search_recency_filter": "month",               # "hour" | "day" | "week" | "month" | "year"
+    "search_after_date_filter": "01/01/2025",       # MM/DD/YYYY
+    "search_before_date_filter": "03/17/2026",      # MM/DD/YYYY
+    "search_language_filter": ["en"],                # ISO 639-1 codes
+    "search_mode": "web",                           # "web" | "academic" | "sec"
+    "disable_search": False,                        # Set True to skip web search
+
+    # Web search options (object)
+    "web_search_options": {
+        "search_context_size": "medium",            # "low" | "medium" | "high"
+    },
+
+    # Response enrichment
+    "return_images": False,                         # Include image results
+    "return_related_questions": False,              # Include follow-up suggestions
+
+    # Structured output
+    "response_format": {
+        "type": "text",                             # "text" or "json_schema"
+    },
+}
+```
+
+#### Response Shape
+
+```json
+{
+  "id": "cmpl-xxxxxxxx",
+  "model": "sonar-pro",
+  "created": 1742169600,
+  "object": "chat.completion",
+  "choices": [
+    {
+      "index": 0,
+      "finish_reason": "stop",
+      "message": {
+        "role": "assistant",
+        "content": "Solid-state batteries have seen breakthroughs in ..."
+      }
+    }
+  ],
+  "citations": [
+    "https://www.nature.com/articles/s41586-025-example",
+    "https://arxiv.org/abs/2025.12345"
+  ],
+  "search_results": [
+    {
+      "title": "Advances in Solid-State Battery Technology",
+      "url": "https://www.nature.com/articles/s41586-025-example",
+      "date": "2025-11-10",
+      "snippet": "Recent developments show ..."
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 42,
+    "completion_tokens": 310,
+    "total_tokens": 352,
+    "citation_tokens": 1200,
+    "num_search_queries": 1
+  }
+}
+```
+
+Key fields in the response:
+
+- **`choices[0].message.content`** -- The generated answer text.
+- **`citations`** -- Ordered list of source URLs. In-text references like `[1]` map to this array by index.
+- **`search_results`** -- Richer metadata per source (title, date, snippet).
+- **`usage`** -- Token counts and search query counts for cost tracking.
+
+#### Streaming Example
+
+```python
+import httpx
+import os
+import asyncio
+
+API_KEY = os.environ["PERPLEXITY_API_KEY"]
+BASE_URL = "https://api.perplexity.ai"
+
+async def stream_chat():
+    payload = {
+        "model": "sonar",
+        "messages": [
+            {"role": "user", "content": "Explain quantum computing in simple terms."},
+        ],
+        "stream": True,
+    }
+    async with httpx.AsyncClient() as client:
+        async with client.stream(
+            "POST",
+            f"{BASE_URL}/v1/sonar",
+            headers={
+                "Authorization": f"Bearer {API_KEY}",
+                "Content-Type": "application/json",
+            },
+            json=payload,
+            timeout=60.0,
+        ) as resp:
+            resp.raise_for_status()
+            async for line in resp.aiter_lines():
+                if line.startswith("data: "):
+                    chunk = line[6:]
+                    if chunk == "[DONE]":
+                        break
+                    import json
+                    data = json.loads(chunk)
+                    delta = data["choices"][0].get("delta", {})
+                    if "content" in delta:
+                        print(delta["content"], end="", flush=True)
+            print()  # newline after stream ends
+
+asyncio.run(stream_chat())
+```
+
+#### Domain-Filtered Academic Search
+
+```python
+async def academic_search(query: str):
+    payload = {
+        "model": "sonar-pro",
+        "messages": [
+            {"role": "system", "content": "You are a research assistant. Cite all claims."},
+            {"role": "user", "content": query},
+        ],
+        "search_domain_filter": ["arxiv.org", "scholar.google.com", "pubmed.ncbi.nlm.nih.gov"],
+        "search_recency_filter": "year",
+        "search_mode": "academic",
+        "return_related_questions": True,
+    }
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{BASE_URL}/v1/sonar",
+            headers={
+                "Authorization": f"Bearer {API_KEY}",
+                "Content-Type": "application/json",
+            },
+            json=payload,
+            timeout=30.0,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return {
+            "answer": data["choices"][0]["message"]["content"],
+            "citations": data.get("citations", []),
+            "related": data.get("related_questions", []),
+        }
+```
+
+#### Structured JSON Output
+
+```python
+async def structured_query():
+    payload = {
+        "model": "sonar",
+        "messages": [
+            {"role": "user", "content": "List the top 3 EV companies by 2025 market cap."},
+        ],
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "ev_companies",
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "companies": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "market_cap_usd": {"type": "string"},
+                                    "country": {"type": "string"},
+                                },
+                                "required": ["name", "market_cap_usd", "country"],
+                            },
+                        }
+                    },
+                    "required": ["companies"],
+                },
+            },
+        },
+    }
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{BASE_URL}/v1/sonar",
+            headers={
+                "Authorization": f"Bearer {API_KEY}",
+                "Content-Type": "application/json",
+            },
+            json=payload,
+            timeout=30.0,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        import json
+        return json.loads(data["choices"][0]["message"]["content"])
+```
+
+---
+
+## Error Handling
+
+### HTTP Status Codes
+
+| Code | Meaning            | Action                                          |
+|------|--------------------|--------------------------------------------------|
+| 200  | Success            | Parse response normally                          |
+| 400  | Bad Request        | Check payload structure and parameter values     |
+| 401  | Authentication     | Verify API key is valid and correctly set        |
+| 403  | Permission Denied  | Check tier access for the requested model        |
+| 404  | Not Found          | Verify endpoint URL                              |
+| 422  | Validation Error   | Inspect `detail` field for parameter issues      |
+| 429  | Rate Limited       | Back off with exponential delay + jitter         |
+| 500+ | Server Error       | Retry after a brief delay; report if persistent  |
+
+### Robust Error Handling Pattern
+
+```python
+import httpx
+import asyncio
+import random
+
+class PerplexityError(Exception):
+    def __init__(self, status_code, message):
+        self.status_code = status_code
+        self.message = message
+        super().__init__(f"HTTP {status_code}: {message}")
+
+async def sonar_request(payload: dict, max_retries: int = 3) -> dict:
+    """Send a request with retry logic for transient errors."""
+    async with httpx.AsyncClient() as client:
+        for attempt in range(max_retries):
+            try:
+                resp = await client.post(
+                    f"{BASE_URL}/v1/sonar",
+                    headers={
+                        "Authorization": f"Bearer {API_KEY}",
+                        "Content-Type": "application/json",
+                    },
+                    json=payload,
+                    timeout=30.0,
+                )
+                if resp.status_code == 200:
+                    return resp.json()
+                if resp.status_code == 429:
+                    wait = (2 ** attempt) + random.uniform(0, 1)
+                    await asyncio.sleep(wait)
+                    continue
+                if resp.status_code >= 500:
+                    await asyncio.sleep(2 ** attempt)
+                    continue
+                # Client errors -- do not retry
+                raise PerplexityError(resp.status_code, resp.text)
+            except httpx.ConnectError:
+                if attempt == max_retries - 1:
+                    raise
+                await asyncio.sleep(1)
+    raise PerplexityError(429, "Rate limit retries exhausted")
+```
+
+---
+
+## Common Pitfalls
+
+1. **Ignoring citations.** The `citations` array is the proof chain for every claim. Always store and surface it. Without citations the output is just an ungrounded LLM generation.
+
+2. **Using `requests` instead of `httpx`.** The `requests` library is synchronous and blocks the event loop. Use `httpx.AsyncClient` for non-blocking I/O, especially if you are running multiple queries concurrently.
+
+3. **Omitting timeouts.** Sonar queries hit the live web. Always set an explicit `timeout` (30-60s) to avoid hanging indefinitely, especially with `sonar-deep-research` which can take longer.
+
+4. **Not handling 429 errors.** Rate limits are per-minute. A tight loop without backoff will get progressively worse. Always implement exponential backoff with jitter.
+
+5. **Sending excessive `search_domain_filter` entries.** The filter accepts a maximum of ~20 domains. Passing more may cause a 422 validation error.
+
+6. **Confusing `search_recency_filter` values.** Valid values are `"hour"`, `"day"`, `"week"`, `"month"`, `"year"`. Passing other strings (e.g., `"recent"`, `"30d"`) will silently fail or error.
+
+7. **Not setting `Content-Type`.** The API expects `application/json`. Missing this header results in a 400 or 415 error.
+
+8. **Forgetting `search_context_size` affects cost.** The per-request fee scales with context size (low/medium/high). Default is medium. Use `"low"` for simple lookups to reduce cost.
+
+9. **Streaming without handling `[DONE]`.** The SSE stream ends with `data: [DONE]`. Attempting to JSON-parse this sentinel will crash your consumer.
+
+10. **Using `sonar-deep-research` for simple questions.** Deep research is designed for multi-query exhaustive reports and costs significantly more. Use plain `sonar` for quick factual queries.

--- a/content/philips-hue/docs/rest-api/python/DOC.md
+++ b/content/philips-hue/docs/rest-api/python/DOC.md
@@ -1,0 +1,264 @@
+---
+name: rest-api
+description: "Philips Hue CLIP API v2 for smart lighting control, sensory environment management, and accessibility-focused ambient automation"
+metadata:
+  languages: "python"
+  versions: "2.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "philips-hue,lighting,smart-home,sensory,autism,accessibility,api"
+---
+
+# Philips Hue REST API Coding Guidelines (Python)
+
+You are a Philips Hue API coding expert. Help me with writing code using httpx async to control Philips Hue smart lights via the local bridge REST API (CLIP API v2) for lighting automation, sensory environment control, and accessibility solutions.
+
+You can find the official documentation here: https://developers.meethue.com/develop/hue-api-v2/
+
+## Golden Rule: Use httpx Async for All API Calls
+
+Always use `httpx` with async/await for all Philips Hue REST API interactions.
+
+- **Correct:** `import httpx` / `async with httpx.AsyncClient(verify=False) as client:`
+- **Incorrect:** Using `requests` or `phue` library
+
+**Important:** The local bridge uses a self-signed HTTPS certificate. You must set `verify=False` for local API calls.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+```
+https://<bridge_ip>/clip/v2/resource/
+```
+
+API v2 uses resource IDs (UUIDs) instead of sequential integer IDs from v1.
+
+## Authentication
+
+The Philips Hue API operates locally via the Hue Bridge using an application key.
+
+### Bridge Discovery and Key Generation
+
+```python
+import httpx
+
+async def discover_bridges():
+    async with httpx.AsyncClient() as client:
+        response = await client.get("https://discovery.meethue.com/")
+        response.raise_for_status()
+        return response.json()  # [{"id": "...", "internalipaddress": "..."}]
+
+async def create_app_key(bridge_ip: str, app_name: str = "python_app"):
+    """Press the bridge link button first! Must be called within 30 seconds."""
+    async with httpx.AsyncClient(verify=False) as client:
+        response = await client.post(
+            f"https://{bridge_ip}/api",
+            json={"devicetype": f"{app_name}#desktop", "generateclientkey": True},
+        )
+        result = response.json()
+        if "error" in result[0]:
+            print(f"Error: {result[0]['error']['description']}")
+            return None
+        return result[0]["success"]  # {"username": "...", "clientkey": "..."}
+```
+
+### Environment Variable Configuration
+
+```bash
+export HUE_BRIDGE_IP="192.168.1.50"
+export HUE_APP_KEY="your-application-key-here"
+```
+
+```python
+import os
+import httpx
+
+BRIDGE_IP = os.environ["HUE_BRIDGE_IP"]
+HUE_APP_KEY = os.environ["HUE_APP_KEY"]
+HUE_BASE_URL = f"https://{BRIDGE_IP}/clip/v2/resource"
+HUE_HEADERS = {"hue-application-key": HUE_APP_KEY}
+```
+
+## Rate Limiting
+
+The bridge processes commands sequentially. Avoid sending more than ~10 requests/second. No formal rate limit response -- commands are queued and may be dropped under heavy load.
+
+## API v2 Resource Types
+
+| Resource | Path | Description |
+|----------|------|-------------|
+| `light` | `/light` | Individual light devices |
+| `grouped_light` | `/grouped_light` | Light groups (rooms/zones) |
+| `room` | `/room` | Physical rooms |
+| `zone` | `/zone` | Logical zones (can span rooms) |
+| `scene` | `/scene` | Saved light configurations |
+| `device` | `/device` | Physical devices |
+| `motion` | `/motion` | Motion sensors |
+| `temperature` | `/temperature` | Temperature sensors |
+| `button` | `/button` | Button/switch devices |
+
+## Methods
+
+### List All Lights
+
+```python
+async def get_lights():
+    async with httpx.AsyncClient(verify=False) as client:
+        response = await client.get(f"{HUE_BASE_URL}/light", headers=HUE_HEADERS)
+        response.raise_for_status()
+        return response.json()["data"]
+```
+
+Each light has: `id`, `on.on` (bool), `dimming.brightness` (0-100), `color_temperature.mirek`, `color.xy`, `metadata.name`.
+
+---
+
+### Turn Light On/Off
+
+```python
+async def set_light_on(light_id: str, on: bool = True):
+    async with httpx.AsyncClient(verify=False) as client:
+        response = await client.put(
+            f"{HUE_BASE_URL}/light/{light_id}",
+            headers=HUE_HEADERS, json={"on": {"on": on}},
+        )
+        response.raise_for_status()
+        return response.json()
+```
+
+---
+
+### Set Light State (Brightness, Color Temperature, Color, Transition)
+
+```python
+async def set_light_state(
+    light_id: str, brightness: float = None, mirek: int = None,
+    color_xy: tuple = None, transition_ms: int = None,
+):
+    """Control light with optional parameters.
+    brightness: 0-100%. mirek: 153 (6500K daylight) to 500 (2000K candle).
+    color_xy: CIE (x, y) tuple. transition_ms: 100-60000ms."""
+    payload = {"on": {"on": True}}
+    if brightness is not None:
+        payload["dimming"] = {"brightness": max(0.0, min(100.0, brightness))}
+    if mirek is not None:
+        payload["color_temperature"] = {"mirek": max(153, min(500, mirek))}
+    if color_xy is not None:
+        payload["color"] = {"xy": {"x": color_xy[0], "y": color_xy[1]}}
+    if transition_ms is not None:
+        payload["dynamics"] = {"duration": transition_ms}
+    async with httpx.AsyncClient(verify=False) as client:
+        response = await client.put(
+            f"{HUE_BASE_URL}/light/{light_id}",
+            headers=HUE_HEADERS, json=payload,
+        )
+        response.raise_for_status()
+        return response.json()
+
+# Common mirek values: 153=Daylight, 250=Cool white, 350=Neutral, 454=Warm, 500=Candle
+# Common CIE xy: Red=(0.675,0.322), Green=(0.409,0.518), Blue=(0.167,0.040), White=(0.323,0.329)
+```
+
+---
+
+### Control Room/Zone (Grouped Light)
+
+```python
+async def set_grouped_light(grouped_light_id: str, on: bool = True, brightness: float = None):
+    payload = {"on": {"on": on}}
+    if brightness is not None:
+        payload["dimming"] = {"brightness": brightness}
+    async with httpx.AsyncClient(verify=False) as client:
+        response = await client.put(
+            f"{HUE_BASE_URL}/grouped_light/{grouped_light_id}",
+            headers=HUE_HEADERS, json=payload,
+        )
+        response.raise_for_status()
+        return response.json()
+```
+
+---
+
+### Activate a Scene
+
+```python
+async def activate_scene(scene_id: str):
+    async with httpx.AsyncClient(verify=False) as client:
+        response = await client.put(
+            f"{HUE_BASE_URL}/scene/{scene_id}",
+            headers=HUE_HEADERS, json={"recall": {"action": "active"}},
+        )
+        response.raise_for_status()
+        return response.json()
+```
+
+---
+
+### List Resources (Generic)
+
+```python
+async def list_resources(resource_type: str):
+    """List any resource type: light, room, zone, scene, device, motion, etc."""
+    async with httpx.AsyncClient(verify=False) as client:
+        response = await client.get(
+            f"{HUE_BASE_URL}/{resource_type}", headers=HUE_HEADERS
+        )
+        response.raise_for_status()
+        return response.json()["data"]
+```
+
+## Error Handling
+
+```python
+async def safe_hue_call(method: str, path: str, payload: dict = None):
+    url = f"{HUE_BASE_URL}/{path}"
+    async with httpx.AsyncClient(verify=False) as client:
+        try:
+            response = await client.request(
+                method, url, headers=HUE_HEADERS,
+                json=payload if method in ("PUT", "POST") else None,
+            )
+            response.raise_for_status()
+            data = response.json()
+            errors = data.get("errors", [])
+            if errors:
+                for error in errors:
+                    print(f"Hue API error: {error.get('description')}")
+                return None
+            return data.get("data", data)
+        except httpx.HTTPStatusError as e:
+            status = e.response.status_code
+            msgs = {401: "Unauthorized -- check application key",
+                    403: "Forbidden -- press link button and re-authenticate",
+                    404: f"Resource not found: {path}",
+                    429: "Rate limited -- too many requests"}
+            print(msgs.get(status, f"HTTP error {status}"))
+            raise
+        except httpx.ConnectError:
+            print(f"Cannot connect to Hue Bridge at {BRIDGE_IP}")
+            raise
+```
+
+## Common Pitfalls
+
+1. **Self-signed certificate** -- The bridge uses HTTPS with a self-signed cert. Always use `verify=False` for local access.
+
+2. **Link button for initial setup only** -- Physical button press is required once during key generation, not for subsequent API calls.
+
+3. **Color temperature range varies** -- Check `mirek_schema` in the light resource for the supported range of each bulb model.
+
+4. **CIE xy color space** -- Hue uses CIE xy, not RGB. Use online converters or the formula for RGB-to-xy conversion.
+
+5. **Bridge command queue** -- The bridge is sequential. Rapid-fire requests may be dropped. Keep under ~10 req/s.
+
+6. **Scenes are stored on the bridge** -- They survive power outages and can be activated without the app.
+
+7. **EventStream for real-time updates** -- Use SSE at `/eventstream/clip/v2` for state change notifications instead of polling.
+
+8. **Max 63 accessories per bridge** -- Plan accordingly for large installations.

--- a/content/polygon/docs/rest-api/python/DOC.md
+++ b/content/polygon/docs/rest-api/python/DOC.md
@@ -1,0 +1,420 @@
+---
+name: rest-api
+description: "Polygon.io Financial Market Data REST API Python coding guidelines using httpx async"
+metadata:
+  languages: "python"
+  versions: "3.12.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "polygon,market-data,stocks,options,forex,crypto,financial,api"
+---
+
+# Polygon.io REST API Python Coding Guidelines
+
+You are a Polygon.io API coding expert. Help me with writing code that calls the Polygon.io Market Data REST API using httpx async in Python.
+
+Official documentation: https://polygon.io/docs
+
+## Golden Rule: Use httpx Async for All REST Calls
+
+Always use `httpx.AsyncClient` for all Polygon.io REST API interactions. Do not use the `polygon-api-client` SDK or `requests`. All code must be async-first using `httpx`.
+
+- **HTTP Library:** httpx (async)
+- **Correct:** `async with httpx.AsyncClient() as client:`
+- **Incorrect:** Using `requests`, `polygon`, `polygon-api-client`, or synchronous httpx
+
+## Installation
+
+```bash
+pip install httpx python-dotenv
+```
+
+**Environment Variables:**
+
+```bash
+export POLYGON_API_KEY='your_api_key_here'
+```
+
+Or create a `.env` file:
+
+```bash
+POLYGON_API_KEY=your_api_key_here
+```
+
+Load in Python:
+
+```python
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+api_key = os.getenv("POLYGON_API_KEY")
+```
+
+## Base URL
+
+All Polygon.io REST API endpoints use a single base URL:
+
+```
+https://api.polygon.io
+```
+
+## Authentication
+
+Polygon.io supports two authentication methods:
+
+1. **Bearer Token (recommended):** `Authorization: Bearer {apiKey}`
+2. **Query Parameter:** `?apiKey={apiKey}`
+
+Always prefer the Authorization header over query parameters.
+
+```python
+import httpx
+
+BASE_URL = "https://api.polygon.io"
+
+HEADERS = {
+    "Authorization": f"Bearer {api_key}",
+}
+
+async def get_ticker_details(ticker: str):
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get(f"/v3/reference/tickers/{ticker}")
+        resp.raise_for_status()
+        return resp.json()
+```
+
+## Rate Limiting
+
+Rate limits vary by subscription plan:
+
+| Plan          | Requests/Minute | Data Access               |
+|---------------|-----------------|---------------------------|
+| **Free**      | 5               | End-of-day, 2yr history   |
+| **Starter**   | Unlimited       | 15-min delayed, 5yr hist  |
+| **Developer** | Unlimited       | 15-min delayed            |
+| **Advanced**  | Unlimited       | Real-time tick-level      |
+
+- Free plan: HTTP `429` returned when exceeding 5 req/min
+- Paid plans: Effectively unlimited REST calls
+
+```python
+import asyncio
+import httpx
+
+async def request_with_retry(client: httpx.AsyncClient, url: str, params: dict | None = None):
+    for attempt in range(5):
+        resp = await client.get(url, params=params)
+        if resp.status_code == 429:
+            wait = 2 ** attempt
+            await asyncio.sleep(wait)
+            continue
+        resp.raise_for_status()
+        return resp.json()
+    raise Exception("Rate limit exceeded after retries")
+```
+
+## Methods
+
+### Reference Data - Tickers
+
+```python
+async def list_tickers(market: str = "stocks", active: bool = True, limit: int = 100):
+    """GET /v3/reference/tickers - List all tickers with optional filters."""
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get("/v3/reference/tickers", params={
+            "market": market,    # "stocks", "crypto", "fx", "otc", "indices"
+            "active": str(active).lower(),
+            "limit": limit,
+        })
+        resp.raise_for_status()
+        return resp.json()
+
+async def get_ticker_details(ticker: str):
+    """GET /v3/reference/tickers/{ticker} - Get detailed info about a ticker."""
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get(f"/v3/reference/tickers/{ticker}")
+        resp.raise_for_status()
+        return resp.json()
+
+async def get_ticker_types():
+    """GET /v3/reference/tickers/types - List all ticker types."""
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get("/v3/reference/tickers/types")
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Stock Aggregates (Bars / OHLCV)
+
+```python
+async def get_aggregates(ticker: str, multiplier: int, timespan: str, from_date: str, to_date: str, adjusted: bool = True, sort: str = "asc", limit: int = 5000):
+    """GET /v2/aggs/ticker/{ticker}/range/{multiplier}/{timespan}/{from}/{to}
+
+    Get OHLCV bars for a ticker over a date range.
+    timespan: "second", "minute", "hour", "day", "week", "month", "quarter", "year"
+    Dates in YYYY-MM-DD format.
+    """
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get(
+            f"/v2/aggs/ticker/{ticker}/range/{multiplier}/{timespan}/{from_date}/{to_date}",
+            params={"adjusted": str(adjusted).lower(), "sort": sort, "limit": limit},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+async def get_grouped_daily(date: str):
+    """GET /v2/aggs/grouped/locale/us/market/stocks/{date} - All tickers' daily bars."""
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get(f"/v2/aggs/grouped/locale/us/market/stocks/{date}")
+        resp.raise_for_status()
+        return resp.json()
+
+async def get_daily_open_close(ticker: str, date: str):
+    """GET /v1/open-close/{ticker}/{date} - Single day OHLCV for a ticker."""
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get(f"/v1/open-close/{ticker}/{date}")
+        resp.raise_for_status()
+        return resp.json()
+
+async def get_previous_close(ticker: str):
+    """GET /v2/aggs/ticker/{ticker}/prev - Previous day's daily bar."""
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get(f"/v2/aggs/ticker/{ticker}/prev")
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Stock Trades and Quotes
+
+```python
+async def get_trades(ticker: str, timestamp: str | None = None, limit: int = 100):
+    """GET /v3/trades/{ticker} - Get historical trades."""
+    params = {"limit": limit}
+    if timestamp:
+        params["timestamp"] = timestamp  # Nanosecond timestamp or RFC3339
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get(f"/v3/trades/{ticker}", params=params)
+        resp.raise_for_status()
+        return resp.json()
+
+async def get_quotes(ticker: str, timestamp: str | None = None, limit: int = 100):
+    """GET /v3/quotes/{ticker} - Get historical NBBO quotes."""
+    params = {"limit": limit}
+    if timestamp:
+        params["timestamp"] = timestamp
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get(f"/v3/quotes/{ticker}", params=params)
+        resp.raise_for_status()
+        return resp.json()
+
+async def get_last_trade(ticker: str):
+    """GET /v2/last/trade/{ticker} - Get last trade for a ticker."""
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get(f"/v2/last/trade/{ticker}")
+        resp.raise_for_status()
+        return resp.json()
+
+async def get_last_quote(ticker: str):
+    """GET /v2/last/nbbo/{ticker} - Get last NBBO quote for a ticker."""
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get(f"/v2/last/nbbo/{ticker}")
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Snapshots
+
+```python
+async def get_all_snapshots():
+    """GET /v2/snapshot/locale/us/markets/stocks/tickers - All stock snapshots."""
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get("/v2/snapshot/locale/us/markets/stocks/tickers")
+        resp.raise_for_status()
+        return resp.json()
+
+async def get_ticker_snapshot(ticker: str):
+    """GET /v2/snapshot/locale/us/markets/stocks/tickers/{ticker} - Single stock snapshot."""
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get(f"/v2/snapshot/locale/us/markets/stocks/tickers/{ticker}")
+        resp.raise_for_status()
+        return resp.json()
+
+async def get_gainers_losers(direction: str = "gainers"):
+    """GET /v2/snapshot/locale/us/markets/stocks/{direction} - Top movers."""
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get(f"/v2/snapshot/locale/us/markets/stocks/{direction}")
+        resp.raise_for_status()
+        return resp.json()
+
+async def get_universal_snapshot(tickers: list[str]):
+    """GET /v3/snapshot - Cross-asset snapshot (stocks, options, forex, crypto)."""
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get("/v3/snapshot", params={
+            "ticker.any_of": ",".join(tickers),
+        })
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Options
+
+```python
+async def get_options_contracts(underlying_ticker: str, expiration_date: str | None = None, limit: int = 100):
+    """GET /v3/reference/options/contracts - List options contracts."""
+    params = {"underlying_ticker": underlying_ticker, "limit": limit}
+    if expiration_date:
+        params["expiration_date"] = expiration_date
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get("/v3/reference/options/contracts", params=params)
+        resp.raise_for_status()
+        return resp.json()
+
+async def get_options_aggregates(options_ticker: str, multiplier: int, timespan: str, from_date: str, to_date: str):
+    """GET /v2/aggs/ticker/{options_ticker}/range/... - Options OHLCV bars.
+    Options ticker format: O:AAPL230120C00150000
+    """
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get(
+            f"/v2/aggs/ticker/{options_ticker}/range/{multiplier}/{timespan}/{from_date}/{to_date}"
+        )
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Forex
+
+```python
+async def get_forex_aggregates(ticker: str, multiplier: int, timespan: str, from_date: str, to_date: str):
+    """GET /v2/aggs/ticker/{ticker}/range/... - Forex OHLCV bars.
+    Ticker format: C:EURUSD
+    """
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get(
+            f"/v2/aggs/ticker/{ticker}/range/{multiplier}/{timespan}/{from_date}/{to_date}"
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+async def get_forex_snapshot(ticker: str):
+    """GET /v2/snapshot/locale/global/markets/forex/tickers/{ticker}"""
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get(f"/v2/snapshot/locale/global/markets/forex/tickers/{ticker}")
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Crypto
+
+```python
+async def get_crypto_aggregates(ticker: str, multiplier: int, timespan: str, from_date: str, to_date: str):
+    """GET /v2/aggs/ticker/{ticker}/range/... - Crypto OHLCV bars.
+    Ticker format: X:BTCUSD
+    """
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get(
+            f"/v2/aggs/ticker/{ticker}/range/{multiplier}/{timespan}/{from_date}/{to_date}"
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+async def get_crypto_snapshot(ticker: str):
+    """GET /v2/snapshot/locale/global/markets/crypto/tickers/{ticker}"""
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get(f"/v2/snapshot/locale/global/markets/crypto/tickers/{ticker}")
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Market Status and Holidays
+
+```python
+async def get_market_status():
+    """GET /v1/marketstatus/now - Current market status (open/closed)."""
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get("/v1/marketstatus/now")
+        resp.raise_for_status()
+        return resp.json()
+
+async def get_market_holidays():
+    """GET /v1/marketstatus/upcoming - Upcoming market holidays."""
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=HEADERS) as client:
+        resp = await client.get("/v1/marketstatus/upcoming")
+        resp.raise_for_status()
+        return resp.json()
+```
+
+## Error Handling
+
+Polygon.io returns standard HTTP status codes with a JSON body containing `status`, `request_id`, and `error` fields.
+
+| Status | Meaning                                      |
+|--------|----------------------------------------------|
+| 200    | Success                                      |
+| 400    | Bad request / invalid parameters             |
+| 401    | Unauthorized (invalid or missing API key)    |
+| 403    | Forbidden (endpoint not in plan)             |
+| 404    | Resource not found                           |
+| 429    | Rate limit exceeded (free plan)              |
+| 500    | Internal server error                        |
+
+```python
+import httpx
+
+async def safe_request(client: httpx.AsyncClient, url: str, params: dict | None = None):
+    try:
+        resp = await client.get(url, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+        if data.get("status") == "ERROR":
+            raise Exception(f"Polygon API error: {data.get('error', 'Unknown error')}")
+        return data
+    except httpx.HTTPStatusError as e:
+        error_body = e.response.json() if e.response.headers.get("content-type", "").startswith("application/json") else {}
+        msg = error_body.get("error", e.response.text)
+        if e.response.status_code == 429:
+            raise Exception(f"Rate limited: {msg}")
+        elif e.response.status_code == 403:
+            raise Exception(f"Plan upgrade required: {msg}")
+        elif e.response.status_code == 401:
+            raise Exception("Unauthorized: check your POLYGON_API_KEY")
+        else:
+            raise Exception(f"Polygon API error {e.response.status_code}: {msg}")
+    except httpx.RequestError as e:
+        raise Exception(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+1. **Ticker prefixes for non-stock assets.** Forex uses `C:` prefix (`C:EURUSD`), crypto uses `X:` prefix (`X:BTCUSD`), options use `O:` prefix (`O:AAPL230120C00150000`). Stocks have no prefix.
+
+2. **Free plan is severely rate-limited.** Only 5 requests/minute on the free tier. Build in aggressive retry/backoff logic or upgrade.
+
+3. **Aggregates endpoint date format.** Use `YYYY-MM-DD` for date parameters, not timestamps.
+
+4. **Pagination with next_url.** List endpoints return a `next_url` field for pagination. Follow it directly (it includes the auth param).
+
+5. **Adjusted vs unadjusted data.** The `adjusted` parameter on aggregates defaults to `true`. Set `adjusted=false` if you need raw split-unadjusted data.
+
+6. **Results limit.** The aggregates endpoint caps at 50,000 results per request. For longer ranges, paginate or reduce the timespan.
+
+7. **API key in query string leaks.** Always use the `Authorization: Bearer` header instead of `?apiKey=` to avoid leaking keys in logs and referrer headers.
+
+8. **Response structure varies by endpoint version.** v2 endpoints return `{"results": [...]}`, v3 endpoints return `{"results": [...], "next_url": "..."}`. Always check the version prefix.
+
+9. **Snapshot endpoints require paid plan.** Real-time snapshot endpoints return 403 on the free plan.
+
+10. **Options ticker format is strict.** Options tickers follow the OCC format: `O:{TICKER}{YYMMDD}{C/P}{STRIKE*1000}`. Example: `O:AAPL230120C00150000` for AAPL Jan 20 2023 $150 Call.
+
+## Useful Links
+
+- Official Documentation: https://polygon.io/docs
+- Stocks API: https://polygon.io/docs/stocks
+- Options API: https://polygon.io/docs/options
+- Forex API: https://polygon.io/docs/forex
+- Crypto API: https://polygon.io/docs/crypto
+- Python Client (reference): https://github.com/polygon-io/client-python
+- Pricing/Plans: https://polygon.io/pricing
+- API Dashboard: https://polygon.io/dashboard

--- a/content/pushover/docs/rest-api/python/DOC.md
+++ b/content/pushover/docs/rest-api/python/DOC.md
@@ -1,0 +1,482 @@
+---
+name: rest-api
+description: "Pushover API for sending push notifications to phones, tablets, and desktops for alerts, reminders, and accessibility notifications"
+metadata:
+  languages: "python"
+  versions: "1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "pushover,notifications,push,alerts,personal,reminders,api"
+---
+
+# Pushover REST API Coding Guidelines (Python)
+
+You are a Pushover API coding expert. Help me with writing code using httpx async to send push notifications via the Pushover REST API for personal alerts, reminders, and accessibility-focused notifications.
+
+You can find the official documentation here: https://pushover.net/api
+
+## Golden Rule: Use httpx Async for All API Calls
+
+Always use `httpx` with async/await for all Pushover REST API interactions.
+
+- **Library Name:** httpx
+- **Python Package:** `httpx`
+- **Installation:** `pip install httpx`
+
+**Correct Usage:**
+
+- **Correct:** `import httpx`
+- **Correct:** `async with httpx.AsyncClient() as client:`
+- **Correct:** `response = await client.post(url, data=payload)`
+- **Incorrect:** Using `requests` or the unofficial `python-pushover` package
+
+## Base URL and Authentication
+
+Pushover uses simple token-based authentication with no OAuth required.
+
+- **Base URL:** `https://api.pushover.net/1/`
+- **App Token:** 30-character alphanumeric string (register at https://pushover.net/apps/build)
+- **User Key:** 30-character alphanumeric string (found on dashboard after login)
+- **Content-Type:** `application/x-www-form-urlencoded` (default) or `multipart/form-data` (for attachments)
+
+### Environment Variable Configuration
+
+Never hardcode tokens. Always use environment variables:
+
+```bash
+export PUSHOVER_TOKEN="your_app_api_token_here"
+export PUSHOVER_USER="your_user_key_here"
+```
+
+```python
+import os
+import httpx
+
+PUSHOVER_URL = "https://api.pushover.net/1"
+PUSHOVER_TOKEN = os.environ["PUSHOVER_TOKEN"]
+PUSHOVER_USER = os.environ["PUSHOVER_USER"]
+```
+
+## Prerequisites
+
+Before using the Pushover API:
+
+- Create a Pushover account at https://pushover.net
+- Install the Pushover app on your device(s) (iOS, Android, or Desktop)
+- Register an application at https://pushover.net/apps/build to get an API token
+- Note your User Key from the Pushover dashboard
+- Free trial: 30 days, then one-time $5 purchase per platform
+
+## Sending Messages
+
+### Basic Notification
+
+```python
+import httpx
+import os
+
+PUSHOVER_URL = "https://api.pushover.net/1"
+PUSHOVER_TOKEN = os.environ["PUSHOVER_TOKEN"]
+PUSHOVER_USER = os.environ["PUSHOVER_USER"]
+
+
+async def send_notification(message: str, title: str = None):
+    payload = {
+        "token": PUSHOVER_TOKEN,
+        "user": PUSHOVER_USER,
+        "message": message,
+    }
+    if title:
+        payload["title"] = title
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{PUSHOVER_URL}/messages.json", data=payload
+        )
+        response.raise_for_status()
+        result = response.json()
+        print(f"Sent. Request ID: {result['request']}")
+        return result
+```
+
+### Notification with All Options
+
+```python
+async def send_rich_notification(
+    message: str,
+    title: str = None,
+    device: str = None,
+    url: str = None,
+    url_title: str = None,
+    priority: int = 0,
+    sound: str = None,
+    html: bool = False,
+    timestamp: int = None,
+    ttl: int = None,
+):
+    """Send a notification with full options.
+
+    Args:
+        message: Message body (max 1024 chars, supports HTML if html=True)
+        title: Message title (max 250 chars, defaults to app name)
+        device: Target specific device name
+        url: Supplementary URL (max 512 chars)
+        url_title: URL title (max 100 chars)
+        priority: -2 (lowest) to 2 (emergency)
+        sound: Notification sound name
+        html: Enable HTML formatting in message
+        timestamp: Unix timestamp to display instead of send time
+        ttl: Time-to-live in seconds (message deleted after expiry)
+    """
+    payload = {
+        "token": PUSHOVER_TOKEN,
+        "user": PUSHOVER_USER,
+        "message": message,
+    }
+    if title:
+        payload["title"] = title
+    if device:
+        payload["device"] = device
+    if url:
+        payload["url"] = url
+    if url_title:
+        payload["url_title"] = url_title
+    if priority != 0:
+        payload["priority"] = priority
+    if sound:
+        payload["sound"] = sound
+    if html:
+        payload["html"] = 1
+    if timestamp:
+        payload["timestamp"] = timestamp
+    if ttl:
+        payload["ttl"] = ttl
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{PUSHOVER_URL}/messages.json", data=payload
+        )
+        response.raise_for_status()
+        return response.json()
+```
+
+### Priority Levels
+
+```python
+# Priority -2: No notification, no sound, no vibration (lowest)
+await send_rich_notification("Background sync complete", priority=-2)
+
+# Priority -1: Quiet, no sound or vibration
+await send_rich_notification("Daily report ready", priority=-1)
+
+# Priority 0: Normal (default)
+await send_rich_notification("New message received")
+
+# Priority 1: High priority, bypasses quiet hours
+await send_rich_notification("Meeting starts in 5 minutes", priority=1)
+
+# Priority 2: Emergency, requires acknowledgment (see below)
+```
+
+### Emergency Priority Notifications
+
+Emergency priority (2) requires `retry` and `expire` parameters. The notification repeats until acknowledged:
+
+```python
+async def send_emergency(
+    message: str,
+    title: str = None,
+    retry: int = 60,
+    expire: int = 3600,
+    callback: str = None,
+    tags: str = None,
+):
+    """Send an emergency notification that repeats until acknowledged.
+
+    Args:
+        message: Message body
+        title: Message title
+        retry: Seconds between retries (min 30)
+        expire: Seconds before stopping retries (max 10800 = 3 hours)
+        callback: URL to POST when user acknowledges
+        tags: Comma-separated tags for cancellation
+    """
+    payload = {
+        "token": PUSHOVER_TOKEN,
+        "user": PUSHOVER_USER,
+        "message": message,
+        "priority": 2,
+        "retry": max(retry, 30),
+        "expire": min(expire, 10800),
+    }
+    if title:
+        payload["title"] = title
+    if callback:
+        payload["callback"] = callback
+    if tags:
+        payload["tags"] = tags
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{PUSHOVER_URL}/messages.json", data=payload
+        )
+        response.raise_for_status()
+        result = response.json()
+        print(f"Emergency receipt: {result.get('receipt')}")
+        return result
+
+
+# Example: Medication reminder that repeats every 60s for 1 hour
+# await send_emergency("Time to take your medication!", title="Medication Reminder", retry=60, expire=3600)
+```
+
+### Cancel Emergency by Tag
+
+```python
+async def cancel_emergency_by_tag(tag: str):
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{PUSHOVER_URL}/receipts/cancel_by_tag/{tag}.json",
+            data={"token": PUSHOVER_TOKEN},
+        )
+        response.raise_for_status()
+        return response.json()
+```
+
+### HTML Formatted Messages
+
+```python
+async def send_html_notification(message_html: str, title: str = None):
+    """Send HTML-formatted notification.
+
+    Supported tags: <b>, <i>, <u>, <font color="#hex">, <a href="url">
+    """
+    payload = {
+        "token": PUSHOVER_TOKEN,
+        "user": PUSHOVER_USER,
+        "message": message_html,
+        "html": 1,
+    }
+    if title:
+        payload["title"] = title
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{PUSHOVER_URL}/messages.json", data=payload
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+# Example: Accessible formatted alert
+# await send_html_notification(
+#     '<b>Door unlocked</b> at <font color="#ff0000">10:32 PM</font>',
+#     title="Security Alert"
+# )
+```
+
+### Send with Image Attachment
+
+```python
+async def send_with_image(message: str, image_path: str, title: str = None):
+    """Send notification with image attachment (max 5MB)."""
+    with open(image_path, "rb") as f:
+        files = {"attachment": (image_path.split("/")[-1], f, "image/jpeg")}
+        data = {
+            "token": PUSHOVER_TOKEN,
+            "user": PUSHOVER_USER,
+            "message": message,
+        }
+        if title:
+            data["title"] = title
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{PUSHOVER_URL}/messages.json",
+                data=data,
+                files=files,
+            )
+            response.raise_for_status()
+            return response.json()
+```
+
+## Validation and Limits
+
+### Validate User/Group Key
+
+```python
+async def validate_user(user_key: str, device: str = None):
+    payload = {
+        "token": PUSHOVER_TOKEN,
+        "user": user_key,
+    }
+    if device:
+        payload["device"] = device
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{PUSHOVER_URL}/users/validate.json", data=payload
+        )
+        result = response.json()
+        if result["status"] == 1:
+            print(f"Valid user. Devices: {result.get('devices', [])}")
+        else:
+            print(f"Invalid: {result.get('errors', [])}")
+        return result
+```
+
+### Check Application Limits
+
+```python
+async def check_limits():
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{PUSHOVER_URL}/apps/limits.json",
+            params={"token": PUSHOVER_TOKEN},
+        )
+        response.raise_for_status()
+        result = response.json()
+        print(f"Limit: {result['limit']}")
+        print(f"Remaining: {result['remaining']}")
+        print(f"Resets at: {result['reset']}")
+        return result
+```
+
+### Get Available Sounds
+
+```python
+async def get_sounds():
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{PUSHOVER_URL}/sounds.json",
+            params={"token": PUSHOVER_TOKEN},
+        )
+        response.raise_for_status()
+        sounds = response.json()["sounds"]
+        for name, description in sounds.items():
+            print(f"{name}: {description}")
+        return sounds
+```
+
+## Error Handling
+
+```python
+async def safe_send(message: str, **kwargs):
+    try:
+        payload = {
+            "token": PUSHOVER_TOKEN,
+            "user": PUSHOVER_USER,
+            "message": message,
+            **kwargs,
+        }
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{PUSHOVER_URL}/messages.json", data=payload
+            )
+            result = response.json()
+
+            if result["status"] == 1:
+                return result
+
+            # Handle errors
+            errors = result.get("errors", [])
+            print(f"Pushover errors: {errors}")
+
+            # Check rate limit headers
+            remaining = response.headers.get("X-Limit-App-Remaining")
+            if remaining and int(remaining) == 0:
+                reset = response.headers.get("X-Limit-App-Reset")
+                print(f"Rate limit reached. Resets at timestamp: {reset}")
+
+            return result
+
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 429:
+            print("Rate limit exceeded")
+        else:
+            print(f"HTTP error: {e.response.status_code}")
+        raise
+    except httpx.ConnectError:
+        print("Cannot connect to Pushover API")
+        raise
+```
+
+### Response Format
+
+All responses include:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status` | int | 1 = success, 0 = failure |
+| `request` | string | Unique request identifier |
+| `errors` | array | Error messages (when status = 0) |
+| `receipt` | string | Receipt ID (emergency priority only) |
+
+### Rate Limits
+
+| Limit | Value |
+|-------|-------|
+| Monthly messages (free) | 10,000 per app |
+| Monthly messages (team) | 25,000 per app |
+| Max concurrent connections | 2 |
+| Message body | 1,024 UTF-8 characters |
+| Title | 250 characters |
+| URL | 512 characters |
+| URL title | 100 characters |
+| Attachment size | 5 MB |
+| Emergency retry minimum | 30 seconds |
+| Emergency expire maximum | 10,800 seconds (3 hours) |
+
+## Accessibility Use Cases
+
+### Medication Reminder System
+
+```python
+async def medication_reminder(medication_name: str, dosage: str):
+    """Send an emergency-priority medication reminder."""
+    await send_emergency(
+        message=f"Take {dosage} of {medication_name} now.",
+        title="Medication Reminder",
+        retry=300,
+        expire=3600,
+        tags=f"med-{medication_name.lower().replace(' ', '-')}",
+    )
+
+
+# Cancel a specific medication reminder
+# await cancel_emergency_by_tag("med-aspirin")
+```
+
+### Safety Alert
+
+```python
+async def safety_alert(sensor_name: str, status: str):
+    """Send high-priority safety alert from smart home sensor."""
+    await send_rich_notification(
+        message=f"{sensor_name} reports: {status}",
+        title="Home Safety Alert",
+        priority=1,
+        sound="siren",
+    )
+```
+
+## Useful Links
+
+- **Official API Documentation:** https://pushover.net/api
+- **Register Application:** https://pushover.net/apps/build
+- **FAQ:** https://pushover.net/faq
+- **Groups API:** https://pushover.net/api/groups
+- **Glances API:** https://pushover.net/api/glances
+- **Receipt/Callback API:** https://pushover.net/api/receipts
+
+## Notes
+
+- Pushover is a one-time $5 purchase per platform (iOS, Android, Desktop) after 30-day trial
+- No ongoing subscription required
+- Messages are delivered via Apple Push Notification Service (iOS), Firebase (Android), or WebSocket (Desktop)
+- Group keys allow sending to multiple users with a single API call
+- The Glances API can update smartwatch complications and widget data
+- Maximum 2 concurrent HTTP connections per IP
+- Retry failed requests with minimum 5-second delay
+- IP blocking may occur for excessive 4xx error responses

--- a/content/razorpay/docs/rest-api/python/DOC.md
+++ b/content/razorpay/docs/rest-api/python/DOC.md
@@ -1,0 +1,230 @@
+---
+name: rest-api
+description: "Razorpay - Indian Payment Gateway REST API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "razorpay,payments,india,upi,orders,refunds,settlements,api"
+---
+
+# Razorpay REST API - Python (httpx) Coding Guidelines
+
+You are a Razorpay REST API coding expert. Help me interact with the Razorpay payment gateway using direct HTTP calls via `httpx` (async).
+
+Official API reference: https://razorpay.com/docs/api/
+
+## Golden Rule: Use httpx for All HTTP Calls
+
+Always use the `httpx` async client for direct REST API interactions with Razorpay. Do NOT use `requests` or the `razorpay` SDK.
+
+**Installation:** `pip install httpx`
+
+## API Fundamentals
+
+- **Base URL:** `https://api.razorpay.com/v1`
+- **Authentication:** HTTP Basic Auth using `key_id` as username and `key_secret` as password
+- **Content-Type:** `application/json` for request bodies
+- **Response Format:** JSON
+- **Amounts:** Always in smallest currency unit (paise for INR, cents for USD). 50000 paise = 500 INR.
+- **Pagination:** Use `count` (max 100) and `skip` query parameters
+- **Idempotency:** Supported via `X-Razorpay-Idempotency-Key` header (recommended for POST requests)
+
+## Authentication and Client Setup
+
+```python
+import httpx, os
+from contextlib import asynccontextmanager
+
+@asynccontextmanager
+async def razorpay_client():
+    async with httpx.AsyncClient(
+        base_url="https://api.razorpay.com/v1",
+        auth=(os.environ["RAZORPAY_KEY_ID"], os.environ["RAZORPAY_KEY_SECRET"]),
+        headers={"Content-Type": "application/json"},
+        timeout=30.0,
+    ) as client:
+        yield client
+```
+
+## Orders API
+
+Orders represent payment intents. Create an order before accepting a payment.
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/orders` | Create an order |
+| GET | `/orders/{order_id}` | Fetch an order by ID |
+| GET | `/orders` | Fetch all orders |
+| GET | `/orders/{order_id}/payments` | Fetch payments for an order |
+
+### Create Order
+
+```python
+import uuid
+
+async def create_order(amount: int, currency: str = "INR", receipt: str | None = None, notes: dict | None = None) -> dict:
+    payload: dict = {"amount": amount, "currency": currency}
+    if receipt:
+        payload["receipt"] = receipt
+    if notes:
+        payload["notes"] = notes
+    async with razorpay_client() as client:
+        resp = await client.post("/orders", json=payload,
+            headers={"X-Razorpay-Idempotency-Key": str(uuid.uuid4())})
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Fetch / List Orders
+
+```python
+async def fetch_order(order_id: str) -> dict:
+    async with razorpay_client() as client:
+        resp = await client.get(f"/orders/{order_id}")
+        resp.raise_for_status()
+        return resp.json()
+
+async def list_orders(count: int = 10, skip: int = 0) -> dict:
+    async with razorpay_client() as client:
+        resp = await client.get("/orders", params={"count": count, "skip": skip})
+        resp.raise_for_status()
+        return resp.json()
+```
+
+## Payments API
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/payments/{payment_id}` | Fetch a payment |
+| GET | `/payments` | Fetch all payments |
+| POST | `/payments/{payment_id}/capture` | Capture an authorized payment |
+
+### Capture Payment
+
+Payments in `authorized` status must be captured to complete the transaction.
+
+```python
+async def capture_payment(payment_id: str, amount: int, currency: str = "INR") -> dict:
+    async with razorpay_client() as client:
+        resp = await client.post(f"/payments/{payment_id}/capture",
+            json={"amount": amount, "currency": currency})
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Fetch Payment
+
+```python
+async def fetch_payment(payment_id: str) -> dict:
+    async with razorpay_client() as client:
+        resp = await client.get(f"/payments/{payment_id}")
+        resp.raise_for_status()
+        return resp.json()
+```
+
+## Refunds API
+
+Refunds can be full or partial. Only `captured` payments can be refunded.
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/payments/{payment_id}/refund` | Create a refund |
+| GET | `/refunds/{refund_id}` | Fetch a refund |
+| GET | `/refunds` | List all refunds |
+
+### Create Refund
+
+```python
+async def create_refund(payment_id: str, amount: int | None = None, speed: str = "normal") -> dict:
+    """Create a full or partial refund. amount=None for full refund. speed: 'normal' or 'optimum' (instant if eligible)."""
+    payload: dict = {"speed": speed}
+    if amount is not None:
+        payload["amount"] = amount
+    async with razorpay_client() as client:
+        resp = await client.post(f"/payments/{payment_id}/refund", json=payload)
+        resp.raise_for_status()
+        return resp.json()
+```
+
+## Additional API Endpoints
+
+| Module | Key Endpoints |
+|--------|---------------|
+| Customers | `POST /customers`, `GET /customers/{id}`, `GET /customers` |
+| Invoices | `POST /invoices`, `GET /invoices/{id}`, `POST /invoices/{id}/issue`, `POST /invoices/{id}/cancel` |
+| Settlements | `GET /settlements`, `GET /settlements/{id}`, `POST /settlements/ondemand` |
+| Virtual Accounts | `POST /virtual_accounts`, `GET /virtual_accounts/{id}`, `POST /virtual_accounts/{id}/close` |
+| QR Codes (UPI) | `POST /payments/qr_codes`, `GET /payments/qr_codes/{id}`, `POST /payments/qr_codes/{id}/close` |
+
+## Error Handling
+
+| Status | Meaning |
+|--------|---------|
+| 200 | Success |
+| 400 | Bad request (invalid parameters) |
+| 401 | Authentication failure |
+| 404 | Resource not found |
+| 500/502 | Server / gateway error |
+
+Error response structure: `{"error": {"code": "BAD_REQUEST_ERROR", "description": "...", "field": "amount"}}`
+
+```python
+import asyncio
+
+class RazorpayAPIError(Exception):
+    def __init__(self, status_code: int, error_code: str, description: str):
+        self.status_code = status_code
+        self.error_code = error_code
+        super().__init__(f"[{status_code}] {error_code}: {description}")
+
+async def razorpay_request(method: str, endpoint: str, json_data: dict | None = None, params: dict | None = None) -> dict:
+    async with razorpay_client() as client:
+        try:
+            resp = await client.request(method, endpoint, json=json_data, params=params)
+            resp.raise_for_status()
+            return resp.json()
+        except httpx.HTTPStatusError as e:
+            body = e.response.json() if e.response.content else {}
+            error = body.get("error", {})
+            raise RazorpayAPIError(
+                status_code=e.response.status_code,
+                error_code=error.get("code", "UNKNOWN"),
+                description=error.get("description", str(e)),
+            ) from e
+        except httpx.TimeoutException as e:
+            raise RazorpayAPIError(408, "TIMEOUT", "Request timed out") from e
+```
+
+## Webhook & Payment Signature Verification
+
+```python
+import hmac, hashlib
+
+def verify_razorpay_webhook(webhook_body: bytes, signature: str, webhook_secret: str) -> bool:
+    expected = hmac.new(webhook_secret.encode(), webhook_body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, signature)
+
+def verify_payment_signature(order_id: str, payment_id: str, signature: str, key_secret: str) -> bool:
+    message = f"{order_id}|{payment_id}"
+    expected = hmac.new(key_secret.encode(), message.encode(), hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, signature)
+```
+
+## Common Pitfalls
+
+1. **Amounts in paise, not rupees.** 50000 paise = INR 500. Always multiply by 100.
+2. **Capture is required.** Authorized payments must be explicitly captured or they auto-refund after a configurable window.
+3. **Use idempotency keys** for POST requests to prevent duplicate orders/refunds.
+4. **UPI Collect is deprecated** (Feb 2026 per NPCI). Use QR codes or UPI Intent instead.
+5. **Test mode keys** are prefixed `rzp_test_*`. Never mix test and live keys.
+6. **Always verify** both webhook signatures and payment signatures server-side.
+
+## Useful Links
+
+- **API Reference:** https://razorpay.com/docs/api/
+- **Dashboard:** https://dashboard.razorpay.com/
+- **Webhooks:** https://razorpay.com/docs/webhooks/
+- **UPI Docs:** https://razorpay.com/docs/payments/payment-methods/upi/

--- a/content/revolut/docs/rest-api/python/DOC.md
+++ b/content/revolut/docs/rest-api/python/DOC.md
@@ -1,0 +1,292 @@
+---
+name: rest-api
+description: "Revolut Business API - European neobank accounts, payments, and transfers"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "revolut,banking,payments,europe,neobank,transfers,api"
+---
+
+# Revolut Business REST API - Python (`httpx`)
+
+## Golden Rule
+
+Always use the correct API version prefix in your endpoint paths (`/api/1.0/` or `/api/2.0/`). Access tokens expire after 40 minutes -- implement automatic refresh using the refresh token. Never hardcode tokens. All requests must include the `Authorization: Bearer` header. Use the sandbox environment for all development and testing.
+
+## Installation
+
+```bash
+pip install httpx python-dotenv pyjwt cryptography
+```
+
+`pyjwt` and `cryptography` are needed to sign JWT tokens for the OAuth consent flow.
+
+## Base URL
+
+| Environment | URL |
+|-------------|-----|
+| Production  | `https://b2b.revolut.com/api/1.0` |
+| Sandbox     | `https://sandbox-b2b.revolut.com/api/1.0` |
+
+Some newer endpoints use `/api/2.0` (e.g., Webhooks v2).
+
+## Authentication
+
+Revolut uses OAuth 2.0 with JWT-signed consent. The flow:
+1. Generate an RSA key pair and upload the public key in the Revolut Business portal.
+2. Create a signed JWT assertion.
+3. Exchange it for an access token.
+
+```python
+import httpx
+import os
+import jwt
+import time
+import uuid
+
+BASE_URL = os.environ.get("REVOLUT_BASE_URL", "https://sandbox-b2b.revolut.com/api/1.0")
+CLIENT_ID = os.environ["REVOLUT_CLIENT_ID"]
+PRIVATE_KEY = os.environ["REVOLUT_PRIVATE_KEY"]  # PEM-encoded RSA private key
+
+def create_jwt_assertion(client_id: str, private_key: str, issuer_url: str) -> str:
+    now = int(time.time())
+    payload = {
+        "iss": issuer_url,
+        "sub": client_id,
+        "aud": "https://revolut.com",
+        "iat": now,
+        "exp": now + 2400,
+        "jti": str(uuid.uuid4()),
+    }
+    return jwt.encode(payload, private_key, algorithm="RS256")
+
+
+async def get_access_token(client: httpx.AsyncClient, refresh_token: str) -> dict:
+    assertion = create_jwt_assertion(CLIENT_ID, PRIVATE_KEY, "revolut.com")
+    resp = await client.post(
+        f"{BASE_URL}/auth/token",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": CLIENT_ID,
+            "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+            "client_assertion": assertion,
+        },
+    )
+    resp.raise_for_status()
+    return resp.json()  # {"access_token": "...", "token_type": "bearer", "expires_in": 2400}
+```
+
+Use the access token in all subsequent requests:
+
+```python
+def auth_headers(access_token: str) -> dict:
+    return {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+    }
+```
+
+## Rate Limiting
+
+Revolut enforces rate limits per endpoint. When rate-limited, you receive HTTP 429. Implement exponential backoff:
+
+```python
+import asyncio
+
+async def revolut_request(
+    client: httpx.AsyncClient, method: str, url: str, token: str, **kwargs
+) -> dict:
+    for attempt in range(5):
+        resp = await client.request(method, url, headers=auth_headers(token), **kwargs)
+        if resp.status_code == 429:
+            await asyncio.sleep(2 ** attempt)
+            continue
+        resp.raise_for_status()
+        return resp.json()
+    raise Exception("Rate limit exceeded after retries")
+```
+
+## Methods
+
+### List Accounts
+
+Retrieve all accounts with their balances.
+
+```python
+async def list_accounts(client: httpx.AsyncClient, token: str) -> list[dict]:
+    resp = await client.get(f"{BASE_URL}/accounts", headers=auth_headers(token))
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Get Account Balance
+
+```python
+async def get_account(client: httpx.AsyncClient, token: str, account_id: str) -> dict:
+    resp = await client.get(
+        f"{BASE_URL}/accounts/{account_id}", headers=auth_headers(token)
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Create Counterparty
+
+Add a payment recipient (internal Revolut user or external bank account).
+
+```python
+async def create_counterparty_external(
+    client: httpx.AsyncClient,
+    token: str,
+    company_name: str,
+    currency: str,
+    iban: str,
+    bic: str,
+) -> dict:
+    payload = {
+        "company_name": company_name,
+        "bank_country": "GB",
+        "currency": currency,
+        "iban": iban,
+        "bic": bic,
+    }
+    resp = await client.post(
+        f"{BASE_URL}/counterparty", headers=auth_headers(token), json=payload
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Create Payment
+
+Send money to a counterparty.
+
+```python
+async def create_payment(
+    client: httpx.AsyncClient,
+    token: str,
+    account_id: str,
+    counterparty_id: str,
+    amount: float,
+    currency: str,
+    reference: str,
+    request_id: str,
+) -> dict:
+    payload = {
+        "request_id": request_id,  # Idempotency key
+        "account_id": account_id,
+        "receiver": {
+            "counterparty_id": counterparty_id,
+        },
+        "amount": amount,
+        "currency": currency,
+        "reference": reference,
+    }
+    resp = await client.post(
+        f"{BASE_URL}/pay", headers=auth_headers(token), json=payload
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Transfer Between Accounts
+
+Move money between your own Revolut accounts.
+
+```python
+async def create_transfer(
+    client: httpx.AsyncClient,
+    token: str,
+    source_account_id: str,
+    target_account_id: str,
+    amount: float,
+    currency: str,
+    request_id: str,
+) -> dict:
+    payload = {
+        "request_id": request_id,
+        "source_account_id": source_account_id,
+        "target_account_id": target_account_id,
+        "amount": amount,
+        "currency": currency,
+    }
+    resp = await client.post(
+        f"{BASE_URL}/transfer", headers=auth_headers(token), json=payload
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### List Transactions
+
+```python
+async def list_transactions(
+    client: httpx.AsyncClient,
+    token: str,
+    from_date: str | None = None,
+    to_date: str | None = None,
+    count: int = 50,
+) -> list[dict]:
+    params = {"count": count}
+    if from_date:
+        params["from"] = from_date
+    if to_date:
+        params["to"] = to_date
+    resp = await client.get(
+        f"{BASE_URL}/transactions", headers=auth_headers(token), params=params
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Get Exchange Rate
+
+```python
+async def get_exchange_rate(
+    client: httpx.AsyncClient, token: str, source: str, target: str, amount: float
+) -> dict:
+    params = {"from": source, "to": target, "amount": amount}
+    resp = await client.get(
+        f"{BASE_URL}/rate", headers=auth_headers(token), params=params
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+## Error Handling
+
+Revolut returns JSON error bodies with a `message` and sometimes a `code` field:
+
+```python
+class RevolutAPIError(Exception):
+    def __init__(self, status: int, body: dict):
+        self.status = status
+        self.code = body.get("code", "UNKNOWN")
+        self.message = body.get("message", str(body))
+        super().__init__(f"HTTP {status} [{self.code}]: {self.message}")
+
+
+async def revolut_request_safe(
+    client: httpx.AsyncClient, method: str, url: str, token: str, **kwargs
+) -> dict:
+    resp = await client.request(method, url, headers=auth_headers(token), **kwargs)
+    if resp.status_code >= 400:
+        raise RevolutAPIError(resp.status_code, resp.json())
+    return resp.json()
+```
+
+Common status codes: 400 (bad request), 401 (unauthorized/expired token), 403 (insufficient permissions), 404 (not found), 405 (method not allowed), 429 (rate limit), 500/503 (server errors).
+
+## Common Pitfalls
+
+1. **Token expiry (40 min)** -- Access tokens expire quickly. Always implement automatic refresh using the refresh token before making requests.
+2. **JWT signing** -- The initial OAuth consent requires signing a JWT with your RSA private key. Ensure the key is in PEM format and the `kid` matches what you uploaded.
+3. **request_id idempotency** -- Every payment and transfer must include a unique `request_id`. Reusing it returns the original result, which is by design for idempotency.
+4. **Sandbox limitations** -- Sandbox does not process real payments. Use the simulation endpoints (`/sandbox/topup`, `/sandbox/transactions/{id}/{action}`) to test state transitions.
+5. **API version mixing** -- Some endpoints are v1.0, others v2.0. Always check the docs for the correct version prefix for each resource.
+6. **Scopes** -- Tokens are scoped (READ, WRITE, PAY). Ensure your token has the correct scope for the operation. A READ-only token cannot create payments.
+7. **Date format** -- Use ISO 8601 format (`2026-01-15T00:00:00Z`) for all date parameters in transaction queries.

--- a/content/sarvam-ai/docs/rest-api/python/DOC.md
+++ b/content/sarvam-ai/docs/rest-api/python/DOC.md
@@ -1,0 +1,279 @@
+---
+name: rest-api
+description: "Sarvam AI - Indian Language AI APIs (STT, TTS, Translation, LLM)"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-13"
+  source: community
+  tags: "sarvam,indian-languages,indic,speech-to-text,text-to-speech,translation,transliteration,llm,hindi,tamil,api,integration"
+---
+
+# Sarvam AI API
+
+> **Golden Rule:** Sarvam AI provides Indian language AI APIs covering speech, translation, and LLM chat. A Python SDK (`sarvamai`) exists on PyPI, but you can also use `httpx` for direct REST access. Most endpoints use `api-subscription-key` header; the chat endpoint uses `Bearer` token. Free ₹1,000 credits on signup.
+
+## Installation
+
+```bash
+pip install httpx
+# Or use the official SDK: pip install -U sarvamai
+```
+
+## Base URL
+
+`https://api.sarvam.ai`
+
+## Authentication
+
+**Type:** API Subscription Key (custom header)
+
+```python
+import httpx
+
+API_KEY = "your-sarvam-api-key"  # From dashboard.sarvam.ai
+BASE_URL = "https://api.sarvam.ai"
+
+# For most endpoints (STT, TTS, Translation, etc.)
+headers = {"api-subscription-key": API_KEY}
+client = httpx.AsyncClient(headers=headers, timeout=60.0)
+
+# For chat/LLM endpoint — use Bearer token instead
+chat_headers = {
+    "Authorization": f"Bearer {API_KEY}",
+    "Content-Type": "application/json"
+}
+```
+
+## Rate Limiting
+
+| Plan | Requests/min | Cost |
+|---|---|---|
+| Starter | 60 | Pay-as-you-go |
+| Pro | 200 | ₹10,000 |
+| Business | 1,000 | ₹50,000 |
+
+All accounts get ₹1,000 free credits (never expire). Chat LLM is currently free.
+
+## Supported Languages
+
+Hindi (`hi-IN`), Bengali (`bn-IN`), Gujarati (`gu-IN`), Kannada (`kn-IN`), Malayalam (`ml-IN`), Marathi (`mr-IN`), Odia (`od-IN`), Punjabi (`pa-IN`), Tamil (`ta-IN`), Telugu (`te-IN`), English (`en-IN`). Extended models support 22 Indian languages total.
+
+## Methods
+
+### `translate`
+
+**Endpoint:** `POST /translate`
+
+Translate text between Indian languages and English.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `input` | `str` | **required** (max 2000 chars) |
+| `source_language_code` | `str` | **required** (`auto` for auto-detect) |
+| `target_language_code` | `str` | **required** (e.g., `hi-IN`) |
+| `model` | `str` | `mayura:v1` (or `sarvam-translate:v1` for 22 langs) |
+| `mode` | `str` | `formal` (also: `modern-colloquial`, `classic-colloquial`, `code-mixed`) |
+| `speaker_gender` | `str` | `None` (`Male` or `Female`) |
+
+**Returns:** JSON with `translated_text`
+
+```python
+payload = {
+    "input": "Hello, how are you?",
+    "source_language_code": "auto",
+    "target_language_code": "hi-IN",
+    "model": "mayura:v1",
+    "mode": "formal"
+}
+response = await client.post(f"{BASE_URL}/translate", json=payload)
+response.raise_for_status()
+data = response.json()
+translated = data["translated_text"]  # "नमस्ते, आप कैसे हैं?"
+```
+
+### `speech_to_text`
+
+**Endpoint:** `POST /speech-to-text`
+
+Transcribe audio in Indian languages. Supports WAV, MP3, OGG, FLAC, and more.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `file` | `binary` | **required** (audio file, max 30s for REST) |
+| `model` | `str` | `saaras:v3` (recommended) |
+| `language_code` | `str` | `unknown` (auto-detect) |
+| `mode` | `str` | `transcribe` (also: `translate`, `verbatim`, `translit`) |
+
+**Returns:** JSON with `transcript`, `language_code`, `language_probability`
+
+```python
+with open("audio.wav", "rb") as f:
+    files = {"file": ("audio.wav", f, "audio/wav")}
+    data = {"model": "saaras:v3", "language_code": "hi-IN"}
+    response = await client.post(
+        f"{BASE_URL}/speech-to-text",
+        files=files, data=data,
+        headers={"api-subscription-key": API_KEY}
+    )
+response.raise_for_status()
+result = response.json()
+transcript = result["transcript"]
+```
+
+### `text_to_speech`
+
+**Endpoint:** `POST /text-to-speech`
+
+Convert text to speech in Indian languages. 38 voice options with bulbul:v3.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `text` | `str` | **required** (max 2500 chars) |
+| `target_language_code` | `str` | **required** |
+| `model` | `str` | `bulbul:v3` |
+| `speaker` | `str` | `Shubh` (38 voices available) |
+| `pace` | `float` | `1.0` (0.5-2.0) |
+| `temperature` | `float` | `0.6` (0.01-2.0, expressiveness) |
+| `speech_sample_rate` | `int` | `24000` |
+
+**Returns:** JSON with `audios` array (base64-encoded audio)
+
+```python
+import base64
+
+payload = {
+    "text": "नमस्ते, मैं सर्वम हूँ",
+    "target_language_code": "hi-IN",
+    "model": "bulbul:v3",
+    "speaker": "Shubh",
+    "pace": 1.0
+}
+response = await client.post(f"{BASE_URL}/text-to-speech", json=payload)
+response.raise_for_status()
+data = response.json()
+audio_bytes = base64.b64decode(data["audios"][0])
+with open("output.wav", "wb") as f:
+    f.write(audio_bytes)
+```
+
+### `transliterate`
+
+**Endpoint:** `POST /transliterate`
+
+Convert text between scripts while preserving pronunciation.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `input` | `str` | **required** |
+| `source_language_code` | `str` | **required** (or `auto`) |
+| `target_language_code` | `str` | **required** |
+| `spoken_form` | `bool` | `False` |
+
+**Returns:** JSON with `transliterated_text`
+
+```python
+payload = {
+    "input": "namaste",
+    "source_language_code": "en-IN",
+    "target_language_code": "hi-IN"
+}
+response = await client.post(f"{BASE_URL}/transliterate", json=payload)
+response.raise_for_status()
+result = response.json()
+# result["transliterated_text"] -> "नमस्ते"
+```
+
+### `detect_language`
+
+**Endpoint:** `POST /text-lid`
+
+Detect language and script of input text.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `input` | `str` | **required** (max 1000 chars) |
+
+**Returns:** JSON with `language_code` and `script_code`
+
+```python
+payload = {"input": "नमस्ते दुनिया"}
+response = await client.post(f"{BASE_URL}/text-lid", json=payload)
+response.raise_for_status()
+data = response.json()
+# data["language_code"] -> "hi-IN", data["script_code"] -> "Deva"
+```
+
+### `chat_completion`
+
+**Endpoint:** `POST /v1/chat/completions`
+
+OpenAI-compatible chat endpoint with Sarvam's multilingual LLMs. Supports function calling, streaming, and wiki grounding.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `model` | `str` | **required** (`sarvam-30b`, `sarvam-105b`, etc.) |
+| `messages` | `list` | **required** |
+| `temperature` | `float` | `0.2` |
+| `max_tokens` | `int` | `None` |
+| `stream` | `bool` | `False` |
+| `wiki_grounding` | `bool` | `False` |
+| `tools` | `list` | `None` (function calling definitions) |
+
+**Returns:** OpenAI-compatible JSON with `choices` array
+
+```python
+payload = {
+    "model": "sarvam-30b",
+    "messages": [
+        {"role": "system", "content": "You are a helpful assistant fluent in Indian languages."},
+        {"role": "user", "content": "भारत की राजधानी क्या है?"}
+    ],
+    "temperature": 0.3,
+    "wiki_grounding": True
+}
+response = await client.post(
+    f"{BASE_URL}/v1/chat/completions",
+    json=payload,
+    headers={"Authorization": f"Bearer {API_KEY}", "Content-Type": "application/json"}
+)
+response.raise_for_status()
+data = response.json()
+reply = data["choices"][0]["message"]["content"]
+```
+
+## Error Handling
+
+```python
+import httpx
+
+try:
+    response = await client.post(f"{BASE_URL}/translate", json=payload)
+    response.raise_for_status()
+    data = response.json()
+except httpx.HTTPStatusError as e:
+    if e.response.status_code == 403:
+        print("Authentication failed -- check your API key")
+    elif e.response.status_code == 429:
+        print("Rate limited or quota exceeded -- back off and retry")
+    elif e.response.status_code == 422:
+        print(f"Validation error: {e.response.text}")
+    else:
+        print(f"Sarvam API error {e.response.status_code}: {e.response.text}")
+except httpx.RequestError as e:
+    print(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+- Most endpoints use `api-subscription-key` header, but chat uses `Authorization: Bearer` -- don't mix them up
+- Speech-to-text REST API is limited to 30 seconds of audio -- use Batch API for longer files
+- TTS returns base64-encoded audio in the `audios` array -- decode with `base64.b64decode()`
+- Text-to-speech max input: 2500 chars (v3) or 1500 chars (v2) -- split longer text
+- Translation max input: 2000 chars (sarvam-translate) or 1000 chars (mayura)
+- Use `language_code: "unknown"` for auto-detection in STT
+- Use `source_language_code: "auto"` for auto-detection in translation
+- Set `timeout=60.0` on your client -- speech processing can be slow
+- Language codes use BCP-47 format: `hi-IN` (Hindi), `ta-IN` (Tamil), `te-IN` (Telugu), etc.
+- Chat LLM is currently free; other APIs use ₹-based credit system

--- a/content/serper/docs/rest-api/python/DOC.md
+++ b/content/serper/docs/rest-api/python/DOC.md
@@ -1,0 +1,239 @@
+---
+name: rest-api
+description: "Serper.dev Google Search API for AI Agents"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-13"
+  source: community
+  tags: "serper,google,search,serp,images,news,videos,scholar,scraping,api,integration"
+---
+
+# Serper.dev API
+
+> **Golden Rule:** Serper.dev has no official Python SDK. Use `httpx` (async) or `requests` (sync) for direct REST API access. All endpoints are POST with JSON body. Authentication uses the `X-API-KEY` header (not Bearer). Free tier includes 2,500 credits.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+`https://google.serper.dev`
+
+Scraping endpoint uses: `https://scrape.serper.dev`
+
+## Authentication
+
+**Type:** API Key (custom header)
+
+```python
+import httpx
+
+API_KEY = "your-serper-api-key"
+BASE_URL = "https://google.serper.dev"
+
+headers = {
+    "X-API-KEY": API_KEY,
+    "Content-Type": "application/json"
+}
+client = httpx.AsyncClient(headers=headers)
+```
+
+**Important:** Serper uses `X-API-KEY` header, NOT `Authorization: Bearer`.
+
+## Rate Limiting
+
+| Tier | Rate Limit |
+|---|---|
+| Free | 5 requests/second |
+| Ultimate | 300 requests/second |
+
+Free tier includes 2,500 credits (no credit card required). Credits expire after 6 months.
+
+## Methods
+
+### `search`
+
+**Endpoint:** `POST /search`
+
+Google web search returning structured JSON with organic results, knowledge graph, answer box, and more.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `q` | `str` | **required** |
+| `gl` | `str` | `None` (country code, e.g., `us`) |
+| `hl` | `str` | `None` (language code, e.g., `en`) |
+| `num` | `int` | `10` (>10 costs 2 credits) |
+| `page` | `int` | `1` |
+| `location` | `str` | `None` |
+| `tbs` | `str` | `None` (time filter: `qdr:h`, `qdr:d`, `qdr:w`, `qdr:m`, `qdr:y`) |
+
+**Returns:** JSON with `organic`, `knowledgeGraph`, `answerBox`, `peopleAlsoAsk`, `relatedSearches`
+
+```python
+payload = {"q": "best AI frameworks 2025", "gl": "us", "num": 10}
+response = await client.post(f"{BASE_URL}/search", json=payload)
+response.raise_for_status()
+data = response.json()
+organic = data.get("organic", [])
+for result in organic:
+    print(f"{result['title']}: {result['link']}")
+```
+
+### `search_news`
+
+**Endpoint:** `POST /news`
+
+Google News search.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `q` | `str` | **required** |
+| `gl` | `str` | `None` |
+| `hl` | `str` | `None` |
+| `num` | `int` | `10` |
+| `tbs` | `str` | `None` (e.g., `qdr:d` for past 24h) |
+
+**Returns:** JSON with `news` array (each: `title`, `link`, `snippet`, `date`, `source`, `imageUrl`)
+
+```python
+payload = {"q": "AI regulation", "gl": "us", "tbs": "qdr:d"}
+response = await client.post(f"{BASE_URL}/news", json=payload)
+response.raise_for_status()
+data = response.json()
+news = data.get("news", [])
+```
+
+### `search_images`
+
+**Endpoint:** `POST /images`
+
+Google Images search.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `q` | `str` | **required** |
+| `gl` | `str` | `None` |
+| `num` | `int` | `10` |
+
+**Returns:** JSON with `images` array (each: `title`, `link`, `imageUrl`, `source`)
+
+```python
+payload = {"q": "machine learning diagram", "num": 5}
+response = await client.post(f"{BASE_URL}/images", json=payload)
+response.raise_for_status()
+images = response.json().get("images", [])
+```
+
+### `search_scholar`
+
+**Endpoint:** `POST /scholar`
+
+Google Scholar academic search.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `q` | `str` | **required** |
+| `as_ylo` | `int` | `None` (filter from this year onward) |
+| `num` | `int` | `10` |
+
+**Returns:** JSON with `organic` array of academic results
+
+```python
+payload = {"q": "transformer architecture attention", "as_ylo": 2023}
+response = await client.post(f"{BASE_URL}/scholar", json=payload)
+response.raise_for_status()
+papers = response.json().get("organic", [])
+```
+
+### `search_places`
+
+**Endpoint:** `POST /places`
+
+Google Maps places search.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `q` | `str` | **required** |
+| `location` | `str` | `None` |
+| `gl` | `str` | `None` |
+
+**Returns:** JSON with `places` array (each: `title`, `address`, `rating`, `ratingCount`, `link`)
+
+```python
+payload = {"q": "coffee shops", "location": "San Francisco, CA"}
+response = await client.post(f"{BASE_URL}/places", json=payload)
+response.raise_for_status()
+places = response.json().get("places", [])
+```
+
+### `scrape_webpage`
+
+**Endpoint:** `POST https://scrape.serper.dev/`
+
+Scrape and extract clean content from a webpage.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `url` | `str` | **required** |
+| `include_markdown` | `bool` | `True` |
+
+**Returns:** Cleaned webpage content (Markdown by default)
+
+```python
+SCRAPE_URL = "https://scrape.serper.dev"
+payload = {"url": "https://example.com/article", "include_markdown": True}
+response = await client.post(SCRAPE_URL, json=payload)
+response.raise_for_status()
+data = response.json()
+```
+
+### Other Endpoints
+
+| Endpoint | Description |
+|---|---|
+| `POST /videos` | Google Videos search |
+| `POST /shopping` | Google Shopping (costs 2 credits) |
+| `POST /maps` | Google Maps search |
+| `POST /reviews` | Google reviews (use `placeId` param for precision) |
+| `POST /patents` | Google Patents search |
+| `POST /autocomplete` | Google autocomplete suggestions |
+| `POST /lens` | Google Lens visual search |
+
+## Error Handling
+
+```python
+import httpx
+
+try:
+    response = await client.post(f"{BASE_URL}/search", json={"q": "test"})
+    response.raise_for_status()
+    data = response.json()
+except httpx.HTTPStatusError as e:
+    if e.response.status_code == 401:
+        print("Authentication failed -- check your X-API-KEY")
+    elif e.response.status_code == 429:
+        print("Rate limited -- reduce request frequency")
+    elif e.response.status_code == 400:
+        print(f"Bad request: {e.response.text}")
+    else:
+        print(f"Serper API error {e.response.status_code}: {e.response.text}")
+except httpx.RequestError as e:
+    print(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+- All endpoints use **POST** (not GET) with JSON body
+- Auth header is `X-API-KEY` (not `Authorization: Bearer`)
+- Requesting `num` > 10 results costs 2 credits instead of 1
+- Shopping searches always cost 2 credits
+- Autocorrect is on by default -- set `"autocorrect": false` to disable
+- Credits expire after 6 months
+- Time filter `tbs` values: `qdr:h` (hour), `qdr:d` (day), `qdr:w` (week), `qdr:m` (month), `qdr:y` (year)
+- Scraping uses a different base URL: `https://scrape.serper.dev`
+- Set a reasonable timeout: `httpx.AsyncClient(timeout=10.0)` -- typical latency is 1-2s

--- a/content/shiprocket/docs/rest-api/python/DOC.md
+++ b/content/shiprocket/docs/rest-api/python/DOC.md
@@ -1,0 +1,266 @@
+---
+name: rest-api
+description: "Shiprocket - Indian E-commerce Shipping & Logistics API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-13"
+  source: community
+  tags: "shiprocket,shipping,logistics,ecommerce,india,courier,tracking,orders,delivery,cod,api,integration"
+---
+
+# Shiprocket API
+
+> **Golden Rule:** Shiprocket has no official Python SDK. Use `httpx` for direct REST access. Auth requires a login call (email/password) that returns a Bearer token valid for 10 days. All endpoints are under `https://apiv2.shiprocket.in/v1/external`. Package dimensions (`length`, `breadth`, `height`, `weight`) are required for order creation.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+```
+https://apiv2.shiprocket.in/v1/external
+```
+
+## Authentication
+
+**Type:** Email/Password login to get Bearer token (valid 10 days)
+
+```python
+import httpx
+
+BASE_URL = "https://apiv2.shiprocket.in/v1/external"
+
+# Step 1: Login to get token
+login_response = await httpx.AsyncClient().post(
+    f"{BASE_URL}/auth/login",
+    json={"email": "your-api-email@example.com", "password": "your-api-password"}
+)
+login_response.raise_for_status()
+token = login_response.json()["token"]
+
+# Step 2: Use token for all subsequent requests
+headers = {
+    "Authorization": f"Bearer {token}",
+    "Content-Type": "application/json"
+}
+client = httpx.AsyncClient(headers=headers, timeout=30.0)
+```
+
+**Important:** API credentials must be created separately from your main Shiprocket account login (Dashboard > Settings > API).
+
+## Rate Limiting
+
+Not publicly documented. HTTP 429 returned when exceeded. Contact Shiprocket support for plan-specific limits.
+
+## Methods
+
+### `create_order`
+
+**Endpoint:** `POST /orders/create/adhoc`
+
+Create a new shipping order. Returns Shiprocket order ID and shipment ID.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `order_id` | `str` | **required** (your unique reference) |
+| `order_date` | `str` | **required** (`YYYY-MM-DD HH:mm`) |
+| `pickup_location` | `str` | **required** (e.g., `"Primary"`) |
+| `billing_customer_name` | `str` | **required** |
+| `billing_address` | `str` | **required** |
+| `billing_city` | `str` | **required** |
+| `billing_pincode` | `str` | **required** |
+| `billing_state` | `str` | **required** |
+| `billing_country` | `str` | **required** |
+| `billing_phone` | `str` | **required** |
+| `shipping_is_billing` | `bool` | **required** |
+| `order_items` | `list` | **required** (array of product objects) |
+| `payment_method` | `str` | **required** (`COD` or `Prepaid`) |
+| `sub_total` | `float` | **required** |
+| `length` | `float` | **required** (cm) |
+| `breadth` | `float` | **required** (cm) |
+| `height` | `float` | **required** (cm) |
+| `weight` | `float` | **required** (kg) |
+
+**Returns:** JSON with `order_id`, `shipment_id`, `status`
+
+```python
+payload = {
+    "order_id": "ORD-12345",
+    "order_date": "2026-03-13 10:00",
+    "pickup_location": "Primary",
+    "billing_customer_name": "Jane",
+    "billing_last_name": "Doe",
+    "billing_address": "123 MG Road",
+    "billing_city": "Mumbai",
+    "billing_pincode": "400001",
+    "billing_state": "Maharashtra",
+    "billing_country": "India",
+    "billing_email": "jane@example.com",
+    "billing_phone": "9876543210",
+    "shipping_is_billing": True,
+    "order_items": [
+        {
+            "name": "Wireless Headphones",
+            "sku": "SKU-001",
+            "units": 1,
+            "selling_price": 1999.00,
+            "discount": 0,
+            "tax": 0
+        }
+    ],
+    "payment_method": "Prepaid",
+    "sub_total": 1999.00,
+    "length": 15,
+    "breadth": 10,
+    "height": 8,
+    "weight": 0.3
+}
+response = await client.post(f"{BASE_URL}/orders/create/adhoc", json=payload)
+response.raise_for_status()
+order = response.json()
+shipment_id = order["shipment_id"]
+```
+
+### `get_order`
+
+**Endpoint:** `GET /orders/{order_id}`
+
+Retrieve order details.
+
+```python
+order_id = "12345"
+response = await client.get(f"{BASE_URL}/orders/{order_id}")
+response.raise_for_status()
+order = response.json()
+```
+
+### `list_orders`
+
+**Endpoint:** `GET /orders/list`
+
+List all orders with pagination.
+
+```python
+response = await client.get(f"{BASE_URL}/orders/list")
+response.raise_for_status()
+orders = response.json()
+```
+
+### `cancel_orders`
+
+**Endpoint:** `POST /orders/cancel/`
+
+Cancel one or more orders by ID.
+
+```python
+payload = {"ids": [12345, 12346]}
+response = await client.post(f"{BASE_URL}/orders/cancel/", json=payload)
+response.raise_for_status()
+```
+
+### `check_serviceability`
+
+**Endpoint:** `GET /courier/serviceability/`
+
+Check which couriers can service a route and get shipping rates.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `pickup_postcode` | `str` | **required** |
+| `delivery_postcode` | `str` | **required** |
+| `weight` | `float` | **required** (kg) |
+| `cod` | `int` | **required** (`1` for COD, `0` for prepaid) |
+
+```python
+params = {
+    "pickup_postcode": "400001",
+    "delivery_postcode": "560001",
+    "weight": 0.5,
+    "cod": 0
+}
+response = await client.get(f"{BASE_URL}/courier/serviceability/", params=params)
+response.raise_for_status()
+couriers = response.json()
+```
+
+### `assign_awb`
+
+**Endpoint:** `POST /courier/assign/awb/`
+
+Generate Air Waybill (AWB) number for a shipment.
+
+**Returns:** JSON with `awb_code` and `courier_name`
+
+```python
+payload = {"shipment_id": [shipment_id], "courier_id": courier_id}
+response = await client.post(f"{BASE_URL}/courier/assign/awb/", json=payload)
+response.raise_for_status()
+awb = response.json()
+awb_code = awb["response"]["data"]["awb_code"]
+```
+
+### `track_shipment`
+
+**Endpoint:** `GET /courier/track/awb/{awb_code}`
+
+Track a shipment by AWB number.
+
+```python
+awb_code = "123456789"
+response = await client.get(f"{BASE_URL}/courier/track/awb/{awb_code}")
+response.raise_for_status()
+tracking = response.json()
+```
+
+### `generate_label`
+
+**Endpoint:** `POST /courier/generate/label`
+
+Generate a shipping label PDF.
+
+```python
+payload = {"shipment_id": [shipment_id]}
+response = await client.post(f"{BASE_URL}/courier/generate/label", json=payload)
+response.raise_for_status()
+label_url = response.json()["label_url"]
+```
+
+## Error Handling
+
+```python
+import httpx
+
+try:
+    response = await client.post(f"{BASE_URL}/orders/create/adhoc", json=payload)
+    response.raise_for_status()
+    data = response.json()
+except httpx.HTTPStatusError as e:
+    if e.response.status_code == 401:
+        print("Auth failed -- token expired (valid 10 days), re-login")
+    elif e.response.status_code == 422:
+        print(f"Validation error: {e.response.json()}")
+    elif e.response.status_code == 429:
+        print("Rate limited -- slow down requests")
+    else:
+        print(f"Shiprocket error {e.response.status_code}: {e.response.text}")
+except httpx.RequestError as e:
+    print(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+- Auth token is valid for **10 days (240 hours)** -- must re-login after expiry
+- API email/password must be **separate from your main Shiprocket account** login
+- Package dimensions (`length`, `breadth`, `height` in cm, `weight` in kg) are **required** for order creation
+- `payment_method` must be `"COD"` or `"Prepaid"` (case-sensitive)
+- `order_date` format is `"YYYY-MM-DD HH:mm"` (not ISO 8601)
+- `order_items` is an array of objects with `name`, `sku`, `units`, `selling_price`
+- Tracking is available by AWB (`/courier/track/awb/{awb}`), shipment ID (`/tracking/shipment/{id}`), or order ID (`/tracking/order/{id}`)
+- Covers 26,000+ PIN codes across India with 25+ courier partners (FedEx, DHL, Delhivery, Blue Dart, etc.)
+- Supports both domestic and international shipping
+- Set a reasonable timeout: `httpx.AsyncClient(timeout=30.0)`

--- a/content/skyscanner/docs/rest-api/python/DOC.md
+++ b/content/skyscanner/docs/rest-api/python/DOC.md
@@ -1,0 +1,251 @@
+---
+name: rest-api
+description: "Skyscanner - Flight, Hotel & Car Hire Search API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "skyscanner,flights,travel,search,comparison,api"
+---
+
+# Skyscanner Travel API (Python / httpx)
+
+## Golden Rule
+
+This is a **partner-only API**. You must apply at <https://www.partners.skyscanner.net/contact/general> and be approved before receiving an API key. There is no public self-serve signup. All flight searches are **two-step**: call `/create` to initiate, then `/poll` with the session token to get complete results. Always poll until `status` is `RESULT_STATUS_COMPLETE`.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+No official Python SDK exists. Use raw `httpx` async calls against the REST endpoints.
+
+## Base URL
+
+```
+https://partners.api.skyscanner.net/apiservices/v3/
+```
+
+All requests must use **HTTPS**.
+
+## Authentication
+
+API key passed via the `x-api-key` request header. Obtain your key by applying through the Skyscanner Partners portal and being approved by their partnerships team.
+
+```python
+import httpx
+
+BASE_URL = "https://partners.api.skyscanner.net/apiservices/v3"
+
+def skyscanner_headers(api_key: str) -> dict[str, str]:
+    return {
+        "x-api-key": api_key,
+        "Content-Type": "application/json",
+    }
+```
+
+## Rate Limiting
+
+Rate limits are set per partner agreement and are not publicly documented. Exceeding your allocation will result in HTTP **429** responses. Contact your account manager for specific thresholds.
+
+## Methods
+
+### Flights Live Search -- Create
+
+Initiates a real-time flight search. Returns a `sessionToken` and an initial (possibly incomplete) set of cached results.
+
+```python
+async def create_flight_search(
+    api_key: str,
+    origin_iata: str,
+    destination_iata: str,
+    year: int,
+    month: int,
+    day: int,
+    adults: int = 1,
+    cabin_class: str = "CABIN_CLASS_ECONOMY",
+    *,
+    market: str = "US",
+    locale: str = "en-US",
+    currency: str = "USD",
+) -> dict:
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{BASE_URL}/flights/live/search/create",
+            headers=skyscanner_headers(api_key),
+            json={
+                "query": {
+                    "market": market,
+                    "locale": locale,
+                    "currency": currency,
+                    "queryLegs": [
+                        {
+                            "originPlaceId": {"iata": origin_iata},
+                            "destinationPlaceId": {"iata": destination_iata},
+                            "date": {"year": year, "month": month, "day": day},
+                        }
+                    ],
+                    "adults": adults,
+                    "cabinClass": cabin_class,
+                }
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Flights Live Search -- Poll
+
+Polls for the complete set of results using the session token from the create step.
+
+```python
+import asyncio
+
+async def poll_flight_search(
+    api_key: str,
+    session_token: str,
+    max_polls: int = 10,
+    poll_interval: float = 1.0,
+) -> dict:
+    async with httpx.AsyncClient() as client:
+        for _ in range(max_polls):
+            resp = await client.post(
+                f"{BASE_URL}/flights/live/search/poll/{session_token}",
+                headers=skyscanner_headers(api_key),
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            if data.get("status") == "RESULT_STATUS_COMPLETE":
+                return data
+            await asyncio.sleep(poll_interval)
+        return data  # Return last partial result
+```
+
+### Full Flight Search Convenience
+
+```python
+async def search_flights(
+    api_key: str,
+    origin: str,
+    destination: str,
+    year: int,
+    month: int,
+    day: int,
+    **kwargs,
+) -> dict:
+    create_resp = await create_flight_search(
+        api_key, origin, destination, year, month, day, **kwargs
+    )
+    session_token = create_resp["sessionToken"]
+    return await poll_flight_search(api_key, session_token)
+```
+
+### Flights Indicative Prices
+
+Returns estimated/historical prices without querying live inventory. More flexible date ranges.
+
+```python
+async def indicative_search(
+    api_key: str,
+    origin_iata: str,
+    destination_iata: str,
+    year: int,
+    month: int,
+    *,
+    market: str = "US",
+    locale: str = "en-US",
+    currency: str = "USD",
+) -> dict:
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{BASE_URL}/flights/indicative/search",
+            headers=skyscanner_headers(api_key),
+            json={
+                "query": {
+                    "market": market,
+                    "locale": locale,
+                    "currency": currency,
+                    "dateTimeGroupingType": "DATE_TIME_GROUPING_TYPE_BY_MONTH",
+                    "queryLegs": [
+                        {
+                            "originPlace": {"queryPlace": {"iata": origin_iata}},
+                            "destinationPlace": {"queryPlace": {"iata": destination_iata}},
+                            "anytime": True,
+                        }
+                    ],
+                }
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Key Endpoint Reference
+
+| Category               | Endpoint                                              | Method |
+|------------------------|-------------------------------------------------------|--------|
+| Flights Live Create    | `/v3/flights/live/search/create`                      | POST   |
+| Flights Live Poll      | `/v3/flights/live/search/poll/{sessionToken}`          | POST   |
+| Flights Indicative     | `/v3/flights/indicative/search`                       | POST   |
+| Car Hire Live          | `/v3/carhire/live/search/create`                      | POST   |
+| Car Hire Indicative    | `/v3/carhire/indicative/search`                       | POST   |
+| Car Hire Agents        | `/v3/carhire/agents`                                  | GET    |
+| Hotels Live            | `/v3/hotels/live/search/create`                       | POST   |
+| Hotels Indicative      | `/v3/hotels/indicative/search`                        | POST   |
+| Hotels Content         | `/v3/hotels/content`                                  | GET    |
+| Hotels Reviews         | `/v3/hotels/reviews`                                  | GET    |
+| Culture                | `/v3/culture/markets/{locale}`                        | GET    |
+| Geo                    | `/v3/geo/hierarchy/flights/{locale}`                  | GET    |
+| Carriers               | `/v3/carriers`                                        | GET    |
+| Autosuggest Flights    | `/v3/autosuggest/flights`                             | POST   |
+
+## Error Handling
+
+```python
+async def safe_skyscanner_request(
+    api_key: str,
+    method: str,
+    path: str,
+    **kwargs,
+) -> dict:
+    async with httpx.AsyncClient() as client:
+        resp = await getattr(client, method)(
+            f"{BASE_URL}{path}",
+            headers=skyscanner_headers(api_key),
+            **kwargs,
+        )
+        if resp.status_code == 401:
+            raise PermissionError("Invalid or missing API key")
+        if resp.status_code == 403:
+            raise PermissionError("Access forbidden -- check partner permissions")
+        if resp.status_code == 429:
+            raise RuntimeError("Rate limit exceeded -- back off and retry")
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### HTTP Status Codes
+
+| Status | Meaning                                    |
+|--------|--------------------------------------------|
+| 200    | Success                                    |
+| 400    | Bad request (malformed query)              |
+| 401    | Invalid or missing API key                 |
+| 403    | Forbidden (insufficient partner access)    |
+| 429    | Rate limit exceeded                        |
+| 500    | Internal server error                      |
+
+## Common Pitfalls
+
+1. **Partner-only access.** There is no public API key. You must be an approved Skyscanner partner. Application at <https://www.partners.skyscanner.net/contact/general>.
+2. **Two-step search pattern.** Live searches require `/create` then `/poll`. The first response from `/create` is often incomplete. Always poll until `status` is `RESULT_STATUS_COMPLETE`.
+3. **Session tokens expire after ~1 hour.** Do not cache session tokens across user sessions.
+4. **Market, locale, and currency are required** on every search request. These control response localization and available routes.
+5. **Place IDs use IATA codes** wrapped in `{"iata": "LHR"}` objects, not plain strings.
+6. **Dates use structured objects** `{"year": 2026, "month": 3, "day": 17}`, not ISO date strings.
+7. **All endpoints are POST** for search operations (even reads). GET is used only for reference data (carriers, geo, culture).
+8. **Never expose your API key** in client-side code. All requests must be server-side.

--- a/content/speechmatics/docs/rest-api/python/DOC.md
+++ b/content/speechmatics/docs/rest-api/python/DOC.md
@@ -1,0 +1,286 @@
+---
+name: rest-api
+description: "Speechmatics Batch Transcription REST API for accurate speech-to-text"
+metadata:
+  languages: "python"
+  versions: "2.0.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "speechmatics,speech-to-text,transcription,accessibility,captioning,api"
+---
+
+# Speechmatics REST API
+
+> **Golden Rule:** Speechmatics has a Python SDK but the REST API can be used directly with `httpx` (async). The Batch API submits audio files as jobs and retrieves transcripts. Authentication uses Bearer token with API key from the Speechmatics Portal. Base URL is `https://asr.api.speechmatics.com/v2`. Free tier allows 2 hours/month of audio processing.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+`https://asr.api.speechmatics.com/v2`
+
+Portal (manage API keys): https://portal.speechmatics.com
+
+## Authentication
+
+**Type:** API Key as Bearer Token
+
+Generate API keys at: Portal > Settings > API Keys
+
+```python
+import httpx
+
+API_KEY = "your-speechmatics-api-key"
+BASE_URL = "https://asr.api.speechmatics.com/v2"
+
+client = httpx.AsyncClient(
+    headers={"Authorization": f"Bearer {API_KEY}"},
+    timeout=60.0,
+)
+```
+
+## Rate Limiting
+
+| Metric | Limit |
+|---|---|
+| New jobs (POST) | 10 per second |
+| Status checks (GET) | 50 per second |
+| Concurrent jobs | 20,000 max |
+| File size (body) | 1 GB max |
+| Audio via URL | No size limit |
+
+Monthly audio processing limits:
+
+| Tier | Limit |
+|---|---|
+| Free | 2 hours/month |
+| Paid | 6,000 hours/month |
+| Enterprise | Custom |
+
+Data retention: audio, transcripts, and config are retained for 7 days, then deleted.
+
+## Methods
+
+### Create Transcription Job
+
+**Endpoint:** `POST /jobs`
+
+Submit an audio file for transcription. Uses `multipart/form-data` with a `data_file` and a `config` JSON field.
+
+| Config Field | Type | Default |
+|---|---|---|
+| `type` | `str` | **required** (`transcription`) |
+| `transcription_config.language` | `str` | **required** (e.g., `en`) |
+| `transcription_config.operating_point` | `str` | `standard` (`standard` or `enhanced`) |
+| `transcription_config.diarization` | `str` | `none` (`none`, `speaker`) |
+| `transcription_config.enable_entities` | `bool` | `false` |
+| `transcription_config.punctuation_overrides.permitted_marks` | `list` | all marks |
+
+```python
+import json
+
+config = {
+    "type": "transcription",
+    "transcription_config": {
+        "language": "en",
+        "operating_point": "enhanced",
+        "diarization": "speaker",
+        "enable_entities": True,
+    }
+}
+
+with open("audio.wav", "rb") as audio_file:
+    response = await client.post(
+        f"{BASE_URL}/jobs",
+        files={"data_file": ("audio.wav", audio_file, "audio/wav")},
+        data={"config": json.dumps(config)},
+    )
+response.raise_for_status()
+job = response.json()
+job_id = job["id"]
+print(f"Job created: {job_id}")
+```
+
+### Create Job from URL
+
+```python
+config = {
+    "type": "transcription",
+    "transcription_config": {
+        "language": "en",
+        "operating_point": "enhanced",
+    },
+    "fetch_data": {
+        "url": "https://example.com/audio.mp3",
+    }
+}
+
+response = await client.post(
+    f"{BASE_URL}/jobs",
+    data={"config": json.dumps(config)},
+)
+response.raise_for_status()
+job_id = response.json()["id"]
+```
+
+### Check Job Status
+
+**Endpoint:** `GET /jobs/{job_id}`
+
+```python
+response = await client.get(f"{BASE_URL}/jobs/{job_id}")
+response.raise_for_status()
+job = response.json()
+status = job["job"]["status"]
+print(f"Status: {status}")
+# Statuses: running, done, rejected, deleted, expired
+```
+
+### Get Transcript
+
+**Endpoint:** `GET /jobs/{job_id}/transcript`
+
+```python
+# Get JSON transcript
+response = await client.get(
+    f"{BASE_URL}/jobs/{job_id}/transcript",
+    params={"format": "json-v2"},
+)
+response.raise_for_status()
+transcript = response.json()
+
+for result in transcript.get("results", []):
+    if result["type"] == "word":
+        print(f"{result['start_time']:.2f}s: {result['content']}", end=" ")
+```
+
+```python
+# Get plain text transcript
+response = await client.get(
+    f"{BASE_URL}/jobs/{job_id}/transcript",
+    params={"format": "txt"},
+)
+response.raise_for_status()
+print(response.text)
+```
+
+```python
+# Get SRT subtitles (for accessibility captioning)
+response = await client.get(
+    f"{BASE_URL}/jobs/{job_id}/transcript",
+    params={"format": "srt"},
+)
+response.raise_for_status()
+print(response.text)
+```
+
+### List All Jobs
+
+**Endpoint:** `GET /jobs`
+
+```python
+response = await client.get(f"{BASE_URL}/jobs")
+response.raise_for_status()
+data = response.json()
+for job in data.get("jobs", []):
+    print(f"{job['id']}: {job['status']} - {job.get('duration', 'N/A')}s")
+```
+
+### Delete Job
+
+**Endpoint:** `DELETE /jobs/{job_id}`
+
+```python
+response = await client.delete(f"{BASE_URL}/jobs/{job_id}")
+response.raise_for_status()
+print("Job deleted")
+```
+
+### Poll Until Complete (Helper)
+
+```python
+import asyncio
+
+async def wait_for_transcript(job_id: str, poll_interval: float = 5.0) -> dict:
+    while True:
+        response = await client.get(f"{BASE_URL}/jobs/{job_id}")
+        response.raise_for_status()
+        job = response.json()["job"]
+
+        if job["status"] == "done":
+            # Fetch the transcript
+            resp = await client.get(
+                f"{BASE_URL}/jobs/{job_id}/transcript",
+                params={"format": "json-v2"},
+            )
+            resp.raise_for_status()
+            return resp.json()
+        elif job["status"] in ("rejected", "deleted", "expired"):
+            raise Exception(f"Job failed with status: {job['status']}")
+
+        await asyncio.sleep(poll_interval)
+
+# Usage
+transcript = await wait_for_transcript(job_id)
+full_text = " ".join(
+    r["content"] for r in transcript.get("results", []) if r["type"] == "word"
+)
+print(full_text)
+```
+
+### Supported Languages
+
+Common language codes: `en` (English), `es` (Spanish), `fr` (French), `de` (German), `it` (Italian), `pt` (Portuguese), `nl` (Dutch), `ja` (Japanese), `ko` (Korean), `zh` (Mandarin), `ar` (Arabic), `hi` (Hindi).
+
+Full list at: https://docs.speechmatics.com/speech-to-text/languages
+
+### Supported Audio Formats
+
+`wav`, `mp3`, `mp4`, `m4a`, `ogg`, `flac`, `aac`, `amr`, `webm`
+
+## Error Handling
+
+```python
+import httpx
+
+try:
+    response = await client.post(f"{BASE_URL}/jobs", files=files, data=data)
+    response.raise_for_status()
+    job = response.json()
+except httpx.HTTPStatusError as e:
+    if e.response.status_code == 401:
+        print("Invalid or missing API key -- check Bearer token")
+    elif e.response.status_code == 429:
+        print("Rate limited -- reduce request frequency")
+    elif e.response.status_code == 400:
+        print(f"Bad request (invalid config or audio): {e.response.text}")
+    elif e.response.status_code == 404:
+        print("Job not found or expired (data retained for 7 days only)")
+    elif e.response.status_code == 413:
+        print("File too large -- max 1 GB via body, use URL for larger files")
+    elif e.response.status_code == 409:
+        print("Max concurrent jobs exceeded (20,000)")
+    else:
+        print(f"Speechmatics error {e.response.status_code}: {e.response.text}")
+except httpx.RequestError as e:
+    print(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+- Job submission uses **multipart/form-data** with `data_file` and `config` fields
+- The `config` field must be a **JSON string**, not a raw dict
+- Transcripts expire after **7 days** -- download results promptly
+- The `enhanced` operating point is more accurate but costs more and takes longer
+- For accessibility captioning, use `format=srt` or `format=vtt` for subtitle output
+- Speaker diarization (`"diarization": "speaker"`) adds speaker labels but increases processing time
+- Free tier is limited to **2 hours/month** of audio -- monitor usage
+- Use `fetch_data.url` for files larger than 1 GB instead of uploading in the body
+- Set a longer timeout for file uploads: `httpx.AsyncClient(timeout=60.0)`
+- Job status must be polled -- there is no webhook/callback for batch jobs in the basic API
+- The `json-v2` transcript format includes word-level timestamps for precise captioning

--- a/content/spotify/docs/rest-api/python/DOC.md
+++ b/content/spotify/docs/rest-api/python/DOC.md
@@ -1,0 +1,434 @@
+---
+name: rest-api
+description: "Spotify Web API - Music streaming, playlists, playback control, and audio metadata"
+metadata:
+  languages: "python"
+  versions: "v1"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "spotify,music,playlists,audio,mood,streaming,api"
+---
+
+# Spotify Web API - Python Reference (httpx)
+
+## Golden Rule
+
+All requests go to `https://api.spotify.com/v1`. Authentication requires an **OAuth2 access token** -- there is no API key auth. Use Authorization Code with PKCE flow for user-specific operations (playback, library). Use Client Credentials flow for public catalog searches. Tokens expire after **1 hour** -- always handle 401 by refreshing. Rate limits are per-app in a rolling 30-second window; the API returns `429` with a `Retry-After` header.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+All examples use `httpx` with async/await. For scripts that need a synchronous entrypoint:
+
+```python
+import asyncio
+import httpx
+
+async def main():
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{BASE_URL}/search",
+            headers=HEADERS,
+            params={"q": "focus playlist", "type": "playlist", "limit": 5},
+        )
+        print(resp.json())
+
+asyncio.run(main())
+```
+
+## Base URL
+
+```
+https://api.spotify.com/v1
+```
+
+Token endpoints:
+```
+https://accounts.spotify.com/api/token
+https://accounts.spotify.com/authorize
+```
+
+```python
+import os
+
+ACCESS_TOKEN = os.environ["SPOTIFY_ACCESS_TOKEN"]
+BASE_URL = "https://api.spotify.com/v1"
+HEADERS = {"Authorization": f"Bearer {ACCESS_TOKEN}"}
+```
+
+## Authentication
+
+Spotify uses **OAuth 2.0** exclusively. Choose the flow based on your needs:
+
+### Client Credentials (Public Data Only)
+
+For searching catalog, getting track metadata -- no user data access.
+
+```python
+import base64
+
+async def get_client_token(client: httpx.AsyncClient) -> str:
+    client_id = os.environ["SPOTIFY_CLIENT_ID"]
+    client_secret = os.environ["SPOTIFY_CLIENT_SECRET"]
+    credentials = base64.b64encode(f"{client_id}:{client_secret}".encode()).decode()
+
+    resp = await client.post(
+        "https://accounts.spotify.com/api/token",
+        headers={
+            "Authorization": f"Basic {credentials}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        data={"grant_type": "client_credentials"},
+    )
+    resp.raise_for_status()
+    return resp.json()["access_token"]  # Expires in 3600 seconds
+```
+
+### Authorization Code with PKCE (User Data)
+
+For playback control, library access, playlist management. Recommended for all user-facing apps.
+
+```python
+import hashlib
+import secrets
+
+def generate_pkce_pair() -> tuple[str, str]:
+    verifier = secrets.token_urlsafe(64)[:128]
+    challenge = base64.urlsafe_b64encode(
+        hashlib.sha256(verifier.encode()).digest()
+    ).decode().rstrip("=")
+    return verifier, challenge
+
+def build_auth_url(client_id: str, redirect_uri: str, scopes: list[str]) -> tuple[str, str]:
+    verifier, challenge = generate_pkce_pair()
+    scope = " ".join(scopes)
+    url = (
+        f"https://accounts.spotify.com/authorize?"
+        f"client_id={client_id}&response_type=code&redirect_uri={redirect_uri}"
+        f"&scope={scope}&code_challenge_method=S256&code_challenge={challenge}"
+    )
+    return url, verifier
+
+async def exchange_code(
+    client: httpx.AsyncClient,
+    code: str,
+    verifier: str,
+    client_id: str,
+    redirect_uri: str,
+) -> dict:
+    resp = await client.post(
+        "https://accounts.spotify.com/api/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "client_id": client_id,
+            "code_verifier": verifier,
+        },
+    )
+    resp.raise_for_status()
+    return resp.json()  # {"access_token": ..., "refresh_token": ..., "expires_in": 3600}
+```
+
+### Common OAuth Scopes
+
+| Scope | Access |
+|---|---|
+| `user-read-private` | User profile details |
+| `user-read-email` | User email |
+| `playlist-read-private` | Private playlists |
+| `playlist-modify-public` | Create/edit public playlists |
+| `playlist-modify-private` | Create/edit private playlists |
+| `user-library-read` | Saved tracks/albums |
+| `user-library-modify` | Save/remove tracks/albums |
+| `user-read-playback-state` | Current playback state |
+| `user-modify-playback-state` | Control playback |
+| `user-read-currently-playing` | Currently playing track |
+| `user-read-recently-played` | Recently played tracks |
+| `user-top-read` | Top artists and tracks |
+| `streaming` | Web Playback SDK (Premium) |
+
+## Rate Limiting
+
+Rate limits are calculated per app in a **rolling 30-second window**. The exact limit depends on your app's quota mode (development vs extended).
+
+When rate limited, the API returns `429` with a `Retry-After` header (seconds).
+
+```python
+import asyncio
+
+async def spotify_request(
+    client: httpx.AsyncClient,
+    method: str,
+    path: str,
+    params: dict = None,
+    json_data: dict = None,
+    max_retries: int = 3,
+) -> httpx.Response:
+    for attempt in range(max_retries):
+        resp = await client.request(
+            method,
+            f"{BASE_URL}{path}",
+            headers=HEADERS,
+            params=params,
+            json=json_data,
+        )
+        if resp.status_code == 429:
+            wait = int(resp.headers.get("Retry-After", 2 ** attempt))
+            await asyncio.sleep(wait)
+            continue
+        if resp.status_code == 401:
+            raise Exception("Access token expired -- refresh and retry")
+        resp.raise_for_status()
+        return resp
+    raise Exception("Max retries exceeded due to rate limiting")
+```
+
+## Methods
+
+### Search
+
+Search the Spotify catalog for tracks, artists, albums, playlists, shows, or episodes.
+
+**Parameters:**
+- `q` (str) -- Search query. Supports field filters: `artist:Beethoven`, `genre:focus`, `year:2020-2025`
+- `type` (str) -- Comma-separated: `track`, `artist`, `album`, `playlist`, `show`, `episode`
+- `limit` (int) -- Max results per type (default 5, max 10 as of Feb 2026)
+- `offset` (int) -- Pagination offset
+- `market` (str) -- ISO 3166-1 country code
+
+```python
+async def search(
+    client: httpx.AsyncClient,
+    query: str,
+    types: str = "track",
+    limit: int = 10,
+    market: str = "US",
+) -> dict:
+    resp = await spotify_request(client, "GET", "/search", params={
+        "q": query,
+        "type": types,
+        "limit": limit,
+        "market": market,
+    })
+    return resp.json()
+
+# Usage -- find focus playlists
+results = await search(client, "focus study concentration", types="playlist", limit=5)
+for p in results["playlists"]["items"]:
+    print(f"{p['name']} -- {p['tracks']['total']} tracks")
+```
+
+### Get a Track
+
+```python
+async def get_track(client: httpx.AsyncClient, track_id: str, market: str = "US") -> dict:
+    resp = await spotify_request(client, "GET", f"/tracks/{track_id}", params={"market": market})
+    return resp.json()
+
+# Returns: {"name": ..., "artists": [...], "album": {...}, "duration_ms": ..., "preview_url": ...}
+```
+
+### Get Audio Features
+
+Get audio analysis data for tracks (tempo, energy, valence/mood, danceability).
+
+```python
+async def get_audio_features(client: httpx.AsyncClient, track_ids: list[str]) -> list:
+    resp = await spotify_request(client, "GET", "/audio-features", params={
+        "ids": ",".join(track_ids),
+    })
+    return resp.json()["audio_features"]
+
+# Returns per track: {"energy": 0.8, "valence": 0.6, "tempo": 120.0, "danceability": 0.7, ...}
+```
+
+### Playlists
+
+#### Get a Playlist
+
+```python
+async def get_playlist(client: httpx.AsyncClient, playlist_id: str, fields: str = None) -> dict:
+    params = {}
+    if fields:
+        params["fields"] = fields  # e.g., "name,tracks.items(track(name,artists))"
+    resp = await spotify_request(client, "GET", f"/playlists/{playlist_id}", params=params)
+    return resp.json()
+```
+
+#### Get Playlist Items
+
+```python
+async def get_playlist_items(
+    client: httpx.AsyncClient,
+    playlist_id: str,
+    limit: int = 50,
+    offset: int = 0,
+) -> dict:
+    resp = await spotify_request(client, "GET", f"/playlists/{playlist_id}/items", params={
+        "limit": limit,
+        "offset": offset,
+    })
+    return resp.json()
+```
+
+#### Create a Playlist
+
+```python
+async def create_playlist(
+    client: httpx.AsyncClient,
+    user_id: str,
+    name: str,
+    public: bool = False,
+    description: str = "",
+) -> dict:
+    resp = await spotify_request(client, "POST", f"/users/{user_id}/playlists", json_data={
+        "name": name,
+        "public": public,
+        "description": description,
+    })
+    return resp.json()
+```
+
+#### Add Items to a Playlist
+
+```python
+async def add_to_playlist(
+    client: httpx.AsyncClient,
+    playlist_id: str,
+    uris: list[str],
+    position: int = None,
+) -> dict:
+    payload = {"uris": uris}  # e.g., ["spotify:track:4iV5W9uYEdYUVa79Axb7Rh"]
+    if position is not None:
+        payload["position"] = position
+    resp = await spotify_request(client, "POST", f"/playlists/{playlist_id}/items", json_data=payload)
+    return resp.json()
+```
+
+### Player (Requires Premium + user-modify-playback-state scope)
+
+#### Get Current Playback
+
+```python
+async def get_playback(client: httpx.AsyncClient) -> dict | None:
+    resp = await spotify_request(client, "GET", "/me/player")
+    if resp.status_code == 204:
+        return None  # No active device
+    return resp.json()
+```
+
+#### Start/Resume Playback
+
+```python
+async def start_playback(
+    client: httpx.AsyncClient,
+    device_id: str = None,
+    context_uri: str = None,
+    uris: list[str] = None,
+) -> None:
+    params = {}
+    if device_id:
+        params["device_id"] = device_id
+    payload = {}
+    if context_uri:
+        payload["context_uri"] = context_uri  # e.g., "spotify:playlist:37i9dQZF1DX..."
+    elif uris:
+        payload["uris"] = uris
+    await spotify_request(client, "PUT", "/me/player/play", params=params, json_data=payload)
+```
+
+### User Library
+
+```python
+async def get_saved_tracks(client: httpx.AsyncClient, limit: int = 50, offset: int = 0) -> dict:
+    resp = await spotify_request(client, "GET", "/me/tracks", params={
+        "limit": limit,
+        "offset": offset,
+    })
+    return resp.json()
+
+async def save_tracks(client: httpx.AsyncClient, track_ids: list[str]) -> None:
+    await spotify_request(client, "PUT", "/me/tracks", json_data={"ids": track_ids})
+
+async def get_top_items(
+    client: httpx.AsyncClient,
+    item_type: str = "tracks",
+    time_range: str = "medium_term",
+    limit: int = 20,
+) -> dict:
+    resp = await spotify_request(client, "GET", f"/me/top/{item_type}", params={
+        "time_range": time_range,  # short_term (4 weeks), medium_term (6 months), long_term (years)
+        "limit": limit,
+    })
+    return resp.json()
+```
+
+### Get Current User Profile
+
+```python
+async def get_me(client: httpx.AsyncClient) -> dict:
+    resp = await spotify_request(client, "GET", "/me")
+    return resp.json()
+```
+
+## Error Handling
+
+| Code | Meaning |
+|---|---|
+| 200 | Success |
+| 201 | Created |
+| 204 | No Content (success, no body) |
+| 400 | Bad Request -- invalid parameters |
+| 401 | Unauthorized -- expired or invalid token |
+| 403 | Forbidden -- bad OAuth scope or Premium required |
+| 404 | Not Found -- resource does not exist |
+| 429 | Too Many Requests -- rate limited |
+
+```python
+class SpotifyError(Exception):
+    def __init__(self, status_code: int, message: str):
+        self.status_code = status_code
+        self.message = message
+        super().__init__(f"[{status_code}] {message}")
+
+async def safe_spotify_request(client: httpx.AsyncClient, method: str, path: str, **kwargs) -> dict | None:
+    try:
+        resp = await spotify_request(client, method, path, **kwargs)
+        if resp.status_code == 204:
+            return None
+        return resp.json()
+    except httpx.HTTPStatusError as e:
+        body = e.response.json() if e.response.content else {}
+        error = body.get("error", {})
+        raise SpotifyError(
+            e.response.status_code,
+            error.get("message", "Unknown error"),
+        ) from e
+```
+
+## Common Pitfalls
+
+1. **Tokens expire after 1 hour.** Always handle 401 by refreshing the token using the refresh_token grant. Store refresh tokens securely.
+
+2. **Search `limit` max reduced to 10 (Feb 2026).** The default is now 5. If you need more results, paginate using `offset`.
+
+3. **Playlist track endpoints renamed to `/items` (Feb 2026).** The old `/tracks` path still works but is deprecated. Use `/playlists/{id}/items` for new code.
+
+4. **Player endpoints require Premium.** Free-tier users get 403 on playback control endpoints. Check the user's `product` field from `/me` before attempting player operations.
+
+5. **Audio features may return null entries.** If a track ID is invalid or the track is unavailable, the corresponding entry in the `audio_features` array is `null`. Always filter nulls.
+
+6. **Use `fields` parameter to reduce payload size.** Playlist responses can be very large. Use Spotify's field filtering syntax: `fields=items(track(name,artists(name)))`.
+
+7. **Market parameter affects availability.** Passing `market` returns only tracks available in that country. Omitting it may return tracks the user cannot play.
+
+8. **URIs vs IDs.** Some endpoints accept Spotify URIs (`spotify:track:xxx`), others accept bare IDs. Check the endpoint docs. Playlist add/remove always uses URIs.
+
+9. **`valence` is the mood metric.** In audio features, `valence` ranges 0.0 (sad/angry) to 1.0 (happy/cheerful). Useful for building mood-based playlists.
+
+10. **Dev mode limits are strict.** Apps in development mode have much lower rate limits. Apply for extended quota mode before deploying to multiple users.

--- a/content/starling/docs/rest-api/python/DOC.md
+++ b/content/starling/docs/rest-api/python/DOC.md
@@ -1,0 +1,466 @@
+---
+name: rest-api
+description: "Starling Bank REST API Coding Guidelines for Python using httpx async HTTP client"
+metadata:
+  languages: "python"
+  versions: "v2"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "starling,banking,uk,neobank,accounts,payments,savings,api"
+---
+
+# Starling Bank REST API Coding Guidelines (Python)
+
+You are a Starling Bank API coding expert. Help me with writing code using the Starling Bank REST API with httpx async HTTP client.
+
+## Golden Rule: Use httpx Async for All API Calls
+
+Always use `httpx.AsyncClient` for all Starling Bank API interactions. Never use `requests` or synchronous HTTP clients.
+
+- **Library Name:** httpx
+- **PyPI Package:** `httpx`
+
+## Installation
+
+```bash
+pip install httpx python-dotenv
+```
+
+## Base URL
+
+| Environment | Base URL |
+|-------------|----------|
+| Production  | `https://api.starlingbank.com` |
+| Sandbox     | `https://api-sandbox.starlingbank.com` |
+
+The sandbox provides a full testing environment with simulated bank data. Register at https://developer.starlingbank.com to get sandbox credentials.
+
+## Authentication
+
+Starling supports two authentication methods:
+
+1. **Personal Access Token** -- for personal integrations (generated in the developer portal)
+2. **OAuth 2.0** -- for applications that access other users' accounts
+
+All requests require a Bearer token in the `Authorization` header.
+
+```python
+import os
+import httpx
+from dotenv import load_dotenv
+
+load_dotenv()
+
+STARLING_BASE_URL = os.environ.get(
+    "STARLING_BASE_URL", "https://api-sandbox.starlingbank.com"
+)
+STARLING_ACCESS_TOKEN = os.environ["STARLING_ACCESS_TOKEN"]
+
+def get_headers() -> dict:
+    return {
+        "Authorization": f"Bearer {STARLING_ACCESS_TOKEN}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "User-Agent": "my-app/1.0",
+    }
+```
+
+### OAuth 2.0 Token Exchange
+
+```python
+async def exchange_auth_code(
+    client_id: str,
+    client_secret: str,
+    redirect_uri: str,
+    auth_code: str,
+) -> dict:
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{STARLING_BASE_URL}/oauth/access-token",
+            json={
+                "grant_type": "authorization_code",
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "redirect_uri": redirect_uri,
+                "code": auth_code,
+            },
+        )
+        response.raise_for_status()
+        return response.json()  # {"access_token": "...", "refresh_token": "...", "token_type": "Bearer"}
+```
+
+### Token Refresh
+
+```python
+async def refresh_access_token(
+    client_id: str,
+    client_secret: str,
+    refresh_token: str,
+) -> dict:
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{STARLING_BASE_URL}/oauth/access-token",
+            json={
+                "grant_type": "refresh_token",
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "refresh_token": refresh_token,
+            },
+        )
+        response.raise_for_status()
+        return response.json()
+```
+
+## Rate Limiting
+
+Starling does not publicly document exact rate limits. Monitor for HTTP 429 responses and implement exponential backoff:
+
+```python
+import asyncio
+
+async def request_with_retry(
+    client: httpx.AsyncClient,
+    method: str,
+    url: str,
+    max_retries: int = 3,
+    **kwargs,
+) -> httpx.Response:
+    for attempt in range(max_retries):
+        response = await client.request(method, url, **kwargs)
+        if response.status_code == 429:
+            retry_after = int(response.headers.get("Retry-After", 2 ** (attempt + 1)))
+            await asyncio.sleep(retry_after)
+            continue
+        response.raise_for_status()
+        return response
+    raise httpx.HTTPStatusError(
+        "Rate limit exceeded after retries",
+        request=response.request,
+        response=response,
+    )
+```
+
+## Methods
+
+### List Accounts
+
+```python
+async def list_accounts() -> list[dict]:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{STARLING_BASE_URL}/api/v2/accounts",
+            headers=get_headers(),
+        )
+        response.raise_for_status()
+        return response.json()["accounts"]
+        # Each account has: accountUid, accountType, defaultCategory, currency, name
+```
+
+### Get Account Identifiers
+
+```python
+async def get_account_identifiers(account_uid: str) -> dict:
+    """Get sort code, account number, IBAN, BIC for an account."""
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{STARLING_BASE_URL}/api/v2/accounts/{account_uid}/identifiers",
+            headers=get_headers(),
+        )
+        response.raise_for_status()
+        return response.json()
+```
+
+### Get Balance
+
+```python
+async def get_balance(account_uid: str) -> dict:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{STARLING_BASE_URL}/api/v2/accounts/{account_uid}/balance",
+            headers=get_headers(),
+        )
+        response.raise_for_status()
+        return response.json()
+        # {"clearedBalance": {"currency": "GBP", "minorUnits": 50000}, ...}
+```
+
+### List Transactions (Feed Items)
+
+```python
+async def list_transactions(
+    account_uid: str,
+    category_uid: str,
+    since: str,
+    until: str | None = None,
+) -> list[dict]:
+    """
+    List settled transactions between dates.
+    since/until: ISO 8601 timestamps (e.g. '2025-01-01T00:00:00.000Z').
+    category_uid: from account's defaultCategory.
+    """
+    params = {"minTransactionTimestamp": since}
+    if until:
+        params["maxTransactionTimestamp"] = until
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{STARLING_BASE_URL}/api/v2/feed/account/{account_uid}/category/{category_uid}/transactions-between",
+            headers=get_headers(),
+            params=params,
+        )
+        response.raise_for_status()
+        return response.json()["feedItems"]
+```
+
+### Get Single Feed Item
+
+```python
+async def get_feed_item(
+    account_uid: str,
+    category_uid: str,
+    feed_item_uid: str,
+) -> dict:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{STARLING_BASE_URL}/api/v2/feed/account/{account_uid}/category/{category_uid}/{feed_item_uid}",
+            headers=get_headers(),
+        )
+        response.raise_for_status()
+        return response.json()["feedItem"]
+```
+
+### Savings Goals
+
+```python
+import uuid
+
+async def list_savings_goals(account_uid: str) -> list[dict]:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{STARLING_BASE_URL}/api/v2/account/{account_uid}/savings-goals",
+            headers=get_headers(),
+        )
+        response.raise_for_status()
+        return response.json()["savingsGoalList"]
+
+async def create_savings_goal(
+    account_uid: str,
+    name: str,
+    target_minor_units: int,
+    currency: str = "GBP",
+) -> dict:
+    async with httpx.AsyncClient() as client:
+        response = await client.put(
+            f"{STARLING_BASE_URL}/api/v2/account/{account_uid}/savings-goals",
+            headers=get_headers(),
+            json={
+                "name": name,
+                "currency": currency,
+                "target": {"currency": currency, "minorUnits": target_minor_units},
+            },
+        )
+        response.raise_for_status()
+        return response.json()
+
+async def add_money_to_savings_goal(
+    account_uid: str,
+    savings_goal_uid: str,
+    amount_minor_units: int,
+    currency: str = "GBP",
+) -> dict:
+    transfer_uid = str(uuid.uuid4())
+    async with httpx.AsyncClient() as client:
+        response = await client.put(
+            f"{STARLING_BASE_URL}/api/v2/account/{account_uid}/savings-goals/{savings_goal_uid}/add-money/{transfer_uid}",
+            headers=get_headers(),
+            json={
+                "amount": {"currency": currency, "minorUnits": amount_minor_units},
+            },
+        )
+        response.raise_for_status()
+        return response.json()
+
+async def withdraw_from_savings_goal(
+    account_uid: str,
+    savings_goal_uid: str,
+    amount_minor_units: int,
+    currency: str = "GBP",
+) -> dict:
+    transfer_uid = str(uuid.uuid4())
+    async with httpx.AsyncClient() as client:
+        response = await client.put(
+            f"{STARLING_BASE_URL}/api/v2/account/{account_uid}/savings-goals/{savings_goal_uid}/withdraw-money/{transfer_uid}",
+            headers=get_headers(),
+            json={
+                "amount": {"currency": currency, "minorUnits": amount_minor_units},
+            },
+        )
+        response.raise_for_status()
+        return response.json()
+```
+
+### Spaces (Spending Spaces)
+
+```python
+async def list_spaces(account_uid: str) -> list[dict]:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{STARLING_BASE_URL}/api/v2/account/{account_uid}/spaces",
+            headers=get_headers(),
+        )
+        response.raise_for_status()
+        return response.json()["spaceItems"]
+```
+
+### Direct Debits
+
+```python
+async def list_direct_debits() -> list[dict]:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{STARLING_BASE_URL}/api/v2/direct-debit/mandates",
+            headers=get_headers(),
+        )
+        response.raise_for_status()
+        return response.json()["mandates"]
+```
+
+### Standing Orders
+
+```python
+async def list_standing_orders(account_uid: str, category_uid: str) -> list[dict]:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{STARLING_BASE_URL}/api/v2/payments/local/account/{account_uid}/category/{category_uid}/standing-orders",
+            headers=get_headers(),
+        )
+        response.raise_for_status()
+        return response.json()["standingOrders"]
+```
+
+### Payees and Payments
+
+```python
+async def list_payees() -> list[dict]:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{STARLING_BASE_URL}/api/v2/payees",
+            headers=get_headers(),
+        )
+        response.raise_for_status()
+        return response.json()["payees"]
+
+async def make_local_payment(
+    account_uid: str,
+    category_uid: str,
+    payee_uid: str,
+    payee_account_uid: str,
+    amount_minor_units: int,
+    reference: str,
+    currency: str = "GBP",
+) -> dict:
+    """Make a domestic (Faster Payments) payment."""
+    payment_uid = str(uuid.uuid4())
+    async with httpx.AsyncClient() as client:
+        response = await client.put(
+            f"{STARLING_BASE_URL}/api/v2/payments/local/account/{account_uid}/category/{category_uid}",
+            headers=get_headers(),
+            json={
+                "externalIdentifier": payment_uid,
+                "paymentRecipient": {
+                    "payeeUid": payee_uid,
+                    "payeeAccountUid": payee_account_uid,
+                },
+                "reference": reference,
+                "amount": {"currency": currency, "minorUnits": amount_minor_units},
+            },
+        )
+        response.raise_for_status()
+        return response.json()
+```
+
+### Webhooks
+
+```python
+async def create_webhook(account_uid: str, url: str) -> dict:
+    """Note: Use the developer portal to manage webhooks. This is for Payment Services API."""
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{STARLING_BASE_URL}/api/v2/feed-hooks",
+            headers=get_headers(),
+            json={"url": url},
+        )
+        response.raise_for_status()
+        return response.json()
+```
+
+## Error Handling
+
+```python
+async def safe_starling_request(
+    method: str,
+    path: str,
+    **kwargs,
+) -> dict | None:
+    async with httpx.AsyncClient(base_url=STARLING_BASE_URL) as client:
+        try:
+            response = await client.request(
+                method, path, headers=get_headers(), **kwargs
+            )
+            response.raise_for_status()
+            return response.json() if response.content else None
+        except httpx.HTTPStatusError as e:
+            status = e.response.status_code
+            body = e.response.text
+            if status == 400:
+                raise ValueError(f"Bad request: {body}")
+            elif status == 401:
+                raise PermissionError("Invalid or expired token.")
+            elif status == 403:
+                raise PermissionError(f"Forbidden: {body}")
+            elif status == 404:
+                raise LookupError(f"Resource not found: {path}")
+            elif status == 409:
+                raise RuntimeError(f"Conflict (duplicate transfer UID?): {body}")
+            elif status == 429:
+                raise RuntimeError("Rate limited. Implement backoff.")
+            elif status >= 500:
+                raise ConnectionError(f"Starling server error ({status}): {body}")
+            raise
+        except httpx.RequestError as e:
+            raise ConnectionError(f"Network error: {e}")
+```
+
+### HTTP Status Codes
+
+| Code | Meaning |
+|------|---------|
+| 200  | Success |
+| 400  | Bad Request |
+| 401  | Unauthorized -- invalid token |
+| 403  | Forbidden -- insufficient scope |
+| 404  | Not Found |
+| 409  | Conflict -- duplicate idempotency key |
+| 429  | Too Many Requests |
+| 500  | Internal Server Error |
+
+## Common Pitfalls
+
+1. **Amounts in Minor Units:** All monetary values are in minor units (pence for GBP). `{"currency": "GBP", "minorUnits": 1000}` = 10.00 GBP.
+2. **UUID Path Parameters:** Many endpoints require UUIDs (accountUid, categoryUid, savingsGoalUid). Always get these from the accounts endpoint first.
+3. **Transfer UIDs for Idempotency:** Savings goal transfers and payments require a unique `transferUid` in the URL path. Generate with `uuid.uuid4()`. Reusing a UID returns the original result (idempotent).
+4. **Default Category:** Each account has a `defaultCategory` UID. Most feed/transaction endpoints require both `accountUid` AND `categoryUid`.
+5. **JSON Bodies:** Unlike Monzo, Starling uses JSON request bodies (`Content-Type: application/json`). Use `json=` not `data=` with httpx.
+6. **PUT for Creates:** Starling uses PUT (not POST) for creating savings goals and making transfers, with the resource ID in the URL.
+7. **Sandbox Data:** The sandbox auto-generates test data. Use it for development before switching to production.
+8. **Timestamp Format:** Use full ISO 8601 with timezone: `2025-01-01T00:00:00.000Z`.
+9. **Personal vs OAuth Tokens:** Personal access tokens are for single-user integrations. Use OAuth for multi-user apps.
+10. **API Version:** All endpoints use `/api/v2/` prefix. The v1 API is deprecated.
+
+## Useful Links
+
+- **Developer Portal:** https://developer.starlingbank.com
+- **API Documentation:** https://developer.starlingbank.com/docs
+- **Sandbox:** https://developer.starlingbank.com/sandbox
+- **API Samples (GitHub):** https://github.com/starlingbank/api-samples
+- **Status Page:** https://starlingbank.statuspage.io

--- a/content/symbl/docs/rest-api/python/DOC.md
+++ b/content/symbl/docs/rest-api/python/DOC.md
@@ -1,0 +1,343 @@
+---
+name: rest-api
+description: "Symbl.ai Conversation Intelligence REST API for transcription, sentiment, and topic extraction"
+metadata:
+  languages: "python"
+  versions: "1.0.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "symbl,conversation-intelligence,transcription,sentiment,topics,accessibility,api"
+---
+
+# Symbl.ai REST API
+
+> **Golden Rule:** Symbl.ai has SDKs but the REST API can be used directly with `httpx` (async). Authentication uses OAuth2 (appId/appSecret exchanged for a Bearer access token). The Async API processes audio/video/text, and the Conversation API retrieves insights (transcripts, topics, sentiment, action items). Base URL is `https://api.symbl.ai/v1`.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+`https://api.symbl.ai/v1`
+
+Labs endpoint: `https://api-labs.symbl.ai/v1`
+
+Sign up at: https://platform.symbl.ai
+
+## Authentication
+
+**Type:** OAuth 2.0 Client Credentials (appId + appSecret)
+
+```python
+import httpx
+
+APP_ID = "your-app-id"
+APP_SECRET = "your-app-secret"
+BASE_URL = "https://api.symbl.ai/v1"
+
+async def get_access_token() -> str:
+    async with httpx.AsyncClient() as c:
+        response = await c.post(
+            "https://api.symbl.ai/oauth2/token:generate",
+            json={
+                "type": "application",
+                "appId": APP_ID,
+                "appSecret": APP_SECRET,
+            },
+        )
+        response.raise_for_status()
+        return response.json()["accessToken"]
+
+access_token = await get_access_token()
+client = httpx.AsyncClient(
+    headers={"Authorization": f"Bearer {access_token}"},
+    timeout=60.0,
+)
+```
+
+**Important:** Access tokens expire. Re-generate when you receive a 401.
+
+## Rate Limiting
+
+| Constraint | Limit |
+|---|---|
+| Audio/video file duration | 4 hours max |
+| Text input | 15,000 words per request |
+| Concurrent async jobs | Varies by plan |
+
+Symbl.ai does not publish fixed rate limits; they vary by plan. Monitor for 429 responses.
+
+## Methods
+
+### Async Audio (URL)
+
+**Endpoint:** `POST /process/audio/url`
+
+Submit audio from a URL for processing.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `url` | `str` | **required** |
+| `name` | `str` | `None` (conversation name) |
+| `confidenceThreshold` | `float` | `0.5` |
+| `languageCode` | `str` | `en-US` |
+| `enableSpeakerDiarization` | `bool` | `true` |
+| `diarizationSpeakerCount` | `int` | `None` |
+
+```python
+payload = {
+    "url": "https://example.com/meeting-recording.mp3",
+    "name": "Team standup",
+    "confidenceThreshold": 0.6,
+    "languageCode": "en-US",
+    "enableSpeakerDiarization": True,
+    "diarizationSpeakerCount": 4,
+}
+response = await client.post(f"{BASE_URL}/process/audio/url", json=payload)
+response.raise_for_status()
+data = response.json()
+conversation_id = data["conversationId"]
+job_id = data["jobId"]
+print(f"Conversation: {conversation_id}, Job: {job_id}")
+```
+
+### Async Audio (File Upload)
+
+**Endpoint:** `POST /process/audio`
+
+```python
+with open("meeting.mp3", "rb") as audio_file:
+    response = await client.post(
+        f"{BASE_URL}/process/audio",
+        content=audio_file.read(),
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "audio/mpeg",
+        },
+    )
+response.raise_for_status()
+data = response.json()
+conversation_id = data["conversationId"]
+job_id = data["jobId"]
+```
+
+### Async Video (URL)
+
+**Endpoint:** `POST /process/video/url`
+
+```python
+payload = {
+    "url": "https://example.com/meeting.mp4",
+    "name": "Video meeting",
+}
+response = await client.post(f"{BASE_URL}/process/video/url", json=payload)
+response.raise_for_status()
+data = response.json()
+conversation_id = data["conversationId"]
+```
+
+### Async Text
+
+**Endpoint:** `POST /process/text`
+
+Process text conversations (chat logs, emails, etc.).
+
+```python
+payload = {
+    "name": "Support chat",
+    "messages": [
+        {
+            "payload": {"content": "Hi, I need help with my account."},
+            "from": {"name": "Customer", "userId": "customer@example.com"},
+        },
+        {
+            "payload": {"content": "Sure, I'd be happy to help. What seems to be the issue?"},
+            "from": {"name": "Agent", "userId": "agent@example.com"},
+        },
+    ],
+}
+response = await client.post(f"{BASE_URL}/process/text", json=payload)
+response.raise_for_status()
+data = response.json()
+conversation_id = data["conversationId"]
+```
+
+### Check Job Status
+
+**Endpoint:** `GET /job/{job_id}`
+
+```python
+response = await client.get(f"{BASE_URL}/job/{job_id}")
+response.raise_for_status()
+job = response.json()
+print(f"Status: {job['status']}")
+# Statuses: scheduled, in_progress, completed, failed
+```
+
+### Poll Until Complete (Helper)
+
+```python
+import asyncio
+
+async def wait_for_job(job_id: str, poll_interval: float = 5.0) -> str:
+    while True:
+        response = await client.get(f"{BASE_URL}/job/{job_id}")
+        response.raise_for_status()
+        job = response.json()
+        if job["status"] == "completed":
+            return job["status"]
+        elif job["status"] == "failed":
+            raise Exception(f"Job failed: {job}")
+        await asyncio.sleep(poll_interval)
+```
+
+### Get Transcript (Messages)
+
+**Endpoint:** `GET /conversations/{conversationId}/messages`
+
+```python
+response = await client.get(f"{BASE_URL}/conversations/{conversation_id}/messages")
+response.raise_for_status()
+data = response.json()
+for msg in data.get("messages", []):
+    speaker = msg.get("from", {}).get("name", "Unknown")
+    text = msg.get("text", "")
+    print(f"[{speaker}]: {text}")
+```
+
+### Get Topics
+
+**Endpoint:** `GET /conversations/{conversationId}/topics`
+
+```python
+response = await client.get(f"{BASE_URL}/conversations/{conversation_id}/topics")
+response.raise_for_status()
+data = response.json()
+for topic in data.get("topics", []):
+    print(f"Topic: {topic['text']} (score: {topic.get('score', 'N/A')})")
+```
+
+### Get Sentiment (Messages with Sentiment)
+
+**Endpoint:** `GET /conversations/{conversationId}/messages?sentiment=true`
+
+```python
+response = await client.get(
+    f"{BASE_URL}/conversations/{conversation_id}/messages",
+    params={"sentiment": "true"},
+)
+response.raise_for_status()
+data = response.json()
+for msg in data.get("messages", []):
+    sentiment = msg.get("sentiment", {})
+    polarity = sentiment.get("polarity", {}).get("score", 0)
+    label = sentiment.get("suggested", "neutral")
+    print(f"[{label} ({polarity:.2f})]: {msg.get('text', '')[:80]}")
+```
+
+### Get Action Items
+
+**Endpoint:** `GET /conversations/{conversationId}/action-items`
+
+```python
+response = await client.get(f"{BASE_URL}/conversations/{conversation_id}/action-items")
+response.raise_for_status()
+data = response.json()
+for item in data.get("actionItems", []):
+    assignee = item.get("assignee", {}).get("name", "Unassigned")
+    print(f"[{assignee}]: {item.get('text', '')}")
+```
+
+### Get Follow-Ups
+
+**Endpoint:** `GET /conversations/{conversationId}/follow-ups`
+
+```python
+response = await client.get(f"{BASE_URL}/conversations/{conversation_id}/follow-ups")
+response.raise_for_status()
+data = response.json()
+for fu in data.get("followUps", []):
+    print(f"Follow-up: {fu.get('text', '')}")
+```
+
+### Get Questions
+
+**Endpoint:** `GET /conversations/{conversationId}/questions`
+
+```python
+response = await client.get(f"{BASE_URL}/conversations/{conversation_id}/questions")
+response.raise_for_status()
+data = response.json()
+for q in data.get("questions", []):
+    print(f"Q: {q.get('text', '')}")
+```
+
+### Get Summary (Labs)
+
+**Endpoint:** `GET /conversations/{conversationId}/summary` (labs endpoint)
+
+```python
+response = await client.get(
+    f"https://api-labs.symbl.ai/v1/conversations/{conversation_id}/summary",
+    headers={"Authorization": f"Bearer {access_token}"},
+)
+response.raise_for_status()
+data = response.json()
+for item in data.get("summary", []):
+    print(item.get("text", ""))
+```
+
+### Delete Conversation
+
+**Endpoint:** `DELETE /conversations/{conversationId}`
+
+```python
+response = await client.delete(f"{BASE_URL}/conversations/{conversation_id}")
+response.raise_for_status()
+print("Conversation deleted")
+```
+
+## Error Handling
+
+```python
+import httpx
+
+try:
+    response = await client.post(f"{BASE_URL}/process/audio/url", json=payload)
+    response.raise_for_status()
+    data = response.json()
+except httpx.HTTPStatusError as e:
+    if e.response.status_code == 401:
+        print("Access token expired or invalid -- regenerate token")
+    elif e.response.status_code == 429:
+        print("Rate limited -- reduce request frequency")
+    elif e.response.status_code == 400:
+        print(f"Bad request (invalid payload): {e.response.text}")
+    elif e.response.status_code == 404:
+        print("Conversation or job not found")
+    elif e.response.status_code == 413:
+        print("File too large -- max 4 hours audio/video")
+    else:
+        print(f"Symbl.ai error {e.response.status_code}: {e.response.text}")
+except httpx.RequestError as e:
+    print(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+- Token generation endpoint uses a colon in the path: `/oauth2/token:generate`
+- The Async API returns a `conversationId` and `jobId` -- you need both: job for polling status, conversation for retrieving insights
+- Audio file uploads use raw body with `Content-Type` header (e.g., `audio/mpeg`), not multipart form
+- Audio/video URL submissions use **JSON body** with POST
+- Text processing expects a `messages` array with `payload.content` and `from` fields
+- Sentiment is not returned by default -- add `?sentiment=true` query param to messages endpoint
+- The Summary endpoint is on the **labs** base URL (`api-labs.symbl.ai`), not the main URL
+- Supported audio formats: mp3, wav, amr, aac, ac3, aiff, flac, ogg, opus, wma, m4a
+- Maximum audio/video duration is **4 hours** per request
+- Maximum text is **15,000 words** per request
+- Access tokens expire -- implement token refresh logic
+- Set a longer timeout for file uploads: `httpx.AsyncClient(timeout=60.0)`

--- a/content/tally/docs/rest-api/python/DOC.md
+++ b/content/tally/docs/rest-api/python/DOC.md
@@ -1,0 +1,410 @@
+---
+name: rest-api
+description: "Tally - Indian Accounting & ERP Integration API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "tally,accounting,erp,india,gst,invoicing,inventory,api"
+---
+
+# Tally Integration API - Python Guide
+
+## Overview
+
+TallyPrime (and Tally.ERP 9) is India's most widely used accounting and ERP software. Tally does **not** expose a traditional REST/JSON API. Instead, it provides an **XML-over-HTTP** interface where TallyPrime runs as a local HTTP server and accepts XML POST requests on a configurable port (default: `9000`).
+
+All communication uses XML envelopes with `HEADER` and `BODY` sections. The three core request types are **Export** (read data), **Import** (create/update data), and **Execute** (run TDL functions).
+
+- **Protocol**: HTTP POST with XML body
+- **Default endpoint**: `http://localhost:9000`
+- **Content-Type**: `text/xml` (responses in UTF-8)
+- **Authentication**: None by default (local network access); configure firewall/network restrictions in production
+- **Official docs**: https://help.tallysolutions.com/xml-interface/
+
+## XML Envelope Structure
+
+Every request follows this structure:
+
+```xml
+<ENVELOPE>
+  <HEADER>
+    <VERSION>1</VERSION>
+    <TALLYREQUEST>Export|Import</TALLYREQUEST>
+    <TYPE>Data|Collection|Object</TYPE>
+    <ID>Report or Collection Name</ID>
+  </HEADER>
+  <BODY>
+    <DESC>
+      <STATICVARIABLES>
+        <!-- Configuration parameters -->
+      </STATICVARIABLES>
+    </DESC>
+    <DATA>
+      <!-- For Import requests only -->
+    </DATA>
+  </BODY>
+</ENVELOPE>
+```
+
+### Header Fields
+
+| Field | Values | Description |
+|-------|--------|-------------|
+| `VERSION` | `1` | XML interface version |
+| `TALLYREQUEST` | `Export`, `Import` | Action type |
+| `TYPE` | `Data`, `Collection`, `Object`, `Function` | What to retrieve or send |
+| `ID` | Report/collection name | e.g., `List of Ledgers`, `All Masters`, `Trial Balance` |
+
+## Installation
+
+```bash
+pip install httpx lxml
+```
+
+## Python Client
+
+```python
+import httpx
+from lxml import etree
+
+
+class TallyClient:
+    """Async client for TallyPrime XML-over-HTTP interface."""
+
+    def __init__(self, host: str = "localhost", port: int = 9000):
+        self.base_url = f"http://{host}:{port}"
+        self.headers = {"Content-Type": "text/xml; charset=utf-8"}
+
+    async def _post_xml(self, xml_body: str) -> str:
+        """Send an XML request to TallyPrime and return the raw XML response."""
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(
+                self.base_url,
+                content=xml_body.encode("utf-8"),
+                headers=self.headers,
+            )
+            response.raise_for_status()
+            return response.text
+
+    def _parse_xml(self, xml_text: str) -> etree._Element:
+        """Parse XML response string into an lxml Element."""
+        return etree.fromstring(xml_text.encode("utf-8"))
+
+    async def export_report(
+        self,
+        report_id: str,
+        report_type: str = "Data",
+        static_vars: dict | None = None,
+    ) -> etree._Element:
+        """Export data from TallyPrime (read operation)."""
+        vars_xml = ""
+        if static_vars:
+            var_lines = [
+                f"<{k}>{v}</{k}>" for k, v in static_vars.items()
+            ]
+            vars_xml = "\n".join(var_lines)
+
+        xml_request = f"""<ENVELOPE>
+  <HEADER>
+    <VERSION>1</VERSION>
+    <TALLYREQUEST>Export</TALLYREQUEST>
+    <TYPE>{report_type}</TYPE>
+    <ID>{report_id}</ID>
+  </HEADER>
+  <BODY>
+    <DESC>
+      <STATICVARIABLES>
+        <SVEXPORTFORMAT>$$SysName:XML</SVEXPORTFORMAT>
+        {vars_xml}
+      </STATICVARIABLES>
+    </DESC>
+  </BODY>
+</ENVELOPE>"""
+        raw = await self._post_xml(xml_request)
+        return self._parse_xml(raw)
+
+    async def import_data(
+        self,
+        tally_message_xml: str,
+        import_id: str = "All Masters",
+        duplicate_handling: str = "@@DUPCOMBINE",
+    ) -> dict:
+        """Import (create/update) masters or vouchers into TallyPrime."""
+        xml_request = f"""<ENVELOPE>
+  <HEADER>
+    <VERSION>1</VERSION>
+    <TALLYREQUEST>Import</TALLYREQUEST>
+    <TYPE>Data</TYPE>
+    <ID>{import_id}</ID>
+  </HEADER>
+  <BODY>
+    <DESC>
+      <STATICVARIABLES>
+        <IMPORTDUPS>{duplicate_handling}</IMPORTDUPS>
+      </STATICVARIABLES>
+    </DESC>
+    <DATA>
+      <TALLYMESSAGE>
+        {tally_message_xml}
+      </TALLYMESSAGE>
+    </DATA>
+  </BODY>
+</ENVELOPE>"""
+        raw = await self._post_xml(xml_request)
+        root = self._parse_xml(raw)
+        return {
+            "created": root.findtext(".//CREATED", "0"),
+            "altered": root.findtext(".//ALTERED", "0"),
+            "errors": root.findtext(".//ERRORS", "0"),
+            "last_vch_id": root.findtext(".//LASTVCHID", "0"),
+        }
+```
+
+## Common Operations
+
+### Export Ledger List
+
+```python
+import asyncio
+
+
+async def list_ledgers():
+    tally = TallyClient()
+
+    # Export the collection of all ledgers
+    xml_request = """<ENVELOPE>
+  <HEADER>
+    <VERSION>1</VERSION>
+    <TALLYREQUEST>Export</TALLYREQUEST>
+    <TYPE>Collection</TYPE>
+    <ID>List of Ledgers</ID>
+  </HEADER>
+  <BODY>
+    <DESC>
+      <STATICVARIABLES>
+        <SVEXPORTFORMAT>$$SysName:XML</SVEXPORTFORMAT>
+      </STATICVARIABLES>
+    </DESC>
+  </BODY>
+</ENVELOPE>"""
+
+    raw_response = await tally._post_xml(xml_request)
+    root = tally._parse_xml(raw_response)
+
+    ledgers = []
+    for collection in root.iter("COLLECTION"):
+        for ledger in collection.iter("LEDGER"):
+            name = ledger.findtext("NAME", "")
+            parent = ledger.findtext("PARENT", "")
+            ledgers.append({"name": name, "parent": parent})
+
+    for ledger in ledgers:
+        print(f"  {ledger['name']} ({ledger['parent']})")
+
+    return ledgers
+
+
+asyncio.run(list_ledgers())
+```
+
+### Export Trial Balance
+
+```python
+async def get_trial_balance():
+    tally = TallyClient()
+    root = await tally.export_report(
+        report_id="Trial Balance",
+        static_vars={"EXPLODEFLAG": "Yes"},
+    )
+
+    for entry in root.iter("DSPACCNAME"):
+        name = entry.findtext("DSPDISPNAME", "")
+        print(f"Account: {name}")
+
+    return root
+
+
+asyncio.run(get_trial_balance())
+```
+
+### Create a Ledger
+
+```python
+async def create_ledger(name: str, parent_group: str, opening_balance: float = 0):
+    tally = TallyClient()
+
+    ledger_xml = f"""<LEDGER NAME="{name}" Action="Create">
+  <NAME>{name}</NAME>
+  <PARENT>{parent_group}</PARENT>
+  <OPENINGBALANCE>{opening_balance}</OPENINGBALANCE>
+</LEDGER>"""
+
+    result = await tally.import_data(ledger_xml)
+    print(f"Created: {result['created']}, Errors: {result['errors']}")
+    return result
+
+
+asyncio.run(create_ledger("HDFC Bank", "Bank Accounts", -50000))
+```
+
+### Create a Sales Voucher (Invoice)
+
+```python
+async def create_sales_voucher(
+    party_name: str,
+    ledger_name: str,
+    amount: float,
+    date: str,
+    voucher_number: str,
+):
+    """Create a sales voucher. Date format: YYYYMMDD."""
+    tally = TallyClient()
+
+    voucher_xml = f"""<VOUCHER VCHTYPE="Sales" Action="Create">
+  <DATE>{date}</DATE>
+  <VOUCHERTYPENAME>Sales</VOUCHERTYPENAME>
+  <VOUCHERNUMBER>{voucher_number}</VOUCHERNUMBER>
+  <PARTYLEDGERNAME>{party_name}</PARTYLEDGERNAME>
+  <ALLLEDGERENTRIES.LIST>
+    <LEDGERNAME>{party_name}</LEDGERNAME>
+    <ISDEEMEDPOSITIVE>Yes</ISDEEMEDPOSITIVE>
+    <AMOUNT>-{amount}</AMOUNT>
+  </ALLLEDGERENTRIES.LIST>
+  <ALLLEDGERENTRIES.LIST>
+    <LEDGERNAME>{ledger_name}</LEDGERNAME>
+    <ISDEEMEDPOSITIVE>No</ISDEEMEDPOSITIVE>
+    <AMOUNT>{amount}</AMOUNT>
+  </ALLLEDGERENTRIES.LIST>
+</VOUCHER>"""
+
+    result = await tally.import_data(
+        voucher_xml, import_id="All Masters"
+    )
+    print(f"Voucher created: {result}")
+    return result
+
+
+asyncio.run(
+    create_sales_voucher(
+        party_name="ABC Enterprises",
+        ledger_name="Sales Account",
+        amount=25000.00,
+        date="20260317",
+        voucher_number="S-001",
+    )
+)
+```
+
+### Export GST Summary Data
+
+```python
+async def get_gst_summary(from_date: str, to_date: str):
+    """Export GST summary. Dates in YYYYMMDD format."""
+    tally = TallyClient()
+    root = await tally.export_report(
+        report_id="GST - GSTR1",
+        static_vars={
+            "SVFROMDATE": from_date,
+            "SVTODATE": to_date,
+            "EXPLODEFLAG": "Yes",
+        },
+    )
+    return root
+
+
+asyncio.run(get_gst_summary("20260401", "20260430"))
+```
+
+### Export Stock Items (Inventory)
+
+```python
+async def list_stock_items():
+    tally = TallyClient()
+
+    xml_request = """<ENVELOPE>
+  <HEADER>
+    <VERSION>1</VERSION>
+    <TALLYREQUEST>Export</TALLYREQUEST>
+    <TYPE>Collection</TYPE>
+    <ID>List of Stock Items</ID>
+  </HEADER>
+  <BODY>
+    <DESC>
+      <STATICVARIABLES>
+        <SVEXPORTFORMAT>$$SysName:XML</SVEXPORTFORMAT>
+      </STATICVARIABLES>
+    </DESC>
+  </BODY>
+</ENVELOPE>"""
+
+    raw = await tally._post_xml(xml_request)
+    root = tally._parse_xml(raw)
+
+    items = []
+    for item in root.iter("STOCKITEM"):
+        items.append({
+            "name": item.findtext("NAME", ""),
+            "parent": item.findtext("PARENT", ""),
+        })
+    return items
+
+
+asyncio.run(list_stock_items())
+```
+
+## Configuration Notes
+
+### Enabling Tally as HTTP Server
+
+1. Open TallyPrime
+2. Press `F12` (Configuration) or go to **Help > Settings**
+3. Under **Connectivity**, set:
+   - **Tally.NET Server**: enable as needed
+   - **Port**: `9000` (or custom)
+4. Ensure the port is accessible from your application host
+
+### Network Access
+
+By default Tally listens on `localhost`. For remote access, bind to `0.0.0.0` in Tally configuration and ensure firewall rules allow traffic on the configured port.
+
+### Date Format
+
+Tally uses `YYYYMMDD` format in XML (e.g., `20260317` for March 17, 2026). Negative amounts in `AMOUNT` fields represent debit entries.
+
+### Duplicate Handling on Import
+
+| Value | Behavior |
+|-------|----------|
+| `@@DUPCOMBINE` | Merge with existing record |
+| `@@DUPMODIFY` | Overwrite existing record |
+| `@@DUPIGNORE` | Skip if record exists |
+
+## Error Handling
+
+```python
+import httpx
+
+
+async def safe_tally_request(tally: TallyClient, xml_body: str) -> str | None:
+    try:
+        return await tally._post_xml(xml_body)
+    except httpx.ConnectError:
+        print("ERROR: Cannot connect to TallyPrime. Is it running on the configured port?")
+        return None
+    except httpx.TimeoutException:
+        print("ERROR: Request timed out. The report may be too large.")
+        return None
+    except httpx.HTTPStatusError as e:
+        print(f"ERROR: HTTP {e.response.status_code}")
+        return None
+```
+
+## References
+
+- Official XML Interface Guide: https://help.tallysolutions.com/xml-interface/
+- Integration Methods: https://help.tallysolutions.com/integration-methods-and-technologies/
+- XML Request Examples: https://help.tallysolutions.com/case-study-1/
+- Sample XML: https://help.tallysolutions.com/sample-xml/

--- a/content/tavily/docs/rest-api/python/DOC.md
+++ b/content/tavily/docs/rest-api/python/DOC.md
@@ -1,0 +1,494 @@
+---
+name: rest-api
+description: "Tavily - Web Search API for AI Agents (REST)"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "tavily,search,web-search,extract,crawl,research,ai-agents,rag,api"
+---
+
+# Tavily REST API Guide (Python / httpx)
+
+## Golden Rule
+
+Use this entry when you need direct HTTP access to the Tavily web search API without the official SDK. All examples use `httpx` with async. For the SDK approach, see `tavily/docs/sdk/`.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+Or with `uv`:
+
+```bash
+uv add httpx
+```
+
+## Base URL
+
+```
+https://api.tavily.com
+```
+
+All endpoint paths below are relative to this base.
+
+## Authentication
+
+Every request requires a Bearer token in the `Authorization` header. Obtain your key from the Tavily dashboard at `app.tavily.com`. Keys are prefixed with `tvly-`.
+
+```bash
+export TAVILY_API_KEY="tvly-..."
+```
+
+```python
+import os
+
+TAVILY_API_KEY = os.environ["TAVILY_API_KEY"]
+HEADERS = {
+    "Authorization": f"Bearer {TAVILY_API_KEY}",
+    "Content-Type": "application/json",
+}
+```
+
+**Optional project tracking header:**
+
+```python
+HEADERS["X-Project-ID"] = "my-project"
+```
+
+This organizes usage by project for filtering and billing visibility.
+
+## Rate Limiting
+
+Rate limits depend on your environment (determined by your API key):
+
+| Environment | Limit |
+|-------------|-------|
+| Development | 100 RPM |
+| Production | 1,000 RPM |
+
+**Endpoint-specific limits:**
+
+| Endpoint | Limit |
+|----------|-------|
+| `/crawl` | 100 RPM (both dev and prod) |
+| `/research` | 20 RPM (both dev and prod) |
+
+When rate limits are exceeded, the API returns HTTP 429 with a `retry-after` header indicating the number of seconds to wait before retrying.
+
+Production keys require an active paid plan or PAYGO enabled.
+
+## Methods
+
+### Search
+
+**POST** `/search`
+
+The core endpoint. Executes a web search and returns ranked results with content snippets. Optionally generates an LLM-powered answer.
+
+```python
+import httpx
+import os
+
+TAVILY_API_KEY = os.environ["TAVILY_API_KEY"]
+BASE_URL = "https://api.tavily.com"
+HEADERS = {
+    "Authorization": f"Bearer {TAVILY_API_KEY}",
+    "Content-Type": "application/json",
+}
+
+
+async def search(query: str, max_results: int = 5):
+    payload = {
+        "query": query,
+        "search_depth": "basic",
+        "max_results": max_results,
+        "include_answer": True,
+    }
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{BASE_URL}/search",
+            headers=HEADERS,
+            json=payload,
+            timeout=30.0,
+        )
+        resp.raise_for_status()
+        return resp.json()
+```
+
+**Request parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | string | required | Search query (keep under 400 chars) |
+| `search_depth` | string | `"basic"` | `"ultra-fast"`, `"fast"`, `"basic"`, or `"advanced"` |
+| `max_results` | integer | 5 | Number of results (0-20) |
+| `topic` | string | `"general"` | `"general"` or `"news"` |
+| `chunks_per_source` | integer | 3 | Content chunks per source (1-3, advanced depth only) |
+| `include_answer` | bool/string | false | `true`/`"basic"` for quick answer, `"advanced"` for detailed |
+| `include_raw_content` | bool/string | false | `true`/`"markdown"` for markdown, `"text"` for plain text |
+| `include_images` | boolean | false | Include image results |
+| `include_image_descriptions` | boolean | false | AI-generated image descriptions |
+| `include_favicon` | boolean | false | Include favicon URL per result |
+| `include_domains` | array | [] | Restrict to these domains (max 300) |
+| `exclude_domains` | array | [] | Exclude these domains (max 150) |
+| `time_range` | string | null | `"day"`, `"week"`, `"month"`, or `"year"` |
+| `start_date` | string | null | Results after this date (YYYY-MM-DD) |
+| `end_date` | string | null | Results before this date (YYYY-MM-DD) |
+| `country` | string | null | Boost results from a specific country |
+| `include_usage` | boolean | false | Include credit usage in response |
+
+**Credit costs:** `"ultra-fast"`, `"fast"`, and `"basic"` cost 1 credit per search. `"advanced"` costs 2 credits.
+
+**Response structure:**
+
+```json
+{
+  "query": "latest AI frameworks 2026",
+  "answer": "The most prominent AI frameworks in 2026 include...",
+  "results": [
+    {
+      "title": "Top AI Frameworks",
+      "url": "https://example.com/ai-frameworks",
+      "content": "A comprehensive overview of...",
+      "score": 0.92,
+      "raw_content": null,
+      "favicon": null
+    }
+  ],
+  "images": [],
+  "response_time": 1.45,
+  "request_id": "abc-123-def"
+}
+```
+
+### Search with Domain Filtering
+
+```python
+import httpx
+import os
+
+TAVILY_API_KEY = os.environ["TAVILY_API_KEY"]
+BASE_URL = "https://api.tavily.com"
+HEADERS = {
+    "Authorization": f"Bearer {TAVILY_API_KEY}",
+    "Content-Type": "application/json",
+}
+
+
+async def search_specific_domains(query: str):
+    payload = {
+        "query": query,
+        "search_depth": "advanced",
+        "max_results": 10,
+        "include_answer": "advanced",
+        "include_raw_content": "markdown",
+        "include_domains": ["arxiv.org", "github.com"],
+        "time_range": "month",
+    }
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{BASE_URL}/search",
+            headers=HEADERS,
+            json=payload,
+            timeout=30.0,
+        )
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Extract
+
+**POST** `/extract`
+
+Extracts clean, readable content from one or more URLs. Useful for feeding full page content into LLMs.
+
+```python
+import httpx
+import os
+
+TAVILY_API_KEY = os.environ["TAVILY_API_KEY"]
+BASE_URL = "https://api.tavily.com"
+HEADERS = {
+    "Authorization": f"Bearer {TAVILY_API_KEY}",
+    "Content-Type": "application/json",
+}
+
+
+async def extract(urls: list[str]):
+    payload = {
+        "urls": urls,
+        "extract_depth": "basic",
+        "format": "markdown",
+        "include_images": False,
+    }
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{BASE_URL}/extract",
+            headers=HEADERS,
+            json=payload,
+            timeout=60.0,
+        )
+        resp.raise_for_status()
+        return resp.json()
+```
+
+**Request parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `urls` | string/array | required | Single URL or list of URLs (max 20) |
+| `query` | string | null | User intent for reranking extracted chunks |
+| `chunks_per_source` | integer | 3 | Relevant chunks per source (1-5, only with query) |
+| `extract_depth` | string | `"basic"` | `"basic"` or `"advanced"` |
+| `format` | string | `"markdown"` | `"markdown"` or `"text"` |
+| `include_images` | boolean | false | Include extracted images |
+| `include_favicon` | boolean | false | Include favicon URL |
+| `timeout` | number | varies | Request timeout in seconds (1.0-60.0) |
+| `include_usage` | boolean | false | Include credit usage in response |
+
+**Response structure:**
+
+```json
+{
+  "results": [
+    {
+      "url": "https://example.com/article",
+      "raw_content": "# Article Title\n\nFull extracted content...",
+      "images": [],
+      "favicon": null
+    }
+  ],
+  "failed_results": [
+    {
+      "url": "https://example.com/broken",
+      "error": "Failed to extract content"
+    }
+  ],
+  "response_time": 2.3,
+  "request_id": "abc-123-def"
+}
+```
+
+### Extract with Relevance Reranking
+
+```python
+import httpx
+import os
+
+TAVILY_API_KEY = os.environ["TAVILY_API_KEY"]
+BASE_URL = "https://api.tavily.com"
+HEADERS = {
+    "Authorization": f"Bearer {TAVILY_API_KEY}",
+    "Content-Type": "application/json",
+}
+
+
+async def extract_with_query(urls: list[str], query: str):
+    payload = {
+        "urls": urls,
+        "query": query,
+        "chunks_per_source": 5,
+        "extract_depth": "advanced",
+        "format": "markdown",
+    }
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{BASE_URL}/extract",
+            headers=HEADERS,
+            json=payload,
+            timeout=60.0,
+        )
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### Crawl
+
+**POST** `/crawl`
+
+Crawls a website starting from a root URL, following links up to a configurable depth and breadth. Returns extracted content from all discovered pages.
+
+```python
+import httpx
+import os
+
+TAVILY_API_KEY = os.environ["TAVILY_API_KEY"]
+BASE_URL = "https://api.tavily.com"
+HEADERS = {
+    "Authorization": f"Bearer {TAVILY_API_KEY}",
+    "Content-Type": "application/json",
+}
+
+
+async def crawl(url: str, max_depth: int = 2, limit: int = 20):
+    payload = {
+        "url": url,
+        "max_depth": max_depth,
+        "max_breadth": 20,
+        "limit": limit,
+        "format": "markdown",
+        "extract_depth": "basic",
+    }
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{BASE_URL}/crawl",
+            headers=HEADERS,
+            json=payload,
+            timeout=180.0,
+        )
+        resp.raise_for_status()
+        return resp.json()
+```
+
+**Request parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `url` | string | required | Root URL to begin crawling |
+| `instructions` | string | null | Natural language guidance for crawl (costs 2 credits/10 pages) |
+| `max_depth` | integer | 1 | Levels from base URL (1-5) |
+| `max_breadth` | integer | 20 | Links per page to follow (1-500) |
+| `limit` | integer | 50 | Total links to process |
+| `select_paths` | array | null | Regex patterns for URL inclusion |
+| `select_domains` | array | null | Regex patterns for domain inclusion |
+| `exclude_paths` | array | null | Regex patterns for URL exclusion |
+| `exclude_domains` | array | null | Regex patterns for domain exclusion |
+| `allow_external` | boolean | true | Follow links to external domains |
+| `include_images` | boolean | false | Include images in results |
+| `extract_depth` | string | `"basic"` | `"basic"` or `"advanced"` |
+| `format` | string | `"markdown"` | `"markdown"` or `"text"` |
+| `include_favicon` | boolean | false | Include favicon URLs |
+| `timeout` | number | 150 | Request timeout (10-150 seconds) |
+| `include_usage` | boolean | false | Include credit usage in response |
+
+**Response structure:**
+
+```json
+{
+  "base_url": "docs.example.com",
+  "results": [
+    {
+      "url": "https://docs.example.com/getting-started",
+      "raw_content": "# Getting Started\n\nWelcome to..."
+    }
+  ],
+  "response_time": 12.5,
+  "usage": {"credits": 5},
+  "request_id": "abc-123-def"
+}
+```
+
+### Crawl with Path Filtering
+
+```python
+import httpx
+import os
+
+TAVILY_API_KEY = os.environ["TAVILY_API_KEY"]
+BASE_URL = "https://api.tavily.com"
+HEADERS = {
+    "Authorization": f"Bearer {TAVILY_API_KEY}",
+    "Content-Type": "application/json",
+}
+
+
+async def crawl_docs_only(url: str):
+    payload = {
+        "url": url,
+        "max_depth": 3,
+        "limit": 100,
+        "select_paths": ["/docs/.*", "/api/.*"],
+        "exclude_paths": ["/blog/.*", "/changelog/.*"],
+        "allow_external": False,
+        "format": "markdown",
+    }
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{BASE_URL}/crawl",
+            headers=HEADERS,
+            json=payload,
+            timeout=180.0,
+        )
+        resp.raise_for_status()
+        return resp.json()
+```
+
+## Error Handling
+
+Tavily returns standard HTTP status codes. On error, the response body contains a JSON object with error details.
+
+**Status codes:**
+
+| Code | Meaning | Action |
+|------|---------|--------|
+| 200 | Success | No action needed |
+| 400 | Bad Request | Fix parameters (e.g. too many URLs for extract) |
+| 401 | Unauthorized | Check API key is valid and included |
+| 403 | Forbidden | URL not supported for extraction |
+| 429 | Rate Limited | Wait `retry-after` seconds and retry |
+| 432 | Plan Limit Exceeded | Upgrade plan or wait for limit reset |
+| 433 | PayGo Limit Exceeded | Increase PayGo spending limit |
+| 500 | Server Error | Retry later |
+
+**Robust error handling with retry:**
+
+```python
+import httpx
+import asyncio
+import os
+
+TAVILY_API_KEY = os.environ["TAVILY_API_KEY"]
+BASE_URL = "https://api.tavily.com"
+HEADERS = {
+    "Authorization": f"Bearer {TAVILY_API_KEY}",
+    "Content-Type": "application/json",
+}
+
+
+async def search_with_retry(payload: dict, max_retries: int = 3):
+    async with httpx.AsyncClient() as client:
+        for attempt in range(max_retries):
+            resp = await client.post(
+                f"{BASE_URL}/search",
+                headers=HEADERS,
+                json=payload,
+                timeout=30.0,
+            )
+            if resp.status_code == 429:
+                retry_after = float(resp.headers.get("retry-after", 2))
+                await asyncio.sleep(retry_after)
+                continue
+            if resp.status_code >= 500:
+                await asyncio.sleep(2 ** attempt)
+                continue
+            resp.raise_for_status()
+            return resp.json()
+    raise RuntimeError("Max retries exceeded")
+```
+
+## Common Pitfalls
+
+1. **Extract URL limit is 20.** Sending more than 20 URLs to `/extract` in a single request returns a 400 error. Batch your requests if you have more.
+
+2. **Crawl timeout is long but finite.** The `/crawl` endpoint default timeout is 150 seconds. Large sites with high `limit` values may time out. Set an appropriate `timeout` parameter and httpx client timeout.
+
+3. **Credit costs vary by depth.** `"advanced"` search depth costs 2 credits instead of 1. Crawl with `instructions` costs 2 credits per 10 pages. Monitor usage with `include_usage: true`.
+
+4. **The `query` parameter on `/extract` enables reranking.** Without it, you get full raw content. With it, content is chunked and ranked by relevance to your query. Use it when you need targeted extraction.
+
+5. **Bearer prefix is required.** The Authorization header must be `Bearer tvly-...`, not just the raw key. Omitting the `Bearer` prefix returns 401.
+
+6. **`search_depth` values have different latency profiles.** `"ultra-fast"` and `"fast"` are significantly faster than `"basic"` and `"advanced"`. Choose based on your latency vs. relevance requirements.
+
+7. **`failed_results` in extract responses.** Always check the `failed_results` array. Some URLs may fail silently while others succeed. Your code should handle partial failures.
+
+8. **Crawl path filters use regex, not glob.** The `select_paths` and `exclude_paths` parameters take regex patterns (e.g. `/docs/.*`), not shell globs (e.g. `/docs/*`).
+
+9. **httpx default timeout is too short for crawl.** The httpx default timeout is 5 seconds. Always set an explicit `timeout=` on the client call, especially for `/crawl` (recommend 180+ seconds).
+
+10. **Development vs. Production keys.** Rate limits differ significantly between environments. Ensure you are using a production key if you need higher throughput (1,000 RPM vs. 100 RPM).

--- a/content/telegram/docs/rest-api/python/DOC.md
+++ b/content/telegram/docs/rest-api/python/DOC.md
@@ -1,0 +1,440 @@
+---
+name: rest-api
+description: "Telegram Bot API - Messaging Platform for AI Bots"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "telegram,bot,messaging,chat,webhook,api,integration"
+---
+
+# Telegram Bot API - Python Reference (httpx)
+
+## Golden Rule
+
+The bot token IS the authentication. It is embedded directly in the URL path, not sent as a header. Treat your bot token like a password -- never commit it to version control, never log full request URLs, and rotate it via @BotFather if compromised.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+All examples use `httpx` with async/await. For scripts that need a synchronous entrypoint:
+
+```python
+import asyncio
+import httpx
+
+async def main():
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{BASE_URL}/getMe")
+        print(resp.json())
+
+asyncio.run(main())
+```
+
+## Base URL
+
+```
+https://api.telegram.org/bot<token>/<method>
+```
+
+Replace `<token>` with your bot token (e.g., `123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11`).
+
+```python
+import os
+
+BOT_TOKEN = os.environ["TELEGRAM_BOT_TOKEN"]
+BASE_URL = f"https://api.telegram.org/bot{BOT_TOKEN}"
+```
+
+## Authentication
+
+Telegram Bot API uses **token-in-URL** authentication. There are no `Authorization` headers. The token is part of the URL path itself:
+
+```
+https://api.telegram.org/bot<token>/sendMessage
+```
+
+The API accepts both GET and POST requests. Parameters can be passed as:
+- URL query string
+- `application/x-www-form-urlencoded` body
+- `application/json` body (except for file uploads)
+- `multipart/form-data` body (required for file uploads)
+
+## Rate Limiting
+
+| Scope | Limit |
+|---|---|
+| Different chats (broadcast) | ~30 messages/second |
+| Same private chat | ~1 message/second (short bursts allowed) |
+| Same group chat | 20 messages/minute |
+| Paid broadcast (100k+ MAU) | Up to 1000 messages/second (0.1 Stars/msg over 30/s) |
+
+When you exceed limits, the API returns HTTP `429 Too Many Requests` with a `retry_after` field in the JSON body indicating how many seconds to wait.
+
+```python
+async def send_with_retry(client: httpx.AsyncClient, url: str, payload: dict, max_retries: int = 3):
+    for attempt in range(max_retries):
+        resp = await client.post(url, json=payload)
+        data = resp.json()
+        if data["ok"]:
+            return data["result"]
+        if resp.status_code == 429:
+            retry_after = data.get("parameters", {}).get("retry_after", 1)
+            await asyncio.sleep(retry_after)
+            continue
+        raise Exception(f"Telegram API error {data['error_code']}: {data['description']}")
+    raise Exception("Max retries exceeded")
+```
+
+## Methods
+
+### getMe
+
+Returns basic information about the bot. Use this to verify your token is valid.
+
+```python
+async def get_me(client: httpx.AsyncClient) -> dict:
+    resp = await client.get(f"{BASE_URL}/getMe")
+    data = resp.json()
+    assert data["ok"]
+    return data["result"]
+    # Returns: {"id": 123456, "is_bot": true, "first_name": "MyBot", "username": "my_bot"}
+```
+
+### sendMessage
+
+Send a text message to a chat.
+
+**Required parameters:**
+- `chat_id` (int | str) -- Target chat ID or @channelusername
+- `text` (str) -- Message text, 1-4096 characters
+
+**Optional parameters:**
+- `parse_mode` (str) -- `"HTML"`, `"Markdown"`, or `"MarkdownV2"`
+- `reply_to_message_id` (int) -- ID of the message to reply to
+- `reply_markup` (dict) -- Inline keyboard, custom reply keyboard, etc.
+
+```python
+async def send_message(client: httpx.AsyncClient, chat_id: int, text: str, parse_mode: str = None) -> dict:
+    payload = {"chat_id": chat_id, "text": text}
+    if parse_mode:
+        payload["parse_mode"] = parse_mode
+    resp = await client.post(f"{BASE_URL}/sendMessage", json=payload)
+    data = resp.json()
+    if not data["ok"]:
+        raise Exception(f"sendMessage failed: {data['description']}")
+    return data["result"]
+
+# Usage
+await send_message(client, chat_id=123456789, text="<b>Hello!</b>", parse_mode="HTML")
+```
+
+### getUpdates
+
+Receive incoming updates via long polling. Returns an array of `Update` objects.
+
+**Optional parameters:**
+- `offset` (int) -- Identifier of the first update to return. Use `last_update_id + 1` to acknowledge previous updates.
+- `limit` (int) -- Number of updates to retrieve, 1-100. Default: 100.
+- `timeout` (int) -- Timeout in seconds for long polling. Recommended: 30-60.
+- `allowed_updates` (list[str]) -- List of update types to receive (e.g., `["message", "callback_query"]`).
+
+```python
+async def poll_updates(client: httpx.AsyncClient, timeout: int = 30):
+    """Long-polling loop for receiving updates."""
+    offset = 0
+    while True:
+        params = {"offset": offset, "timeout": timeout, "allowed_updates": ["message", "callback_query"]}
+        resp = await client.get(f"{BASE_URL}/getUpdates", params=params, timeout=timeout + 10)
+        data = resp.json()
+        if not data["ok"]:
+            await asyncio.sleep(1)
+            continue
+        for update in data["result"]:
+            offset = update["update_id"] + 1
+            yield update
+
+# Usage
+async with httpx.AsyncClient() as client:
+    async for update in poll_updates(client):
+        if "message" in update:
+            chat_id = update["message"]["chat"]["id"]
+            text = update["message"].get("text", "")
+            await send_message(client, chat_id, f"Echo: {text}")
+```
+
+### setWebhook
+
+Set a webhook URL so Telegram pushes updates to your server instead of polling.
+
+**Required parameters:**
+- `url` (str) -- HTTPS URL to receive updates
+
+**Optional parameters:**
+- `certificate` (file) -- Public key certificate for self-signed certs
+- `max_connections` (int) -- Max simultaneous connections, 1-100. Default: 40.
+- `allowed_updates` (list[str]) -- Update types to receive
+- `secret_token` (str) -- Secret token for `X-Telegram-Bot-Api-Secret-Token` header validation, 1-256 chars
+- `drop_pending_updates` (bool) -- Drop all pending updates on webhook set
+
+```python
+async def set_webhook(client: httpx.AsyncClient, webhook_url: str, secret_token: str = None) -> bool:
+    payload = {"url": webhook_url}
+    if secret_token:
+        payload["secret_token"] = secret_token
+    resp = await client.post(f"{BASE_URL}/setWebhook", json=payload)
+    data = resp.json()
+    if not data["ok"]:
+        raise Exception(f"setWebhook failed: {data['description']}")
+    return data["result"]
+
+# Usage -- set webhook with secret for verification
+await set_webhook(client, "https://example.com/webhook/telegram", secret_token="my-secret-123")
+```
+
+**Webhook handler example (using a lightweight ASGI framework):**
+
+```python
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+WEBHOOK_SECRET = os.environ["TELEGRAM_WEBHOOK_SECRET"]
+
+async def webhook_handler(request: Request):
+    # Verify the secret token header
+    token = request.headers.get("X-Telegram-Bot-Api-Secret-Token")
+    if token != WEBHOOK_SECRET:
+        return JSONResponse({"error": "unauthorized"}, status_code=403)
+
+    update = await request.json()
+
+    # Process the update
+    if "message" in update:
+        chat_id = update["message"]["chat"]["id"]
+        text = update["message"].get("text", "")
+        async with httpx.AsyncClient() as client:
+            await send_message(client, chat_id, f"Webhook echo: {text}")
+
+    return JSONResponse({"ok": True})
+
+app = Starlette(routes=[Route("/webhook/telegram", webhook_handler, methods=["POST"])])
+```
+
+### sendPhoto
+
+Send a photo to a chat.
+
+**Required parameters:**
+- `chat_id` (int | str) -- Target chat
+- `photo` (str | file) -- Photo file_id, HTTP URL, or file upload
+
+```python
+async def send_photo_by_url(client: httpx.AsyncClient, chat_id: int, photo_url: str, caption: str = None) -> dict:
+    payload = {"chat_id": chat_id, "photo": photo_url}
+    if caption:
+        payload["caption"] = caption
+    resp = await client.post(f"{BASE_URL}/sendPhoto", json=payload)
+    return resp.json()["result"]
+
+async def send_photo_file(client: httpx.AsyncClient, chat_id: int, filepath: str, caption: str = None) -> dict:
+    """Upload a local file as photo."""
+    with open(filepath, "rb") as f:
+        files = {"photo": (os.path.basename(filepath), f, "image/jpeg")}
+        data = {"chat_id": str(chat_id)}
+        if caption:
+            data["caption"] = caption
+        resp = await client.post(f"{BASE_URL}/sendPhoto", data=data, files=files)
+    return resp.json()["result"]
+```
+
+### sendDocument
+
+Send a general file/document.
+
+**Required parameters:**
+- `chat_id` (int | str) -- Target chat
+- `document` (str | file) -- Document file_id, HTTP URL, or file upload
+
+```python
+async def send_document(client: httpx.AsyncClient, chat_id: int, filepath: str, caption: str = None) -> dict:
+    with open(filepath, "rb") as f:
+        files = {"document": (os.path.basename(filepath), f, "application/octet-stream")}
+        data = {"chat_id": str(chat_id)}
+        if caption:
+            data["caption"] = caption
+        resp = await client.post(f"{BASE_URL}/sendDocument", data=data, files=files)
+    data = resp.json()
+    if not data["ok"]:
+        raise Exception(f"sendDocument failed: {data['description']}")
+    return data["result"]
+```
+
+### answerCallbackQuery
+
+Respond to a callback query from an inline keyboard button press. Must be called to stop the loading indicator on the button.
+
+**Required parameters:**
+- `callback_query_id` (str) -- Unique ID from the callback query
+
+**Optional parameters:**
+- `text` (str) -- Notification text shown to the user (0-200 chars)
+- `show_alert` (bool) -- If true, show an alert dialog instead of a toast notification
+
+```python
+async def answer_callback(client: httpx.AsyncClient, callback_query_id: str, text: str = None, show_alert: bool = False) -> bool:
+    payload = {"callback_query_id": callback_query_id}
+    if text:
+        payload["text"] = text
+    if show_alert:
+        payload["show_alert"] = True
+    resp = await client.post(f"{BASE_URL}/answerCallbackQuery", json=payload)
+    return resp.json()["result"]
+
+# Typical usage inside an update handler:
+async def handle_callback(client, update):
+    cq = update["callback_query"]
+    await answer_callback(client, cq["id"], text="Button clicked!")
+    # Now edit the message or take further action
+    if cq.get("data") == "confirm":
+        await edit_message_text(client, cq["message"]["chat"]["id"], cq["message"]["message_id"], "Confirmed!")
+```
+
+### editMessageText
+
+Edit the text of a previously sent message.
+
+**Required parameters (bot-sent messages):**
+- `chat_id` (int | str) -- Target chat
+- `message_id` (int) -- ID of the message to edit
+- `text` (str) -- New message text
+
+**Required parameters (inline messages):**
+- `inline_message_id` (str) -- ID of the inline message
+- `text` (str) -- New message text
+
+```python
+async def edit_message_text(client: httpx.AsyncClient, chat_id: int, message_id: int, text: str, parse_mode: str = None, reply_markup: dict = None) -> dict:
+    payload = {"chat_id": chat_id, "message_id": message_id, "text": text}
+    if parse_mode:
+        payload["parse_mode"] = parse_mode
+    if reply_markup:
+        payload["reply_markup"] = reply_markup
+    resp = await client.post(f"{BASE_URL}/editMessageText", json=payload)
+    data = resp.json()
+    if not data["ok"]:
+        raise Exception(f"editMessageText failed: {data['description']}")
+    return data["result"]
+```
+
+## Error Handling
+
+All API responses are JSON with this structure:
+
+```json
+{
+    "ok": true,
+    "result": { ... }
+}
+```
+
+On failure:
+
+```json
+{
+    "ok": false,
+    "error_code": 400,
+    "description": "Bad Request: chat not found",
+    "parameters": {
+        "retry_after": 30
+    }
+}
+```
+
+The `parameters` field is optional and may contain:
+- `retry_after` (int) -- Seconds to wait before retrying (on 429 errors)
+- `migrate_to_chat_id` (int) -- New chat ID when a group is migrated to a supergroup
+
+**Common error codes:**
+
+| Code | Meaning |
+|---|---|
+| 400 | Bad Request -- invalid parameters, chat not found, message too long |
+| 401 | Unauthorized -- invalid or revoked bot token |
+| 403 | Forbidden -- bot was blocked by user, or lacks permissions in chat |
+| 404 | Not Found -- method does not exist |
+| 409 | Conflict -- webhook is already set (when using getUpdates) or another getUpdates instance is running |
+| 429 | Too Many Requests -- rate limited, check `retry_after` |
+
+**Robust error handling pattern:**
+
+```python
+import asyncio
+import httpx
+import logging
+
+logger = logging.getLogger(__name__)
+
+class TelegramAPIError(Exception):
+    def __init__(self, error_code: int, description: str, parameters: dict = None):
+        self.error_code = error_code
+        self.description = description
+        self.parameters = parameters or {}
+        super().__init__(f"[{error_code}] {description}")
+
+async def api_request(client: httpx.AsyncClient, method: str, payload: dict = None, max_retries: int = 3) -> dict:
+    url = f"{BASE_URL}/{method}"
+    for attempt in range(max_retries):
+        try:
+            resp = await client.post(url, json=payload or {})
+            data = resp.json()
+        except httpx.RequestError as e:
+            logger.warning(f"Network error on {method} (attempt {attempt+1}): {e}")
+            await asyncio.sleep(2 ** attempt)
+            continue
+
+        if data["ok"]:
+            return data["result"]
+
+        error_code = data.get("error_code", 0)
+        description = data.get("description", "Unknown error")
+        parameters = data.get("parameters", {})
+
+        if error_code == 429:
+            retry_after = parameters.get("retry_after", 1)
+            logger.warning(f"Rate limited on {method}, retrying in {retry_after}s")
+            await asyncio.sleep(retry_after)
+            continue
+
+        raise TelegramAPIError(error_code, description, parameters)
+
+    raise TelegramAPIError(429, f"Max retries exceeded for {method}")
+```
+
+## Common Pitfalls
+
+1. **Polling and webhooks conflict.** You cannot use `getUpdates` while a webhook is active. Call `deleteWebhook` first, or you will get a 409 error. Conversely, setting a webhook disables `getUpdates`.
+
+2. **Not acknowledging updates.** When using `getUpdates`, always set `offset` to `last_update_id + 1`. Otherwise Telegram re-delivers the same updates on every poll, and your bot processes duplicates forever.
+
+3. **Forgetting to answer callback queries.** If you handle an `InlineKeyboardButton` press but never call `answerCallbackQuery`, the user sees a perpetual loading spinner on the button.
+
+4. **Token in logs.** Since the token is in the URL, standard HTTP logging will leak it. Filter or redact URLs in your logging configuration.
+
+5. **httpx timeout vs. long polling timeout.** When using `getUpdates` with `timeout=30`, set your httpx client timeout higher (e.g., `timeout=40`) or the HTTP client will close the connection before Telegram responds.
+
+6. **File uploads require multipart.** You cannot send local files with `application/json`. Use `multipart/form-data` (the `files=` parameter in httpx) for uploading photos, documents, etc.
+
+7. **HTML parse_mode escaping.** When using `parse_mode="HTML"`, you must escape `<`, `>`, and `&` in user-supplied text as `&lt;`, `&gt;`, and `&amp;` or the API returns a 400 error.
+
+8. **Group chat message limit.** The 20 messages/minute limit per group is much stricter than private chats. Batch or queue messages when your bot serves active groups.
+
+9. **Chat migration.** When a group upgrades to a supergroup, the `chat_id` changes. Watch for error responses containing `migrate_to_chat_id` and update your stored IDs.
+
+10. **Webhook must be HTTPS.** Self-signed certificates work but must be uploaded via the `certificate` parameter in `setWebhook`. Plain HTTP URLs are rejected.

--- a/content/todoist/docs/rest-api/python/DOC.md
+++ b/content/todoist/docs/rest-api/python/DOC.md
@@ -1,0 +1,375 @@
+---
+name: rest-api
+description: "Todoist REST API v2 - Task and project management for personal productivity"
+metadata:
+  languages: "python"
+  versions: "v2"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "todoist,tasks,productivity,todo,adhd,organization,api"
+---
+
+# Todoist REST API v2 - Python Reference (httpx)
+
+## Golden Rule
+
+Use the **REST API v2** at `https://api.todoist.com/rest/v2`. Authentication is a Bearer token in the `Authorization` header. Rate limit is **1,000 requests per 15 minutes per user**. All responses are JSON. Task due dates use natural language or explicit date strings. Always use `X-Request-Id` header with a UUID for POST/PUT requests to enable idempotent retries.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+All examples use `httpx` with async/await. For scripts that need a synchronous entrypoint:
+
+```python
+import asyncio
+import httpx
+
+async def main():
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{BASE_URL}/tasks",
+            headers=HEADERS,
+        )
+        print(resp.json())
+
+asyncio.run(main())
+```
+
+## Base URL
+
+```
+https://api.todoist.com/rest/v2
+```
+
+```python
+import os
+
+API_TOKEN = os.environ["TODOIST_API_TOKEN"]
+BASE_URL = "https://api.todoist.com/rest/v2"
+HEADERS = {
+    "Authorization": f"Bearer {API_TOKEN}",
+    "Content-Type": "application/json",
+}
+```
+
+## Authentication
+
+Todoist uses **Bearer token** authentication:
+
+```
+Authorization: Bearer <API-TOKEN>
+```
+
+Obtain your personal API token from Todoist Settings > Integrations > Developer. For third-party apps, use the OAuth2 flow to get user tokens.
+
+## Rate Limiting
+
+| Limit | Value |
+|---|---|
+| Requests per user | 1,000 per 15 minutes |
+
+When exceeded, the API returns HTTP `429 Too Many Requests`.
+
+```python
+import asyncio
+import uuid
+
+async def todoist_request(
+    client: httpx.AsyncClient,
+    method: str,
+    path: str,
+    params: dict = None,
+    json_data: dict = None,
+    max_retries: int = 3,
+) -> httpx.Response:
+    headers = {**HEADERS}
+    if method.upper() in ("POST", "PUT", "PATCH"):
+        headers["X-Request-Id"] = str(uuid.uuid4())
+
+    for attempt in range(max_retries):
+        resp = await client.request(
+            method,
+            f"{BASE_URL}{path}",
+            headers=headers,
+            params=params,
+            json=json_data,
+        )
+        if resp.status_code == 429:
+            wait = min(2 ** attempt, 30)
+            await asyncio.sleep(wait)
+            continue
+        resp.raise_for_status()
+        return resp
+    raise Exception("Max retries exceeded due to rate limiting")
+```
+
+## Methods
+
+### Projects
+
+#### List All Projects
+
+```python
+async def list_projects(client: httpx.AsyncClient) -> list:
+    resp = await todoist_request(client, "GET", "/projects")
+    return resp.json()
+
+# Returns: [{"id": "123", "name": "Work", "color": "blue", "order": 1, ...}]
+```
+
+#### Create a Project
+
+```python
+async def create_project(
+    client: httpx.AsyncClient,
+    name: str,
+    color: str = None,
+    parent_id: str = None,
+    is_favorite: bool = False,
+) -> dict:
+    payload = {"name": name, "is_favorite": is_favorite}
+    if color:
+        payload["color"] = color
+    if parent_id:
+        payload["parent_id"] = parent_id
+    resp = await todoist_request(client, "POST", "/projects", json_data=payload)
+    return resp.json()
+```
+
+#### Get / Update / Delete a Project
+
+```python
+async def get_project(client: httpx.AsyncClient, project_id: str) -> dict:
+    resp = await todoist_request(client, "GET", f"/projects/{project_id}")
+    return resp.json()
+
+async def update_project(client: httpx.AsyncClient, project_id: str, **kwargs) -> dict:
+    resp = await todoist_request(client, "POST", f"/projects/{project_id}", json_data=kwargs)
+    return resp.json()
+
+async def delete_project(client: httpx.AsyncClient, project_id: str) -> None:
+    await todoist_request(client, "DELETE", f"/projects/{project_id}")
+```
+
+### Tasks
+
+#### List Active Tasks
+
+**Parameters:**
+- `project_id` (str) -- Filter by project
+- `section_id` (str) -- Filter by section
+- `label` (str) -- Filter by label name
+- `filter` (str) -- Todoist filter query (e.g., `"today"`, `"overdue"`, `"p1"`)
+- `ids` (str) -- Comma-separated task IDs
+
+```python
+async def list_tasks(
+    client: httpx.AsyncClient,
+    project_id: str = None,
+    section_id: str = None,
+    label: str = None,
+    filter_query: str = None,
+) -> list:
+    params = {}
+    if project_id:
+        params["project_id"] = project_id
+    if section_id:
+        params["section_id"] = section_id
+    if label:
+        params["label"] = label
+    if filter_query:
+        params["filter"] = filter_query
+    resp = await todoist_request(client, "GET", "/tasks", params=params)
+    return resp.json()
+
+# Usage -- get today's tasks
+today = await list_tasks(client, filter_query="today")
+for t in today:
+    print(f"[{'x' if t['is_completed'] else ' '}] {t['content']} (p{t['priority']})")
+```
+
+#### Create a Task
+
+```python
+async def create_task(
+    client: httpx.AsyncClient,
+    content: str,
+    project_id: str = None,
+    section_id: str = None,
+    description: str = "",
+    due_string: str = None,
+    due_date: str = None,
+    priority: int = 1,
+    labels: list[str] = None,
+    parent_id: str = None,
+) -> dict:
+    payload = {"content": content, "priority": priority}
+    if project_id:
+        payload["project_id"] = project_id
+    if section_id:
+        payload["section_id"] = section_id
+    if description:
+        payload["description"] = description
+    if due_string:
+        payload["due_string"] = due_string  # Natural language: "tomorrow at 3pm"
+    elif due_date:
+        payload["due_date"] = due_date  # ISO date: "2026-04-01"
+    if labels:
+        payload["labels"] = labels
+    if parent_id:
+        payload["parent_id"] = parent_id
+    resp = await todoist_request(client, "POST", "/tasks", json_data=payload)
+    return resp.json()
+
+# Usage
+task = await create_task(
+    client,
+    content="Review math homework",
+    due_string="tomorrow at 4pm",
+    priority=3,
+    labels=["school", "important"],
+)
+```
+
+#### Get / Update / Close / Reopen / Delete a Task
+
+```python
+async def get_task(client: httpx.AsyncClient, task_id: str) -> dict:
+    resp = await todoist_request(client, "GET", f"/tasks/{task_id}")
+    return resp.json()
+
+async def update_task(client: httpx.AsyncClient, task_id: str, **kwargs) -> dict:
+    resp = await todoist_request(client, "POST", f"/tasks/{task_id}", json_data=kwargs)
+    return resp.json()
+
+async def close_task(client: httpx.AsyncClient, task_id: str) -> None:
+    await todoist_request(client, "POST", f"/tasks/{task_id}/close")
+
+async def reopen_task(client: httpx.AsyncClient, task_id: str) -> None:
+    await todoist_request(client, "POST", f"/tasks/{task_id}/reopen")
+
+async def delete_task(client: httpx.AsyncClient, task_id: str) -> None:
+    await todoist_request(client, "DELETE", f"/tasks/{task_id}")
+```
+
+### Sections
+
+```python
+async def list_sections(client: httpx.AsyncClient, project_id: str) -> list:
+    resp = await todoist_request(client, "GET", "/sections", params={"project_id": project_id})
+    return resp.json()
+
+async def create_section(client: httpx.AsyncClient, project_id: str, name: str, order: int = None) -> dict:
+    payload = {"project_id": project_id, "name": name}
+    if order is not None:
+        payload["order"] = order
+    resp = await todoist_request(client, "POST", "/sections", json_data=payload)
+    return resp.json()
+```
+
+### Labels
+
+```python
+async def list_labels(client: httpx.AsyncClient) -> list:
+    resp = await todoist_request(client, "GET", "/labels")
+    return resp.json()
+
+async def create_label(client: httpx.AsyncClient, name: str, color: str = None) -> dict:
+    payload = {"name": name}
+    if color:
+        payload["color"] = color
+    resp = await todoist_request(client, "POST", "/labels", json_data=payload)
+    return resp.json()
+```
+
+### Comments
+
+```python
+async def list_comments(
+    client: httpx.AsyncClient,
+    task_id: str = None,
+    project_id: str = None,
+) -> list:
+    params = {}
+    if task_id:
+        params["task_id"] = task_id
+    if project_id:
+        params["project_id"] = project_id
+    resp = await todoist_request(client, "GET", "/comments", params=params)
+    return resp.json()
+
+async def create_comment(
+    client: httpx.AsyncClient,
+    content: str,
+    task_id: str = None,
+    project_id: str = None,
+) -> dict:
+    payload = {"content": content}
+    if task_id:
+        payload["task_id"] = task_id
+    elif project_id:
+        payload["project_id"] = project_id
+    resp = await todoist_request(client, "POST", "/comments", json_data=payload)
+    return resp.json()
+```
+
+## Error Handling
+
+| Code | Meaning |
+|---|---|
+| 200 | Success (GET, POST updates) |
+| 204 | Success (DELETE, close, reopen) |
+| 400 | Bad Request -- invalid parameters |
+| 401 | Unauthorized -- invalid token |
+| 403 | Forbidden -- insufficient permissions |
+| 404 | Not Found -- resource does not exist |
+| 429 | Too Many Requests -- rate limit exceeded |
+| 500 | Internal Server Error |
+
+```python
+class TodoistError(Exception):
+    def __init__(self, status_code: int, message: str):
+        self.status_code = status_code
+        self.message = message
+        super().__init__(f"[{status_code}] {message}")
+
+async def safe_todoist_request(
+    client: httpx.AsyncClient,
+    method: str,
+    path: str,
+    **kwargs,
+) -> dict | None:
+    try:
+        resp = await todoist_request(client, method, path, **kwargs)
+        if resp.status_code == 204:
+            return None
+        return resp.json()
+    except httpx.HTTPStatusError as e:
+        raise TodoistError(e.response.status_code, e.response.text) from e
+```
+
+## Common Pitfalls
+
+1. **Priority numbering is inverted.** Priority 1 is normal (lowest), priority 4 is urgent (highest). The UI shows `p1` as urgent, but the API value for urgent is `4`.
+
+2. **Use `X-Request-Id` for write operations.** POST and PUT requests should include a UUID in the `X-Request-Id` header. This makes retries safe -- Todoist deduplicates requests with the same ID.
+
+3. **`due_string` uses natural language.** Pass strings like `"every Monday"`, `"tomorrow at 3pm"`, `"in 2 hours"`. The API parses these using Todoist's date engine. Use `due_date` for explicit ISO dates.
+
+4. **IDs are strings, not integers.** All resource IDs in REST API v2 are returned as strings. Do not cast them to integers.
+
+5. **`filter` parameter uses Todoist filter syntax.** This is not a generic search. Use Todoist filter expressions like `"today | overdue"`, `"#Work & p1"`, `"assigned to: me"`.
+
+6. **Labels are referenced by name, not ID, in task creation.** The `labels` field on tasks takes an array of label name strings, not IDs.
+
+7. **Closing a task is not deleting.** `POST /tasks/{id}/close` marks it complete. `DELETE /tasks/{id}` permanently removes it. Closed tasks can be reopened; deleted tasks cannot.
+
+8. **No built-in pagination for tasks.** The REST API v2 returns all matching tasks in a single response. For very large task lists, use project or section filters to reduce response size.
+
+9. **Recurring tasks reset on close.** Closing a recurring task automatically creates the next occurrence. The task ID stays the same but the due date advances.
+
+10. **REST API v2 may be superseded.** Todoist has announced a unified API v1. Check the developer portal for migration guidance if building new integrations.

--- a/content/truelayer/docs/rest-api/python/DOC.md
+++ b/content/truelayer/docs/rest-api/python/DOC.md
@@ -1,0 +1,304 @@
+---
+name: rest-api
+description: "TrueLayer Open Banking REST API Coding Guidelines for Python using httpx async HTTP client"
+metadata:
+  languages: "python"
+  versions: "v3"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "truelayer,open-banking,psd2,uk,europe,payments,data,api"
+---
+
+# TrueLayer REST API Coding Guidelines (Python)
+
+You are a TrueLayer API coding expert. Help me with writing code using the TrueLayer Open Banking REST API with httpx async HTTP client.
+
+## Golden Rule: Use httpx Async for All API Calls
+
+Always use `httpx.AsyncClient` for all TrueLayer API interactions. Never use `requests` or synchronous HTTP clients.
+
+- **Library Name:** httpx
+- **PyPI Package:** `httpx`
+
+TrueLayer is an Open Banking API aggregator enabling access to bank accounts and payment initiation across UK and EU banks under PSD2 regulation. It provides two main APIs: the **Data API** (read account/transaction data) and the **Payments API v3** (initiate payments, payouts, refunds, and mandates).
+
+## Installation
+
+```bash
+pip install httpx python-dotenv
+```
+
+## Base URL
+
+| Environment | API Base URL | Auth Base URL |
+|-------------|-------------|---------------|
+| Production  | `https://api.truelayer.com` | `https://auth.truelayer.com` |
+| Sandbox     | `https://api.truelayer-sandbox.com` | `https://auth.truelayer-sandbox.com` |
+
+All Payments API v3 endpoints start with `/v3/`. Data API endpoints start with `/data/v1/`.
+
+## Authentication
+
+TrueLayer uses OAuth 2.0. You obtain an access token via client credentials (for Payments API) or authorization code (for Data API user consent).
+
+```python
+import os
+import httpx
+from dotenv import load_dotenv
+
+load_dotenv()
+
+TRUELAYER_CLIENT_ID = os.environ["TRUELAYER_CLIENT_ID"]
+TRUELAYER_CLIENT_SECRET = os.environ["TRUELAYER_CLIENT_SECRET"]
+TRUELAYER_AUTH_URL = os.environ.get("TRUELAYER_AUTH_URL", "https://auth.truelayer-sandbox.com")
+TRUELAYER_API_URL = os.environ.get("TRUELAYER_API_URL", "https://api.truelayer-sandbox.com")
+```
+
+### Client Credentials Token (Payments API)
+
+```python
+async def get_client_token() -> str:
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{TRUELAYER_AUTH_URL}/connect/token",
+            data={
+                "grant_type": "client_credentials",
+                "client_id": TRUELAYER_CLIENT_ID,
+                "client_secret": TRUELAYER_CLIENT_SECRET,
+                "scope": "payments",
+            },
+        )
+        response.raise_for_status()
+        return response.json()["access_token"]
+```
+
+### Authorization Code Exchange (Data API)
+
+```python
+async def exchange_auth_code(auth_code: str, redirect_uri: str) -> dict:
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{TRUELAYER_AUTH_URL}/connect/token",
+            data={
+                "grant_type": "authorization_code",
+                "client_id": TRUELAYER_CLIENT_ID,
+                "client_secret": TRUELAYER_CLIENT_SECRET,
+                "redirect_uri": redirect_uri,
+                "code": auth_code,
+            },
+        )
+        response.raise_for_status()
+        return response.json()
+```
+
+### Helper Headers
+
+```python
+def get_headers(access_token: str) -> dict:
+    return {
+        "Authorization": f"Bearer {access_token}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+```
+
+## Rate Limiting
+
+TrueLayer monitors API call volume. HTTP 429 responses include rate limit details:
+
+```python
+import asyncio
+
+async def request_with_retry(
+    client: httpx.AsyncClient, method: str, url: str, max_retries: int = 3, **kwargs,
+) -> httpx.Response:
+    for attempt in range(max_retries):
+        response = await client.request(method, url, **kwargs)
+        if response.status_code == 429:
+            retry_after = int(response.headers.get("Retry-After", 2 ** (attempt + 1)))
+            await asyncio.sleep(retry_after)
+            continue
+        response.raise_for_status()
+        return response
+    raise httpx.HTTPStatusError("Rate limit exceeded after retries", request=response.request, response=response)
+```
+
+## Methods
+
+### Data API -- Account Information
+
+#### List Accounts
+
+```python
+async def list_accounts(access_token: str) -> list[dict]:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{TRUELAYER_API_URL}/data/v1/accounts",
+            headers=get_headers(access_token),
+        )
+        response.raise_for_status()
+        return response.json()["results"]
+```
+
+#### Get Account Balance
+
+```python
+async def get_account_balance(access_token: str, account_id: str) -> list[dict]:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{TRUELAYER_API_URL}/data/v1/accounts/{account_id}/balance",
+            headers=get_headers(access_token),
+        )
+        response.raise_for_status()
+        return response.json()["results"]
+```
+
+#### List Account Transactions
+
+```python
+async def list_account_transactions(
+    access_token: str, account_id: str,
+    from_date: str | None = None, to_date: str | None = None,
+) -> list[dict]:
+    """from_date/to_date: ISO 8601 (e.g. '2025-01-01T00:00:00Z')."""
+    params = {}
+    if from_date:
+        params["from"] = from_date
+    if to_date:
+        params["to"] = to_date
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{TRUELAYER_API_URL}/data/v1/accounts/{account_id}/transactions",
+            headers=get_headers(access_token),
+            params=params,
+        )
+        response.raise_for_status()
+        return response.json()["results"]
+```
+
+Additional Data API endpoints follow the same pattern: `/data/v1/cards`, `/data/v1/accounts/{id}/direct-debits`, `/data/v1/accounts/{id}/standing-orders`, `/data/v1/providers`.
+
+### Payments API v3
+
+#### Create Payment
+
+```python
+async def create_payment(
+    access_token: str, amount_minor_units: int, currency: str,
+    merchant_account_id: str, beneficiary_name: str,
+    beneficiary_sort_code: str | None = None,
+    beneficiary_account_number: str | None = None,
+    beneficiary_iban: str | None = None,
+    reference: str = "Payment",
+) -> dict:
+    """Create a payment. Provide sort_code+account_number (UK) or iban (EU)."""
+    beneficiary = {"type": "external_account", "account_holder_name": beneficiary_name, "reference": reference}
+    if beneficiary_iban:
+        beneficiary["account_identifier"] = {"type": "iban", "iban": beneficiary_iban}
+    else:
+        beneficiary["account_identifier"] = {
+            "type": "sort_code_account_number",
+            "sort_code": beneficiary_sort_code,
+            "account_number": beneficiary_account_number,
+        }
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{TRUELAYER_API_URL}/v3/payments",
+            headers=get_headers(access_token),
+            json={
+                "amount_in_minor": amount_minor_units,
+                "currency": currency,
+                "payment_method": {
+                    "type": "bank_transfer",
+                    "provider_selection": {"type": "user_selected"},
+                    "beneficiary": beneficiary,
+                },
+            },
+        )
+        response.raise_for_status()
+        return response.json()
+```
+
+#### Get Payment Status
+
+```python
+async def get_payment(access_token: str, payment_id: str) -> dict:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{TRUELAYER_API_URL}/v3/payments/{payment_id}",
+            headers=get_headers(access_token),
+        )
+        response.raise_for_status()
+        return response.json()
+```
+
+#### Start Authorization Flow
+
+```python
+async def start_auth_flow(access_token: str, payment_id: str, redirect_uri: str) -> dict:
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{TRUELAYER_API_URL}/v3/payments/{payment_id}/authorization-flow",
+            headers=get_headers(access_token),
+            json={"provider_selection": {}, "redirect": {"return_uri": redirect_uri}},
+        )
+        response.raise_for_status()
+        return response.json()
+```
+
+Additional Payments API v3 endpoints: `POST /v3/payments/{id}/cancel`, `POST /v3/payments/{id}/refunds`, `POST /v3/payouts`, `GET /v3/payouts/{id}`, `POST /v3/mandates`, `GET /v3/mandates/{id}`.
+
+## Error Handling
+
+TrueLayer Payments API v3 errors follow the IETF Problem Details standard. Each error includes a `trace_id` for support requests. Data API errors use `{"error": "...", "error_description": "..."}`.
+
+```python
+async def safe_truelayer_request(method: str, path: str, access_token: str, **kwargs) -> dict | None:
+    async with httpx.AsyncClient(base_url=TRUELAYER_API_URL) as client:
+        try:
+            response = await client.request(method, path, headers=get_headers(access_token), **kwargs)
+            response.raise_for_status()
+            return response.json() if response.content else None
+        except httpx.HTTPStatusError as e:
+            status = e.response.status_code
+            try:
+                error_body = e.response.json()
+            except Exception:
+                error_body = {"detail": e.response.text}
+            trace_id = error_body.get("trace_id", "unknown")
+            if status == 400:
+                raise ValueError(f"Bad request (trace: {trace_id}): {error_body}")
+            elif status == 401:
+                raise PermissionError(f"Unauthorized (trace: {trace_id}). Refresh token.")
+            elif status == 403:
+                raise PermissionError(f"Forbidden (trace: {trace_id}): {error_body}")
+            elif status == 404:
+                raise LookupError(f"Not found (trace: {trace_id}): {path}")
+            elif status == 429:
+                raise RuntimeError(f"Rate limited (trace: {trace_id}). Implement backoff.")
+            elif status >= 500:
+                raise ConnectionError(f"Server error {status} (trace: {trace_id}): {error_body}")
+            raise
+        except httpx.RequestError as e:
+            raise ConnectionError(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+1. **Two Separate APIs:** Data API (`/data/v1/`) uses authorization code tokens (user consent). Payments API (`/v3/`) uses client credentials tokens. Do not mix them.
+2. **Amounts in Minor Units:** All Payments API amounts are in minor units (`amount_in_minor`). 1000 = 10.00 GBP/EUR.
+3. **Sandbox vs Production URLs:** Both API and Auth URLs change between environments. Use `truelayer-sandbox.com` for testing, `truelayer.com` for production.
+4. **Auth Token for Data:** Use `data={...}` (form-encoded) for `/connect/token`, but `json={...}` for all other API calls.
+5. **trace_id:** Always log the `trace_id` from error responses -- TrueLayer support requires it for debugging.
+6. **Token Expiry:** Data API access tokens expire. Use refresh tokens to maintain access without requiring the user to re-authorize.
+7. **Response Wrapping:** Data API responses wrap results in `{"results": [...]}`. Payments API responses return the object directly.
+8. **Webhook Verification:** Verify webhook signatures using your webhook secret for payment status changes.
+
+## Useful Links
+
+- **API Reference:** https://docs.truelayer.com/
+- **Payments API v3:** https://docs.truelayer.com/reference/create-payment
+- **Data API:** https://docs.truelayer.com/docs/data-api-basics
+- **Console (Dashboard):** https://console.truelayer.com/
+- **Sandbox Testing:** https://docs.truelayer.com/docs/test-payments-in-sandbox

--- a/content/upstash/docs/rest-api/python/DOC.md
+++ b/content/upstash/docs/rest-api/python/DOC.md
@@ -1,0 +1,278 @@
+---
+name: rest-api
+description: "Upstash - Serverless Redis, Vector DB & QStash REST API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "upstash,redis,vector,qstash,serverless,edge,cache,message-queue,api"
+---
+
+# Upstash REST API Reference (Python / httpx)
+
+Upstash provides three HTTP-native serverless products: **Redis** (key-value cache/store),
+**Vector** (vector database for AI/embeddings), and **QStash** (message queue & scheduler).
+All three are accessed entirely over HTTPS REST APIs -- no persistent connections, no TCP sockets,
+no VPC peering required. Ideal for serverless, edge, and Lambda environments.
+
+## Golden Rule
+
+> Every Upstash operation is a plain HTTPS request with a Bearer token.
+> There is no proprietary binary protocol. If your runtime can make an HTTP call, it can talk to Upstash.
+
+Never hard-code tokens in source. Always load them from environment variables or a secrets manager.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+```python
+import httpx, os
+
+client = httpx.AsyncClient(timeout=10.0)
+```
+
+## Base URLs
+
+Each product has its own base URL format, found in the [Upstash Console](https://console.upstash.com).
+
+| Product | Base URL Pattern |
+|---------|-----------------|
+| **Redis** | `https://<region>-<name>-<id>.upstash.io` (instance-specific) |
+| **Vector** | `https://<name>-<id>.upstash.io` (instance-specific) |
+| **QStash** | `https://qstash.upstash.io` (fixed, global) |
+
+```python
+REDIS_URL   = os.environ["UPSTASH_REDIS_REST_URL"]
+REDIS_TOKEN = os.environ["UPSTASH_REDIS_REST_TOKEN"]
+VECTOR_URL   = os.environ["UPSTASH_VECTOR_REST_URL"]
+VECTOR_TOKEN = os.environ["UPSTASH_VECTOR_REST_TOKEN"]
+QSTASH_URL   = "https://qstash.upstash.io"
+QSTASH_TOKEN = os.environ["QSTASH_TOKEN"]
+```
+
+## Authentication
+
+All three products use a **Bearer token** in the `Authorization` header.
+
+```python
+def redis_headers():
+    return {"Authorization": f"Bearer {REDIS_TOKEN}"}
+def vector_headers():
+    return {"Authorization": f"Bearer {VECTOR_TOKEN}"}
+def qstash_headers():
+    return {"Authorization": f"Bearer {QSTASH_TOKEN}"}
+```
+
+Redis also provides a read-only token restricted to GET, MGET, LRANGE, etc.
+
+## Rate Limiting
+
+Upstash uses **pay-per-request** pricing rather than traditional rate limits.
+
+| Product | Free Tier | Throttling Behavior |
+|---------|-----------|---------------------|
+| **Redis** | 10,000 commands/day | Exceeding limits blocks writes or all traffic |
+| **Vector** | 10,000 queries/day | Similar throttling on plan limits |
+| **QStash** | 500 messages/day | Messages rejected with 429 |
+
+No per-second rate limits on paid plans. Enable **auto-upgrade** to avoid hard throttling.
+
+## Methods
+
+### Redis Commands over HTTP
+
+Redis commands are sent as **URL path segments** or as a **JSON array in a POST body**.
+
+#### Path-Segment Style (simple commands)
+
+```python
+async def redis_set(key: str, value: str, ex: int | None = None) -> dict:
+    path = f"/set/{key}/{value}"
+    if ex is not None:
+        path += f"/EX/{ex}"
+    resp = await client.get(f"{REDIS_URL}{path}", headers=redis_headers())
+    resp.raise_for_status()
+    return resp.json()
+
+async def redis_get(key: str) -> dict:
+    resp = await client.get(f"{REDIS_URL}/get/{key}", headers=redis_headers())
+    resp.raise_for_status()
+    return resp.json()
+```
+
+#### POST Body Style (complex commands)
+
+Required for values containing special characters, spaces, or binary data.
+
+```python
+async def redis_post(command: list) -> dict:
+    resp = await client.post(REDIS_URL, headers=redis_headers(), json=command)
+    resp.raise_for_status()
+    return resp.json()
+
+# Examples:
+# await redis_post(["SET", "greeting", "hello world", "EX", 3600])
+# await redis_post(["HSET", "user:1", "name", "Alice", "age", "30"])
+# await redis_post(["LPUSH", "queue", "item1", "item2"])
+```
+
+#### Pipelining (batch non-atomic)
+
+```python
+async def redis_pipeline(commands: list[list]) -> list[dict]:
+    resp = await client.post(f"{REDIS_URL}/pipeline", headers=redis_headers(), json=commands)
+    resp.raise_for_status()
+    return resp.json()
+```
+
+For atomic execution, use `/multi-exec` instead of `/pipeline`.
+
+Redis REST responses return `{"result": "<value>"}` on success, `{"error": "..."}` on error.
+For binary safety, add header `"Upstash-Encoding": "base64"`.
+
+### Vector Operations
+
+The Vector API uses POST/DELETE with JSON bodies. All endpoints optionally accept a `/{namespace}` suffix.
+
+#### Upsert Vectors
+
+```python
+async def vector_upsert(vectors: list[dict], namespace: str = "") -> dict:
+    """Each vector: {"id": str, "vector": list[float], "metadata": dict (opt), "data": str (opt)}"""
+    path = f"/upsert/{namespace}" if namespace else "/upsert"
+    resp = await client.post(f"{VECTOR_URL}{path}", headers=vector_headers(), json=vectors)
+    resp.raise_for_status()
+    return resp.json()
+```
+
+#### Query Vectors
+
+```python
+async def vector_query(
+    vector: list[float], top_k: int = 10, filter: str = "",
+    include_metadata: bool = True, include_vectors: bool = False, namespace: str = "",
+) -> dict:
+    path = f"/query/{namespace}" if namespace else "/query"
+    body = {"vector": vector, "topK": top_k, "includeMetadata": include_metadata, "includeVectors": include_vectors}
+    if filter:
+        body["filter"] = filter
+    resp = await client.post(f"{VECTOR_URL}{path}", headers=vector_headers(), json=body)
+    resp.raise_for_status()
+    return resp.json()
+```
+
+Additional Vector endpoints: `POST /fetch` (fetch by IDs), `DELETE /delete` (delete by IDs or filter).
+
+### QStash Publishing & Scheduling
+
+QStash base URL is always `https://qstash.upstash.io`. API version prefix: `/v2`.
+
+#### Publish a Message
+
+```python
+async def qstash_publish(
+    destination_url: str, body: dict | str, *,
+    retries: int = 3, delay: str | None = None,
+    callback_url: str | None = None, method: str = "POST",
+    forward_headers: dict | None = None,
+) -> dict:
+    headers = {**qstash_headers(), "Content-Type": "application/json", "Upstash-Method": method, "Upstash-Retries": str(retries)}
+    if delay: headers["Upstash-Delay"] = delay
+    if callback_url: headers["Upstash-Callback"] = callback_url
+    if forward_headers:
+        for key, val in forward_headers.items():
+            headers[f"Upstash-Forward-{key}"] = val
+    resp = await client.post(
+        f"{QSTASH_URL}/v2/publish/{destination_url}", headers=headers,
+        json=body if isinstance(body, dict) else None,
+        content=body if isinstance(body, str) else None,
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+#### Create a Schedule (recurring)
+
+```python
+async def qstash_create_schedule(
+    destination_url: str, cron: str, body: dict | str | None = None, *,
+    retries: int = 3, method: str = "POST",
+) -> dict:
+    """Cron evaluated in UTC by default. Use "CRON_TZ=America/New_York 0 9 * * *" for other timezones."""
+    headers = {**qstash_headers(), "Content-Type": "application/json",
+               "Upstash-Cron": cron, "Upstash-Method": method, "Upstash-Retries": str(retries)}
+    resp = await client.post(
+        f"{QSTASH_URL}/v2/schedules/{destination_url}", headers=headers,
+        json=body if isinstance(body, dict) else None,
+        content=body if isinstance(body, str) else None,
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+#### QStash Custom Headers Reference
+
+| Header | Description |
+|--------|-------------|
+| `Upstash-Method` | HTTP method for the destination |
+| `Upstash-Retries` | Retry attempts (default 3) |
+| `Upstash-Delay` | Delay before first delivery (max 90 days) |
+| `Upstash-Timeout` | Destination request timeout |
+| `Upstash-Callback` / `Upstash-Failure-Callback` | URLs called on success/failure |
+| `Upstash-Deduplication-Id` | Deduplicate identical messages |
+| `Upstash-Cron` | Cron expression (schedules endpoint only) |
+| `Upstash-Forward-*` | Headers forwarded to the destination |
+
+## Error Handling
+
+All three products return errors as JSON. HTTP status codes are consistent:
+
+| Status | Meaning | Action |
+|--------|---------|--------|
+| **200** | Success | Parse `result` from JSON body |
+| **400** | Bad request | Fix the request syntax |
+| **401** | Invalid or missing token | Check `Authorization` header |
+| **422** | Unprocessable entity (Vector) | Check vector dimensions match index |
+| **429** | Rate limited / quota exceeded | Back off and retry |
+| **500** | Server error | Retry with exponential backoff |
+
+```python
+class UpstashError(Exception):
+    def __init__(self, status: int, message: str):
+        self.status, self.message = status, message
+        super().__init__(f"Upstash [{status}]: {message}")
+
+async def checked_request(method: str, url: str, **kwargs) -> dict:
+    import asyncio
+    for attempt in range(3):
+        try:
+            resp = await client.request(method, url, **kwargs)
+            if resp.status_code == 429:
+                await asyncio.sleep(2 ** attempt)
+                continue
+            data = resp.json()
+            if "error" in data:
+                raise UpstashError(resp.status_code, data["error"])
+            resp.raise_for_status()
+            return data
+        except httpx.TimeoutException:
+            if attempt == 2: raise
+    raise UpstashError(429, "Rate limited after max retries")
+```
+
+## Common Pitfalls
+
+1. **URL-encoding in path segments** -- If Redis key/value contains `/`, `?`, `#`, or spaces, use the POST body style instead.
+2. **Forgetting the Bearer prefix** -- Token must be `"Bearer <token>"`, not just `"<token>"`. Omitting "Bearer" results in a silent 401.
+3. **Mixing up base URLs** -- Redis and Vector URLs are instance-specific. QStash is always `https://qstash.upstash.io`.
+4. **Vector dimension mismatch** -- Upserting a vector with wrong dimensions returns 422. Match your embedding model's output.
+5. **QStash cron timezone** -- Defaults to UTC. Prepend `CRON_TZ=America/New_York` for local time.
+6. **QStash message size limit** -- Bodies limited to 1 MB. Store larger payloads elsewhere and send a reference URL.
+7. **Not reusing httpx client** -- Creating a new `httpx.AsyncClient()` per request wastes connections. Instantiate once and reuse.
+8. **Redis pipeline is non-atomic** -- `/pipeline` executes in order but not transactionally. Use `/multi-exec` for atomicity.
+9. **Read-only tokens on write commands** -- Using a read-only token for SET/DEL silently fails. Use the standard token for writes.

--- a/content/val-town/docs/rest-api/python/DOC.md
+++ b/content/val-town/docs/rest-api/python/DOC.md
@@ -1,0 +1,272 @@
+---
+name: rest-api
+description: "Val Town Serverless Functions, SQLite & Blob Storage API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-13"
+  source: community
+  tags: "valtown,serverless,functions,sqlite,blob,email,api,integration"
+---
+
+# Val Town API
+
+> **Golden Rule:** Val Town has a TypeScript SDK but no official Python SDK. Use `httpx` (async) or `requests` (sync) for direct REST API access. Val Town provides serverless functions, SQLite, blob storage, and email sending -- all via simple REST endpoints.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+`https://api.val.town`
+
+## Authentication
+
+**Type:** Bearer Token
+
+```python
+import httpx
+
+VALTOWN_TOKEN = "your-val-town-api-token"  # Create at val.town/settings/api
+BASE_URL = "https://api.val.town"
+
+headers = {"Authorization": f"Bearer {VALTOWN_TOKEN}"}
+client = httpx.AsyncClient(headers=headers)
+```
+
+Tokens support configurable scopes: `val` (read/write), `user` (read/write), `blob` (read/write), `sqlite` (read/write), `email` (read/write). Default excludes `val:write` and `user:write` for safety.
+
+## Rate Limiting
+
+- Email sending: 100/minute
+- Blob storage: Free = 10MB, Pro = 1GB
+- Private vals: Free = 5, Pro = unlimited
+- Max files per val: 1,000
+
+## Methods
+
+### `list_vals`
+
+**Endpoint:** `GET /v2/vals`
+
+List vals (serverless functions).
+
+**Returns:** JSON with array of val objects
+
+```python
+response = await client.get(f"{BASE_URL}/v2/vals")
+response.raise_for_status()
+data = response.json()
+vals = data.get("data", [])
+```
+
+### `create_val`
+
+**Endpoint:** `POST /v2/vals`
+
+Create a new serverless function.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `name` | `str` | **required** |
+| `type` | `str` | `"script"` (also: `"http"`, `"email"`, `"cron"`) |
+
+**Returns:** JSON with created val details
+
+```python
+payload = {
+    "name": "myFunction",
+    "type": "http"
+}
+response = await client.post(f"{BASE_URL}/v2/vals", json=payload)
+response.raise_for_status()
+val = response.json()
+```
+
+### `get_val`
+
+**Endpoint:** `GET /v2/vals/{valId}`
+
+Get val details.
+
+```python
+val_id = "abc123"
+response = await client.get(f"{BASE_URL}/v2/vals/{val_id}")
+response.raise_for_status()
+val = response.json()
+```
+
+### `get_val_by_name`
+
+**Endpoint:** `GET /v2/alias/vals/{username}/{valName}`
+
+Look up a val by username and name.
+
+```python
+response = await client.get(f"{BASE_URL}/v2/alias/vals/myuser/myFunction")
+response.raise_for_status()
+val = response.json()
+```
+
+### `get_me`
+
+**Endpoint:** `GET /v1/me`
+
+Get the authenticated user's profile.
+
+```python
+response = await client.get(f"{BASE_URL}/v1/me")
+response.raise_for_status()
+user = response.json()
+```
+
+### `execute_sql`
+
+**Endpoint:** `POST /v1/sqlite/execute`
+
+Execute a SQL statement against your Val Town SQLite database.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `statement` | `str` | **required** |
+| `args` | `list` or `dict` | `[]` |
+
+**Returns:** JSON with `columns`, `columnTypes`, `rows`, `rowsAffected`, `lastInsertRowid`
+
+```python
+payload = {
+    "statement": "SELECT * FROM users WHERE age > ?",
+    "args": [21]
+}
+response = await client.post(f"{BASE_URL}/v1/sqlite/execute", json=payload)
+response.raise_for_status()
+data = response.json()
+rows = data.get("rows", [])
+columns = data.get("columns", [])
+```
+
+```python
+# Create a table
+payload = {
+    "statement": "CREATE TABLE IF NOT EXISTS notes (id INTEGER PRIMARY KEY, content TEXT, created_at TEXT)"
+}
+response = await client.post(f"{BASE_URL}/v1/sqlite/execute", json=payload)
+response.raise_for_status()
+```
+
+### `send_email`
+
+**Endpoint:** `POST /v1/email`
+
+Send an email. Free tier can only email yourself; Pro can email anyone.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `to` | `str` | **required** |
+| `subject` | `str` | **required** |
+| `text` | `str` | `None` |
+| `from` | `str` | `None` |
+| `replyTo` | `str` | `None` |
+| `cc` | `str` | `None` |
+| `bcc` | `str` | `None` |
+
+**Returns:** JSON confirmation
+
+```python
+payload = {
+    "to": "user@example.com",
+    "subject": "Hello from Val Town",
+    "text": "This email was sent via the Val Town API."
+}
+response = await client.post(f"{BASE_URL}/v1/email", json=payload)
+response.raise_for_status()
+```
+
+### `store_blob`
+
+**Endpoint:** `POST /v1/blob/{key}`
+
+Store a blob (binary data, JSON, text).
+
+```python
+key = "my-data"
+data = {"results": [1, 2, 3]}
+response = await client.post(
+    f"{BASE_URL}/v1/blob/{key}",
+    json=data
+)
+response.raise_for_status()
+```
+
+### `get_blob`
+
+**Endpoint:** `GET /v1/blob/{key}`
+
+Retrieve a stored blob.
+
+```python
+response = await client.get(f"{BASE_URL}/v1/blob/{key}")
+response.raise_for_status()
+data = response.json()  # or response.content for binary
+```
+
+### `list_blobs`
+
+**Endpoint:** `GET /v1/blob`
+
+List all blob keys.
+
+```python
+response = await client.get(f"{BASE_URL}/v1/blob")
+response.raise_for_status()
+keys = response.json()
+```
+
+### `delete_blob`
+
+**Endpoint:** `DELETE /v1/blob/{key}`
+
+Delete a stored blob.
+
+```python
+response = await client.delete(f"{BASE_URL}/v1/blob/{key}")
+response.raise_for_status()
+```
+
+## Error Handling
+
+```python
+import httpx
+
+try:
+    response = await client.post(f"{BASE_URL}/v1/sqlite/execute", json=payload)
+    response.raise_for_status()
+    data = response.json()
+except httpx.HTTPStatusError as e:
+    if e.response.status_code == 401:
+        print("Authentication failed -- check your API token")
+    elif e.response.status_code == 429:
+        print("Rate limited -- reduce request frequency")
+    elif e.response.status_code == 403:
+        print("Forbidden -- check token scopes")
+    else:
+        print(f"Val Town API error {e.response.status_code}: {e.response.text}")
+except httpx.RequestError as e:
+    print(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+- Val Town has two API versions: use `/v2/` for vals, `/v1/` for SQLite, email, and blobs
+- Token scopes matter -- default tokens exclude `val:write` and `user:write` for safety
+- Free tier email sending is restricted to your own email address only
+- Blob keys have a max length of 512 characters
+- SQLite `args` can be a positional array `[1, "two"]` or named object `{"id": 1}`
+- Email sending is rate-limited to 100/minute
+- Free tier blob storage is capped at 10MB total
+- Always call `response.raise_for_status()` to catch HTTP errors
+- Set a reasonable timeout: `httpx.AsyncClient(timeout=30.0)`

--- a/content/whatsapp-cloud/docs/rest-api/python/DOC.md
+++ b/content/whatsapp-cloud/docs/rest-api/python/DOC.md
@@ -1,0 +1,353 @@
+---
+name: rest-api
+description: "WhatsApp Cloud API - Business Messaging Platform (Meta)"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "whatsapp,meta,messaging,business,cloud-api,webhook,api,integration"
+---
+
+# WhatsApp Cloud API
+
+The WhatsApp Cloud API, hosted by Meta, allows businesses to send and receive messages through WhatsApp programmatically. It supports text, template, media, interactive, location, and contact messages. Webhook notifications deliver inbound messages and status updates in real time.
+
+## Golden Rule
+
+Always use async `httpx` for all HTTP calls. Never use the `facebook-sdk`, `requests`, or any third-party WhatsApp SDK. Message bodies are JSON (`json=`), media uploads are multipart form-data (`files=`). All endpoints require a valid System User Access Token in the `Authorization: Bearer` header. Template messages are the only way to initiate conversations outside the 24-hour customer service window.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+```
+https://graph.facebook.com/v21.0
+```
+
+All endpoints are relative to this base. Replace `v21.0` with the latest Graph API version as needed. Responses are JSON.
+
+## Authentication
+
+All requests require a **System User Access Token** (long-lived, generated in Meta Business Suite) or a temporary access token from the App Dashboard.
+
+```python
+import httpx
+
+ACCESS_TOKEN = "your_system_user_access_token"
+PHONE_NUMBER_ID = "your_whatsapp_business_phone_number_id"
+
+HEADERS = {
+    "Authorization": f"Bearer {ACCESS_TOKEN}",
+    "Content-Type": "application/json",
+}
+
+BASE_URL = "https://graph.facebook.com/v21.0"
+```
+
+### Token Types
+
+| Token | Lifetime | Use Case |
+|---|---|---|
+| Temporary token | 24 hours | Testing from App Dashboard |
+| System User Access Token | Does not expire | Production (recommended) |
+
+Generate a System User Access Token in **Meta Business Suite > Business Settings > System Users**. Required permissions: `whatsapp_business_messaging`, `whatsapp_business_management`.
+
+## Rate Limiting
+
+| Tier | Default | Upgraded |
+|---|---|---|
+| Messages per second (MPS) | 80 MPS per phone number | Up to 1,000 MPS |
+
+Messaging limits determine how many unique users you can message in a rolling 24-hour window (business portfolio level):
+
+| Tier | Unique Users / 24 Hours |
+|---|---|
+| Tier 1 (new) | 1,000 |
+| Tier 2 | 10,000 |
+| Tier 3 | 100,000 |
+| Tier 4 | Unlimited |
+
+Key rate limits: media upload 25 req/s per phone number, general Graph API 200 calls/hour per user token. When rate-limited, the API returns HTTP `429` or error code `4`/`80007`.
+
+## Methods
+
+### Send Text Message
+
+Send a plain text message to a WhatsApp user. The user must have messaged you first (within 24-hour window) or you must use a template.
+
+```python
+async def send_text_message(
+    client: httpx.AsyncClient, to: str, body: str, preview_url: bool = False,
+) -> dict:
+    resp = await client.post(
+        f"{BASE_URL}/{PHONE_NUMBER_ID}/messages",
+        headers=HEADERS,
+        json={
+            "messaging_product": "whatsapp",
+            "recipient_type": "individual",
+            "to": to,
+            "type": "text",
+            "text": {"preview_url": preview_url, "body": body},
+        },
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+**Parameters:** `to` -- recipient phone in international format (no `+` prefix, e.g., `919876543210`). `messaging_product` -- always `"whatsapp"`. `recipient_type` -- always `"individual"`.
+
+---
+
+### Send Template Message
+
+Template messages are pre-approved formats required for initiating conversations outside the 24-hour service window.
+
+```python
+async def send_template_message(
+    client: httpx.AsyncClient, to: str, template_name: str,
+    language_code: str = "en_US", components: list | None = None,
+) -> dict:
+    payload = {
+        "messaging_product": "whatsapp",
+        "to": to,
+        "type": "template",
+        "template": {"name": template_name, "language": {"code": language_code}},
+    }
+    if components:
+        payload["template"]["components"] = components
+    resp = await client.post(
+        f"{BASE_URL}/{PHONE_NUMBER_ID}/messages", headers=HEADERS, json=payload,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+# Example: Template with body parameters
+result = await send_template_message(
+    client, to="919876543210", template_name="order_confirmation",
+    components=[{
+        "type": "body",
+        "parameters": [
+            {"type": "text", "text": "ORDER-12345"},
+            {"type": "text", "text": "$49.99"},
+        ],
+    }],
+)
+```
+
+---
+
+### Send Media Message (Image, Document, Audio, Video)
+
+All media types follow the same pattern. Provide either a URL (`link`) or a previously uploaded `media_id`:
+
+```python
+async def send_media_message(
+    client: httpx.AsyncClient, to: str,
+    media_type: str, media_url: str | None = None,
+    media_id: str | None = None, caption: str = "", filename: str = "",
+) -> dict:
+    media_obj = {"id": media_id} if media_id else {"link": media_url}
+    if caption:
+        media_obj["caption"] = caption
+    if filename and media_type == "document":
+        media_obj["filename"] = filename
+    resp = await client.post(
+        f"{BASE_URL}/{PHONE_NUMBER_ID}/messages",
+        headers=HEADERS,
+        json={
+            "messaging_product": "whatsapp", "to": to,
+            "type": media_type, media_type: media_obj,
+        },
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+Supported `media_type` values: `image`, `document`, `audio`, `video`. Size limits: images 5 MB, audio/video 16 MB, documents 100 MB.
+
+---
+
+### Send Interactive Message (Buttons)
+
+```python
+async def send_button_message(
+    client: httpx.AsyncClient, to: str, body_text: str,
+    buttons: list[dict], header_text: str = "", footer_text: str = "",
+) -> dict:
+    interactive = {
+        "type": "button",
+        "body": {"text": body_text},
+        "action": {"buttons": [
+            {"type": "reply", "reply": {"id": btn["id"], "title": btn["title"]}}
+            for btn in buttons
+        ]},
+    }
+    if header_text:
+        interactive["header"] = {"type": "text", "text": header_text}
+    if footer_text:
+        interactive["footer"] = {"text": footer_text}
+    resp = await client.post(
+        f"{BASE_URL}/{PHONE_NUMBER_ID}/messages",
+        headers=HEADERS,
+        json={
+            "messaging_product": "whatsapp", "to": to,
+            "type": "interactive", "interactive": interactive,
+        },
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+**Limits:** Maximum 3 reply buttons. Button titles max 20 characters.
+
+---
+
+### Upload Media
+
+Upload a media file to WhatsApp's servers. Returns a `media_id` for use in messages.
+
+```python
+async def upload_media(client: httpx.AsyncClient, file_path: str, mime_type: str) -> str:
+    with open(file_path, "rb") as f:
+        resp = await client.post(
+            f"{BASE_URL}/{PHONE_NUMBER_ID}/media",
+            headers={"Authorization": f"Bearer {ACCESS_TOKEN}"},
+            data={"messaging_product": "whatsapp", "type": mime_type},
+            files={"file": (file_path.split("/")[-1], f, mime_type)},
+        )
+    resp.raise_for_status()
+    return resp.json()["id"]
+```
+
+Uploaded media is stored for **30 days**. Media download URLs (via `GET /{media_id}`) expire after **5 minutes**.
+
+---
+
+### Webhook Verification (GET)
+
+When you configure a webhook URL in the App Dashboard, Meta sends a GET request to verify your endpoint.
+
+```python
+async def webhook_verify(request) -> str:
+    VERIFY_TOKEN = "your_verify_token_string"
+    mode = request.query_params.get("hub.mode")
+    token = request.query_params.get("hub.verify_token")
+    challenge = request.query_params.get("hub.challenge")
+    if mode == "subscribe" and token == VERIFY_TOKEN:
+        return PlainTextResponse(challenge, status_code=200)
+    return PlainTextResponse("Forbidden", status_code=403)
+```
+
+Your endpoint must use HTTPS with a valid CA-signed TLS certificate. Return the `hub.challenge` value as plain text (not JSON).
+
+---
+
+### Webhook Event Handler (POST)
+
+Inbound messages and status updates arrive as POST requests to your webhook URL.
+
+```python
+async def webhook_handler(request) -> dict:
+    body = await request.json()
+    for entry in body.get("entry", []):
+        for change in entry.get("changes", []):
+            value = change.get("value", {})
+            for message in value.get("messages", []):
+                sender = message["from"]
+                msg_type = message["type"]
+                msg_id = message["id"]
+                if msg_type == "text":
+                    text_body = message["text"]["body"]
+                elif msg_type == "image":
+                    media_id = message["image"]["id"]
+                elif msg_type == "interactive":
+                    if "button_reply" in message["interactive"]:
+                        button_id = message["interactive"]["button_reply"]["id"]
+            for status in value.get("statuses", []):
+                status_value = status["status"]  # sent/delivered/read/failed
+    return {"status": "ok"}
+```
+
+## Error Handling
+
+### Error Response Format
+
+```json
+{
+    "error": {
+        "message": "Human-readable description",
+        "type": "OAuthException",
+        "code": 100,
+        "error_subcode": 33,
+        "fbtrace_id": "trace_id_for_debugging"
+    }
+}
+```
+
+### Common Error Codes
+
+| Code | Subcode | Meaning |
+|---|---|---|
+| `4` | -- | API throttling (rate limited) |
+| `100` | `33` | Parameter missing or invalid |
+| `100` | `2494010` | Phone number not registered on WhatsApp |
+| `131047` | -- | Re-engagement: >24 hours since last reply |
+| `131048` | -- | Spam rate limit hit |
+| `132000` | -- | Template parameter count mismatch |
+| `132001` | -- | Template does not exist |
+| `190` | -- | Access token expired or invalid |
+| `80007` | -- | Rate limit exceeded |
+
+### Recommended Error Handling Pattern
+
+```python
+class WhatsAppAPIError(Exception):
+    def __init__(self, code: int, message: str, subcode: int = 0):
+        self.code = code
+        self.subcode = subcode
+        super().__init__(f"[{code}/{subcode}] {message}")
+
+async def safe_send(client: httpx.AsyncClient, payload: dict) -> dict:
+    try:
+        resp = await client.post(
+            f"{BASE_URL}/{PHONE_NUMBER_ID}/messages", headers=HEADERS, json=payload,
+        )
+        data = resp.json()
+        if "error" in data:
+            err = data["error"]
+            raise WhatsAppAPIError(err.get("code", 0), err.get("message", "Unknown"), err.get("error_subcode", 0))
+        resp.raise_for_status()
+        return data
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 429:
+            await asyncio.sleep(5)
+            return await safe_send(client, payload)
+        raise
+```
+
+## Common Pitfalls
+
+1. **24-hour messaging window** -- Free-form messages only within 24 hours of the user's last message. Outside this window, use an approved template. Violating this returns error `131047`.
+
+2. **Phone number format** -- International format without `+` prefix or formatting: `919876543210`, not `+91 98765 43210`.
+
+3. **`messaging_product` is required** -- Every message body must include `"messaging_product": "whatsapp"`. Omitting it returns 400.
+
+4. **Template approval delay** -- New templates must be approved by Meta before use (minutes to 24+ hours). Unapproved template returns `132001`.
+
+5. **Media URL expiry** -- Download URLs expire after **5 minutes**. Uploaded media expires after **30 days**.
+
+6. **Webhook must return 200 quickly** -- Process messages asynchronously. Meta retries and disables webhooks that time out.
+
+7. **Webhook verification is GET, events are POST** -- Verification returns challenge as plain text. Events arrive as POST with JSON. Self-signed certificates are not supported.
+
+8. **Template parameter indexing** -- Parameters are positional. Mismatched count returns `132000`.
+
+9. **Duplicate webhook events** -- Use WAMID (`message.id`) to deduplicate. One webhook per Meta App; fan out internally.

--- a/content/wise/docs/rest-api/python/DOC.md
+++ b/content/wise/docs/rest-api/python/DOC.md
@@ -1,0 +1,269 @@
+---
+name: rest-api
+description: "Wise (TransferWise) - International money transfer and multi-currency account REST API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "wise,transferwise,money-transfer,international,fx,payments,europe,api"
+---
+
+# Wise REST API - Python (`httpx`)
+
+## Golden Rule
+
+Always use API version paths as documented (v1, v2, v3, v4 depending on endpoint). The Wise API returns two different error formats (key/value and array) -- your code must handle both. Never store API tokens in source code; use environment variables. All monetary amounts use minor units or decimal strings depending on the endpoint -- always check the docs for each resource.
+
+## Installation
+
+```bash
+pip install httpx python-dotenv
+```
+
+## Base URL
+
+| Environment | URL |
+|-------------|-----|
+| Production  | `https://api.wise.com` |
+| Sandbox     | `https://api.sandbox.transferwise.tech` |
+
+## Authentication
+
+Wise supports multiple auth methods. The most common for server integrations is a Personal Token or OAuth 2.0 Bearer token.
+
+```python
+import httpx
+import os
+
+WISE_API_TOKEN = os.environ["WISE_API_TOKEN"]
+BASE_URL = os.environ.get("WISE_BASE_URL", "https://api.wise.com")
+
+headers = {
+    "Authorization": f"Bearer {WISE_API_TOKEN}",
+    "Content-Type": "application/json",
+}
+```
+
+OAuth 2.0 tokens (UserToken) expire after 12 hours and must be refreshed. Personal tokens do not expire but have limited scope.
+
+## Rate Limiting
+
+- **100 requests per second** and **1,000 requests per minute** (default thresholds).
+- On HTTP 429, check the `Retry-After` header and implement exponential backoff.
+
+```python
+import asyncio
+
+async def wise_request(client: httpx.AsyncClient, method: str, url: str, **kwargs):
+    for attempt in range(5):
+        resp = await client.request(method, url, **kwargs)
+        if resp.status_code == 429:
+            retry_after = int(resp.headers.get("Retry-After", 2 ** attempt))
+            await asyncio.sleep(retry_after)
+            continue
+        resp.raise_for_status()
+        return resp.json()
+    raise Exception("Rate limit exceeded after retries")
+```
+
+## Methods
+
+### Get Profiles
+
+Retrieve your personal and business profiles (needed for most subsequent calls).
+
+```python
+async def get_profiles(client: httpx.AsyncClient) -> list[dict]:
+    resp = await client.get(f"{BASE_URL}/v2/profiles", headers=headers)
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Create Quote
+
+Create a quote for a transfer with exchange rate and fees.
+
+```python
+async def create_quote(
+    client: httpx.AsyncClient,
+    profile_id: int,
+    source_currency: str,
+    target_currency: str,
+    source_amount: float | None = None,
+    target_amount: float | None = None,
+) -> dict:
+    payload = {
+        "sourceCurrency": source_currency,
+        "targetCurrency": target_currency,
+        "profileId": profile_id,
+    }
+    if source_amount:
+        payload["sourceAmount"] = source_amount
+    elif target_amount:
+        payload["targetAmount"] = target_amount
+
+    resp = await client.post(
+        f"{BASE_URL}/v3/profiles/{profile_id}/quotes",
+        headers=headers,
+        json=payload,
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Create Recipient
+
+Add a beneficiary account for transfers.
+
+```python
+async def create_recipient(
+    client: httpx.AsyncClient,
+    profile_id: int,
+    account_holder: str,
+    currency: str,
+    recipient_type: str,
+    details: dict,
+) -> dict:
+    payload = {
+        "profile": profile_id,
+        "accountHolderName": account_holder,
+        "currency": currency,
+        "type": recipient_type,
+        "details": details,
+    }
+    resp = await client.post(
+        f"{BASE_URL}/v1/accounts", headers=headers, json=payload
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Create Transfer
+
+Initiate a transfer against an existing quote and recipient.
+
+```python
+async def create_transfer(
+    client: httpx.AsyncClient,
+    target_account_id: int,
+    quote_id: str,
+    reference: str,
+    idempotency_uuid: str,
+) -> dict:
+    payload = {
+        "targetAccount": target_account_id,
+        "quoteUuid": quote_id,
+        "customerTransactionId": idempotency_uuid,
+        "details": {"reference": reference},
+    }
+    resp = await client.post(
+        f"{BASE_URL}/v1/transfers", headers=headers, json=payload
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Fund Transfer
+
+Fund a transfer from your Wise balance.
+
+```python
+async def fund_transfer(
+    client: httpx.AsyncClient, profile_id: int, transfer_id: int
+) -> dict:
+    payload = {"type": "BALANCE"}
+    resp = await client.post(
+        f"{BASE_URL}/v3/profiles/{profile_id}/transfers/{transfer_id}/payments",
+        headers=headers,
+        json=payload,
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Get Balances
+
+List multi-currency balances on your account.
+
+```python
+async def get_balances(client: httpx.AsyncClient, profile_id: int) -> list[dict]:
+    resp = await client.get(
+        f"{BASE_URL}/v4/profiles/{profile_id}/balances?types=STANDARD",
+        headers=headers,
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### Get Exchange Rate
+
+Fetch live exchange rates.
+
+```python
+async def get_rate(
+    client: httpx.AsyncClient, source: str, target: str
+) -> list[dict]:
+    resp = await client.get(
+        f"{BASE_URL}/v1/rates",
+        headers=headers,
+        params={"source": source, "target": target},
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+## Error Handling
+
+Wise returns two error response formats:
+
+**Key/Value format:**
+```json
+{"error": "INVALID_REQUEST", "error_description": "Quote has expired"}
+```
+
+**Array format:**
+```json
+{
+  "errors": [
+    {"code": "NOT_VALID", "message": "Field is required", "path": "details.iban", "arguments": ["iban"]}
+  ]
+}
+```
+
+Handle both:
+
+```python
+class WiseAPIError(Exception):
+    def __init__(self, status: int, body: dict):
+        self.status = status
+        self.body = body
+        if "error" in body:
+            msg = f"{body['error']}: {body.get('error_description', '')}"
+        elif "errors" in body:
+            msgs = [f"{e['path']}: {e['message']}" for e in body["errors"]]
+            msg = "; ".join(msgs)
+        else:
+            msg = str(body)
+        super().__init__(f"HTTP {status} - {msg}")
+
+
+async def wise_request_safe(client: httpx.AsyncClient, method: str, url: str, **kwargs) -> dict:
+    resp = await client.request(method, url, **kwargs)
+    if resp.status_code >= 400:
+        raise WiseAPIError(resp.status_code, resp.json())
+    return resp.json()
+```
+
+Key HTTP status codes: 400/422 (validation), 401 (auth), 403 (forbidden), 404 (not found), 408 (timeout), 429 (rate limit), 500 (server error).
+
+## Common Pitfalls
+
+1. **Quote expiry** -- Quotes have a limited TTL. Always create a fresh quote before initiating a transfer. Do not cache quote IDs.
+2. **Two error formats** -- The API returns either key/value or array-based errors depending on the endpoint. Handle both structures.
+3. **Profile ID required everywhere** -- Most endpoints require a `profileId`. Fetch profiles first and cache the ID.
+4. **Idempotency** -- Always provide a unique `customerTransactionId` (UUID) per transfer to avoid duplicate payments.
+5. **Sandbox vs Production URLs** -- The sandbox uses a completely different domain (`sandbox.transferwise.tech`), not a subdomain of `wise.com`.
+6. **SCA (Strong Customer Authentication)** -- Certain operations (large transfers, sensitive changes) may trigger SCA challenges requiring additional user interaction.
+7. **Currency precision** -- Different currencies have different decimal precisions. Always check the quote response for the exact amounts.

--- a/content/withings/docs/rest-api/python/DOC.md
+++ b/content/withings/docs/rest-api/python/DOC.md
@@ -1,0 +1,326 @@
+---
+name: rest-api
+description: "Withings API for connected health devices (scales, blood pressure, sleep trackers)"
+metadata:
+  languages: "python"
+  versions: "2.0.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "withings,health,devices,blood-pressure,weight,sleep,api"
+---
+
+# Withings API
+
+> **Golden Rule:** Withings has no official Python SDK for REST. Use `httpx` (async) for direct API access. All data endpoints are POST to `https://wbsapi.withings.net` with `action` parameter specifying the operation. Authentication uses OAuth 2.0. Responses use a `status` field (0 = success) instead of HTTP status codes for application errors.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+`https://wbsapi.withings.net`
+
+OAuth authorization URL: `https://account.withings.com/oauth2_user/authorize2`
+OAuth token endpoint: `https://wbsapi.withings.net/v2/oauth2`
+
+Register your app at: https://developer.withings.com/
+
+## Authentication
+
+**Type:** OAuth 2.0 Authorization Code Grant
+
+### Step 1: Build Authorization URL
+
+```python
+CLIENT_ID = "your-client-id"
+REDIRECT_URI = "https://your-app.com/callback"
+SCOPES = "user.info,user.metrics,user.activity,user.sleepevents"
+STATE = "random-csrf-token"
+
+auth_url = (
+    f"https://account.withings.com/oauth2_user/authorize2"
+    f"?response_type=code"
+    f"&client_id={CLIENT_ID}"
+    f"&redirect_uri={REDIRECT_URI}"
+    f"&scope={SCOPES}"
+    f"&state={STATE}"
+)
+# Direct user to auth_url in browser
+```
+
+### Step 2: Exchange Code for Tokens
+
+```python
+import httpx
+
+CLIENT_SECRET = "your-client-secret"
+BASE_URL = "https://wbsapi.withings.net"
+
+async def exchange_code(authorization_code: str) -> dict:
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{BASE_URL}/v2/oauth2",
+            data={
+                "action": "requesttoken",
+                "grant_type": "authorization_code",
+                "client_id": CLIENT_ID,
+                "client_secret": CLIENT_SECRET,
+                "code": authorization_code,
+                "redirect_uri": REDIRECT_URI,
+            },
+        )
+        response.raise_for_status()
+        data = response.json()
+        if data["status"] != 0:
+            raise Exception(f"Withings error: {data['status']} - {data.get('error', 'unknown')}")
+        return data["body"]
+        # Returns: access_token, refresh_token, userid, expires_in
+```
+
+### Step 3: Make Authenticated Requests
+
+```python
+ACCESS_TOKEN = "your-access-token"
+
+client = httpx.AsyncClient(
+    headers={"Authorization": f"Bearer {ACCESS_TOKEN}"},
+    timeout=30.0,
+)
+```
+
+### Refresh Token
+
+```python
+async def refresh_access_token(refresh_token: str) -> dict:
+    async with httpx.AsyncClient() as c:
+        response = await c.post(
+            f"{BASE_URL}/v2/oauth2",
+            data={
+                "action": "requesttoken",
+                "grant_type": "refresh_token",
+                "client_id": CLIENT_ID,
+                "client_secret": CLIENT_SECRET,
+                "refresh_token": refresh_token,
+            },
+        )
+        response.raise_for_status()
+        data = response.json()
+        if data["status"] != 0:
+            raise Exception(f"Refresh error: {data['status']}")
+        return data["body"]
+```
+
+## Rate Limiting
+
+Withings applies rate limiting but does not publish specific numbers. Recommended best practices:
+- Limit to 120 requests per minute
+- Use webhooks (notifications) instead of polling when possible
+- Check API status at: https://status.withings.com
+
+## Methods
+
+### Get Measurements (Weight, BP, etc.)
+
+**Endpoint:** `POST /measure`
+**Action:** `getmeas`
+
+Retrieve body measurements from scales and blood pressure monitors.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `action` | `str` | **required** (`getmeas`) |
+| `meastype` | `int` | `None` (filter by type) |
+| `category` | `int` | `None` (1=real, 2=user-objective) |
+| `startdate` | `int` | `None` (Unix timestamp) |
+| `enddate` | `int` | `None` (Unix timestamp) |
+| `lastupdate` | `int` | `None` (Unix timestamp) |
+
+Measurement types:
+- `1` -- Weight (kg)
+- `4` -- Height (m)
+- `5` -- Fat Free Mass (kg)
+- `6` -- Fat Ratio (%)
+- `8` -- Fat Mass Weight (kg)
+- `9` -- Diastolic Blood Pressure (mmHg)
+- `10` -- Systolic Blood Pressure (mmHg)
+- `11` -- Heart Pulse (bpm)
+- `76` -- Muscle Mass (kg)
+- `77` -- Hydration (kg)
+- `88` -- Bone Mass (kg)
+
+```python
+import time
+
+params = {
+    "action": "getmeas",
+    "meastype": 1,  # Weight
+    "category": 1,  # Real measurements only
+    "startdate": int(time.time()) - 86400 * 30,  # Last 30 days
+    "enddate": int(time.time()),
+}
+response = await client.post(f"{BASE_URL}/measure", data=params)
+response.raise_for_status()
+data = response.json()
+
+if data["status"] == 0:
+    for group in data["body"]["measuregrps"]:
+        for measure in group["measures"]:
+            if measure["type"] == 1:
+                weight = measure["value"] * 10 ** measure["unit"]
+                print(f"Weight: {weight:.1f} kg")
+```
+
+### Get Activity
+
+**Endpoint:** `POST /v2/measure`
+**Action:** `getactivity`
+
+Retrieve daily activity data (steps, calories, distance).
+
+```python
+params = {
+    "action": "getactivity",
+    "startdateymd": "2025-01-01",
+    "enddateymd": "2025-01-07",
+}
+response = await client.post(f"{BASE_URL}/v2/measure", data=params)
+response.raise_for_status()
+data = response.json()
+
+if data["status"] == 0:
+    for activity in data["body"]["activities"]:
+        print(f"{activity['date']}: {activity.get('steps', 0)} steps, "
+              f"{activity.get('calories', 0)} cal")
+```
+
+### Get Sleep Data
+
+**Endpoint:** `POST /v2/sleep`
+**Action:** `get`
+
+Retrieve detailed sleep data.
+
+```python
+params = {
+    "action": "get",
+    "startdate": int(time.time()) - 86400,  # Yesterday
+    "enddate": int(time.time()),
+}
+response = await client.post(f"{BASE_URL}/v2/sleep", data=params)
+response.raise_for_status()
+data = response.json()
+
+if data["status"] == 0:
+    for series in data["body"]["series"]:
+        state_map = {0: "awake", 1: "light", 2: "deep", 3: "REM"}
+        state = state_map.get(series.get("state", -1), "unknown")
+        print(f"State: {state}, Duration: {series.get('enddate', 0) - series.get('startdate', 0)}s")
+```
+
+### Get Sleep Summary
+
+**Endpoint:** `POST /v2/sleep`
+**Action:** `getsummary`
+
+```python
+params = {
+    "action": "getsummary",
+    "startdateymd": "2025-01-01",
+    "enddateymd": "2025-01-07",
+}
+response = await client.post(f"{BASE_URL}/v2/sleep", data=params)
+response.raise_for_status()
+data = response.json()
+
+if data["status"] == 0:
+    for night in data["body"]["series"]:
+        duration_h = night.get("data", {}).get("total_sleep_time", 0) / 3600
+        print(f"{night['date']}: {duration_h:.1f} hours sleep")
+```
+
+### Get Heart Rate (ECG)
+
+**Endpoint:** `POST /v2/heart`
+**Action:** `list`
+
+```python
+params = {
+    "action": "list",
+    "startdate": int(time.time()) - 86400 * 7,
+    "enddate": int(time.time()),
+}
+response = await client.post(f"{BASE_URL}/v2/heart", data=params)
+response.raise_for_status()
+data = response.json()
+
+if data["status"] == 0:
+    for entry in data["body"].get("series", []):
+        hr = entry.get("heart_rate", "N/A")
+        print(f"HR: {hr} bpm")
+```
+
+### Get User Devices
+
+**Endpoint:** `POST /v2/user`
+**Action:** `getdevice`
+
+```python
+params = {"action": "getdevice"}
+response = await client.post(f"{BASE_URL}/v2/user", data=params)
+response.raise_for_status()
+data = response.json()
+
+if data["status"] == 0:
+    for device in data["body"]["devices"]:
+        print(f"{device['model']}: Battery {device.get('battery', 'N/A')}%")
+```
+
+## Error Handling
+
+```python
+import httpx
+
+try:
+    response = await client.post(f"{BASE_URL}/measure", data={"action": "getmeas"})
+    response.raise_for_status()
+    data = response.json()
+
+    # Withings uses status codes in the JSON body, not HTTP status codes
+    if data["status"] != 0:
+        status = data["status"]
+        if status == 401:
+            print("Invalid or expired access token -- refresh token")
+        elif status == 293:
+            print("Invalid action parameter")
+        elif status == 2554:
+            print("Rate limited -- slow down requests")
+        elif status == 2555:
+            print("IP blocked temporarily")
+        elif status in (100, 101, 200, 300):
+            print(f"Parameter error (status {status}): check required fields")
+        else:
+            print(f"Withings API error status: {status}")
+except httpx.HTTPStatusError as e:
+    print(f"HTTP error {e.response.status_code}: {e.response.text}")
+except httpx.RequestError as e:
+    print(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+- All data endpoints use **POST** (not GET) with form-encoded data
+- Every request requires an `action` parameter specifying the operation
+- API errors return HTTP 200 with error info in the JSON `status` field (0 = success)
+- Dates use **Unix timestamps** (integers) for most endpoints, but some use `YYYY-MM-DD` (the `ymd` variants)
+- Measurement values use scientific notation: `value * 10^unit` (e.g., weight 7200 with unit -2 = 72.00 kg)
+- OAuth tokens are sent via `Bearer` token in Authorization header
+- Token endpoint uses the `action: requesttoken` parameter (not standard OAuth paths)
+- The v2 endpoints (`/v2/measure`, `/v2/sleep`, `/v2/heart`) differ from v1 (`/measure`)
+- Scopes are comma-separated (not space-separated like standard OAuth)
+- Heart v2 List API may return empty results for some devices
+- Regional availability: some metrics are EU-only or US-only
+- Set a reasonable timeout: `httpx.AsyncClient(timeout=30.0)`

--- a/content/xai/docs/rest-api/python/DOC.md
+++ b/content/xai/docs/rest-api/python/DOC.md
@@ -1,0 +1,118 @@
+---
+name: rest-api
+description: "xAI (Grok) API Integration"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-13"
+  source: community
+  tags: "xai,grok,llm,ai,chat,completions,api,integration"
+---
+
+# xAI (Grok) API
+
+> **Golden Rule:** xAI has no official Python SDK. Use `httpx` (async) or `requests` (sync) for direct REST API access. The API is OpenAI-compatible. Always handle rate limits, retries, and error responses explicitly.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+`https://api.x.ai/v1`
+
+## Authentication
+
+**Type:** Bearer Token (API Key)
+
+```python
+import httpx
+
+API_KEY = "your-xai-api-key"
+BASE_URL = "https://api.x.ai/v1"
+
+headers = {"Authorization": f"Bearer {API_KEY}"}
+client = httpx.AsyncClient(headers=headers)
+```
+
+## Rate Limiting
+
+**Limit:** 100 requests/minute
+
+The API enforces rate limits. Check `X-RateLimit-Remaining` and `Retry-After` response headers. Implement exponential backoff on 429 responses.
+
+## Methods
+
+### `list_models`
+
+**Endpoint:** `GET /models`
+
+List available Grok models
+
+**Returns:** JSON response with `data` array of model objects
+
+```python
+response = await client.get(f"{BASE_URL}/models")
+response.raise_for_status()
+data = response.json()
+models = data.get("data", [])
+```
+
+### `create_chat_completion`
+
+**Endpoint:** `POST /chat/completions`
+
+Create a chat completion (OpenAI-compatible format)
+
+| Parameter | Type | Default |
+|---|---|---|
+| `model` | `str` | **required** |
+| `messages` | `list` | **required** |
+
+**Returns:** JSON response with `choices` array
+
+```python
+payload = {
+    "model": "grok-2",
+    "messages": [
+        {"role": "user", "content": "Hello, Grok!"}
+    ]
+}
+response = await client.post(f"{BASE_URL}/chat/completions", json=payload)
+response.raise_for_status()
+data = response.json()
+reply = data["choices"][0]["message"]["content"]
+```
+
+## Error Handling
+
+```python
+import httpx
+
+try:
+    response = await client.post(f"{BASE_URL}/chat/completions", json=payload)
+    response.raise_for_status()
+    data = response.json()
+except httpx.HTTPStatusError as e:
+    if e.response.status_code == 401:
+        print("Authentication failed -- check your API key")
+    elif e.response.status_code == 429:
+        retry_after = e.response.headers.get("Retry-After", "60")
+        print(f"Rate limited -- retry after {retry_after}s")
+    else:
+        print(f"xAI API error {e.response.status_code}: {e.response.text}")
+except httpx.RequestError as e:
+    print(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+- Always call `response.raise_for_status()` to catch HTTP errors
+- Use `async with httpx.AsyncClient() as client:` to auto-close connections
+- Handle 429 (rate limit) responses with exponential backoff
+- Set a reasonable timeout: `httpx.AsyncClient(timeout=30.0)`
+- For POST requests, pass data via `json=` parameter (not `data=`) to auto-set Content-Type
+- The API follows OpenAI's chat completions format -- `messages` must be a list of `{"role": ..., "content": ...}` objects

--- a/content/zerodha-kite/docs/rest-api/python/DOC.md
+++ b/content/zerodha-kite/docs/rest-api/python/DOC.md
@@ -1,0 +1,239 @@
+---
+name: rest-api
+description: "Zerodha Kite Connect - Indian Stock Trading API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "zerodha,kite,trading,stocks,india,algo-trading,market-data,portfolio,api"
+---
+
+# Zerodha Kite Connect REST API
+
+Kite Connect is the trading and investment API platform from Zerodha, India's largest stockbroker. It provides REST-like HTTP APIs for programmatic trading on NSE, BSE, NFO, MCX, and other Indian exchanges.
+
+## Golden Rule
+
+Always use async `httpx` for all HTTP calls. Never use the `kiteconnect` Python SDK or `requests` library. All form-encoded POST/PUT bodies use `data=` (not `json=`). All responses are JSON with a top-level `status` field (`"success"` or `"error"`). The access token expires daily at 6:00 AM IST -- re-authenticate each trading day.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+```
+https://api.kite.trade
+```
+
+All endpoints are relative to this base. Responses are JSON. The API is not CORS-enabled.
+
+## Authentication
+
+Kite Connect uses a three-step OAuth-like login flow:
+
+### Step 1: Redirect User to Kite Login
+
+```
+https://kite.zerodha.com/connect/login?v=3&api_key=YOUR_API_KEY
+```
+
+After login, the user is redirected to your `redirect_url` with a `request_token` query parameter.
+
+### Step 2: Exchange Request Token for Access Token
+
+```python
+import hashlib, httpx
+
+API_KEY = "your_api_key"
+API_SECRET = "your_api_secret"
+REQUEST_TOKEN = "token_from_redirect"
+
+checksum = hashlib.sha256(f"{API_KEY}{REQUEST_TOKEN}{API_SECRET}".encode()).hexdigest()
+
+async def get_access_token():
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            "https://api.kite.trade/session/token",
+            data={"api_key": API_KEY, "request_token": REQUEST_TOKEN, "checksum": checksum},
+        )
+        return resp.json()["data"]["access_token"]
+```
+
+### Step 3: Use Access Token in All Requests
+
+```python
+HEADERS = {"Authorization": f"token {API_KEY}:{ACCESS_TOKEN}", "X-Kite-Version": "3"}
+```
+
+The access token is valid until 6:00 AM IST the next day.
+
+## Rate Limiting
+
+| Endpoint Category | Limit |
+|---|---|
+| Order placement | 10 req/s, 200 orders/min |
+| Quote endpoints | 1 req/s |
+| Historical candle data | 3 req/s |
+| Instruments list | 1 req/min |
+| All other endpoints | 10 req/s |
+| Daily order cap | 3,000 orders/day per user |
+
+Exceeding limits returns HTTP `429`. A sliding 10-second cooldown window applies.
+
+## Methods
+
+### Place Order
+
+```python
+async def place_order(client: httpx.AsyncClient, variety: str, params: dict) -> str:
+    """Place an order. Varieties: regular, amo, co, iceberg, auction."""
+    resp = await client.post(f"https://api.kite.trade/orders/{variety}", headers=HEADERS, data=params)
+    resp.raise_for_status()
+    return resp.json()["data"]["order_id"]
+
+# Example: Buy 1 share of INFY at market price
+order_id = await place_order(client, "regular", {
+    "tradingsymbol": "INFY", "exchange": "NSE", "transaction_type": "BUY",
+    "order_type": "MARKET", "quantity": 1, "product": "CNC", "validity": "DAY",
+})
+```
+
+**Required:** `tradingsymbol`, `exchange`, `transaction_type` (BUY/SELL), `order_type` (MARKET/LIMIT/SL/SL-M), `quantity`, `product` (CNC/NRML/MIS).
+**Optional:** `price`, `trigger_price`, `disclosed_quantity`, `validity` (DAY/IOC/TTL), `tag`, `iceberg_legs`, `iceberg_quantity`.
+
+### Modify Order
+
+```python
+async def modify_order(client: httpx.AsyncClient, variety: str, order_id: str, params: dict) -> str:
+    resp = await client.put(f"https://api.kite.trade/orders/{variety}/{order_id}", headers=HEADERS, data=params)
+    resp.raise_for_status()
+    return resp.json()["data"]["order_id"]
+```
+
+### Cancel Order
+
+```python
+async def cancel_order(client: httpx.AsyncClient, variety: str, order_id: str) -> str:
+    resp = await client.delete(f"https://api.kite.trade/orders/{variety}/{order_id}", headers=HEADERS)
+    resp.raise_for_status()
+    return resp.json()["data"]["order_id"]
+```
+
+### Get Orders
+
+```python
+async def get_orders(client: httpx.AsyncClient) -> list:
+    resp = await client.get("https://api.kite.trade/orders", headers=HEADERS)
+    resp.raise_for_status()
+    return resp.json()["data"]
+```
+
+### Get Holdings
+
+```python
+async def get_holdings(client: httpx.AsyncClient) -> list:
+    resp = await client.get("https://api.kite.trade/portfolio/holdings", headers=HEADERS)
+    resp.raise_for_status()
+    return resp.json()["data"]
+```
+
+### Get Positions
+
+```python
+async def get_positions(client: httpx.AsyncClient) -> dict:
+    resp = await client.get("https://api.kite.trade/portfolio/positions", headers=HEADERS)
+    resp.raise_for_status()
+    return resp.json()["data"]  # {"net": [...], "day": [...]}
+```
+
+### Get Market Quotes
+
+```python
+async def get_quotes(client: httpx.AsyncClient, instruments: list[str]) -> dict:
+    """Full quotes for up to 500 instruments. Format: EXCHANGE:SYMBOL (e.g., NSE:INFY)."""
+    resp = await client.get(
+        "https://api.kite.trade/quote", headers=HEADERS,
+        params=[("i", inst) for inst in instruments],
+    )
+    resp.raise_for_status()
+    return resp.json()["data"]
+```
+
+Lighter alternatives: `GET /quote/ohlc` (OHLC only, up to 1,000 instruments), `GET /quote/ltp` (last price only, up to 1,000).
+
+### Get Historical Data
+
+```python
+async def get_historical_data(
+    client: httpx.AsyncClient, instrument_token: int, interval: str,
+    from_dt: str, to_dt: str, continuous: bool = False, oi: bool = False,
+) -> list:
+    """Intervals: minute, 3minute, 5minute, 10minute, 15minute, 30minute, 60minute, day.
+    Date format: yyyy-mm-dd HH:MM:SS"""
+    resp = await client.get(
+        f"https://api.kite.trade/instruments/historical/{instrument_token}/{interval}",
+        headers=HEADERS,
+        params={"from": from_dt, "to": to_dt, "continuous": int(continuous), "oi": int(oi)},
+    )
+    resp.raise_for_status()
+    return resp.json()["data"]["candles"]
+    # Each candle: [timestamp, open, high, low, close, volume] (+ oi if oi=True)
+```
+
+Additional endpoints: `GET /user/profile`, `GET /user/margins`, `GET /user/margins/{segment}`,
+`GET /orders/{order_id}` (history), `GET /trades`, `GET /orders/{order_id}/trades`,
+`PUT /portfolio/positions` (convert), `GET /instruments` (CSV dump), `DELETE /session/token` (logout).
+
+## Error Handling
+
+All error responses follow this structure:
+
+```json
+{"status": "error", "message": "Human-readable description", "error_type": "ExceptionClassName"}
+```
+
+| Exception | Meaning |
+|---|---|
+| `TokenException` | Session expired or invalid (HTTP 403) |
+| `InputException` | Missing or invalid parameters (HTTP 400) |
+| `OrderException` | Order placement/retrieval failure |
+| `MarginException` | Insufficient funds |
+| `NetworkException` | API cannot reach OMS |
+
+```python
+import asyncio
+
+async def safe_request(client: httpx.AsyncClient, method: str, url: str, **kwargs):
+    try:
+        resp = await client.request(method, url, **kwargs)
+        resp.raise_for_status()
+        body = resp.json()
+        if body.get("status") == "error":
+            error_type = body.get("error_type", "GeneralException")
+            if error_type == "TokenException":
+                raise RuntimeError(f"Session expired: {body.get('message')}")
+            raise RuntimeError(f"{error_type}: {body.get('message')}")
+        return body["data"]
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 429:
+            await asyncio.sleep(10)
+            return await safe_request(client, method, url, **kwargs)
+        raise
+```
+
+## Common Pitfalls
+
+1. **Token format** -- `Authorization: token api_key:access_token` (not `Bearer`). Wrong format returns 403.
+2. **Form-encoded bodies** -- POST/PUT use `data=`, not `json=`. JSON bodies cause silent failures or 400 errors.
+3. **Daily re-authentication** -- Access tokens expire at 6:00 AM IST daily. No refresh token mechanism.
+4. **Request token is single-use** -- The `request_token` can only be exchanged once and expires within minutes.
+5. **Instruments CSV, not JSON** -- `/instruments` returns gzipped CSV, not JSON. Parse accordingly.
+6. **Rate limit cooldown is sliding** -- After 429, the 10-second window resets if you send more requests. Use exponential backoff.
+7. **Instrument identification** -- Quotes use `EXCHANGE:SYMBOL`, historical data uses numeric `instrument_token`. Map via instruments CSV.
+8. **Indian market hours** -- NSE/BSE equity: 9:15 AM - 3:30 PM IST. Use AMO variety for after-hours orders.
+9. **Quote instrument limits** -- Full quotes: max 500. OHLC/LTP: max 1,000. Exceeding returns an error.

--- a/content/zoho-books/docs/rest-api/python/DOC.md
+++ b/content/zoho-books/docs/rest-api/python/DOC.md
@@ -1,0 +1,254 @@
+---
+name: rest-api
+description: "Zoho Books - Cloud Accounting & Invoicing REST API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "zoho,books,accounting,invoicing,expenses,payments,tax,gst,api"
+---
+
+# Zoho Books REST API v3 -- Python (`httpx` Async)
+
+Zoho Books is cloud-based accounting software for managing invoices, expenses,
+bills, payments, taxes, and more. All examples below use **`httpx`** with
+`AsyncClient`.
+
+## Golden Rule
+
+Always use the correct regional API domain, include `organization_id` as a query parameter on every call, and refresh your OAuth token before it expires. Access tokens last 1 hour.
+
+**Installation:** `pip install httpx`
+
+## Base URL & Region Domains
+
+| Region | Accounts Server | API Base URL |
+|---|---|---|
+| US | `https://accounts.zoho.com` | `https://www.zohoapis.com/books/v3` |
+| EU | `https://accounts.zoho.eu` | `https://www.zohoapis.eu/books/v3` |
+| India | `https://accounts.zoho.in` | `https://www.zohoapis.in/books/v3` |
+| Australia | `https://accounts.zoho.com.au` | `https://www.zohoapis.com.au/books/v3` |
+| Japan | `https://accounts.zoho.jp` | `https://www.zohoapis.jp/books/v3` |
+| Canada | `https://accounts.zoho.ca` | `https://www.zohoapis.ca/books/v3` |
+
+## Authentication -- OAuth 2.0
+
+Zoho Books uses the same OAuth 2.0 flow shared across the Zoho ecosystem.
+
+1. **Register a Client** at <https://api-console.zoho.com/> (Server-based).
+2. **Obtain Authorization Code** -- redirect to `{accounts_server}/oauth/v2/auth?client_id=...&response_type=code&redirect_uri=...&scope=ZohoBooks.invoices.ALL,ZohoBooks.contacts.ALL&access_type=offline`
+3. **Exchange Code for Tokens:**
+
+```python
+import httpx
+
+async def exchange_code(accounts_server: str, client_id: str, client_secret: str, code: str, redirect_uri: str) -> dict:
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(f"{accounts_server}/oauth/v2/token", params={
+            "grant_type": "authorization_code", "code": code,
+            "client_id": client_id, "client_secret": client_secret,
+            "redirect_uri": redirect_uri,
+        })
+        resp.raise_for_status()
+        return resp.json()
+```
+
+4. **Refresh Access Token** (tokens expire after 1 hour; refresh tokens do not expire, max 20 per user):
+
+```python
+async def refresh_access_token(accounts_server: str, client_id: str, client_secret: str, refresh_token: str) -> dict:
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(f"{accounts_server}/oauth/v2/token", params={
+            "grant_type": "refresh_token", "refresh_token": refresh_token,
+            "client_id": client_id, "client_secret": client_secret,
+        })
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### OAuth Scopes
+
+Format: `ZohoBooks.{module}.{operation}` -- Operations: `CREATE`, `READ`, `UPDATE`, `DELETE`, `ALL`
+
+Key modules: `contacts`, `invoices`, `estimates`, `creditnotes`, `bills`, `expenses`, `customerpayments`, `settings`
+
+## Rate Limits
+
+| Plan | Daily Requests | Concurrent |
+|---|---|---|
+| Free | 1,000 | 5 |
+| Standard | 2,000 | 10 |
+| Professional | 5,000 | 10 |
+| Premium+ | 10,000 | 10 |
+
+Per-minute soft cap: 100 requests per org. Exceeding returns HTTP 429.
+
+## Reusable Client with Auto-Refresh
+
+```python
+import httpx, time
+
+class ZohoBooksClient:
+    def __init__(self, client_id: str, client_secret: str, refresh_token: str, org_id: str, region: str = "com"):
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.refresh_token = refresh_token
+        self.org_id = org_id
+        self.accounts_url = f"https://accounts.zoho.{region}"
+        self.api_base = f"https://www.zohoapis.{region}/books/v3"
+        self._access_token: str | None = None
+        self._token_expiry: float = 0.0
+
+    async def _ensure_token(self, client: httpx.AsyncClient) -> str:
+        if self._access_token and time.time() < self._token_expiry:
+            return self._access_token
+        resp = await client.post(f"{self.accounts_url}/oauth/v2/token", params={
+            "grant_type": "refresh_token", "refresh_token": self.refresh_token,
+            "client_id": self.client_id, "client_secret": self.client_secret,
+        })
+        resp.raise_for_status()
+        data = resp.json()
+        self._access_token = data["access_token"]
+        self._token_expiry = time.time() + data.get("expires_in", 3600) - 60
+        return self._access_token
+
+    async def request(self, method: str, path: str, *, json: dict | None = None, params: dict | None = None) -> dict:
+        async with httpx.AsyncClient() as client:
+            token = await self._ensure_token(client)
+            all_params = {"organization_id": self.org_id}
+            if params:
+                all_params.update(params)
+            resp = await client.request(method, f"{self.api_base}{path}",
+                headers={"Authorization": f"Zoho-oauthtoken {token}"}, params=all_params, json=json)
+            resp.raise_for_status()
+            return resp.json()
+```
+
+### Retrieving Your Organization ID
+
+```python
+async def get_organizations(access_token: str) -> list[dict]:
+    async with httpx.AsyncClient() as client:
+        resp = await client.get("https://www.zohoapis.com/books/v3/organizations",
+            headers={"Authorization": f"Zoho-oauthtoken {access_token}"})
+        resp.raise_for_status()
+        return resp.json()["organizations"]
+```
+
+## Invoices
+
+### Create an Invoice
+
+```python
+async def create_invoice(books: ZohoBooksClient, customer_id: str, line_items: list[dict], **optional) -> dict:
+    payload = {"customer_id": customer_id, "line_items": line_items, **optional}
+    result = await books.request("POST", "/invoices", json=payload)
+    return result["invoice"]
+```
+
+### List Invoices
+
+```python
+async def list_invoices(books: ZohoBooksClient, status: str | None = None, page: int = 1, per_page: int = 200) -> dict:
+    params = {"page": page, "per_page": per_page}
+    if status:
+        params["status"] = status
+    return await books.request("GET", "/invoices", params=params)
+```
+
+### Get / Email / Mark Sent
+
+```python
+async def get_invoice(books: ZohoBooksClient, invoice_id: str) -> dict:
+    result = await books.request("GET", f"/invoices/{invoice_id}")
+    return result["invoice"]
+
+async def email_invoice(books: ZohoBooksClient, invoice_id: str, to_emails: list[str], subject: str = "", body: str = "") -> dict:
+    return await books.request("POST", f"/invoices/{invoice_id}/email",
+        json={"to_mail_ids": to_emails, "subject": subject, "body": body})
+
+async def mark_invoice_sent(books: ZohoBooksClient, invoice_id: str) -> dict:
+    return await books.request("POST", f"/invoices/{invoice_id}/status/sent")
+```
+
+### Other Invoice Status Endpoints
+
+| Action | Method | Path |
+|---|---|---|
+| Void invoice | POST | `/invoices/{id}/status/void` |
+| Revert to draft | POST | `/invoices/{id}/status/draft` |
+| Approve invoice | POST | `/invoices/{id}/approve` |
+
+## Contacts
+
+```python
+async def create_contact(books: ZohoBooksClient, contact_name: str, contact_type: str = "customer", **optional) -> dict:
+    payload = {"contact_name": contact_name, "contact_type": contact_type, **optional}
+    result = await books.request("POST", "/contacts", json=payload)
+    return result["contact"]
+
+async def list_contacts(books: ZohoBooksClient, contact_type: str | None = None) -> dict:
+    params = {}
+    if contact_type:
+        params["contact_type"] = contact_type
+    return await books.request("GET", "/contacts", params=params)
+```
+
+Key endpoints: `GET /contacts/{id}`, `PUT /contacts/{id}`, `DELETE /contacts/{id}`, `POST /contacts/{id}/active`, `POST /contacts/{id}/inactive`.
+
+## Additional Module Endpoints
+
+| Module | Create | List | Get | Update | Delete |
+|---|---|---|---|---|---|
+| Items | `POST /items` | `GET /items` | `GET /items/{id}` | `PUT /items/{id}` | `DELETE /items/{id}` |
+| Expenses | `POST /expenses` | `GET /expenses` | `GET /expenses/{id}` | `PUT /expenses/{id}` | `DELETE /expenses/{id}` |
+| Bills | `POST /bills` | `GET /bills` | `GET /bills/{id}` | `PUT /bills/{id}` | `DELETE /bills/{id}` |
+| Payments | `POST /customerpayments` | `GET /customerpayments` | `GET /customerpayments/{id}` | `PUT /customerpayments/{id}` | `DELETE /customerpayments/{id}` |
+| Credit Notes | `POST /creditnotes` | `GET /creditnotes` | `GET /creditnotes/{id}` | `PUT /creditnotes/{id}` | `DELETE /creditnotes/{id}` |
+| Taxes | `POST /settings/taxes` | `GET /settings/taxes` | `GET /settings/taxes/{id}` | `PUT /settings/taxes/{id}` | `DELETE /settings/taxes/{id}` |
+
+## Error Handling
+
+All responses include a `code` field (0 = success) and a `message`.
+
+```python
+import asyncio
+
+async def safe_request(books: ZohoBooksClient, method: str, path: str, **kw):
+    try:
+        return await books.request(method, path, **kw)
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 429:
+            retry_after = int(exc.response.headers.get("Retry-After", "60"))
+            await asyncio.sleep(retry_after)
+            return await books.request(method, path, **kw)
+        raise
+```
+
+Common status codes: `200` OK, `201` Created, `400` Bad Request, `401` Unauthorized (token expired), `404` Not Found, `429` Rate Limit, `500` Internal Error.
+
+## Pagination
+
+List endpoints accept `page` (1-based) and `per_page` (max 200). Response includes `page_context` with `has_more_page`.
+
+```python
+async def fetch_all_invoices(books: ZohoBooksClient) -> list[dict]:
+    all_invoices, page = [], 1
+    while True:
+        data = await books.request("GET", "/invoices", params={"page": page, "per_page": 200})
+        all_invoices.extend(data["invoices"])
+        if not data["page_context"]["has_more_page"]:
+            break
+        page += 1
+    return all_invoices
+```
+
+## Common Pitfalls
+
+1. **`organization_id` is a query parameter**, not a header (unlike Zoho Desk).
+2. Updates use **`PUT`**, not `PATCH` (unlike Zoho Desk).
+3. Pagination uses **`page` + `per_page`** (max 200), 1-based.
+4. Field names are **snake_case** (e.g., `customer_id`, `contact_name`).
+5. Response bodies wrap data in a named key (e.g., `resp["invoice"]`, `resp["invoices"]`).

--- a/content/zoho-crm/docs/rest-api/python/DOC.md
+++ b/content/zoho-crm/docs/rest-api/python/DOC.md
@@ -1,0 +1,258 @@
+---
+name: rest-api
+description: "Zoho CRM - Customer Relationship Management REST API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "zoho,crm,sales,leads,contacts,deals,accounts,automation,api"
+---
+
+# Zoho CRM REST API v7 - Python (httpx)
+
+## Golden Rule
+
+**Always refresh your OAuth access token before it expires, and always use the correct regional API domain.** A token generated on `accounts.zoho.com` will NOT work against `www.zohoapis.eu`. Match your accounts server and API domain to the datacenter where the Zoho org was created. Access tokens expire every hour.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+All examples use `httpx` with async/await. Minimal client skeleton:
+
+```python
+import httpx, time
+from typing import Any
+
+class ZohoCRMClient:
+    REGIONS = {
+        "us": {"accounts": "https://accounts.zoho.com", "api": "https://www.zohoapis.com"},
+        "eu": {"accounts": "https://accounts.zoho.eu", "api": "https://www.zohoapis.eu"},
+        "in": {"accounts": "https://accounts.zoho.in", "api": "https://www.zohoapis.in"},
+        "au": {"accounts": "https://accounts.zoho.com.au", "api": "https://www.zohoapis.com.au"},
+        "jp": {"accounts": "https://accounts.zoho.jp", "api": "https://www.zohoapis.jp"},
+    }
+
+    def __init__(self, client_id: str, client_secret: str, refresh_token: str, region: str = "us"):
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.refresh_token = refresh_token
+        self.accounts_url = self.REGIONS[region]["accounts"]
+        self.api_base = self.REGIONS[region]["api"] + "/crm/v7"
+        self._access_token: str | None = None
+        self._token_expiry: float = 0
+        self._client = httpx.AsyncClient(timeout=30.0)
+
+    async def _ensure_token(self) -> str:
+        if self._access_token and time.time() < self._token_expiry - 60:
+            return self._access_token
+        resp = await self._client.post(f"{self.accounts_url}/oauth/v2/token", params={
+            "grant_type": "refresh_token", "client_id": self.client_id,
+            "client_secret": self.client_secret, "refresh_token": self.refresh_token,
+        })
+        resp.raise_for_status()
+        data = resp.json()
+        if "access_token" not in data:
+            raise ValueError(f"Token refresh failed: {data}")
+        self._access_token = data["access_token"]
+        self._token_expiry = time.time() + data.get("expires_in", 3600)
+        return self._access_token
+
+    async def _headers(self) -> dict[str, str]:
+        token = await self._ensure_token()
+        return {"Authorization": f"Zoho-oauthtoken {token}"}
+
+    async def close(self):
+        await self._client.aclose()
+```
+
+## Base URL
+
+`https://www.zohoapis.com/crm/v7/` -- use the regional variant matching your datacenter (see REGIONS dict above).
+
+## Authentication
+
+Zoho CRM uses **OAuth 2.0** exclusively. Recommended for backend: **Self-Client** flow.
+
+1. Register a Self Client at [Zoho API Console](https://api-console.zoho.com/)
+2. Generate a grant code with scopes: `ZohoCRM.modules.ALL,ZohoCRM.settings.ALL`
+3. Exchange for tokens (grant code expires in ~3 minutes):
+
+```python
+async def get_initial_tokens(accounts_url: str, client_id: str, client_secret: str, grant_code: str) -> dict:
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(f"{accounts_url}/oauth/v2/token", params={
+            "grant_type": "authorization_code", "client_id": client_id,
+            "client_secret": client_secret, "code": grant_code,
+        })
+        resp.raise_for_status()
+        return resp.json()
+```
+
+Token limits: max 15 active access tokens per refresh token, max 20 refresh tokens per user, access tokens expire in 1 hour.
+
+### OAuth Scopes
+
+| Scope | Description |
+|-------|-------------|
+| `ZohoCRM.modules.ALL` | Full CRUD on all modules |
+| `ZohoCRM.modules.{Module}.{Op}` | Per-module: READ, CREATE, UPDATE, DELETE, WRITE |
+| `ZohoCRM.settings.ALL` | Org settings and metadata |
+| `ZohoSearch.securesearch.READ` | Required for search_records |
+
+## Rate Limiting
+
+Credit-based system on a rolling 24-hour window. Base: 50,000 credits (Free: 5,000). Per-user additions vary by edition (+250 to +2,000). Concurrent limit: 5-25 depending on edition; sub-concurrency of 10 for heavy operations (search, COQL, bulk insert/update >10 records).
+
+```python
+import asyncio
+
+async def _request_with_retry(self, method: str, url: str, **kwargs) -> httpx.Response:
+    headers = await self._headers()
+    for attempt in range(3):
+        resp = await self._client.request(method, url, headers=headers, **kwargs)
+        if resp.status_code == 429:
+            await asyncio.sleep(int(resp.headers.get("Retry-After", 60)))
+            continue
+        return resp
+    return resp
+```
+
+## Methods
+
+All methods are async and belong to the `ZohoCRMClient` class.
+
+### get_records -- `GET /crm/v7/{module}`
+
+```python
+async def get_records(self, module: str, fields: list[str], per_page: int = 200, page: int = 1,
+                      sort_by: str = "id", sort_order: str = "desc", page_token: str | None = None) -> dict[str, Any]:
+    params: dict = {"fields": ",".join(fields), "per_page": per_page, "sort_by": sort_by, "sort_order": sort_order}
+    if page_token:
+        params["page_token"] = page_token
+    else:
+        params["page"] = page
+    resp = await self._client.get(f"{self.api_base}/{module}", headers=await self._headers(), params=params)
+    resp.raise_for_status()
+    return resp.json()
+```
+
+Pagination: `page` works for first 2,000 records. Beyond that, use `page_token` from `info.next_page_token`. Tokens expire after 24 hours. Max 100,000 records via page_token.
+
+### create_records -- `POST /crm/v7/{module}`
+
+```python
+async def create_records(self, module: str, records: list[dict[str, Any]], trigger: list[str] | None = None) -> dict[str, Any]:
+    body: dict[str, Any] = {"data": records}
+    if trigger is not None:
+        body["trigger"] = trigger
+    resp = await self._client.post(f"{self.api_base}/{module}", headers=await self._headers(), json=body)
+    resp.raise_for_status()
+    return resp.json()
+
+# Example: create a Lead
+# result = await crm.create_records("Leads", [{"Last_Name": "Doe", "Email": "doe@example.com", "Company": "Acme"}])
+```
+
+### search_records -- `GET /crm/v7/{module}/search`
+
+```python
+async def search_records(self, module: str, criteria: str | None = None, email: str | None = None,
+                         word: str | None = None, fields: list[str] | None = None, per_page: int = 200) -> dict[str, Any]:
+    params: dict[str, Any] = {"per_page": per_page}
+    if criteria:
+        params["criteria"] = criteria
+    if email:
+        params["email"] = email
+    if word:
+        params["word"] = word
+    if fields:
+        params["fields"] = ",".join(fields)
+    resp = await self._client.get(f"{self.api_base}/{module}/search", headers=await self._headers(), params=params)
+    resp.raise_for_status()
+    return resp.json()
+
+# Criteria syntax: "((Company:equals:Acme Corp)and(Email:contains:acme))"
+# Operators: equals, not_equal, starts_with, contains, in, between, greater_than, less_than, etc.
+# Max 10 criteria, max 2,000 records returned. Requires ZohoSearch.securesearch.READ scope.
+```
+
+### upsert_records -- `POST /crm/v7/{module}/upsert`
+
+```python
+async def upsert_records(self, module: str, records: list[dict[str, Any]],
+                         duplicate_check_fields: list[str] | None = None, trigger: list[str] | None = None) -> dict[str, Any]:
+    body: dict[str, Any] = {"data": records}
+    if duplicate_check_fields:
+        body["duplicate_check_fields"] = duplicate_check_fields
+    if trigger is not None:
+        body["trigger"] = trigger
+    resp = await self._client.post(f"{self.api_base}/{module}/upsert", headers=await self._headers(), json=body)
+    resp.raise_for_status()
+    return resp.json()
+
+# Defaults: Leads->Email, Contacts->Email, Accounts->Account_Name, Deals->Deal_Name
+# result["data"][0]["action"] returns "insert" or "update"
+```
+
+### Other Methods
+
+| Operation | HTTP | Endpoint | Notes |
+|-----------|------|----------|-------|
+| Get record | GET | `/{module}/{record_id}` | Single record by ID |
+| Update records | PUT | `/{module}` | Body: `{"data": [{...}]}`, each must include `id` |
+| Delete records | DELETE | `/{module}?ids=id1,id2` | Max 100 per request |
+| COQL query | POST | `/coql` | SQL-like: `SELECT ... FROM ... WHERE ...` (WHERE required, max 200/call) |
+
+## Error Handling
+
+| Status | Meaning |
+|--------|---------|
+| 200/201 | Success |
+| 204 | No Content (empty result -- not an error) |
+| 400 | Bad Request (invalid params/body) |
+| 401 | Unauthorized (expired token) |
+| 403 | Forbidden (insufficient scope) |
+| 404 | Not Found (invalid module or ID) |
+| 429 | Rate limit exceeded |
+
+```python
+class ZohoCRMError(Exception):
+    def __init__(self, status_code: int, code: str, message: str, details: dict | None = None):
+        self.status_code = status_code
+        self.code = code
+        self.details = details or {}
+        super().__init__(f"[{status_code}] {code}: {message}")
+
+async def _handle_response(resp: httpx.Response) -> dict[str, Any]:
+    if resp.status_code == 204:
+        return {"data": []}
+    data = resp.json()
+    if resp.status_code >= 400:
+        raise ZohoCRMError(resp.status_code, data.get("code", "UNKNOWN"), data.get("message", resp.text))
+    if "data" in data:
+        for item in data["data"]:
+            if isinstance(item, dict) and item.get("status") == "error":
+                raise ZohoCRMError(resp.status_code, item.get("code", "UNKNOWN"),
+                    item.get("message", ""), item.get("details", {}))
+    return data
+```
+
+Common error codes: `INVALID_TOKEN` (refresh it), `INVALID_DATA` (validation), `MANDATORY_NOT_FOUND`, `DUPLICATE_DATA`, `INVALID_MODULE`, `LIMIT_EXCEEDED`.
+
+## Common Pitfalls
+
+1. **Wrong regional domain.** EU org requires `zohoapis.eu` + `accounts.zoho.eu`. Using `.com` returns 401 even with valid tokens.
+2. **Grant code expires in ~3 minutes.** Have your exchange script ready before generating it.
+3. **Refresh token limits.** Max 20 per user. Multiple services generating their own will silently invalidate older ones.
+4. **Field API names, not display labels.** Use `Last_Name` not "Last Name". Check metadata API for API names.
+5. **Bulk limit is 100.** Create/update/upsert/delete cap at 100 records per request.
+6. **Pagination beyond 2,000 records** requires `page_token`. Page tokens expire after 24 hours.
+7. **Search caps at 2,000 records.** Use COQL for larger result sets (up to 100,000 via LIMIT/OFFSET).
+8. **204 No Content is not an error.** Check for 204 before parsing JSON.
+9. **`trigger` parameter controls side effects.** Pass `trigger=[]` to skip workflows during bulk migrations.
+10. **COQL requires a WHERE clause.** Use `WHERE id > 0` as a workaround for all records.

--- a/content/zoho-desk/docs/rest-api/python/DOC.md
+++ b/content/zoho-desk/docs/rest-api/python/DOC.md
@@ -1,0 +1,248 @@
+---
+name: rest-api
+description: "Zoho Desk - Help Desk & Customer Support REST API"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "zoho,desk,helpdesk,support,tickets,customer-service,api"
+---
+
+# Zoho Desk REST API v1 -- Python (`httpx` Async)
+
+Zoho Desk is help desk and customer support software for managing tickets,
+contacts, accounts, agents, departments, and knowledge base articles. All
+examples below use **`httpx`** with `AsyncClient`.
+
+## Golden Rule
+
+Always use the correct regional domain and include the `orgId` header on every request (except `/organizations`). Access tokens expire every hour -- build automatic refresh into every client.
+
+**Installation:** `pip install httpx`
+
+## Base URL & Region Domains
+
+| Region | Accounts Server | API Base URL |
+|---|---|---|
+| US | `https://accounts.zoho.com` | `https://desk.zoho.com/api/v1` |
+| EU | `https://accounts.zoho.eu` | `https://desk.zoho.eu/api/v1` |
+| India | `https://accounts.zoho.in` | `https://desk.zoho.in/api/v1` |
+| Australia | `https://accounts.zoho.com.au` | `https://desk.zoho.com.au/api/v1` |
+| Japan | `https://accounts.zoho.jp` | `https://desk.zoho.jp/api/v1` |
+| Canada | `https://accounts.zoho.ca` | `https://desk.zoho.ca/api/v1` |
+
+## Authentication -- OAuth 2.0
+
+Zoho Desk shares the Zoho-wide OAuth 2.0 flow.
+
+1. **Register a Client** at <https://api-console.zoho.com/> (Server-based). You get a Client ID and Client Secret.
+2. **Obtain an Authorization Code** -- redirect user to `{accounts_server}/oauth/v2/auth?client_id=...&response_type=code&redirect_uri=...&scope=Desk.tickets.ALL,Desk.contacts.READ,Desk.basic.READ&access_type=offline`
+3. **Exchange Code for Tokens:**
+
+```python
+import httpx
+
+async def exchange_code(accounts_server: str, client_id: str, client_secret: str, code: str, redirect_uri: str) -> dict:
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(f"{accounts_server}/oauth/v2/token", params={
+            "grant_type": "authorization_code", "code": code,
+            "client_id": client_id, "client_secret": client_secret,
+            "redirect_uri": redirect_uri,
+        })
+        resp.raise_for_status()
+        return resp.json()
+```
+
+4. **Refresh Access Token** (tokens expire after 1 hour; refresh tokens do not expire, max 20 per user):
+
+```python
+async def refresh_access_token(accounts_server: str, client_id: str, client_secret: str, refresh_token: str) -> dict:
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(f"{accounts_server}/oauth/v2/token", params={
+            "grant_type": "refresh_token", "refresh_token": refresh_token,
+            "client_id": client_id, "client_secret": client_secret,
+        })
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### OAuth Scopes
+
+Format: `Desk.{module}.{operation}` -- Operations: `READ`, `WRITE`, `UPDATE`, `DELETE`, `ALL`
+
+Key scopes: `Desk.tickets.ALL`, `Desk.contacts.READ`, `Desk.contacts.WRITE`, `Desk.basic.READ`, `Desk.search.READ`, `Desk.articles.ALL`
+
+## Rate Limits
+
+| Plan | Base Credits | Per User | Concurrent |
+|---|---|---|---|
+| Free / Trial | 5,000 | -- | 5 |
+| Standard | 50,000 | +250 | 10 |
+| Professional | 75,000 | +500 | 15 |
+| Enterprise | 100,000 | +1,000 | 25 |
+
+Headers: `X-Rate-Limit-Remaining-v3` (credits left), `Retry-After` (seconds, on 429).
+
+## Reusable Client with Auto-Refresh
+
+```python
+import httpx, time
+
+class ZohoDeskClient:
+    def __init__(self, client_id: str, client_secret: str, refresh_token: str, org_id: str, region: str = "com"):
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.refresh_token = refresh_token
+        self.org_id = org_id
+        self.accounts_url = f"https://accounts.zoho.{region}"
+        self.api_base = f"https://desk.zoho.{region}/api/v1"
+        self._access_token: str | None = None
+        self._token_expiry: float = 0.0
+
+    async def _ensure_token(self, client: httpx.AsyncClient) -> str:
+        if self._access_token and time.time() < self._token_expiry:
+            return self._access_token
+        resp = await client.post(f"{self.accounts_url}/oauth/v2/token", params={
+            "grant_type": "refresh_token", "refresh_token": self.refresh_token,
+            "client_id": self.client_id, "client_secret": self.client_secret,
+        })
+        resp.raise_for_status()
+        data = resp.json()
+        self._access_token = data["access_token"]
+        self._token_expiry = time.time() + data.get("expires_in", 3600) - 60
+        return self._access_token
+
+    def _base_headers(self, token: str) -> dict:
+        return {"Authorization": f"Zoho-oauthtoken {token}", "orgId": self.org_id, "Content-Type": "application/json"}
+
+    async def request(self, method: str, path: str, *, json: dict | None = None, params: dict | None = None, files: dict | None = None) -> dict:
+        async with httpx.AsyncClient() as client:
+            token = await self._ensure_token(client)
+            headers = self._base_headers(token)
+            if files:
+                headers.pop("Content-Type", None)
+            resp = await client.request(method, f"{self.api_base}{path}", headers=headers, params=params, json=json, files=files)
+            resp.raise_for_status()
+            return resp.json()
+```
+
+### Retrieving Your Organization ID
+
+```python
+async def get_organizations(access_token: str) -> list[dict]:
+    async with httpx.AsyncClient() as client:
+        resp = await client.get("https://desk.zoho.com/api/v1/organizations",
+            headers={"Authorization": f"Zoho-oauthtoken {access_token}"})
+        resp.raise_for_status()
+        return resp.json()["data"]
+```
+
+## Tickets
+
+### Create a Ticket
+
+```python
+async def create_ticket(desk: ZohoDeskClient, subject: str, department_id: str, contact_id: str, **optional) -> dict:
+    payload = {"subject": subject, "departmentId": department_id, "contactId": contact_id, **optional}
+    return await desk.request("POST", "/tickets", json=payload)
+```
+
+### List Tickets
+
+```python
+async def list_tickets(desk: ZohoDeskClient, from_index: int = 0, limit: int = 50, **filters) -> dict:
+    params = {"from": from_index, "limit": limit, **filters}
+    return await desk.request("GET", "/tickets", params=params)
+```
+
+### Get / Update / Close Tickets
+
+```python
+async def get_ticket(desk: ZohoDeskClient, ticket_id: str) -> dict:
+    return await desk.request("GET", f"/tickets/{ticket_id}")
+
+async def update_ticket(desk: ZohoDeskClient, ticket_id: str, **fields) -> dict:
+    return await desk.request("PATCH", f"/tickets/{ticket_id}", json=fields)
+
+async def close_tickets(desk: ZohoDeskClient, ticket_ids: list[str]) -> dict:
+    return await desk.request("POST", "/closeTickets", json={"ids": ticket_ids})
+```
+
+### Other Ticket Endpoints
+
+| Action | Method | Path |
+|---|---|---|
+| Move to trash | POST | `/tickets/moveToTrash` (body: `{"ticketIds": [...]}`) |
+| Merge tickets | POST | `/tickets/{id}/merge` |
+| Ticket history | GET | `/tickets/{id}/History` |
+| Send reply | POST | `/tickets/{id}/sendReply` |
+| List threads | GET | `/tickets/{id}/threads` |
+| Add comment | POST | `/tickets/{id}/comments` |
+| List comments | GET | `/tickets/{id}/comments` |
+
+## Contacts
+
+```python
+async def create_contact(desk: ZohoDeskClient, last_name: str, email: str, **optional) -> dict:
+    payload = {"lastName": last_name, "email": email, **optional}
+    return await desk.request("POST", "/contacts", json=payload)
+```
+
+Key endpoints: `POST /contacts` (create), `GET /contacts` (list), `GET /contacts/{id}` (get), `PATCH /contacts/{id}` (update), `GET /contacts/{id}/tickets` (contact's tickets).
+
+## Additional Module Endpoints
+
+| Module | Create | List | Get | Update |
+|---|---|---|---|---|
+| Accounts | `POST /accounts` | `GET /accounts` | `GET /accounts/{id}` | `PATCH /accounts/{id}` |
+| Agents | `POST /agents` | `GET /agents` | `GET /agents/{id}` | `PATCH /agents/{id}` |
+| Departments | `POST /departments` | `GET /departments` | `GET /departments/{id}` | `PATCH /departments/{id}` |
+| Tasks | `POST /tasks` | `GET /tasks` | `GET /tasks/{id}` | `PATCH /tasks/{id}` |
+| Attachments | `POST /tickets/{tid}/attachments` | `GET /tickets/{tid}/attachments` | -- | -- |
+
+## Error Handling
+
+```python
+import asyncio
+
+async def safe_request(desk: ZohoDeskClient, method: str, path: str, **kw):
+    try:
+        return await desk.request(method, path, **kw)
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 429:
+            retry_after = int(exc.response.headers.get("Retry-After", "60"))
+            await asyncio.sleep(retry_after)
+            return await desk.request(method, path, **kw)
+        raise
+```
+
+Common status codes: `200` OK, `201` Created, `204` No Content, `400` Bad Request, `401` Unauthorized (token expired), `403` Forbidden, `404` Not Found, `429` Rate Limit, `500` Internal Error.
+
+## Pagination
+
+List endpoints use offset-based pagination: `from` (0-based offset) + `limit` (max 50 per page).
+
+```python
+async def fetch_all_tickets(desk: ZohoDeskClient) -> list[dict]:
+    all_tickets, offset, limit = [], 0, 50
+    while True:
+        data = await desk.request("GET", "/tickets", params={"from": offset, "limit": limit})
+        tickets = data.get("data", [])
+        if not tickets:
+            break
+        all_tickets.extend(tickets)
+        if len(tickets) < limit:
+            break
+        offset += limit
+    return all_tickets
+```
+
+## Common Pitfalls
+
+1. **`orgId` is a header**, not a query parameter (unlike Zoho Books).
+2. Updates use **`PATCH`**, not `PUT`.
+3. Pagination uses **`from` + `limit`** (max 50), not `page` + `per_page`.
+4. Field names are **camelCase** (e.g., `departmentId`, `contactId`).
+5. The `from` param is 0-based offset, not 1-based page number.

--- a/content/zoom/docs/rest-api/python/DOC.md
+++ b/content/zoom/docs/rest-api/python/DOC.md
@@ -1,0 +1,258 @@
+---
+name: rest-api
+description: "Zoom Integration with Complete API Implementation"
+metadata:
+  languages: "python"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-03-13"
+  source: community
+  tags: "zoom,communication,video,meetings,api,integration"
+---
+
+# Zoom API
+
+> **Golden Rule:** Zoom has no official Python SDK. Use `httpx` (async) or `requests` (sync) for direct REST API access. Always handle rate limits, retries, and error responses explicitly.
+
+## Installation
+
+```bash
+pip install httpx
+```
+
+## Base URL
+
+`https://api.zoom.us/v2`
+
+## Authentication
+
+**Type:** Oauth2
+
+```python
+import httpx
+
+ACCESS_TOKEN = "your-oauth-access-token"
+BASE_URL = "https://api.zoom.us/v2"
+
+headers = {"Authorization": f"Bearer {ACCESS_TOKEN}"}
+client = httpx.AsyncClient(headers=headers)
+```
+
+## Rate Limiting
+
+**Limit:** 60 requests/minute
+
+The API enforces rate limits. Check `X-RateLimit-Remaining` and `Retry-After` response headers. Implement exponential backoff on 429 responses.
+
+## Methods
+
+### `get_user`
+
+**Endpoint:** `GET /users/me`
+
+Get user
+
+| Parameter | Type | Default |
+|---|---|---|
+| `limit` | `int` | `100` |
+
+**Returns:** JSON response
+
+```python
+params = {
+    "limit": 100
+}
+response = await client.get(f"{BASE_URL}/users/me", params=params)
+response.raise_for_status()
+data = response.json()
+```
+
+### `list_meetings`
+
+**Endpoint:** `GET /users/me/meetings`
+
+List meetings
+
+| Parameter | Type | Default |
+|---|---|---|
+| `type` | `str` | **required** |
+| `limit` | `int` | `100` |
+
+**Returns:** JSON response
+
+```python
+params = {
+    "type": "...",
+    "limit": 100
+}
+response = await client.get(f"{BASE_URL}/users/me/meetings", params=params)
+response.raise_for_status()
+data = response.json()
+```
+
+### `get_meeting`
+
+**Endpoint:** `GET /meetings/{meetingId}`
+
+Get meeting
+
+| Parameter | Type | Default |
+|---|---|---|
+| `meetingId` | `str` | **required** |
+| `limit` | `int` | `100` |
+
+**Returns:** JSON response
+
+```python
+params = {
+    "meetingId": "...",
+    "limit": 100
+}
+response = await client.get(f"{BASE_URL}/meetings/{meetingId}", params=params)
+response.raise_for_status()
+data = response.json()
+```
+
+### `list_users`
+
+**Endpoint:** `GET /users`
+
+List users
+
+| Parameter | Type | Default |
+|---|---|---|
+| `status` | `str` | **required** |
+| `limit` | `int` | `100` |
+
+**Returns:** JSON response
+
+```python
+params = {
+    "status": "...",
+    "limit": 100
+}
+response = await client.get(f"{BASE_URL}/users", params=params)
+response.raise_for_status()
+data = response.json()
+```
+
+### `list_recordings`
+
+**Endpoint:** `GET /users/me/recordings`
+
+List cloud recordings
+
+| Parameter | Type | Default |
+|---|---|---|
+| `from` | `str` | **required** |
+| `to` | `str` | **required** |
+| `page_size` | `int` | `100` |
+
+**Returns:** JSON response
+
+```python
+params = {
+    "from": "2024-01-01",
+    "to": "2024-12-31",
+    "page_size": 100
+}
+response = await client.get(f"{BASE_URL}/users/me/recordings", params=params)
+response.raise_for_status()
+data = response.json()
+```
+
+### `get_recording`
+
+**Endpoint:** `GET /meetings/{meetingId}/recordings`
+
+Get meeting recordings
+
+| Parameter | Type | Default |
+|---|---|---|
+| `meetingId` | `str` | **required** |
+| `limit` | `int` | `100` |
+
+**Returns:** JSON response
+
+```python
+params = {
+    "meetingId": "...",
+    "limit": 100
+}
+response = await client.get(f"{BASE_URL}/meetings/{meetingId}/recordings", params=params)
+response.raise_for_status()
+data = response.json()
+```
+
+### `list_webinars`
+
+**Endpoint:** `GET /users/me/webinars`
+
+List webinars
+
+| Parameter | Type | Default |
+|---|---|---|
+| `limit` | `int` | `100` |
+
+**Returns:** JSON response
+
+```python
+params = {
+    "limit": 100
+}
+response = await client.get(f"{BASE_URL}/users/me/webinars", params=params)
+response.raise_for_status()
+data = response.json()
+```
+
+### `get_webinar`
+
+**Endpoint:** `GET /webinars/{webinarId}`
+
+Get webinar
+
+| Parameter | Type | Default |
+|---|---|---|
+| `webinarId` | `str` | **required** |
+| `limit` | `int` | `100` |
+
+**Returns:** JSON response
+
+```python
+params = {
+    "webinarId": "...",
+    "limit": 100
+}
+response = await client.get(f"{BASE_URL}/webinars/{webinarId}", params=params)
+response.raise_for_status()
+data = response.json()
+```
+
+## Error Handling
+
+```python
+import httpx
+
+try:
+    response = await client.get(f"{BASE_URL}/users/me")
+    response.raise_for_status()
+    data = response.json()
+except httpx.HTTPStatusError as e:
+    if e.response.status_code == 401:
+        print("Authentication failed -- check your API key")
+    elif e.response.status_code == 429:
+        retry_after = e.response.headers.get("Retry-After", "60")
+        print(f"Rate limited -- retry after {retry_after}s")
+    else:
+        print(f"Zoom API error {e.response.status_code}: {e.response.text}")
+except httpx.RequestError as e:
+    print(f"Network error: {e}")
+```
+
+## Common Pitfalls
+
+- Always call `response.raise_for_status()` to catch HTTP errors
+- Use `async with httpx.AsyncClient() as client:` to auto-close connections
+- Handle 429 (rate limit) responses with exponential backoff
+- Set a reasonable timeout: `httpx.AsyncClient(timeout=30.0)`
+- The `limit` / `per_page` parameter controls page size, not total results -- paginate to get all data


### PR DESCRIPTION
What
Adds 100 new REST API documentation entries (DOC.md) covering services across 17 categories — from AI/ML inference providers to fintech, health, IoT, and charity APIs. All docs use raw httpx async Python (no SDK dependencies), making them immediately usable by any AI agent.

Why
Context Hub currently has strong SDK/package coverage but limited REST API documentation. AI agents frequently need to call APIs directly via HTTP — especially for newer services, regional providers, and niche domains that lack mature SDKs. This contribution fills that gap across:

- AI agent tooling (12): Inference, search, code execution, web scraping — the core loop for agentic workflows (cerebras, e2b, exa, fal, firecrawl, fireworks, groq, open-router, perplexity, sarvam-ai, tavily, xai)
- Search/Web (3): Headless browsing, content extraction, SERP results (browserless, jina-reader, serper)
- Communication (7): Omnichannel messaging, video, and CPaaS for agent-to-human handoff (gupshup, kaleyra, line, msg91, telegram, whatsapp-cloud, zoom)
- Indian ecosystem (19): Payments, logistics, government, mapping, and commerce — enabling automation across India's digital infrastructure (bhashini, cashfree, clevertap, delhivery, digilocker, exotel, gstn, indian-railway, isro, krutrim-cloud, leadsquared, mappls, moengage, ola-maps, ondc, razorpay, shiprocket, tally, zerodha-kite)
- Zoho Suite (3): CRM, accounting, and helpdesk for business automation (zoho-books, zoho-crm, zoho-desk)
- European fintech (6): Cross-border payments and checkout (adyen, gocardless, klarna, mollie, revolut, wise)
- UK banking (3): Open Banking APIs for account access and payments (monzo, starling, truelayer)
- US finance (3): Trading, banking, and market data (alpaca, mercury, polygon)
- Crypto (4): Exchange trading, market data, and on-chain analytics (coinbase, coingecko, kraken, moralis)
- Africa/LATAM (4): Mobile money and payments for emerging markets (flutterwave, mercadopago, mpesa, paystack)
- Travel/Geo (7): Flights, weather, geocoding, currency, and music (amadeus, aviationstack, currencyapi, nominatim, openweather, skyscanner, spotify)
- CRM/Marketing (4): Lead enrichment, billing, support, and workflow automation (apollo-io, chargebee, freshdesk, make)
- Health (6): Drug data, NHS services, wearables, speech-to-text, and conversation intelligence (fitbit, nhs, openfda, speechmatics, symbl, withings)
- Education/Personal (6): LMS, scheduling, food data, gamified productivity (calendly, canvas-lms, google-classroom, habitica, openfoodfacts, todoist)
- Charity/Community (5): Donations, civic services, and environmental data (charity-navigator, globalgiving, justgiving, open311, openaq)
- IoT/Assistive (5): Home automation, notifications, and self-hosted tools (home-assistant, nextcloud, ntfy, philips-hue, pushover)
- Dev Tools (2): Serverless data and script hosting (upstash, val-town)

## Testing
- [ ] `npm test` passes
- [ ] `chub build sample-content/ --validate-only` succeeds
- [ ] Manual testing done (describe below)

## Notes

Any additional context for reviewers.
