### PR TITLE
feat(content): add Hyperliquid DEX API docs (JS + Python)

### DIFF
--- a/content/hyperliquid/docs/api/javascript/DOC.md
+++ b/content/hyperliquid/docs/api/javascript/DOC.md
@@ -1,0 +1,141 @@
+---
+name: api
+description: "Hyperliquid DEX API for perpetuals trading — market data, account info, order placement, and WebSocket feeds"
+metadata:
+  languages: "javascript"
+  versions: "1.5.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "hyperliquid,dex,trading,perpetuals,crypto,defi"
+---
+
+# Hyperliquid API (JavaScript/TypeScript)
+
+Hyperliquid is a high-performance perpetuals DEX on its own L1. Two endpoints:
+- **Info API** (read-only): `https://api.hyperliquid.xyz/info`
+- **Exchange API** (trading): `https://api.hyperliquid.xyz/exchange`
+
+## Install
+
+```bash
+npm install hyperliquid
+```
+
+## Initialization
+
+```typescript
+import { Hyperliquid } from "hyperliquid";
+
+// Read-only
+const sdk = new Hyperliquid();
+
+// Trading (requires private key)
+const sdk = new Hyperliquid({
+  privateKey: process.env.HYPERLIQUID_PRIVATE_KEY, // 0x-prefixed hex
+  testnet: false, // set true for testnet
+});
+```
+
+## Market Data
+
+```typescript
+// All mids (asset → mid price)
+const mids = await sdk.info.getAllMids();
+// { "BTC": "74000.0", "ETH": "2100.0", ... }
+
+// L2 order book
+const book = await sdk.info.getL2Book("BTC");
+// { coin: "BTC", levels: [[bids], [asks]], time: 1234567890 }
+
+// Funding rates
+const meta = await sdk.info.getMetaAndAssetCtxs();
+// meta[1] is array of asset contexts with fundingRate, openInterest, etc.
+
+// Candles (OHLCV)
+const candles = await sdk.info.getCandleSnapshot("BTC", "15m", startTime, endTime);
+```
+
+## Account Info
+
+```typescript
+// Wallet address (no private key needed for reads)
+const address = "0xYourWalletAddress";
+
+// Perpetuals state: positions, equity, margin
+const state = await sdk.info.perpetuals.getClearinghouseState(address);
+// state.crossMarginSummary.accountValue — total equity
+// state.assetPositions — array of open positions
+
+// Open orders
+const orders = await sdk.info.getUserOpenOrders(address);
+
+// Trade history
+const fills = await sdk.info.getUserFills(address);
+```
+
+## Trading
+
+```typescript
+// Place limit order
+const order = await sdk.exchange.placeOrder({
+  coin: "BTC",
+  is_buy: true,
+  sz: 0.001,           // size in base asset
+  limit_px: 74000,     // limit price (ignored for market)
+  order_type: { limit: { tif: "Gtc" } }, // Gtc | Alo | Ioc
+  reduce_only: false,
+});
+
+// Place market order
+const market = await sdk.exchange.placeOrder({
+  coin: "BTC",
+  is_buy: true,
+  sz: 0.001,
+  limit_px: 0,  // ignored
+  order_type: { market: {} },
+  reduce_only: false,
+});
+
+// Cancel order
+await sdk.exchange.cancelOrder({ coin: "BTC", oid: orderId });
+
+// Close position (market)
+await sdk.exchange.closePosition("BTC");
+
+// Set leverage
+await sdk.exchange.updateLeverage({
+  coin: "BTC",
+  is_cross: true,  // true = cross margin, false = isolated
+  leverage: 10,
+});
+```
+
+## WebSocket
+
+```typescript
+import { WebSocketClient } from "hyperliquid";
+
+const ws = new WebSocketClient();
+await ws.connect();
+
+// Subscribe to live prices
+ws.subscribe({ type: "allMids" }, (data) => {
+  console.log(data.mids); // { BTC: "74000", ... }
+});
+
+// Subscribe to user fills
+ws.subscribe({ type: "userFills", user: address }, (data) => {
+  console.log(data.fills);
+});
+
+await ws.disconnect();
+```
+
+## Notes
+
+- All prices are strings to preserve precision — convert with `parseFloat()` when needed
+- Size (`sz`) is in base asset units (BTC, ETH, etc.), not USD
+- `limit_px` for market orders: set to a very high/low value or 0; it's ignored
+- Private key must be the EVM wallet key that controls the Hyperliquid vault
+- Testnet endpoint: `https://api.hyperliquid-testnet.xyz`

--- a/content/hyperliquid/docs/api/python/DOC.md
+++ b/content/hyperliquid/docs/api/python/DOC.md
@@ -1,0 +1,139 @@
+---
+name: api
+description: "Hyperliquid DEX API for perpetuals trading — market data, account info, order placement, and WebSocket feeds"
+metadata:
+  languages: "python"
+  versions: "0.5.0"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: community
+  tags: "hyperliquid,dex,trading,perpetuals,crypto,defi"
+---
+
+# Hyperliquid API (Python)
+
+Hyperliquid is a high-performance perpetuals DEX on its own L1. Two endpoints:
+- **Info API** (read-only): `https://api.hyperliquid.xyz/info`
+- **Exchange API** (trading): `https://api.hyperliquid.xyz/exchange`
+
+## Install
+
+```bash
+pip install hyperliquid-python-sdk
+```
+
+## Initialization
+
+```python
+from hyperliquid.info import Info
+from hyperliquid.exchange import Exchange
+from hyperliquid.utils import constants
+import eth_account
+
+# Read-only
+info = Info(constants.MAINNET_API_URL, skip_ws=True)
+
+# Trading
+account = eth_account.Account.from_key(os.environ["HYPERLIQUID_PRIVATE_KEY"])
+exchange = Exchange(account, constants.MAINNET_API_URL)
+```
+
+## Market Data
+
+```python
+# All mid prices
+mids = info.all_mids()
+# { "BTC": "74000.0", "ETH": "2100.0", ... }
+
+# L2 order book
+book = info.l2_snapshot("BTC")
+# { "coin": "BTC", "levels": [[bids], [asks]], "time": 1234567890 }
+
+# Meta + asset contexts (funding rates, OI, etc.)
+meta, asset_ctxs = info.meta_and_asset_ctxs()
+# asset_ctxs[i]["fundingRate"], asset_ctxs[i]["openInterest"]
+
+# Candles
+candles = info.candles_snapshot("BTC", "15m", start_time_ms, end_time_ms)
+```
+
+## Account Info
+
+```python
+address = account.address  # or any wallet address for read-only
+
+# Perp state: positions, equity, margin
+state = info.user_state(address)
+# state["crossMarginSummary"]["accountValue"] — total equity
+# state["assetPositions"] — list of open positions
+
+# Open orders
+orders = info.open_orders(address)
+
+# Trade history
+fills = info.user_fills(address)
+```
+
+## Trading
+
+```python
+# Place limit order (GTC)
+result = exchange.order(
+    "BTC",
+    is_buy=True,
+    sz=0.001,
+    limit_px=74000,
+    order_type={"limit": {"tif": "Gtc"}},
+    reduce_only=False,
+)
+
+# Place market order
+result = exchange.order(
+    "BTC",
+    is_buy=True,
+    sz=0.001,
+    limit_px=0,
+    order_type={"market": {}},
+    reduce_only=False,
+)
+
+# Cancel order
+exchange.cancel("BTC", order_id)
+
+# Close position (market)
+exchange.market_close("BTC")
+
+# Set leverage
+exchange.update_leverage(10, "BTC", is_cross=True)
+```
+
+## WebSocket
+
+```python
+from hyperliquid.utils.signing import get_timestamp_ms
+import websocket, json, threading
+
+ws_url = "wss://api.hyperliquid.xyz/ws"
+
+def on_message(ws, message):
+    data = json.loads(message)
+    print(data)
+
+ws = websocket.WebSocketApp(ws_url, on_message=on_message)
+
+# Subscribe after connect
+def on_open(ws):
+    ws.send(json.dumps({"method": "subscribe", "subscription": {"type": "allMids"}}))
+
+ws.on_open = on_open
+thread = threading.Thread(target=ws.run_forever)
+thread.start()
+```
+
+## Notes
+
+- All prices returned as strings — use `float()` when doing arithmetic
+- `sz` is in base asset units (BTC, ETH, etc.), not USD notional
+- Private key is the EVM wallet key controlling the Hyperliquid vault
+- Testnet: use `constants.TESTNET_API_URL` and `wss://api.hyperliquid-testnet.xyz/ws`
+- Rate limit: ~1200 requests/min for info, lower for exchange


### PR DESCRIPTION
## Summary

Adds curated API documentation for [Hyperliquid](https://hyperliquid.xyz) — the highest-volume perpetuals DEX by volume.

### What's included

- **JavaScript/TypeScript** — `hyperliquid` npm package (v1.5.0)
- **Python** — `hyperliquid-python-sdk` (v0.5.0)

Both docs cover:
- SDK initialization (read-only and trading modes)
- Market data: mid prices, L2 order book, funding rates, candles
- Account info: positions, equity, open orders, trade history
- Trading: limit orders, market orders, cancel, close position, leverage
- WebSocket subscriptions

### Why this matters

Hyperliquid is the largest perps DEX by open interest. Agents working on crypto trading frequently need to integrate with it, and without curated docs they hallucinate SDK methods. This doc gives agents a reliable reference.

### Notes

- All prices are returned as strings — docs include the note to use `parseFloat()` / `float()`
- Testnet URLs included
- Rate limits noted