### PR TITLE
Add Snowflake Cortex Code CLI documentation

### DIFF
--- a/content/snowflake/docs/cortex-code/DOC.md
+++ b/content/snowflake/docs/cortex-code/DOC.md
@@ -1,0 +1,242 @@
+---
+name: cortex-code
+description: "Snowflake Cortex Code CLI — AI-powered coding assistant with native Snowflake integration, SQL execution, semantic views, MCP support, skills, and subagents"
+metadata:
+  languages: "bash"
+  versions: "1.0.36"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "snowflake,cortex,cli,ai,coding-assistant,sql,mcp,agents,skills"
+---
+
+# Cortex Code CLI
+
+Cortex Code (CoCo) is Snowflake's AI-powered coding assistant CLI. It connects directly to your Snowflake account and orchestrates SQL execution, object discovery, semantic views, Cortex Analyst, MCP integrations, skills, and subagents from your terminal.
+
+## Install
+
+```bash
+# Linux / macOS / WSL
+curl -LsS https://ai.snowflake.com/static/cc-scripts/install.sh | sh
+
+# Windows (PowerShell)
+irm https://ai.snowflake.com/static/cc-scripts/install.ps1 | iex
+```
+
+The `cortex` binary installs to `~/.local/bin` (Linux/macOS) or `%LOCALAPPDATA%\cortex` (Windows).
+
+## Connect to Snowflake
+
+Run `cortex` to launch the setup wizard. It reads connections from `~/.snowflake/connections.toml`:
+
+```toml
+[default]
+account = "myaccount"
+user = "myuser"
+authenticator = "externalbrowser"
+database = "MYDB"
+schema = "PUBLIC"
+warehouse = "COMPUTE_WH"
+role = "DEVELOPER"
+```
+
+Supported auth methods: `externalbrowser` (SSO), `snowflake_jwt` (key-pair), `snowflake` (password), `oauth`, `PROGRAMMATIC_ACCESS_TOKEN`.
+
+## Quick Start
+
+```bash
+cortex                              # Start interactive REPL
+cortex -p "summarize README.md"     # Non-interactive (print) mode
+cortex --resume last                # Resume last session
+cortex -c my-connection             # Use specific Snowflake connection
+cortex --plan                       # Start in plan mode
+```
+
+## Core Concepts
+
+### Special Input Syntax
+
+| Syntax | Action | Example |
+|--------|--------|---------|
+| `@path` | Include file context | `@src/app.ts` |
+| `@path$N-M` | Include line range | `@src/app.ts$10-50` |
+| `$skill` | Invoke a skill | `$ml-guide help` |
+| `#TABLE` | Inject Snowflake table metadata | `#MY_DB.PUBLIC.USERS` |
+| `!cmd` | Run bash (output goes to agent) | `!git status` |
+| `/cmd` | Slash command | `/help` |
+| `?` | Quick help overlay | `?` |
+
+### Operational Modes
+
+| Mode | Activate | Description |
+|------|----------|-------------|
+| Confirm Actions | default | Normal with permission checks |
+| Plan Mode | `/plan` or `Ctrl+P` | Review actions before execution |
+| Bypass Safeguards | `/bypass` | Auto-approve all tool calls |
+
+Cycle modes with `Shift+Tab`.
+
+### Essential Keyboard Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| `Enter` | Submit message |
+| `Ctrl+J` | Insert newline |
+| `Ctrl+C` | Cancel / Exit |
+| `Shift+Tab` | Cycle operational modes |
+| `Ctrl+P` | Toggle plan mode |
+| `Ctrl+O` | Cycle display mode |
+| `Ctrl+R` | Search prompt history |
+| `Ctrl+B` | Background bash process |
+| `Ctrl+D` | Fullscreen todo view |
+| `Ctrl+T` | SQL table view |
+| `Escape` | Cancel streaming |
+
+## Snowflake Integration
+
+Cortex Code connects natively to Snowflake. No separate SDK needed.
+
+### #TABLE Context Injection
+
+Type `#` followed by a fully-qualified table name to auto-inject metadata (columns, types, sample rows):
+
+```
+Analyze the data in #MY_DB.PUBLIC.USERS
+```
+
+### SQL Execution
+
+```
+/sql SELECT COUNT(*) FROM my_table
+```
+
+Use `/table` to view results in a fullscreen table. The agent also executes SQL autonomously when needed.
+
+### Object Search
+
+```bash
+cortex search object "user activity tables"
+```
+
+Semantic search across databases, schemas, tables, views, and functions.
+
+### Cortex Analyst
+
+```bash
+cortex analyst query "What was revenue last month?" --model=revenue.yaml
+cortex analyst query "Top customers by spend" --view=ANALYTICS.CORE.REVENUE_METRICS
+cortex reflect revenue.yaml    # Validate semantic model
+```
+
+### Semantic Views
+
+```bash
+cortex semantic-views discover          # Find all semantic views
+cortex semantic-views describe <view>   # Show dimensions, facts, metrics
+cortex semantic-views search "revenue"  # Search by keyword
+```
+
+### Product Docs Search
+
+```bash
+cortex search docs "how to create a stored procedure"
+```
+
+## Session Management
+
+| Command | Description |
+|---------|-------------|
+| `/resume` | Resume a previous session |
+| `/fork` | Fork conversation from a specific point |
+| `/rewind` | Roll back to a previous state |
+| `/compact` | Summarize and clear history (frees context) |
+| `/rename <name>` | Name the session for easy retrieval |
+| `/diff` | Fullscreen git diff viewer |
+
+```bash
+cortex -r last                  # Resume last session from CLI
+cortex resume                   # Interactive session picker
+```
+
+## Key Slash Commands
+
+| Command | Description |
+|---------|-------------|
+| `/help` | Show help |
+| `/status` | Session status |
+| `/model <name>` | Switch model |
+| `/sql <query>` | Execute SQL |
+| `/settings` | Interactive settings editor |
+| `/connections` | Connection manager |
+| `/mcp` | MCP server manager |
+| `/skill` | Skill manager |
+| `/hooks` | Hook manager |
+| `/agents` | Subagent manager |
+| `/theme` | Theme selector |
+
+## Skills
+
+Skills are reusable instruction sets invoked with the `$` prefix:
+
+```
+$developing-with-streamlit build a dashboard for my sales data
+```
+
+Skill locations (priority order): project (`.cortex/skills/`) > global (`~/.snowflake/cortex/skills/`) > remote > bundled.
+
+## Subagents
+
+Cortex Code spawns autonomous child agents for complex tasks:
+
+| Agent Type | Description |
+|------------|-------------|
+| `general-purpose` | Full tool access for multi-step tasks |
+| `Explore` | Fast read-only codebase exploration |
+| `Plan` | Architecture and implementation planning (read-only) |
+
+Agents can run in background. Use `/agents` to manage them.
+
+## MCP (Model Context Protocol)
+
+Extend Cortex Code by connecting external services:
+
+```bash
+cortex mcp add github -e GITHUB_TOKEN=$GITHUB_TOKEN -- npx -y @modelcontextprotocol/server-github
+cortex mcp list
+```
+
+Config: `~/.snowflake/cortex/mcp.json`. Supports `stdio`, `sse`, and `http` transports.
+
+## Supported Models
+
+| Model | Identifier |
+|-------|------------|
+| Auto (recommended) | `auto` |
+| Claude Opus 4.6 | `claude-opus-4-6` |
+| Claude Sonnet 4.6 | `claude-sonnet-4-6` |
+| Claude Opus 4.5 | `claude-opus-4-5` |
+| Claude Sonnet 4.5 | `claude-sonnet-4-5` |
+| Claude Sonnet 4.0 | `claude-4-sonnet` |
+| OpenAI GPT 5.2 | `openai-gpt-5.2` |
+
+Switch models: `/model claude-opus-4-6`
+
+## Prerequisites
+
+- Snowflake account with `SNOWFLAKE.CORTEX_USER` database role
+- At least one supported model available in your account
+- Supported platforms: macOS (arm64/x64), Linux (x64/arm64), Windows WSL, Windows native (preview)
+- If your model is not in-region, enable cross-region inference:
+  ```sql
+  ALTER ACCOUNT SET CORTEX_ENABLED_CROSS_REGION = 'AWS_US';
+  ```
+
+## Reference Files
+
+For detailed documentation, see:
+
+- `references/commands.md` — Full CLI commands, slash commands, and flags
+- `references/snowflake-tools.md` — SQL execution, #TABLE, object search, Cortex Analyst, semantic views, artifacts
+- `references/mcp-and-agents.md` — MCP configuration, transport types, subagent system, custom agents
+- `references/configuration.md` — Settings, environment variables, connections, skills, hooks

--- a/content/snowflake/docs/cortex-code/references/commands.md
+++ b/content/snowflake/docs/cortex-code/references/commands.md
@@ -1,0 +1,131 @@
+# Commands Reference
+
+Full reference for Cortex Code CLI commands, slash commands, and flags.
+
+## CLI Entry Points
+
+```bash
+cortex                              # Start interactive REPL
+cortex -p "query"                   # Non-interactive print mode
+cortex resume                       # Interactive session picker
+cortex -r last                      # Resume last session
+cortex -r <session_id>              # Resume specific session
+```
+
+## CLI Subcommands
+
+| Command | Description |
+|---------|-------------|
+| `cortex mcp list\|add\|remove\|show` | Manage MCP servers |
+| `cortex skill list\|add\|remove` | Manage skills |
+| `cortex resume [id]` | Resume session |
+| `cortex update` | Update CLI |
+| `cortex versions` | List available versions |
+| `cortex worktree list\|create\|switch\|delete` | Git worktrees |
+| `cortex completion install\|generate` | Shell tab-completion (bash/zsh/fish) |
+| `cortex connections list\|set` | Snowflake connections |
+| `cortex env detect` | Detect Python environment |
+| `cortex source <conn> -- <cmd>` | Run command with Snowflake credentials as env vars |
+| `cortex ctx` | Long-term AI memory and task management |
+| `cortex browser` | Browser automation (Playwright MCP) |
+| `cortex search object "<query>"` | Search Snowflake objects |
+| `cortex search docs "<query>"` | Search Snowflake product docs |
+| `cortex reflect <file.yaml>` | Validate semantic model YAML |
+| `cortex semantic-views list\|discover\|describe\|search\|ddl\|query` | Semantic view operations |
+| `cortex analyst query "<question>"` | Query via Cortex Analyst |
+| `cortex artifact create notebook\|file <name> <path>` | Upload to Snowflake Workspace |
+| `cortex agents discover\|list\|describe\|search` | Cortex Agent operations |
+
+## CLI Flags
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--resume <id\|last>` | `-r` | Resume session |
+| `--print <query>` | `-p` | Non-interactive mode |
+| `--workdir <dir>` | `-w` | Working directory |
+| `--worktree <name>` | | Git worktree |
+| `--connection <name>` | `-c` | Snowflake connection |
+| `--model <name>` | `-m` | Model override |
+| `--plan` | | Start in plan mode |
+| `--bypass` | | Start in bypass mode |
+| `--config <path>` | | Custom settings.json |
+| `--no-mcp` | | Disable MCP servers |
+| `--version` | `-V` | Show version |
+
+## Slash Commands — Session
+
+| Command | Description |
+|---------|-------------|
+| `/quit`, `/q` | Exit |
+| `/clear` | Clear screen |
+| `/new` | New session |
+| `/fork [name]` | Fork conversation from a chosen point |
+| `/resume` | Session picker |
+| `/rename <name>` | Rename session |
+| `/rewind [N]` | Rewind N user messages (or interactive) |
+| `/compact [instructions]` | Summarize context and clear history |
+
+## Slash Commands — Information
+
+| Command | Description |
+|---------|-------------|
+| `/help` | Show help |
+| `/status` | Session status |
+| `/commands` | List all commands |
+
+## Slash Commands — Modes
+
+| Command | Description |
+|---------|-------------|
+| `/plan` | Enable plan mode |
+| `/plan-off` | Disable plan mode |
+| `/bypass` | Enable bypass mode |
+| `/bypass-off` | Disable bypass mode |
+| `/model <name>` | Switch model |
+
+## Slash Commands — Configuration
+
+| Command | Description |
+|---------|-------------|
+| `/settings` | Interactive settings editor |
+| `/mcp` | MCP server manager |
+| `/skill` | Skill manager |
+| `/hooks` | Hook manager |
+| `/theme` | Theme selector |
+| `/connections` | Connection manager |
+
+## Slash Commands — Development
+
+| Command | Description |
+|---------|-------------|
+| `/add-dir <path>` | Add working directory |
+| `/sh <cmd>` | Execute shell command |
+| `/sql <query>` | Execute SQL |
+| `/table` | Fullscreen SQL results view |
+| `/diff` | Fullscreen git diff viewer |
+| `/tasks` | Active background tasks |
+| `/worktree` | Worktree manager |
+| `/sandbox` | Sandbox settings |
+
+## Slash Commands — Utilities
+
+| Command | Description |
+|---------|-------------|
+| `/fdbt` | dbt operations |
+| `/lineage <model>` | Model lineage |
+| `/agents` | Subagent manager |
+| `/setup-jupyter` | Setup Jupyter |
+| `/feedback` | Submit feedback |
+| `/clear-cache` | Clear caches |
+| `/doctor` | Diagnose environment issues |
+| `/update` | Update Cortex Code CLI |
+
+## Custom Slash Commands
+
+Define custom commands as Markdown files. Loaded in priority order:
+
+1. **Project** — `.cortex/commands/`, `.claude/commands/`
+2. **Global** — `~/.snowflake/cortex/commands/`
+3. **User** — `~/.claude/commands/`
+
+Each `.md` file becomes a `/command` named after the file.

--- a/content/snowflake/docs/cortex-code/references/configuration.md
+++ b/content/snowflake/docs/cortex-code/references/configuration.md
@@ -1,0 +1,200 @@
+# Configuration Reference
+
+Settings, environment variables, connections, skills, and hooks for Cortex Code.
+
+## Directory Structure
+
+```
+~/.snowflake/cortex/
+├── settings.json           # Main configuration
+├── skills.json             # Skills configuration
+├── permissions.json        # Permission history (auto-generated)
+├── hooks.json              # Hook configurations
+├── mcp.json                # MCP server configurations
+├── skills/                 # Global skills
+│   └── my-skill/
+│       └── SKILL.md
+├── agents/                 # Custom agent definitions
+├── commands/               # Custom slash commands
+└── conversations/          # Session history
+```
+
+## settings.json
+
+Main configuration file at `~/.snowflake/cortex/settings.json`:
+
+```json
+{
+  "env": {
+    "CORTEX_AGENT_MODEL": "claude-sonnet-4-5",
+    "CORTEX_AGENT_ENABLE_SUBAGENTS": true,
+    "SNOVA_DEBUG": false,
+    "CORTEX_CHANNEL": "stable"
+  },
+  "diffDisplayMode": "unified",
+  "compactMode": false,
+  "bashDefaultTimeoutMs": 180000,
+  "theme": "dark"
+}
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `diffDisplayMode` | `"unified"` \| `"side_by_side"` | Diff display style |
+| `compactMode` | boolean | Start in compact UI mode |
+| `bashDefaultTimeoutMs` | number | Default bash timeout (ms) |
+| `theme` | `"dark"` \| `"light"` \| `"pro"` | UI color theme |
+
+## Environment Variables
+
+### Core
+
+| Variable | Description |
+|----------|-------------|
+| `CORTEX_CODE_STREAMING` | Enable live streaming mode |
+| `CORTEX_ENABLE_MEMORY` | Enable memory tool |
+| `CORTEX_ENABLE_EXPERIMENTAL_SKILLS` | Enable experimental skills |
+| `CORTEX_AGENT_ENABLE_SUBAGENTS` | Enable subagent spawning |
+
+### Snowflake
+
+| Variable | Description |
+|----------|-------------|
+| `SNOWFLAKE_CONNECTION` | Default connection name |
+| `SNOWFLAKE_ACCOUNT` | Snowflake account |
+| `SNOWFLAKE_USER` | Snowflake username |
+| `SNOWFLAKE_WAREHOUSE` | Default warehouse |
+| `SNOWFLAKE_DATABASE` | Default database |
+| `SNOWFLAKE_SCHEMA` | Default schema |
+
+### Priority Order
+
+1. **CLI flags** (highest)
+2. **Environment variables**
+3. **settings.json**
+4. **Built-in defaults** (lowest)
+
+## Skills System
+
+Skills are reusable instruction sets that guide the agent. Invoked with `$skill-name`.
+
+### Skill Locations (Priority Order)
+
+| Priority | Location |
+|----------|----------|
+| 1 | `.cortex/skills/`, `.claude/skills/` (project) |
+| 2 | `~/.snowflake/cortex/skills/` (global) |
+| 3 | Remote (cached from repositories) |
+| 4 | Bundled (shipped with Cortex Code) |
+
+### SKILL.md Format
+
+```markdown
+---
+name: my-skill
+description: "Purpose. Use when: situations. Triggers: keywords."
+tools: ["bash", "edit"]
+---
+
+# My Skill
+
+## Workflow
+1. Step one
+2. Step two
+```
+
+### Remote Skills
+
+Configure in `~/.snowflake/cortex/skills.json`:
+
+```json
+{
+  "paths": ["/path/to/additional/skills"],
+  "remote": [
+    {
+      "source": "https://github.com/org/skills-repo",
+      "ref": "main",
+      "skills": [{ "name": "skill-name" }]
+    }
+  ]
+}
+```
+
+### Managing Skills
+
+```
+/skill                              # Interactive skill manager
+```
+
+Press `a` to add, view conflicts, sync project skills to global, or delete.
+
+## Hooks System
+
+Hooks run custom code at specific points during execution.
+
+### Hook Events
+
+| Event | When | Use Case |
+|-------|------|----------|
+| `PreToolUse` | Before tool execution | Validate, block, modify tool calls |
+| `PostToolUse` | After tool execution | Log, validate outputs |
+| `UserPromptSubmit` | User submits prompt | Validate or transform input |
+| `Stop` | Agent stops | Verify completion |
+| `SessionStart` | Session begins | Initialize context |
+| `SessionEnd` | Session ends | Cleanup |
+| `PreCompact` | Before compaction | Inject context |
+
+### Configuration
+
+Hooks are configured in `~/.snowflake/cortex/hooks.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "/path/to/validator.sh", "timeout": 30 }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Matchers
+
+| Pattern | Matches |
+|---------|---------|
+| `Bash` | Exact tool name |
+| `Bash\|Edit` | Bash or Edit |
+| `.*` or `*` | All tools |
+| `snowflake_.*` | All Snowflake tools |
+| `mcp__github__.*` | All GitHub MCP tools |
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success, continue |
+| 2 | Block the operation (stderr sent to agent) |
+| Other | Non-blocking error (shown to user) |
+
+### Hook Input
+
+Hooks receive JSON on stdin with fields: `session_id`, `transcript_path`, `cwd`, `permission_mode`, `hook_event_name`. Tool events add `tool_name`, `tool_input`.
+
+### Managing Hooks
+
+```
+/hooks                              # Interactive hook manager
+```
+
+## Theme Configuration
+
+```
+/theme                              # Interactive theme selector
+/theme dark                         # Set dark theme
+/theme light                        # Set light theme
+```

--- a/content/snowflake/docs/cortex-code/references/mcp-and-agents.md
+++ b/content/snowflake/docs/cortex-code/references/mcp-and-agents.md
@@ -1,0 +1,165 @@
+# MCP and Agents Reference
+
+Extending Cortex Code with MCP servers and autonomous subagents.
+
+## MCP (Model Context Protocol)
+
+MCP connects Cortex Code to external services, databases, APIs, and tools.
+
+### Managing Servers
+
+```bash
+cortex mcp add <name> <command>         # Add server
+cortex mcp list                         # List all servers
+cortex mcp remove <name>                # Remove server
+cortex mcp show <name>                  # Show server details
+/mcp                                    # Interactive manager
+```
+
+### Configuration
+
+MCP servers are configured in `~/.snowflake/cortex/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": { "GITHUB_TOKEN": "${GITHUB_TOKEN}" },
+      "transport": "stdio",
+      "timeout": 60000
+    }
+  }
+}
+```
+
+### Config Fields
+
+| Field | Description |
+|-------|-------------|
+| `command` | Command to start server |
+| `args` | Command arguments |
+| `env` | Environment variables (`${VAR}` for expansion) |
+| `transport` | `stdio` (default), `sse`, or `http` |
+| `timeout` | Connection timeout in ms |
+| `url` | Server URL (for SSE/HTTP) |
+| `headers` | HTTP headers (for SSE/HTTP) |
+
+### Transport Types
+
+| Type | Use Case | Key Config |
+|------|----------|------------|
+| `stdio` | Local process | `command`, `args` |
+| `sse` | Remote SSE server | `url`, `headers` |
+| `http` | Remote HTTP API | `url`, `headers` |
+
+### Adding Servers
+
+```bash
+# stdio
+cortex mcp add my-server -- npx -y @scope/mcp-server
+
+# With env vars
+cortex mcp add my-server -e API_KEY=secret -- npx -y @scope/mcp-server
+
+# SSE
+cortex mcp add my-server --transport sse https://example.com/sse
+
+# HTTP with auth header
+cortex mcp add my-server --transport http -H "Authorization: Bearer token" https://example.com/api
+```
+
+### Common MCP Servers
+
+```bash
+# GitHub
+cortex mcp add github -e GITHUB_TOKEN=$GITHUB_TOKEN -- npx -y @modelcontextprotocol/server-github
+
+# Filesystem
+cortex mcp add filesystem -- npx -y @modelcontextprotocol/server-filesystem ~/Documents
+
+# PostgreSQL
+cortex mcp add postgres -e DATABASE_URL=$DATABASE_URL -- npx -y @modelcontextprotocol/server-postgres
+```
+
+### MCP Tool Naming
+
+Tools follow the pattern `mcp__<server>__<tool>`. Example: `mcp__github__create_issue`.
+
+### Disabling MCP
+
+```bash
+cortex --no-mcp                         # Start without MCP
+```
+
+## Subagents
+
+Cortex Code spawns autonomous child agents for complex, multi-step tasks.
+
+### Built-in Agent Types
+
+| Type | Description | Capabilities |
+|------|-------------|--------------|
+| `general-purpose` | Multi-step tasks, code changes | All tools |
+| `Explore` | Fast codebase exploration | Read-only |
+| `Plan` | Architecture and implementation planning | Read-only |
+| `feedback` | Collect and process user feedback | Ask questions |
+| `dbt-verify` | dbt project verification | All tools |
+
+### Explore Agent Thoroughness
+
+When asking for exploration, specify a level:
+- `"quick"` — basic file/keyword search
+- `"medium"` — moderate exploration across related files
+- `"very thorough"` — comprehensive multi-location analysis
+
+### Background Execution
+
+Agents can run in background while you continue working:
+- Use `/agents` to view status and manage running agents
+- Background agents return an `agent_id` for retrieving results later
+- Background agents cannot spawn other background agents
+
+### Custom Agents
+
+Define custom agents as Markdown files with YAML frontmatter:
+
+```markdown
+---
+name: my-agent
+description: "What this agent does. Triggers: relevant keywords."
+tools: ["Bash", "Read", "Edit"]
+---
+
+# My Agent
+
+Instructions for the agent (used as the system prompt).
+```
+
+### Loading Locations (Priority Order)
+
+| Priority | Location |
+|----------|----------|
+| 1 | `~/.snowflake/cortex/agents/` (global) |
+| 2 | `~/.claude/agents/` (global, compatibility) |
+| 3 | `.cortex/agents/` (project-local) |
+| 4 | `.claude/agents/` (project-local, compatibility) |
+
+### Worktree Isolation
+
+For parallel agent work without file conflicts:
+
+```bash
+cortex worktree create <name>           # Create worktree
+cortex worktree list                    # List worktrees
+cortex --worktree <name>               # Start session in worktree
+```
+
+### /agents Command
+
+```
+/agents
+```
+
+Opens a fullscreen tabbed interface showing available agent types, active sessions, and management options.

--- a/content/snowflake/docs/cortex-code/references/snowflake-tools.md
+++ b/content/snowflake/docs/cortex-code/references/snowflake-tools.md
@@ -1,0 +1,172 @@
+# Snowflake-Native Tools Reference
+
+Cortex Code integrates directly with Snowflake for SQL execution, object discovery, semantic analysis, and artifact management.
+
+## #TABLE Context Injection
+
+Type `#` followed by a fully-qualified 3-part table name to auto-inject metadata into your prompt:
+
+```
+Analyze the data in #MY_DB.PUBLIC.USERS
+```
+
+This fetches and injects:
+- Column metadata (name, type, nullable, default, comment)
+- Primary keys
+- Approximate row count
+- Up to 3 sample rows
+
+Autocomplete is available after typing `#`. Names are case-insensitive.
+
+## SQL Execution
+
+### /sql Slash Command
+
+```
+/sql SELECT COUNT(*) FROM my_table
+```
+
+Runs SQL inline. Use `/table` or `Ctrl+T` for a fullscreen table view of results.
+
+### Agent SQL Execution
+
+The agent executes SQL autonomously when needed via the `snowflake_sql_execute` tool:
+- Runs on the active Snowflake connection
+- Handles large result sets with truncation
+- Auto-refreshes expired tokens
+- Supports `only_compile` mode for validation without execution
+
+## Object Search
+
+Search for Snowflake objects using semantic (natural language) search:
+
+```bash
+cortex search object "user activity tables"
+cortex search object "revenue" --types=table,view
+```
+
+Searches across databases, schemas, tables, views, semantic views, and functions.
+
+## Cortex Analyst
+
+Convert natural language questions to SQL using semantic models or semantic views:
+
+```bash
+# Using a local YAML semantic model
+cortex analyst query "What were total sales last quarter?" --model=sales_model.yaml
+
+# Using a semantic view
+cortex analyst query "Top customers by spend" --view=ANALYTICS.CORE.REVENUE_METRICS
+
+# Validate a semantic model file
+cortex reflect revenue.yaml
+cortex reflect revenue.yaml --target-schema DB.SCHEMA
+```
+
+Returns generated SQL, explanation, and suggested follow-up questions.
+
+## Semantic Views
+
+Semantic views are curated data models with business-friendly definitions built on top of raw tables.
+
+```bash
+cortex semantic-views discover              # Find all semantic views in account
+cortex semantic-views list [--limit=N]      # List views
+cortex semantic-views describe <view>       # Show dimensions, facts, metrics
+cortex semantic-views search "revenue"      # Search by keyword
+cortex semantic-views ddl <view>            # Show SQL DDL definition
+cortex semantic-views query <view>          # Execute query against view
+```
+
+**Best practice:** Before writing complex SQL for business analytics, check if a semantic view exists. Semantic views provide verified business definitions more reliable than raw SQL.
+
+## Cortex Agent Discovery
+
+Cortex Agents contain curated instructions about which data sources to use:
+
+```bash
+cortex agents discover                      # Find all agents in account
+cortex agents list [--database DB]          # List agents in scope
+cortex agents describe <agent>              # Show instructions, tools, data sources
+cortex agents search "revenue"              # Search by domain
+```
+
+## Product Docs Search
+
+```bash
+cortex search docs "how to create a stored procedure"
+cortex search docs "dynamic tables target lag"
+```
+
+Searches Snowflake product documentation and returns relevant results.
+
+## Artifact Creation
+
+Upload files to Snowflake Workspace:
+
+```bash
+cortex artifact create notebook my_analysis ./analysis.ipynb
+cortex artifact create file my_report ./report.csv
+```
+
+Supports notebooks (`.ipynb`) and generic files. Default workspace: `USER$.PUBLIC.DEFAULT$`.
+
+## Connection Management
+
+### CLI
+
+```bash
+cortex connections list             # List configured connections
+cortex connections set <name>       # Switch active connection
+cortex --connection <name>          # Start with specific connection
+```
+
+### /connections
+
+Opens an interactive fullscreen connection manager.
+
+### connections.toml
+
+Connections are defined in `~/.snowflake/connections.toml`:
+
+```toml
+[default]
+account = "myaccount"
+user = "myuser"
+authenticator = "externalbrowser"
+database = "MYDB"
+schema = "PUBLIC"
+warehouse = "COMPUTE_WH"
+role = "DEVELOPER"
+
+[prod]
+account = "myaccount"
+user = "myuser"
+authenticator = "snowflake_jwt"
+private_key_path = "~/.snowflake/rsa_key.p8"
+database = "PROD_DB"
+schema = "PUBLIC"
+warehouse = "PROD_WH"
+role = "ANALYST"
+```
+
+### Authentication Methods
+
+| Method | Value |
+|--------|-------|
+| Browser SSO | `externalbrowser` |
+| Key-pair | `snowflake_jwt` |
+| Password | `snowflake` |
+| OAuth | `oauth` |
+| Programmatic access token | `PROGRAMMATIC_ACCESS_TOKEN` |
+
+## Source Command
+
+Run a command with Snowflake credentials injected as environment variables:
+
+```bash
+cortex source <connection> --map account=SF_ACCOUNT --map user=SF_USER -- python myscript.py
+cortex source myconn --map password=SNOWFLAKE_PASS -- dbt run
+```
+
+Available fields: `account`, `user`, `password`, `authenticator`, `warehouse`, `database`, `schema`, `role`, `host`, `token`.


### PR DESCRIPTION
## Summary

- Adds curated, LLM-friendly documentation for **Snowflake Cortex Code CLI** — Snowflake's AI-powered coding assistant
- Main `DOC.md` (242 lines) covers install, connect, quick start, special syntax, modes, shortcuts, Snowflake integration, sessions, skills, agents, MCP, and supported models
- 4 reference files for deep dives: commands, Snowflake-native tools, MCP/agents, and configuration

## Content structure

```
content/iamontheinet/docs/cortex-code/
├── DOC.md                              # Main entry (<500 lines)
└── references/
    ├── commands.md                     # CLI commands, slash commands, flags
    ├── snowflake-tools.md              # #TABLE, SQL, object search, Cortex Analyst, semantic views
    ├── mcp-and-agents.md               # MCP config, transports, subagent system, custom agents
    └── configuration.md                # Settings, env vars, connections, skills, hooks
```

## Validation

```
$ chub build content/ --validate-only
Valid: 1545 docs, 5 skills, 0 warnings
```

## Test plan

- [x] `chub build content/ --validate-only` passes with 0 warnings
- [x] DOC.md under 500 lines (242 lines)
- [x] YAML frontmatter matches content guide schema
- [x] Reference files follow progressive disclosure pattern per content guide
- [ ] Verify `chub get iamontheinet/cortex-code` fetches the doc correctly after build

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
