### PR TITLE
Add comprehensive Snowflake documentation (6 topics)

### DIFF
--- a/content/snowflake/docs/cortex-ai-functions/DOC.md
+++ b/content/snowflake/docs/cortex-ai-functions/DOC.md
@@ -1,0 +1,246 @@
+---
+name: cortex-ai-functions
+description: "Snowflake Cortex AI Functions — SQL and Python functions for text generation, classification, sentiment analysis, extraction, summarization, translation, embedding, and document parsing"
+metadata:
+  languages: "sql,python"
+  versions: "2026-03"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "snowflake,cortex,ai,llm,sql,functions,nlp,embeddings,rag,document-processing"
+---
+
+# Cortex AI Functions
+
+Snowflake Cortex AI Functions are SQL-callable AI functions that run LLMs directly inside Snowflake. No external APIs, no data movement — call them in SQL or Python on your Snowflake data.
+
+## Access Control
+
+```sql
+-- Required role (run as ACCOUNTADMIN)
+GRANT DATABASE ROLE SNOWFLAKE.CORTEX_USER TO ROLE my_role;
+```
+
+## Function Reference
+
+### AI_COMPLETE — Text Generation
+
+Generate text from a prompt using your choice of model.
+
+```sql
+-- Simple completion
+SELECT AI_COMPLETE('claude-4-sonnet', 'Summarize: ' || my_text) FROM documents;
+
+-- With system prompt and options
+SELECT AI_COMPLETE(
+  'claude-4-sonnet',
+  [
+    {'role': 'system', 'content': 'You are a helpful assistant.'},
+    {'role': 'user', 'content': 'Analyze this data trend.'}
+  ],
+  {'temperature': 0.7, 'max_tokens': 1024, 'guardrails': TRUE}
+);
+```
+
+**Options**: `temperature` (0-1), `top_p` (0-1), `max_tokens` (default 4096, max 8192), `guardrails` (TRUE/FALSE — uses Cortex Guard), `response_format` (JSON schema for structured output).
+
+**Supported models**: `claude-4-opus`, `claude-4-sonnet`, `claude-3-7-sonnet`, `claude-3-5-sonnet`, `deepseek-r1`, `llama3.1-8b`, `llama3.1-70b`, `llama3.1-405b`, `llama3.3-70b`, `llama4-maverick`, `llama4-scout`, `mistral-large2`, `openai-gpt-4.1`, `openai-o4-mini`, `snowflake-llama-3.3-70b`, and more.
+
+### AI_CLASSIFY — Text/Image Classification
+
+Categorize text into predefined buckets with zero training data.
+
+```sql
+SELECT
+  feedback_text,
+  AI_CLASSIFY(
+    feedback_text,
+    ['billing issue', 'product bug', 'feature request', 'praise', 'other']
+  ) AS category
+FROM customer_feedback;
+```
+
+### AI_SENTIMENT — Sentiment Analysis
+
+Returns a score from -1 (negative) to 1 (positive).
+
+```sql
+SELECT
+  review_text,
+  AI_SENTIMENT(review_text) AS score,
+  CASE
+    WHEN AI_SENTIMENT(review_text) > 0.3 THEN 'Positive'
+    WHEN AI_SENTIMENT(review_text) < -0.3 THEN 'Negative'
+    ELSE 'Neutral'
+  END AS label
+FROM product_reviews;
+
+-- Multi-dimension sentiment
+SELECT AI_SENTIMENT(call_text, ['Professionalism', 'Resolution', 'Wait Time'])
+FROM support_calls;
+```
+
+### AI_EXTRACT — Structured Extraction
+
+Pull specific fields from unstructured text, images, or documents.
+
+```sql
+SELECT AI_EXTRACT(
+  invoice_text,
+  {'vendor_name': 'STRING', 'total_amount': 'NUMBER', 'invoice_date': 'DATE'}
+) AS extracted
+FROM invoices;
+```
+
+### AI_SUMMARIZE — Text Summarization
+
+```sql
+SELECT AI_SUMMARIZE(article_content) AS summary FROM articles;
+```
+
+### AI_TRANSLATE — Translation
+
+```sql
+SELECT AI_TRANSLATE(description, 'en', 'fr') AS french_description
+FROM products;
+```
+
+Supports dozens of language pairs. Specify source and target language codes.
+
+### AI_EMBED — Vector Embeddings
+
+Create embeddings for semantic search, similarity, and RAG.
+
+```sql
+SELECT AI_EMBED('snowflake-arctic-embed-l-v2.0', product_description)
+FROM products;
+```
+
+### AI_FILTER — Boolean Condition Check
+
+Evaluate text/images against a condition, returning TRUE/FALSE.
+
+```sql
+SELECT * FROM emails
+WHERE AI_FILTER(body, 'Contains a meeting request') = TRUE;
+```
+
+### AI_AGG — Aggregate Insights
+
+Aggregate text across rows and generate insights.
+
+```sql
+SELECT AI_AGG(feedback_text, 'Summarize the top 3 themes') AS themes
+FROM customer_feedback
+GROUP BY product_id;
+```
+
+### AI_PARSE_DOCUMENT — Document Intelligence
+
+Extract text and structured data from PDF, images, and documents stored in stages.
+
+```sql
+SELECT AI_PARSE_DOCUMENT(
+  TO_FILE('@my_stage', 'contract.pdf'),
+  {'mode': 'LAYOUT'}
+) AS parsed
+FROM DUAL;
+```
+
+### AI_REDACT — PII Redaction
+
+Redact personally identifiable information from text.
+
+```sql
+SELECT AI_REDACT(customer_notes) AS redacted FROM support_tickets;
+```
+
+## Cortex REST API
+
+Access the same models via REST for application integration.
+
+### Chat Completions API (OpenAI-compatible)
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="<SNOWFLAKE_PAT>",
+    base_url="https://<account>.snowflakecomputing.com/api/v2/cortex/v1"
+)
+
+response = client.chat.completions.create(
+    model="claude-sonnet-4-5",
+    messages=[{"role": "user", "content": "How does a snowflake form?"}]
+)
+print(response.choices[0].message.content)
+```
+
+### Messages API (Anthropic-compatible, Claude models only)
+
+```python
+import httpx, anthropic
+
+PAT = "<SNOWFLAKE_PAT>"
+http_client = httpx.Client(headers={"Authorization": f"Bearer {PAT}"})
+
+client = anthropic.Anthropic(
+    api_key="not-used",
+    base_url="https://<account>.snowflakecomputing.com/api/v2/cortex",
+    http_client=http_client,
+    default_headers={"Authorization": f"Bearer {PAT}"}
+)
+
+response = client.messages.create(
+    model="claude-sonnet-4-5",
+    max_tokens=1024,
+    messages=[{"role": "user", "content": "How does a snowflake form?"}]
+)
+```
+
+### curl
+
+```bash
+curl "https://<account>.snowflakecomputing.com/api/v2/cortex/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $SNOWFLAKE_PAT" \
+  -d '{"model": "claude-sonnet-4-5", "messages": [{"role": "user", "content": "Hello"}]}'
+```
+
+Both APIs support **streaming** via `stream: true` / `"stream": true`.
+
+## Python SDK
+
+```python
+from snowflake.cortex import Complete, Sentiment, Summarize, Translate, ExtractAnswer
+
+# In a Snowpark session
+result = Complete("claude-4-sonnet", "Write a brief intro about Snowflake Cortex")
+score = Sentiment("I really enjoyed this. Fantastic service!")
+summary = Summarize(long_text)
+translated = Translate(text, "en", "fr")
+```
+
+## Cross-Region Inference
+
+```sql
+-- Enable access to models not in your region (run as ACCOUNTADMIN)
+ALTER ACCOUNT SET CORTEX_ENABLED_CROSS_REGION = 'AWS_US';
+```
+
+Options: `AWS_US`, `AWS_EU`, `AWS_APJ`, `ANY_REGION`.
+
+## Cost and Billing
+
+- Token-based billing: input + output tokens for generative functions (AI_COMPLETE, AI_SUMMARIZE, AI_TRANSLATE); input tokens only for extraction functions (AI_SENTIMENT, AI_EXTRACT)
+- Monitor usage:
+  ```sql
+  SELECT * FROM SNOWFLAKE.ACCOUNT_USAGE.METERING_DAILY_HISTORY
+  WHERE SERVICE_TYPE = 'AI_SERVICES';
+  ```
+
+## Limitations
+
+- Cortex AI Functions do not support dynamic tables
+- Usage quotas apply per account
+- Model availability varies by region — use cross-region inference for full access

--- a/content/snowflake/docs/cortex-analyst/DOC.md
+++ b/content/snowflake/docs/cortex-analyst/DOC.md
@@ -1,0 +1,208 @@
+---
+name: cortex-analyst
+description: "Snowflake Cortex Analyst — natural language to SQL engine powered by semantic views for self-serve analytics, REST API integration, and multi-turn conversations"
+metadata:
+  languages: "sql,python"
+  versions: "2026-03"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "snowflake,cortex,analyst,natural-language,sql,semantic-model,analytics,rest-api"
+---
+
+# Cortex Analyst
+
+Cortex Analyst is a fully managed Snowflake Cortex feature that converts natural language questions into accurate SQL queries against your structured data. Business users ask questions in plain English and get direct answers — no SQL required.
+
+## How It Works
+
+1. User asks a question in natural language
+2. Cortex Analyst uses a **semantic model** (or **semantic view**) to understand your data's business context
+3. It generates and executes a SQL query against Snowflake
+4. Results are returned to the user
+
+## Access Control
+
+```sql
+-- Required: one of these database roles (run as ACCOUNTADMIN)
+GRANT DATABASE ROLE SNOWFLAKE.CORTEX_USER TO ROLE my_role;
+-- OR for Analyst-only access:
+GRANT DATABASE ROLE SNOWFLAKE.CORTEX_ANALYST_USER TO ROLE my_role;
+```
+
+Additional requirements:
+- `READ` or `WRITE` on the stage containing the semantic model YAML (if stage-based)
+- `USAGE` on any Cortex Search services referenced in the model
+- `SELECT` on tables referenced in the model
+
+## Semantic Views (Recommended)
+
+Semantic Views are schema-level objects that define business concepts over your data. They are the recommended approach for Cortex Analyst.
+
+### What Semantic Views Define
+
+- **Logical tables**: Business entities (customers, orders, products)
+- **Dimensions**: Categorical context (customer name, product category, order date)
+- **Facts**: Row-level quantitative data (sale amounts, quantities)
+- **Metrics**: Aggregated KPIs (total revenue, average order value)
+- **Relationships**: How tables join together
+
+### Why Use Semantic Views
+
+- **Rich metadata**: Descriptions, synonyms, and data types help the LLM understand your data
+- **Business logic**: Metrics capture correct aggregation formulas
+- **Predefined joins**: Relationship paths ensure correct multi-table queries
+- **Verified examples**: Sample questions and SQL answers guide generation
+- **Native Snowflake integration**: Full RBAC, privileges, governance, and sharing
+- **Derived metrics**: Combine data from multiple tables
+- **Access modifiers**: Mark facts/metrics as public or private
+
+### Creating a Semantic View
+
+```sql
+CREATE OR REPLACE SEMANTIC VIEW revenue_analytics
+  COMMENT = 'Revenue analytics for sales team'
+  AS
+  TABLES (
+    orders_table AS (
+      SELECT * FROM analytics.public.orders
+    )
+      PRIMARY KEY (order_id)
+      WITH DIMENSIONS (
+        order_id COMMENT 'Unique order identifier',
+        customer_name COMMENT 'Customer full name',
+        order_date COMMENT 'Date the order was placed'
+      )
+      WITH FACTS (
+        amount COMMENT 'Order total in USD',
+        quantity COMMENT 'Number of items'
+      )
+      WITH METRICS (
+        total_revenue AS SUM(amount) COMMENT 'Total revenue in USD',
+        avg_order_value AS AVG(amount) COMMENT 'Average order value'
+      )
+  );
+```
+
+## Legacy Semantic Model (YAML)
+
+Stage-based YAML files are still supported for backward compatibility. Upload a YAML file defining tables, dimensions, time dimensions, measures, and sample queries to a Snowflake stage.
+
+## REST API
+
+Cortex Analyst is accessed via REST API for integration into any application.
+
+### Endpoint
+
+```
+POST https://<account>.snowflakecomputing.com/api/v2/cortex/analyst/message
+```
+
+### Request Body
+
+```json
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {"type": "text", "text": "What was total revenue last month?"}
+      ]
+    }
+  ],
+  "semantic_model_file": "@my_stage/revenue_model.yaml"
+}
+```
+
+Or with a semantic view:
+
+```json
+{
+  "messages": [...],
+  "semantic_view": "my_db.my_schema.revenue_analytics"
+}
+```
+
+### Response
+
+The response contains either:
+- A SQL query (type `sql`) that answers the question
+- A text explanation (type `text`) if the question cannot be answered with SQL
+- A suggestion list if the question is ambiguous
+
+### Multi-Turn Conversations
+
+Pass conversation history in the `messages` array to enable follow-up questions:
+
+```json
+{
+  "messages": [
+    {"role": "user", "content": [{"type": "text", "text": "What is revenue by region for 2024?"}]},
+    {"role": "analyst", "content": [{"type": "sql", "statement": "SELECT ..."}]},
+    {"role": "user", "content": [{"type": "text", "text": "What about just North America?"}]}
+  ]
+}
+```
+
+## Python Integration (Streamlit Example)
+
+```python
+import streamlit as st
+from snowflake.snowpark.context import get_active_session
+import json
+
+session = get_active_session()
+
+def query_analyst(question, messages):
+    messages.append({"role": "user", "content": [{"type": "text", "text": question}]})
+    response = session.sql(f"""
+        SELECT SNOWFLAKE.CORTEX.ANALYST(
+            '{json.dumps({"messages": messages, "semantic_view": "MY_DB.ANALYTICS.REVENUE"})}'
+        )
+    """).collect()
+    return response
+
+st.title("Revenue Analytics")
+question = st.text_input("Ask a question about revenue:")
+if question:
+    result = query_analyst(question, st.session_state.get("messages", []))
+    st.write(result)
+```
+
+## Using Cortex Analyst from Cortex Code
+
+In Cortex Code (CLI or Snowsight), you can query semantic models directly:
+
+```
+Use the @models/revenue.yaml semantic model to answer "What was revenue last month?"
+```
+
+```bash
+# CLI
+cortex analyst query "Top customers by spend" --view=ANALYTICS.CORE.REVENUE_METRICS
+```
+
+## Key Features
+
+- **Automatic model selection**: If multiple semantic models exist, Cortex Analyst picks the right one
+- **Security**: No data leaves Snowflake's governance boundary; full RBAC enforcement
+- **No model training**: Cortex Analyst does not train on customer data
+- **Powered by frontier LLMs**: Uses Snowflake-hosted models from Mistral, Meta, and others
+
+## Limiting Access
+
+```sql
+-- Revoke broad access and grant to specific roles
+REVOKE DATABASE ROLE SNOWFLAKE.CORTEX_USER FROM ROLE PUBLIC;
+
+CREATE ROLE cortex_analyst_role;
+GRANT DATABASE ROLE SNOWFLAKE.CORTEX_ANALYST_USER TO ROLE cortex_analyst_role;
+GRANT ROLE cortex_analyst_role TO USER analyst_user;
+```
+
+## Prerequisites
+
+- Snowflake account with `CORTEX_USER` or `CORTEX_ANALYST_USER` database role
+- A semantic view or semantic model YAML file defining your data
+- SELECT privileges on underlying tables
+- Cross-region inference enabled if needed

--- a/content/snowflake/docs/cortex-code-snowsight/DOC.md
+++ b/content/snowflake/docs/cortex-code-snowsight/DOC.md
@@ -1,0 +1,152 @@
+---
+name: cortex-code-snowsight
+description: "Cortex Code in Snowsight — Snowflake's agentic AI assistant embedded in the web UI for SQL authoring, code review, data exploration, and account administration"
+metadata:
+  languages: "sql"
+  versions: "2026-03"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "snowflake,cortex,snowsight,ai,coding-assistant,sql,workspaces,code-review"
+---
+
+# Cortex Code in Snowsight
+
+Cortex Code is an agentic AI assistant embedded directly in Snowsight (Snowflake's web UI). It translates natural language instructions into executable actions across SQL development, data exploration, and account administration — all without leaving the browser.
+
+## Access
+
+1. Sign in to Snowsight.
+2. Select the **Cortex Code** icon in the lower-right corner.
+3. Type a natural language prompt and press Enter.
+
+If the response includes SQL, you can execute it directly or copy to clipboard.
+
+## Access Control
+
+| Database Role | Notes |
+|---------------|-------|
+| `SNOWFLAKE.COPILOT_USER` | Required for all users |
+| `SNOWFLAKE.CORTEX_USER` or `SNOWFLAKE.CORTEX_AGENT_USER` | At least one required; `CORTEX_AGENT_USER` enables agentic workflows |
+
+```sql
+-- Grant access (run as ACCOUNTADMIN)
+GRANT DATABASE ROLE SNOWFLAKE.COPILOT_USER TO ROLE my_role;
+GRANT DATABASE ROLE SNOWFLAKE.CORTEX_AGENT_USER TO ROLE my_role;
+```
+
+## Key Capabilities
+
+### Agentic Coding in Workspaces
+
+- **Code generation**: Generate SQL queries, create files, build data pipeline logic
+- **Code modification**: Refine SQL, identify errors, suggest performance optimizations
+- **Change review**: Preview AI changes using a diff view before applying
+- **Code explanation**: Request explanations of existing SQL for understanding or collaboration
+- **Follow-up questions**: Continue conversations for clarifying or deeper analysis
+- **Inline catalog context**: Type `@` in the message box to search for and add catalog objects (tables, schemas, views) as context
+- **Quick actions**: Highlight SQL text to access Quick Edit, Format, Add to Chat, and Explain
+- **Fix SQL errors**: Use the Fix button in the results grid when a SQL statement fails
+
+### AI Code Suggestions (Preview)
+
+Context-aware inline SQL suggestions displayed as gray text at cursor position. Cortex Code uses query history, workspace content, table schemas, and recent executed queries.
+
+- **Accept**: `Shift + Enter`
+- **Dismiss**: `Esc`, `Delete`, `Backspace`, or keep typing
+- **Disable**: Workspaces → SQL file → Settings → User preferences → AI code suggestions toggle
+
+### Data and Catalog Discovery
+
+- **Natural language schema search**: Find database objects using plain language
+- **Integrated Q&A**: Get answers about Snowflake features and SQL syntax from official docs
+- **Marketplace discovery**: Search and return listings from Snowflake Marketplace
+- **Tag, masking policy, and lineage context** included when available
+
+### Account Administration
+
+- **Governance & security**: User and role access, data ownership, PII identification
+- **Cost management**: Credit consumption, high-cost warehouses and queries
+
+## Example Prompts
+
+### SQL Development
+
+| Use Case | Prompt |
+|----------|--------|
+| Logic explanation | "What does this SQL script do?" |
+| Generation | "Write a query for top 10 customers by revenue and a 7-day moving average." |
+| Query refinement | "Update the top performers query to show the top 100." |
+| Performance optimization | "Explain why this query is slow and optimize it." |
+| Data synthesis | "Generate synthetic data for 30 days of sales for an e-commerce site in the SAMPLEDATA.SALES table." |
+
+### Data Discovery and Governance
+
+| Use Case | Prompt |
+|----------|--------|
+| Access discovery | "What databases do I have access to?" |
+| Security auditing | "Find all tables that have PII in them." |
+| Tag discovery | "List every table tagged PII = TRUE in ANALYTICS_DB." |
+| Lineage and tagging | "Show the lineage from RAW_DB.ORDERS to downstream dashboards." |
+| Metadata search | "Where can I find tables related to customer churn and subscription status?" |
+
+### Notebooks and ML
+
+| Use Case | Prompt |
+|----------|--------|
+| EDA & ML | "Build me a notebook for customer churn prediction using pandas, matplotlib, seaborn, and scikit-learn." |
+| Deep learning | "Create a new notebook and build a CNN for the MNIST dataset." |
+| Pipeline engineering | "Create a dbt project to transform raw sales data." |
+
+### Semantic Models
+
+| Use Case | Prompt |
+|----------|--------|
+| Semantic queries | "Use the @models/revenue.yaml semantic model to answer 'What was revenue last month?'" |
+| Model debugging | "Identify errors in my semantic model at @models/revenue.yaml" |
+
+### Administration
+
+| Use Case | Prompt |
+|----------|--------|
+| Resource monitoring | "Which 5 service types are using the most credits? Show me a visualization and how to reduce costs." |
+
+## Supported Models
+
+- **Claude Opus 4.6** (`claude-opus-4-6`) — recommended
+- Claude Opus 4.5 (`claude-opus-4-5`)
+- Claude Sonnet 4.5 (`claude-sonnet-4-5`)
+- Claude Sonnet 4.0 (`claude-4-sonnet`)
+
+## Cross-Region Inference
+
+Cortex Code works in any region when cross-region inference is enabled:
+
+```sql
+-- Run as ACCOUNTADMIN
+ALTER ACCOUNT SET CORTEX_ENABLED_CROSS_REGION = 'AWS_US';
+```
+
+Replace `AWS_US` with: `AWS_EU`, `AWS_APJ`, or `ANY_REGION`.
+
+## Web Search
+
+An ACCOUNTADMIN can enable web search for Cortex Code:
+
+1. Navigate to **AI/ML → Agents**
+2. Select **Settings**
+3. Toggle **Web search** to enable
+
+## Cortex Code vs Snowflake Intelligence vs Copilot (Legacy)
+
+| Feature | Cortex Code | Snowflake Intelligence | Copilot (Legacy) |
+|---------|-------------|----------------------|------------------|
+| Use case | SQL authoring, data exploration, admin tasks | Natural language data analysis and insights | Basic SQL assistance (deprecated) |
+| Integration | Snowsight Workspaces | Intelligence UI, Cortex Agents API | Separate copilot panel |
+| Key capabilities | Code gen/modify, diff review, code explanation | Data analysis, summaries, NL interactions | Contextual SQL suggestions |
+
+## Prerequisites
+
+- Snowflake account (Commercial — not Gov, VPS, or Sovereign)
+- Required database roles: `SNOWFLAKE.COPILOT_USER` + `SNOWFLAKE.CORTEX_USER` or `SNOWFLAKE.CORTEX_AGENT_USER`
+- Cross-region inference enabled if your model is not available in your region

--- a/content/snowflake/docs/cortex-search/DOC.md
+++ b/content/snowflake/docs/cortex-search/DOC.md
@@ -1,0 +1,183 @@
+---
+name: cortex-search
+description: "Snowflake Cortex Search — managed hybrid search service for RAG applications, enterprise search, with automatic indexing and refresh"
+metadata:
+  languages: "sql,python"
+  versions: "2026-03"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "snowflake,cortex,search,rag,hybrid-search,vector-search,embeddings,retrieval"
+---
+
+# Cortex Search
+
+Cortex Search is a fully managed hybrid (vector + keyword) search engine for Snowflake data. It powers RAG applications and enterprise search with automatic embedding, index management, and refresh — no infrastructure to maintain.
+
+## Use Cases
+
+- **RAG engine for LLM chatbots**: Semantic retrieval for grounding LLM responses in your data
+- **Enterprise search**: High-quality search bar backend for applications
+
+## Quick Start
+
+### 1. Create Source Data
+
+```sql
+CREATE DATABASE IF NOT EXISTS cortex_search_db;
+CREATE OR REPLACE SCHEMA cortex_search_db.services;
+
+CREATE OR REPLACE TABLE support_transcripts (
+  transcript_text VARCHAR,
+  region VARCHAR,
+  agent_id VARCHAR
+);
+
+INSERT INTO support_transcripts VALUES
+  ('My internet has been down since yesterday, can you help?', 'North America', 'AG1001'),
+  ('I was overcharged for my last bill, need an explanation.', 'Europe', 'AG1002'),
+  ('How do I reset my password? The email link is not working.', 'Asia', 'AG1003'),
+  ('I received a faulty router, can I get it replaced?', 'North America', 'AG1004');
+```
+
+### 2. Create Search Service
+
+```sql
+CREATE OR REPLACE CORTEX SEARCH SERVICE transcript_search_service
+  ON transcript_text
+  ATTRIBUTES region
+  WAREHOUSE = cortex_search_wh
+  TARGET_LAG = '1 day'
+  EMBEDDING_MODEL = 'snowflake-arctic-embed-l-v2.0'
+  AS (
+    SELECT transcript_text, region, agent_id
+    FROM support_transcripts
+  );
+```
+
+Key parameters:
+- `ON`: Column to search against
+- `ATTRIBUTES`: Columns available as filter attributes and returned in results
+- `TARGET_LAG`: How often the index refreshes from base data (e.g., `'1 hour'`, `'1 day'`)
+- `EMBEDDING_MODEL`: Model used to generate embeddings
+- `WAREHOUSE`: Used for materializing the source query
+
+### 3. Grant Access
+
+```sql
+GRANT USAGE ON DATABASE cortex_search_db TO ROLE customer_support;
+GRANT USAGE ON SCHEMA services TO ROLE customer_support;
+GRANT USAGE ON CORTEX SEARCH SERVICE transcript_search_service TO ROLE customer_support;
+```
+
+### 4. Preview Results (SQL)
+
+```sql
+SELECT PARSE_JSON(
+  SNOWFLAKE.CORTEX.SEARCH_PREVIEW(
+    'cortex_search_db.services.transcript_search_service',
+    '{
+      "query": "internet issues",
+      "columns": ["transcript_text", "region"],
+      "filter": {"@eq": {"region": "North America"}},
+      "limit": 1
+    }'
+  )
+)['results'] AS results;
+```
+
+### 5. Query from Python
+
+```python
+from snowflake.core import Root
+from snowflake.snowpark import Session
+
+session = Session.builder.configs(CONNECTION_PARAMS).create()
+root = Root(session)
+
+search_service = (
+    root
+    .databases["cortex_search_db"]
+    .schemas["services"]
+    .cortex_search_services["transcript_search_service"]
+)
+
+results = search_service.search(
+    query="internet issues",
+    columns=["transcript_text", "region"],
+    filter={"@eq": {"region": "North America"}},
+    limit=5
+)
+print(results.to_json())
+```
+
+## Creating via Snowsight
+
+1. Navigate to **AI & ML → AI Studio**
+2. Select **+ Create** from the Cortex Search Service box
+3. Choose role, warehouse, database, and schema
+4. Select the source table and search columns
+5. Set filter columns and target lag
+6. Create the service
+
+## Query Filters
+
+Filter search results using attribute columns:
+
+```json
+{
+  "query": "billing problem",
+  "columns": ["transcript_text", "region", "agent_id"],
+  "filter": {
+    "@and": [
+      {"@eq": {"region": "North America"}},
+      {"@eq": {"agent_id": "AG1001"}}
+    ]
+  },
+  "limit": 10
+}
+```
+
+Supported operators: `@eq`, `@and`, `@or`, `@not`, `@gte`, `@lte`, `@gt`, `@lt`.
+
+## Inspecting Service Data
+
+```sql
+SELECT * FROM TABLE(
+  CORTEX_SEARCH_DATA_SCAN(SERVICE_NAME => 'transcript_search_service')
+);
+```
+
+## RAG Architecture
+
+Combine Cortex Search with Cortex AI Functions for RAG:
+
+```python
+# 1. Retrieve relevant context
+results = search_service.search(query=user_question, columns=["text"], limit=5)
+context = "\n".join([r["text"] for r in results.results])
+
+# 2. Generate grounded response
+from snowflake.cortex import Complete
+response = Complete("claude-4-sonnet", f"Answer based on this context:\n{context}\n\nQuestion: {user_question}")
+```
+
+## Access Control
+
+- Creating a service requires `SNOWFLAKE.CORTEX_USER` database role
+- The warehouse specified is used during index build and refresh
+- Grant `USAGE` on the service to allow other roles to query it
+
+## Key Considerations
+
+- Index build time depends on dataset size and warehouse size (use dedicated warehouse, size MEDIUM or smaller)
+- `TARGET_LAG` controls freshness vs. cost tradeoff
+- Columns in `ATTRIBUTES` must be included in the source query
+- Services automatically refresh when base data changes
+- Supports both SQL and Python query interfaces
+
+## Prerequisites
+
+- Snowflake account with `SNOWFLAKE.CORTEX_USER` database role
+- A warehouse for index materialization
+- Source table with text data to search

--- a/content/snowflake/docs/snowflake-notebooks/DOC.md
+++ b/content/snowflake/docs/snowflake-notebooks/DOC.md
@@ -1,0 +1,234 @@
+---
+name: snowflake-notebooks
+description: "Snowflake Notebooks — interactive cell-based development environment for SQL, Python, and Markdown with Snowpark integration, ML workflows, and scheduled pipelines"
+metadata:
+  languages: "sql,python"
+  versions: "2026-03"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "snowflake,notebooks,python,sql,data-science,ml,snowpark,visualization,pipelines"
+---
+
+# Snowflake Notebooks
+
+Snowflake Notebooks is an interactive, cell-based development environment in Snowsight for SQL, Python, and Markdown. Build data pipelines, train ML models, create visualizations, and schedule automated workflows — all on Snowflake compute.
+
+## Key Features
+
+- **Multi-language cells**: SQL, Python, and Markdown in the same notebook
+- **Cross-cell references**: Use SQL results in Python cells and vice versa
+- **Built-in visualizations**: Streamlit, Altair, Matplotlib, seaborn
+- **Git integration**: Sync notebooks with Git repositories (Preview)
+- **Scheduling**: Run notebooks as automated tasks on a schedule (Preview)
+- **Role-based access**: Leverage Snowflake RBAC for collaboration
+- **File uploads**: Load data from local files, cloud storage, or Snowflake Marketplace
+
+## Notebook Runtimes
+
+| Feature | Warehouse Runtime | Container Runtime |
+|---------|-------------------|-------------------|
+| Compute | Notebook warehouse | Compute pool node |
+| Python version | 3.9, 3.10 (Preview) | 3.10 |
+| Base image | Streamlit + Snowpark | Container Runtime (CPU/GPU with pre-installed ML packages) |
+| Package install | Snowflake Anaconda or stage | pip, conda, or stage |
+| Best for | SQL analytics, Snowpark | ML, deep learning, custom packages |
+
+Both runtimes execute SQL and Snowpark queries on the warehouse.
+
+### Choose Warehouse Runtime When
+
+- Doing SQL analytics and data engineering
+- Using Snowpark DataFrames and UDFs
+- Standard Python packages available in Snowflake Anaconda suffice
+
+### Choose Container Runtime When
+
+- Training ML/deep learning models (GPU support)
+- Need custom pip/conda packages not in Anaconda
+- Running compute-intensive Python workloads
+
+## Getting Started
+
+### Create a Notebook
+
+1. Sign in to Snowsight
+2. Navigate to **Projects → Notebooks** (Legacy) or **Projects → Workspaces** (New)
+3. Select **+ Notebook**
+4. Choose a database, schema, warehouse, and runtime
+
+### Cell Types
+
+**SQL Cell**:
+```sql
+-- Results available as a DataFrame in Python cells
+SELECT region, SUM(revenue) AS total_revenue
+FROM sales
+GROUP BY region
+ORDER BY total_revenue DESC;
+```
+
+**Python Cell**:
+```python
+# Reference SQL cell results
+import streamlit as st
+
+# cell1 refers to the SQL cell above
+df = cell1.to_pandas()
+st.bar_chart(df.set_index("REGION"))
+```
+
+**Markdown Cell**:
+```markdown
+## Analysis Summary
+Key findings from the revenue analysis...
+```
+
+### Cross-Cell References
+
+SQL cell results are automatically available as Snowpark DataFrames in Python cells:
+
+```python
+# If a SQL cell named "revenue_query" exists:
+df = revenue_query.to_pandas()
+print(df.head())
+```
+
+Python variables can be referenced in SQL cells:
+
+```sql
+-- Reference Python variable
+SELECT * FROM my_table WHERE date > '{{start_date}}'
+```
+
+## Python Packages
+
+### Warehouse Runtime
+
+```python
+# Use the package selector in the toolbar, or:
+# Install from Snowflake Anaconda channel
+# Available packages: pandas, numpy, scikit-learn, matplotlib, seaborn, etc.
+```
+
+### Container Runtime
+
+```python
+!pip install transformers torch
+```
+
+## Visualizations
+
+### Streamlit (Built-in)
+
+```python
+import streamlit as st
+
+st.title("Sales Dashboard")
+st.bar_chart(df)
+st.line_chart(df.set_index("date")["revenue"])
+st.dataframe(df)
+```
+
+### Matplotlib / Seaborn
+
+```python
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+fig, ax = plt.subplots()
+sns.barplot(data=df, x="region", y="revenue", ax=ax)
+st.pyplot(fig)
+```
+
+### Altair
+
+```python
+import altair as alt
+
+chart = alt.Chart(df).mark_bar().encode(x="region", y="revenue")
+st.altair_chart(chart)
+```
+
+## ML Workflows
+
+### Training with scikit-learn
+
+```python
+from sklearn.model_selection import train_test_split
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.metrics import accuracy_score
+
+# Get data from SQL cell
+df = training_data.to_pandas()
+X = df[["feature1", "feature2", "feature3"]]
+y = df["label"]
+
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
+model = RandomForestClassifier(n_estimators=100)
+model.fit(X_train, y_train)
+
+accuracy = accuracy_score(y_test, model.predict(X_test))
+st.metric("Model Accuracy", f"{accuracy:.2%}")
+```
+
+### Using Snowpark ML
+
+```python
+from snowflake.ml.modeling.ensemble import RandomForestClassifier as SnowRF
+
+model = SnowRF(input_cols=["F1", "F2", "F3"], label_cols=["LABEL"])
+model.fit(snowpark_df)
+predictions = model.predict(test_df)
+```
+
+## Scheduling
+
+Run notebooks on a schedule as Snowflake tasks:
+
+1. Select the **Scheduler** icon in the notebook toolbar
+2. Set a CRON schedule (e.g., daily at 6 AM)
+3. The notebook runs as a task using the notebook's warehouse
+
+```sql
+-- Or create via SQL
+CREATE OR REPLACE TASK run_etl_notebook
+  WAREHOUSE = COMPUTE_WH
+  SCHEDULE = 'USING CRON 0 6 * * * America/Los_Angeles'
+AS
+  EXECUTE NOTEBOOK mydb.myschema.etl_notebook;
+```
+
+## Notebooks in Workspaces (New)
+
+The next generation of Snowflake Notebooks lives in **Workspaces** with:
+- Full Jupyter compatibility
+- Workspace integration alongside SQL files, Python files, and dbt projects
+- Enhanced collaboration features
+
+Legacy Notebooks will be migrated to Workspaces over the coming quarters.
+
+## Toolbar Controls
+
+| Control | Description |
+|---------|-------------|
+| **Package selector** | Install Python packages |
+| **Start / Active** | Start session or view session details |
+| **Run All / Stop** | Execute all cells or stop execution |
+| **Scheduler** | Set automated run schedule |
+| **Collapse results** | Toggle code/output visibility |
+
+## Git Integration (Preview)
+
+Sync notebooks with a Git repository for version control:
+
+1. Connect your Git provider in Snowsight
+2. Link the notebook to a repository
+3. Push/pull changes to keep notebooks in sync
+
+## Prerequisites
+
+- Snowflake account with access to Snowsight
+- Warehouse for compute (Warehouse Runtime) or compute pool (Container Runtime)
+- Appropriate role with CREATE NOTEBOOK privileges
+- For Container Runtime: SPCS compute pool configured

--- a/content/snowflake/docs/snowpark-python/DOC.md
+++ b/content/snowflake/docs/snowpark-python/DOC.md
@@ -1,0 +1,262 @@
+---
+name: snowpark-python
+description: "Snowpark Python — DataFrame API, UDFs, stored procedures, and pandas on Snowflake for building data pipelines and ML workflows without moving data"
+metadata:
+  languages: "python"
+  versions: "1.x"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "snowflake,snowpark,python,dataframe,udf,stored-procedure,pandas,ml,data-engineering"
+---
+
+# Snowpark Python
+
+Snowpark provides a Python API for querying and processing data in Snowflake without moving data out of the platform. Build data pipelines, write UDFs, create stored procedures, and run pandas code directly on Snowflake compute.
+
+## Setup
+
+### Install
+
+```bash
+pip install snowflake-snowpark-python
+```
+
+### Create a Session
+
+```python
+from snowflake.snowpark import Session
+
+connection_params = {
+    "account": "myaccount",
+    "user": "myuser",
+    "password": "mypassword",
+    "warehouse": "COMPUTE_WH",
+    "database": "MYDB",
+    "schema": "PUBLIC",
+    "role": "DEVELOPER"
+}
+
+session = Session.builder.configs(connection_params).create()
+```
+
+Authentication supports password, key-pair, SSO (`externalbrowser`), OAuth, and programmatic access tokens.
+
+## DataFrames
+
+Snowpark DataFrames are lazily evaluated — transformations build a query plan that executes on Snowflake when you trigger an action.
+
+### Basic Operations
+
+```python
+# Read a table
+df = session.table("customers")
+
+# Select, filter, aggregate
+result = (
+    df.select("name", "region", "revenue")
+      .filter(df["revenue"] > 1000)
+      .group_by("region")
+      .agg(sum("revenue").alias("total_revenue"))
+      .sort("total_revenue", ascending=False)
+)
+
+result.show()
+```
+
+### Joins
+
+```python
+orders = session.table("orders")
+customers = session.table("customers")
+
+joined = orders.join(customers, orders["customer_id"] == customers["id"])
+joined.select("order_id", "name", "amount").show()
+```
+
+### Writing Data
+
+```python
+# Write DataFrame to a table
+df.write.mode("overwrite").save_as_table("output_table")
+
+# Append
+df.write.mode("append").save_as_table("output_table")
+```
+
+### SQL Interop
+
+```python
+# Run raw SQL and get a DataFrame
+df = session.sql("SELECT * FROM my_table WHERE date > '2024-01-01'")
+df.show()
+```
+
+## User-Defined Functions (UDFs)
+
+### Inline UDF
+
+```python
+from snowflake.snowpark.functions import udf
+from snowflake.snowpark.types import StringType
+
+@udf(name="categorize_amount", return_type=StringType(), replace=True)
+def categorize_amount(amount: float) -> str:
+    if amount > 10000:
+        return "high"
+    elif amount > 1000:
+        return "medium"
+    else:
+        return "low"
+
+# Use in a query
+df = session.table("orders")
+df.select("order_id", categorize_amount("amount").alias("category")).show()
+```
+
+### Vectorized UDF (Batch Processing)
+
+```python
+from snowflake.snowpark.functions import pandas_udf
+from snowflake.snowpark.types import IntegerType
+import pandas as pd
+
+@pandas_udf(name="double_values", return_type=IntegerType(), replace=True)
+def double_values(series: pd.Series) -> pd.Series:
+    return series * 2
+```
+
+## User-Defined Table Functions (UDTFs)
+
+```python
+from snowflake.snowpark.functions import udtf
+from snowflake.snowpark.types import StructType, StructField, StringType
+
+@udtf(
+    name="split_words",
+    output_schema=StructType([StructField("word", StringType())]),
+    replace=True
+)
+class SplitWords:
+    def process(self, text: str):
+        for word in text.split():
+            yield (word,)
+
+# Use it
+session.table_function("split_words", lit("hello world")).show()
+```
+
+## Stored Procedures
+
+```python
+from snowflake.snowpark import Session
+
+def process_data(session: Session, input_table: str, output_table: str) -> str:
+    df = session.table(input_table)
+    result = df.filter(df["status"] == "active").group_by("region").count()
+    result.write.mode("overwrite").save_as_table(output_table)
+    return f"Wrote {result.count()} rows to {output_table}"
+
+# Register as stored procedure
+session.sproc.register(
+    func=process_data,
+    name="process_data_sp",
+    replace=True,
+    packages=["snowflake-snowpark-python"]
+)
+
+# Call it
+session.call("process_data_sp", "raw_customers", "processed_customers")
+```
+
+### Schedule as a Task
+
+```sql
+CREATE OR REPLACE TASK daily_processing
+  WAREHOUSE = COMPUTE_WH
+  SCHEDULE = 'USING CRON 0 6 * * * America/Los_Angeles'
+AS
+  CALL process_data_sp('raw_customers', 'processed_customers');
+```
+
+## pandas on Snowflake
+
+Run pandas code that executes on Snowflake compute (not locally):
+
+```python
+import modin.pandas as pd
+import snowflake.snowpark.modin.plugin
+
+# Read from Snowflake
+df = pd.read_snowflake("customers")
+
+# Standard pandas operations — executed on Snowflake
+result = df.groupby("region")["revenue"].mean()
+result.to_snowflake("avg_revenue_by_region", if_exists="replace")
+```
+
+## Machine Learning
+
+### Train Models with Stored Procedures
+
+```python
+from snowflake.snowpark import Session
+from sklearn.linear_model import LogisticRegression
+import pandas as pd
+
+def train_model(session: Session) -> str:
+    df = session.table("training_data").to_pandas()
+    X = df[["feature1", "feature2", "feature3"]]
+    y = df["label"]
+
+    model = LogisticRegression()
+    model.fit(X, y)
+
+    # Save model to stage
+    import joblib
+    joblib.dump(model, "/tmp/model.pkl")
+    session.file.put("/tmp/model.pkl", "@models", auto_compress=False, overwrite=True)
+    return "Model trained and saved"
+
+session.sproc.register(func=train_model, name="train_model_sp", replace=True,
+    packages=["snowflake-snowpark-python", "scikit-learn", "joblib", "pandas"])
+```
+
+## File Operations
+
+```python
+# Upload to stage
+session.file.put("local_file.csv", "@my_stage", auto_compress=False)
+
+# Read from stage
+df = session.read.csv("@my_stage/data.csv")
+df = session.read.parquet("@my_stage/data.parquet")
+df = session.read.json("@my_stage/data.json")
+```
+
+## Logging and Troubleshooting
+
+```python
+# View the generated SQL for any DataFrame
+print(df.queries)
+
+# Enable logging
+import logging
+logging.basicConfig(level=logging.DEBUG)
+```
+
+Record log messages and trace events to an event table for production monitoring.
+
+## Key Concepts
+
+- **Lazy evaluation**: DataFrame transformations build a plan; actions (`.show()`, `.collect()`, `.save_as_table()`) trigger execution
+- **Server-side execution**: UDFs and stored procedures run on Snowflake compute, not locally
+- **pandas on Snowflake**: Uses Modin + Snowpark to push pandas operations to Snowflake
+- **No data movement**: Data stays in Snowflake throughout the pipeline
+
+## Prerequisites
+
+- `pip install snowflake-snowpark-python`
+- Python 3.9+ (3.10 for some features)
+- Snowflake account with appropriate roles and warehouse access
+- For pandas on Snowflake: `pip install "snowflake-snowpark-python[modin]"`


### PR DESCRIPTION
## Summary

Adds comprehensive Snowflake AI and developer platform documentation to Context Hub under `content/snowflake/docs/`:

- **cortex-code-snowsight** — Agentic AI assistant in Snowsight web UI (SQL authoring, code review, data exploration, admin tasks, AI code suggestions)
- **cortex-ai-functions** — SQL-callable AI functions (AI_COMPLETE, AI_CLASSIFY, AI_SENTIMENT, AI_EXTRACT, AI_SUMMARIZE, AI_TRANSLATE, AI_EMBED, AI_PARSE_DOCUMENT, AI_REDACT, AI_AGG, AI_FILTER) + Cortex REST API
- **cortex-analyst** — Natural language to SQL engine powered by semantic views, REST API integration, multi-turn conversations
- **cortex-search** — Managed hybrid (vector + keyword) search service for RAG applications and enterprise search
- **snowpark-python** — DataFrame API, UDFs, stored procedures, pandas on Snowflake for data pipelines and ML
- **snowflake-notebooks** — Interactive cell-based development (SQL, Python, Markdown) with ML workflows and scheduling

### Directory convention

Follows the company-level convention used by other contributors (e.g., `content/google/docs/`, `content/aws/docs/`, `content/openai/docs/`):

```
content/snowflake/docs/
├── cortex-code-snowsight/DOC.md
├── cortex-ai-functions/DOC.md
├── cortex-analyst/DOC.md
├── cortex-search/DOC.md
├── snowpark-python/DOC.md
└── snowflake-notebooks/DOC.md
```

### Validation

All 6 docs pass `chub build content/ --validate-only` (1550 docs, 0 warnings).

## Test plan

- [ ] Verify `node cli/bin/chub build content/ --validate-only` passes with 0 warnings
- [ ] Confirm frontmatter schema (name, description, metadata fields) matches expected format
- [ ] Check each DOC.md is under 500 lines
- [ ] Verify directory structure follows `content/<company>/docs/<product>/DOC.md` convention

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
