### PR TITLE
Add Brakit observability docs (Node.js + Python)

### DIFF
--- a/content/brakit/docs/observability/javascript/DOC.md
+++ b/content/brakit/docs/observability/javascript/DOC.md
@@ -1,0 +1,191 @@
+---
+name: observability
+description: "Brakit Node.js SDK for zero-config API observability: live dashboard, security scanning, N+1 detection, and AI-native MCP integration"
+metadata:
+  languages: "javascript"
+  versions: "0.8.7"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: maintainer
+  tags: "brakit,observability,security,n+1,mcp,api-monitoring"
+---
+
+# Brakit — Node.js SDK
+
+Zero-config observability for API backends. Brakit intercepts every request, query, fetch call, and error in your running app — surfaces security issues and performance problems as you develop.
+
+## Golden Rule
+
+Brakit is a **dev-only** tool. It never runs in production — 7 independent safety layers guarantee it (NODE_ENV check, localhost-only dashboard, circuit breaker, manual kill switch, and more). Brakit installs as a regular dependency (not devDependency) so that `import 'brakit'` never throws in production — it simply no-ops.
+
+## Installation
+
+```bash
+npx brakit install
+```
+
+Then start your app however you normally do (e.g., `npm run dev`, `node server.js`, `next dev`, etc.).
+
+`brakit install` does three things:
+
+1. Adds `brakit` as a dependency
+2. Creates an instrumentation file (`instrumentation.ts` or equivalent)
+3. Configures the MCP server for Claude Code / Cursor
+
+Dashboard is at `http://localhost:<port>/__brakit` on your existing dev server port.
+
+## Framework Setup
+
+Brakit auto-detects your framework. The instrumentation file created by `brakit install` handles everything. Here's what it generates for each framework:
+
+### Next.js
+
+```typescript
+// instrumentation.ts (project root)
+export async function register() {
+  if (process.env.NODE_ENV === "development") {
+    await import("brakit");
+  }
+}
+```
+
+### Express / Fastify / Other Node.js Servers
+
+```typescript
+// Add as the first import in your entry file
+import "brakit";
+import express from "express";
+
+const app = express();
+// ... your routes
+```
+
+### Remix / Nuxt / Vite / Astro
+
+Brakit auto-detects these frameworks and hooks in via `instrumentation.ts` or equivalent entry point. `npx brakit install` creates the correct file for your project.
+
+## What Gets Captured (Zero Code Changes)
+
+| Category      | What's Traced                                                       |
+| ------------- | ------------------------------------------------------------------- |
+| HTTP Requests | Every incoming request/response with timing, status, headers, body  |
+| Fetch Calls   | All outgoing `fetch()` calls with URL, timing, response             |
+| DB Queries    | SQL queries via pg, mysql2, Prisma — with params, timing, row count |
+| Console Logs  | `console.log/warn/error` output captured and linked to requests     |
+| Errors        | Unhandled exceptions and rejections with stack traces               |
+
+Everything is grouped into **actions** — "Sign Up", "Load Dashboard" — not raw HTTP noise.
+
+## Dashboard
+
+Access at `/__brakit` on your dev server. It shows:
+
+- **Actions view** — endpoints grouped by the user action that triggered them
+- **Request timeline** — scatter chart of all requests by latency
+- **Health grades** — per-endpoint performance grades (A through F)
+- **Security findings** — issues detected in live traffic
+- **Performance insights** — N+1 queries, duplicates, slow endpoints, overfetch
+
+## Security Rules
+
+8 high-confidence rules scan your live traffic:
+
+| Severity | Rule               | Detects                                                                     |
+| -------- | ------------------ | --------------------------------------------------------------------------- |
+| Critical | Exposed Secret     | `password`, `api_key`, `client_secret` fields with real values in responses |
+| Critical | Token in URL       | Auth tokens in query parameters instead of headers                          |
+| Critical | Stack Trace Leak   | Internal stack traces sent to the client                                    |
+| Critical | Error Info Leak    | DB connection strings, SQL queries in error responses                       |
+| Warning  | PII in Response    | Emails, full user records with internal IDs echoed back                     |
+| Warning  | Insecure Cookie    | Missing `HttpOnly` or `SameSite` flags                                      |
+| Warning  | Sensitive Logs     | Passwords, secrets, or tokens in console output                             |
+| Warning  | CORS + Credentials | `credentials: true` with wildcard origin                                    |
+
+See **[references/security-rules.md](references/security-rules.md)** for detailed detection logic and fix examples.
+
+## Performance Insights
+
+| Severity | Insight              | Detects                                                              |
+| -------- | -------------------- | -------------------------------------------------------------------- |
+| Critical | N+1 Query            | Same query pattern 5+ times in one request                           |
+| Critical | Error Hotspot        | Endpoint error rate >= 20%                                           |
+| Critical | Unhandled Error      | Uncaught exceptions in request handlers                              |
+| Warning  | Slow Endpoint        | Average latency >= 1000ms with time breakdown                        |
+| Warning  | Query-Heavy          | More than 5 queries per request on average                           |
+| Warning  | Duplicate API Call   | Same endpoint called multiple times across actions                   |
+| Warning  | Regression           | p95 latency increase >= 200ms / 50%, or query count increase >= 1.5x |
+| Warning  | Cross-Endpoint Query | Same query runs on 3+ endpoints (50%+ of all endpoints)              |
+| Warning  | Redundant Query      | Exact same SQL + params runs 2+ times in one request                 |
+| Warning  | SELECT \*            | `SELECT *` query executed 2+ times                                   |
+| Info     | Response Overfetch   | Large response with 8+ fields, many nulls, or internal IDs           |
+| Info     | Large Response       | Average response > 50KB                                              |
+
+See **[references/insight-rules.md](references/insight-rules.md)** for thresholds and fix examples.
+
+## MCP Integration
+
+Brakit includes an MCP server so AI assistants (Claude Code, Cursor) can query findings and verify fixes directly.
+
+`npx brakit install` auto-configures MCP. Available tools:
+
+| Tool                 | Purpose                                                  |
+| -------------------- | -------------------------------------------------------- |
+| `get_findings`       | Get all security and performance findings with fix hints |
+| `get_endpoints`      | Endpoint summary with p95, error rate, query count       |
+| `get_request_detail` | Full request detail: queries, fetches, timeline          |
+| `verify_fix`         | Check if a previously found issue is resolved            |
+| `get_report`         | Summary report of all findings and app health            |
+| `report_fix`         | Report fix outcome (fixed / won't fix) to dashboard      |
+| `clear_findings`     | Reset finding history for a fresh session                |
+
+See **[references/mcp-tools.md](references/mcp-tools.md)** for full parameter schemas and examples.
+
+## Supported Frameworks
+
+| Framework | Status                     |
+| --------- | -------------------------- |
+| Next.js   | Full support (auto-detect) |
+| Remix     | Auto-detect                |
+| Nuxt      | Auto-detect                |
+| Vite      | Auto-detect                |
+| Astro     | Auto-detect                |
+| Express   | Auto-detect                |
+| Fastify   | Auto-detect                |
+
+## Supported Databases
+
+| Driver  | Status    |
+| ------- | --------- |
+| pg      | Supported |
+| mysql2  | Supported |
+| Prisma  | Supported |
+| SQLite  | Planned   |
+| MongoDB | Planned   |
+| Drizzle | Planned   |
+
+## Production Safety
+
+Multiple independent layers prevent brakit from ever running in production:
+
+| #   | Layer                        | How It Blocks                             |
+| --- | ---------------------------- | ----------------------------------------- |
+| 1   | `shouldActivate()`           | Checks `NODE_ENV` + 15 cloud/CI env vars  |
+| 2   | `instrumentation.ts` guard   | Its own `NODE_ENV !== 'production'` check |
+| 3   | Safe no-op in production     | Import succeeds but does nothing          |
+| 4   | Localhost-only dashboard     | Non-local IPs get 404 on `/__brakit`      |
+| 5   | `safeWrap` + circuit breaker | 10 errors = brakit self-disables          |
+| 6   | `BRAKIT_DISABLE=true`        | Manual kill switch                        |
+
+## Uninstall
+
+```bash
+npx brakit uninstall
+```
+
+Removes the instrumentation file, MCP configuration, `.brakit` data directory, `.gitignore` entry, and the dependency. Your app is unchanged.
+
+## Useful Links
+
+- [Architecture](https://github.com/brakit-ai/brakit/blob/main/docs/design/architecture.md)
+- [Contributing](https://github.com/brakit-ai/brakit/blob/main/CONTRIBUTING.md)
+- [Website](https://brakit.ai)

--- a/content/brakit/docs/observability/python/DOC.md
+++ b/content/brakit/docs/observability/python/DOC.md
@@ -1,0 +1,175 @@
+---
+name: observability
+description: "Brakit Python SDK for zero-config API observability with FastAPI and Flask, forwarding telemetry to the Node.js dashboard"
+metadata:
+  languages: "python"
+  versions: "0.1.2"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: maintainer
+  tags: "brakit,observability,security,fastapi,flask,api-monitoring"
+---
+
+# Brakit — Python SDK
+
+Zero-config observability for Python API backends. The Python SDK captures every request, query, fetch call, and error in your FastAPI or Flask app and forwards telemetry to the Brakit Node.js dashboard.
+
+## Golden Rule
+
+`import brakit` must be the **very first import** in your application — before any framework or library imports. This is required because brakit patches framework constructors and library entry points at import time.
+
+```python
+import brakit          # MUST be first
+from fastapi import FastAPI  # framework import after brakit
+```
+
+## Prerequisites
+
+Brakit is a full-stack observability tool. The Python SDK forwards telemetry to the **Node.js Brakit dashboard**. You need:
+
+1. Node.js Brakit installed in your project: `npx brakit install`
+2. The Node.js app running (provides the dashboard at `/__brakit`)
+3. Python >= 3.9
+
+The Python SDK auto-discovers the Node.js dashboard port — no manual configuration needed.
+
+## Installation
+
+```bash
+pip install brakit              # core only
+pip install brakit[fastapi]     # with FastAPI extras
+pip install brakit[flask]       # with Flask extras
+pip install brakit[dev]         # development extras
+```
+
+## FastAPI Setup
+
+```python
+import brakit                   # must be first import
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/users")
+async def get_users():
+    return [{"id": 1, "name": "Alice"}]
+```
+
+Brakit auto-detects FastAPI and injects ASGI middleware. No other configuration needed.
+
+## Flask Setup
+
+```python
+import brakit                   # must be first import
+from flask import Flask
+
+app = Flask(__name__)
+
+@app.route("/users")
+def get_users():
+    return [{"id": 1, "name": "Alice"}]
+```
+
+Brakit auto-detects Flask and injects before/after request hooks.
+
+## What Gets Captured (Zero Code Changes)
+
+| Category | What's Traced | Library |
+|----------|--------------|---------|
+| HTTP Requests | Every incoming request/response with timing, status, headers | FastAPI, Flask |
+| DB Queries | SQL queries with params, timing, row count | SQLAlchemy, asyncpg |
+| Fetch Calls | All outgoing HTTP calls with URL, timing, response | httpx, aiohttp, requests/urllib3 |
+| Logs | All Python logging output linked to requests | stdlib `logging` |
+| Errors | Unhandled exceptions with stack traces | Global exception hooks |
+
+## Cross-Service Tracing
+
+When your Node.js frontend calls your Python API, brakit automatically nests the Python telemetry under the originating fetch call in the dashboard.
+
+```
+Next.js frontend (Node.js brakit)
+  └── fetch POST /api/signup
+        └── FastAPI backend (Python brakit)
+              ├── INSERT INTO users ...
+              ├── SELECT FROM plans ...
+              └── fetch POST https://api.stripe.com/charges
+```
+
+This works via request ID propagation through HTTP headers (`x-brakit-request-id`, `x-brakit-fetch-id`). No configuration needed.
+
+## Supported Frameworks
+
+| Framework | Status |
+|-----------|--------|
+| FastAPI | Full support (auto-detect) |
+| Flask | Full support (auto-detect) |
+| Django | Planned |
+
+## Supported Databases
+
+| Driver | Status |
+|--------|--------|
+| SQLAlchemy | Supported (sync and async) |
+| asyncpg | Supported |
+| psycopg | Planned |
+
+## Supported HTTP Clients
+
+| Library | Status |
+|---------|--------|
+| httpx | Supported (sync and async) |
+| aiohttp | Supported |
+| requests / urllib3 | Supported |
+
+## How It Works Internally
+
+1. **Import-time patching** — `import brakit` patches framework constructors (FastAPI, Flask) and library entry points (httpx, SQLAlchemy, etc.)
+2. **Request context** — Uses `contextvars.ContextVar` for async-safe request ID propagation
+3. **Event bus** — Decoupled pub/sub system connects adapters to stores
+4. **Ring buffer stores** — Bounded in-memory storage with FIFO eviction (configurable max entries)
+5. **Forwarder thread** — Background thread sends telemetry to Node.js dashboard via localhost HTTP
+6. **Circuit breaker** — 10 errors = brakit self-disables to never affect your app
+7. **Port discovery** — Auto-discovers Node.js dashboard port via port file negotiation
+
+## Production Safety
+
+Brakit never runs in production. Safety layers include:
+
+- `should_activate()` checks `NODE_ENV` and 15+ cloud/CI env vars
+- Framework-level guards with additional `NODE_ENV` checks
+- `try/except` on import — missing dependency = silent no-op
+- Circuit breaker — 10 errors = auto-disable
+- `BRAKIT_DISABLE=true` manual kill switch
+
+## Troubleshooting
+
+### Import order issues
+
+`import brakit` must be the first import. If you see "Framework not detected", check that brakit is imported before FastAPI/Flask.
+
+```python
+# WRONG — brakit can't patch FastAPI if it's already imported
+from fastapi import FastAPI
+import brakit
+
+# CORRECT
+import brakit
+from fastapi import FastAPI
+```
+
+### SDK not connecting to Node.js dashboard
+
+1. Ensure the Node.js app is running (start it however you normally do)
+2. Check that `npx brakit install` was run in the Node.js project
+3. Verify the port file exists at `.brakit/port` in the Node.js project
+4. Set `BRAKIT_PORT=<port>` if auto-discovery fails
+
+### Framework not detected
+
+Brakit patches framework constructors at import time. If you create the app before importing brakit, it won't be instrumented. Always import brakit first.
+
+## Useful Links
+
+- [GitHub](https://github.com/brakit-ai/brakit)
+- [Contributing](https://github.com/brakit-ai/brakit/blob/main/CONTRIBUTING.md)
+- [Website](https://brakit.ai)

--- a/content/brakit/docs/observability/references/insight-rules.md
+++ b/content/brakit/docs/observability/references/insight-rules.md
@@ -1,0 +1,254 @@
+# Brakit Performance Insight Rules Reference
+
+Brakit automatically analyzes your API traffic and surfaces performance issues. Each rule runs continuously against captured telemetry.
+
+---
+
+## Critical Severity
+
+### N+1 Query Pattern (`n1`)
+
+**Threshold:** Same query pattern executed **5+ times** in a single request.
+
+**What it detects:** Fetching related data in a loop instead of batching.
+
+**Example:**
+```
+GET /api/posts
+  → SELECT * FROM posts                    (1 query)
+  → SELECT * FROM users WHERE id = 1       (repeated per post)
+  → SELECT * FROM users WHERE id = 2
+  → SELECT * FROM users WHERE id = 3
+  → SELECT * FROM users WHERE id = 4
+  → SELECT * FROM users WHERE id = 5       ← N+1 flagged (5 identical patterns)
+```
+
+**How to fix:**
+```typescript
+// WRONG: query per item
+const posts = await db.query('SELECT * FROM posts');
+for (const post of posts) {
+  post.author = await db.query('SELECT * FROM users WHERE id = $1', [post.author_id]);
+}
+
+// CORRECT: batch query
+const posts = await db.query('SELECT * FROM posts');
+const authorIds = posts.map(p => p.author_id);
+const authors = await db.query('SELECT * FROM users WHERE id = ANY($1)', [authorIds]);
+```
+
+```python
+# SQLAlchemy: use joinedload or selectinload
+from sqlalchemy.orm import selectinload
+
+posts = session.query(Post).options(selectinload(Post.author)).all()
+```
+
+---
+
+### Error Hotspot (`error-hotspot`)
+
+**Threshold:** Error rate >= **20%** on an endpoint (minimum 2 requests).
+
+**What it detects:** Endpoints that frequently return error status codes (4xx-5xx).
+
+**How to fix:** Check response bodies for error details and stack traces. Common causes: missing validation, unhandled null cases, database connection issues.
+
+---
+
+### Unhandled Error (`error`)
+
+**Threshold:** Any uncaught exception during request handling.
+
+**What it detects:** Errors that crash request handlers without being caught.
+
+**How to fix:**
+```typescript
+// Wrap async handlers
+app.get('/api/data', async (req, res, next) => {
+  try {
+    const data = await fetchData();
+    res.json(data);
+  } catch (err) {
+    next(err);  // pass to error-handling middleware
+  }
+});
+```
+
+---
+
+## Warning Severity
+
+### Slow Endpoint (`slow`)
+
+**Threshold:** Average latency >= **1000ms** (minimum 2 requests).
+
+**What it detects:** Endpoints where total response time exceeds 1 second. Includes time breakdown showing where time is spent: DB queries, fetch calls, or application code.
+
+**How to fix:** The insight tells you the dominant category:
+- **DB-heavy:** Optimize queries, add indexes, reduce query count
+- **Fetch-heavy:** Parallelize upstream calls, add caching, reduce call count
+- **App-heavy:** Profile application code, check for CPU-bound operations
+
+---
+
+### Query-Heavy Endpoint (`query-heavy`)
+
+**Threshold:** Average queries per request > **5** (minimum 2 requests).
+
+**What it detects:** Endpoints making too many database queries per request.
+
+**How to fix:**
+```sql
+-- Combine multiple queries with JOINs
+SELECT posts.*, users.name as author_name
+FROM posts
+JOIN users ON users.id = posts.author_id
+WHERE posts.published = true;
+
+-- Instead of separate queries for posts and authors
+```
+
+---
+
+### Duplicate API Call (`duplicate`)
+
+**Threshold:** Same API endpoint called multiple times across actions. Shows top 3 by count.
+
+**What it detects:** Redundant fetch calls — the same endpoint loaded repeatedly.
+
+**How to fix:**
+```typescript
+// Lift fetch to parent component
+// Use caching (React Query, SWR, or manual cache)
+// Deduplicate with request coalescing
+
+// React Query example
+const { data } = useQuery(['users'], () => fetch('/api/users'));
+// Subsequent useQuery('users') calls reuse the cached result
+```
+
+---
+
+### Performance Regression (`regression`)
+
+**Threshold:** Either:
+- p95 latency increased by >= **200ms** AND >= **50%** compared to previous session
+- Query count increased by >= **1.5x** (minimum 5 requests in both sessions)
+
+**What it detects:** Endpoints that got slower or started making more queries since the last dev session.
+
+**How to fix:** Check recent code changes for:
+- New N+1 patterns introduced
+- Removed query optimizations or caching
+- Added middleware or processing steps
+- New upstream service calls
+
+---
+
+### Cross-Endpoint Repeated Query (`cross-endpoint`)
+
+**Threshold:** Same query runs on **3+ endpoints**, covering >= **50%** of all endpoints, with >= **5 total occurrences**.
+
+**What it detects:** A query that runs on most endpoints, signaling it should be in middleware or cached.
+
+**How to fix:**
+```typescript
+// Move repeated query to middleware
+app.use(async (req, res, next) => {
+  req.currentUser = await db.query('SELECT * FROM users WHERE id = $1', [req.userId]);
+  next();
+});
+
+// Or cache the result
+const userCache = new Map();
+```
+
+---
+
+### Redundant Query (`redundant-query`)
+
+**Threshold:** Exact same SQL with identical parameters runs **2+ times** in a single request.
+
+**What it detects:** The same query (same SQL, same params) executing multiple times within one request handler.
+
+**How to fix:**
+```typescript
+// Cache the first result
+const getUser = memoize(async (id) => db.query('SELECT * FROM users WHERE id = $1', [id]));
+
+// Or lift the query to a shared variable
+const user = await getUser(userId);
+// Use `user` in multiple places instead of re-querying
+```
+
+---
+
+### Large Result Set (`high-rows`)
+
+**Threshold:** Query returns **100+ rows**, occurring 2+ times.
+
+**What it detects:** Queries fetching many rows, which slows responses and uses excess memory.
+
+**How to fix:**
+```sql
+-- Add LIMIT and pagination
+SELECT * FROM products ORDER BY created_at DESC LIMIT 20 OFFSET 0;
+
+-- Or filter with WHERE
+SELECT * FROM orders WHERE status = 'pending' AND created_at > NOW() - INTERVAL '7 days';
+```
+
+---
+
+### SELECT * Query (`select-star`)
+
+**Threshold:** `SELECT *` query executed **2+ times**.
+
+**What it detects:** Queries fetching all columns instead of specifying only needed ones.
+
+**How to fix:**
+```sql
+-- Specify only required columns
+SELECT id, name, email FROM users WHERE active = true;
+-- Instead of: SELECT * FROM users WHERE active = true;
+```
+
+---
+
+## Info Severity
+
+### Response Overfetch (`response-overfetch`)
+
+**Threshold:** Response has >= **8 fields** AND at least one of:
+- 2+ internal ID fields (e.g., `role_id`, `org_id`)
+- 30%+ null fields
+- 12+ total fields
+
+**What it detects:** API returning more data than the client likely needs.
+
+**How to fix:**
+```typescript
+// Use a DTO or select specific fields
+const userDTO = {
+  id: user.id,
+  name: user.name,
+  avatar: user.avatar
+};
+return userDTO;
+// Instead of returning the full database record
+```
+
+---
+
+### Large Response (`large-response`)
+
+**Threshold:** Average response size > **50KB** (51,200 bytes), minimum 2 requests.
+
+**What it detects:** Large API responses that increase transfer time and client memory usage.
+
+**How to fix:**
+- Implement pagination for list endpoints
+- Add field filtering (`?fields=id,name,email`)
+- Enable gzip/brotli compression
+- Return IDs and let client fetch details on demand

--- a/content/brakit/docs/observability/references/mcp-tools.md
+++ b/content/brakit/docs/observability/references/mcp-tools.md
@@ -1,0 +1,161 @@
+# Brakit MCP Tools Reference
+
+Brakit exposes 7 MCP tools for AI assistants (Claude Code, Cursor) to query findings, inspect endpoints, and verify fixes.
+
+The MCP server is auto-configured during `npx brakit install`. It runs alongside the Brakit dashboard.
+
+---
+
+## get_findings
+
+Get all security findings and performance insights from the running app. Returns enriched findings with actionable fix hints, endpoint context, and evidence.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `severity` | string | No | Filter by `"critical"` or `"warning"` |
+| `state` | string | No | Filter by `"open"`, `"fixing"`, `"resolved"`, `"stale"`, or `"regressed"` |
+
+**Example usage:**
+```
+get_findings({ severity: "critical" })
+get_findings({ state: "open" })
+get_findings({})  // all findings
+```
+
+**Response includes:** Finding ID, rule ID, severity, state, affected endpoint, evidence (query patterns, response excerpts), and actionable fix hint.
+
+---
+
+## get_endpoints
+
+Get a summary of all observed API endpoints with performance stats.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `sort_by` | string | No | Sort by `"p95"` (default), `"error_rate"`, `"query_count"`, or `"requests"` |
+
+**Example usage:**
+```
+get_endpoints({ sort_by: "error_rate" })
+get_endpoints({})  // sorted by p95 latency
+```
+
+**Response includes:** Endpoint (method + path), request count, p95 latency, error rate, average query count, time breakdown (DB / Fetch / App), health grade.
+
+---
+
+## get_request_detail
+
+Get full details of a specific HTTP request including all DB queries, fetches, response, and a timeline of events.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `request_id` | string | No | The specific request ID to look up |
+| `endpoint` | string | No | Get the latest request for an endpoint (e.g., `"GET /api/users"`) |
+
+Must provide either `request_id` OR `endpoint`.
+
+**Example usage:**
+```
+get_request_detail({ request_id: "abc-123" })
+get_request_detail({ endpoint: "GET /api/users" })
+```
+
+**Response includes:** Full request/response (method, URL, status, headers, body), all DB queries fired (SQL, params, timing, row count), all outgoing fetch calls (URL, timing, status), console logs, errors, and an ordered timeline.
+
+---
+
+## verify_fix
+
+Verify whether a previously found security or performance issue has been resolved. After fixing code, the user should trigger the endpoint again, then call this tool.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `finding_id` | string | No | The finding ID to verify |
+| `endpoint` | string | No | Check if a specific endpoint still has issues (e.g., `"GET /api/users"`) |
+
+Must provide either `finding_id` OR `endpoint`.
+
+**Example usage:**
+```
+verify_fix({ finding_id: "exposed-secret-abc123" })
+verify_fix({ endpoint: "GET /api/users" })
+```
+
+**Response includes:** Whether the issue is resolved, still present, or if more requests are needed to confirm.
+
+---
+
+## get_report
+
+Generate a summary report of all findings. Returns a high-level overview of the application's health with critical issues listed first.
+
+**Parameters:** None.
+
+**Example usage:**
+```
+get_report({})
+```
+
+**Response includes:** Total findings found, open count, resolved count, critical vs warning breakdown, and a list of all findings sorted by severity.
+
+---
+
+## clear_findings
+
+Reset finding history for a fresh session. Use when starting a new development session or after major refactoring.
+
+**Parameters:** None.
+
+**Example usage:**
+```
+clear_findings({})
+```
+
+---
+
+## report_fix
+
+Report the result of fixing a brakit finding. Call this after attempting to fix each finding to update the dashboard with the outcome.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `finding_id` | string | **Yes** | The finding ID to report on |
+| `status` | string | **Yes** | `"fixed"` or `"wont_fix"` |
+| `summary` | string | **Yes** | Brief description of what was done or why it can't be fixed |
+
+**Example usage:**
+```
+report_fix({
+  finding_id: "exposed-secret-abc123",
+  status: "fixed",
+  summary: "Stripped password field from user response DTO"
+})
+
+report_fix({
+  finding_id: "pii-leak-def456",
+  status: "wont_fix",
+  summary: "Email is required in response for the user profile endpoint"
+})
+```
+
+---
+
+## Typical AI Workflow
+
+1. **Discover issues:** `get_findings({})` or `get_report({})`
+2. **Inspect details:** `get_request_detail({ endpoint: "GET /api/users" })`
+3. **Fix the code** based on the hint and evidence
+4. **User triggers the endpoint** (refreshes page, runs curl, etc.)
+5. **Verify:** `verify_fix({ finding_id: "..." })`
+6. **Report:** `report_fix({ finding_id: "...", status: "fixed", summary: "..." })`

--- a/content/brakit/docs/observability/references/security-rules.md
+++ b/content/brakit/docs/observability/references/security-rules.md
@@ -1,0 +1,228 @@
+# Brakit Security Rules Reference
+
+8 high-confidence rules that scan live API traffic. Each rule runs against every request/response pair in real time.
+
+---
+
+## Critical Severity
+
+### Exposed Secret (`exposed-secret`)
+
+**Detects:** Response JSON contains fields like `password`, `api_key`, `client_secret`, `secret_key`, `auth_token` with real values (minimum 4 characters, not masked with `***`).
+
+**Example trigger:**
+```json
+// GET /api/users/1 response
+{
+  "id": 1,
+  "email": "alice@example.com",
+  "password": "$2b$10$abc123hashedvalue",
+  "api_key": "sk-live-abc123def456"
+}
+```
+
+**How to fix:**
+```typescript
+// Strip sensitive fields before returning
+const { password, api_key, ...safeUser } = user;
+return safeUser;
+
+// Or use a DTO / select specific fields
+const user = await db.query('SELECT id, email, name FROM users WHERE id = $1', [id]);
+```
+
+---
+
+### Token in URL (`token-in-url`)
+
+**Detects:** Auth tokens passed as query parameters instead of headers. Checks for: `token`, `api_key`, `secret`, `password`, `access_token`, `session_id` in the URL query string.
+
+**Example trigger:**
+```
+GET /api/data?access_token=eyJhbGciOiJIUzI1NiJ9...&user_id=42
+```
+
+**How to fix:**
+```typescript
+// WRONG: token in URL
+fetch('/api/data?access_token=eyJ...');
+
+// CORRECT: token in Authorization header
+fetch('/api/data', {
+  headers: { 'Authorization': 'Bearer eyJ...' }
+});
+```
+
+---
+
+### Stack Trace Leak (`stack-trace-leak`)
+
+**Detects:** Internal stack traces sent to the client in error responses. Matches patterns like `at Module._compile`, `File "..."`, `Traceback (most recent call last)`.
+
+**Example trigger:**
+```json
+// 500 response
+{
+  "error": "TypeError: Cannot read property 'id' of undefined\n    at UserController.getUser (/app/src/controllers/user.ts:42:15)\n    at Module._compile (node:internal/modules/cjs/loader:1234:14)"
+}
+```
+
+**How to fix:**
+```typescript
+// Add error-handling middleware
+app.use((err, req, res, next) => {
+  console.error(err);  // log internally
+  res.status(500).json({ error: 'Internal server error' });  // generic message to client
+});
+```
+
+```python
+# FastAPI
+@app.exception_handler(Exception)
+async def generic_handler(request, exc):
+    logger.error(f"Unhandled: {exc}")
+    return JSONResponse(status_code=500, content={"error": "Internal server error"})
+```
+
+---
+
+### Error Info Leak (`error-info-leak`)
+
+**Detects:** Error responses (4xx-5xx) containing sensitive internal details:
+- Database connection strings (`postgresql://`, `mysql://`, `mongodb://`)
+- SQL query fragments (`SELECT`, `INSERT`, `UPDATE`, `DELETE` with table names)
+- Secret values (same patterns as exposed-secret rule)
+
+**Example trigger:**
+```json
+// 500 response
+{
+  "error": "connection refused: postgresql://admin:pass@db.internal:5432/myapp",
+  "query": "SELECT * FROM users WHERE email = 'alice@example.com'"
+}
+```
+
+**How to fix:**
+```typescript
+// Sanitize error responses — never forward raw error messages
+app.use((err, req, res, next) => {
+  // Log full error internally
+  logger.error({ err, url: req.url });
+  // Return generic message
+  res.status(500).json({ error: 'Something went wrong' });
+});
+```
+
+---
+
+## Warning Severity
+
+### PII in Response (`response-pii-leak`)
+
+**Detects:**
+- API echoes back email addresses in responses
+- Full user records with internal IDs (8+ fields indicates a full DB record)
+- Lists containing email addresses (2+ items with emails)
+- Unambiguous PII fields: `phone`, `ssn`, `social_security`, `date_of_birth`, `address`, `credit_card`, `passport`
+
+**Example trigger:**
+```json
+// GET /api/users response returning full records
+[
+  {
+    "id": 1,
+    "email": "alice@example.com",
+    "created_at": "2024-01-01",
+    "internal_role_id": 5,
+    "password_hash": "...",
+    "last_login_ip": "192.168.1.1",
+    "phone": "+1-555-0123",
+    "ssn": "123-45-6789"
+  }
+]
+```
+
+**How to fix:**
+```typescript
+// Return only the fields the client needs
+const users = await db.query('SELECT id, name, avatar FROM users');
+// Instead of: SELECT * FROM users
+```
+
+---
+
+### Insecure Cookie (`insecure-cookie`)
+
+**Detects:** `Set-Cookie` headers missing `HttpOnly` or `SameSite` flags.
+
+**Example trigger:**
+```
+Set-Cookie: session=abc123; Path=/
+```
+
+**How to fix:**
+```typescript
+res.cookie('session', token, {
+  httpOnly: true,      // prevents JavaScript access
+  sameSite: 'lax',     // prevents CSRF
+  secure: true,        // HTTPS only
+  maxAge: 86400000
+});
+```
+
+```python
+# FastAPI
+response.set_cookie("session", token, httponly=True, samesite="lax", secure=True)
+```
+
+---
+
+### Sensitive Logs (`sensitive-logs`)
+
+**Detects:** Console output containing secret or token values. Matches patterns like `password`, `secret`, `token`, `api_key` followed by values of 8+ characters.
+
+**Example trigger:**
+```typescript
+console.log('User login:', { email: 'alice@example.com', password: 'hunter2secret' });
+console.log(`API key: sk-live-abc123def456ghi789`);
+```
+
+**How to fix:**
+```typescript
+// Redact sensitive fields before logging
+const { password, ...safeData } = loginPayload;
+console.log('User login:', safeData);
+
+// Or use a logging library with redaction
+logger.info('Login attempt', { email: user.email });  // only log what's needed
+```
+
+---
+
+### CORS + Credentials (`cors-credentials`)
+
+**Detects:** Response has both `Access-Control-Allow-Origin: *` (wildcard) and `Access-Control-Allow-Credentials: true`. This combination is forbidden by browsers and indicates a misconfiguration.
+
+**Example trigger:**
+```
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Credentials: true
+```
+
+**How to fix:**
+```typescript
+// Specify explicit origins instead of wildcard
+app.use(cors({
+  origin: ['https://myapp.com', 'http://localhost:3000'],
+  credentials: true
+}));
+```
+
+```python
+# FastAPI
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["https://myapp.com", "http://localhost:3000"],
+    allow_credentials=True,
+)
+```


### PR DESCRIPTION
## What
Adds curated documentation for [Brakit](https://brakit.ai) — a zero-config dev dashboard for API backends that groups every request, query, and fetch by the user action that triggered them. Includes Node.js and Python SDK docs with reference files for security rules, performance insights, and MCP tools.

## Why
As AI writes more application code, developers lose the mental model of what their API actually does — which endpoints exist, what queries they fire, and how they perform. Brakit is an open-source dev dashboard (like Laravel Telescope for Node.js) that gives that visibility back, grouping every request, query, and fetch by the user action that triggered them. Adding brakit to Context Hub helps coding agents discover and correctly set up a tool that solves a problem unique to AI-assisted development — and gives agents the exact installation commands, framework-specific setup, and reference material to do it without hallucinating configuration options or import order.

## Testing

- [x] `npm test` passes
- [x] `chub build content/ --validate-only` succeeds — `Valid: 1545 docs, 5 skills, 0 warnings`
- [x] Manual testing done — verified brakit entry appears in built `registry.json` with both `javascript` and `python` language variants

## Notes

Brakit is a full-stack observability tool (like Laravel Telescope for Node.js). The Node.js SDK runs the dashboard; the Python SDK forwards telemetry from FastAPI/Flask to it. The two language variants reflect this architecture — the Python doc clearly states the Node.js prerequisite.