### PR TITLE
Add hookpipe — webhook infrastructure CLI for AI agents

### DIFF
--- a/content/hookpipe/docs/cli/DOC.md
+++ b/content/hookpipe/docs/cli/DOC.md
@@ -1,0 +1,282 @@
+---
+name: cli
+description: "Webhook infrastructure CLI for AI agents — receive webhooks from Stripe, GitHub, Slack, Shopify, Vercel with signature verification, durable queuing, and automatic retries on Cloudflare Workers"
+metadata:
+  languages: "javascript"
+  versions: "0.0.5"
+  revision: 1
+  updated-on: "2026-03-17"
+  source: maintainer
+  tags: "webhooks,webhook,stripe,github,slack,shopify,vercel,cloudflare-workers,cli,agent"
+---
+# hookpipe CLI
+
+Receive webhooks from external services, queue them durably on Cloudflare Workers, and deliver them to your application with automatic retries. Built-in signature verification for Stripe, GitHub, Slack, Shopify, and Vercel.
+
+## Installation
+
+```bash
+npm install -g hookpipe
+```
+
+```bash
+brew install hookpipe/hookpipe/hookpipe
+```
+
+## Quick Start
+
+### One-shot setup (most common)
+
+```bash
+hookpipe connect stripe \
+  --secret whsec_xxx \
+  --to https://your-app.com/webhook \
+  --events "payment_intent.*"
+```
+
+This creates a source, destination, and subscription in one command. The output includes a **Webhook URL** — register it in the provider's dashboard.
+
+### Local development
+
+```bash
+hookpipe dev --port 3000 --provider stripe --secret whsec_xxx
+```
+
+Creates a secure tunnel (Cloudflare Quick Tunnel) to your local machine. Paste the printed URL into Stripe's webhook dashboard. Signatures are verified locally before forwarding.
+
+## Core Concepts
+
+Three resources, one attribute:
+
+| Resource | Description | ID prefix |
+|----------|-------------|-----------|
+| **Source** | Webhook receiver endpoint, optionally tied to a provider | `src_` |
+| **Destination** | Target URL with retry policy | `dst_` |
+| **Subscription** | Routes events from source to destination with event type filters | `sub_` |
+| **Provider** | Static knowledge about a webhook sender (read-only catalog) | — |
+
+## Provider Discovery
+
+List all built-in providers:
+
+```bash
+hookpipe providers ls
+hookpipe providers ls --json
+```
+
+Inspect a provider's event types, presets, and setup instructions:
+
+```bash
+hookpipe providers describe stripe
+hookpipe providers describe stripe --json
+```
+
+Built-in providers: `stripe`, `github`, `slack`, `shopify`, `vercel`.
+
+For any webhook service not in the catalog, use generic HMAC verification:
+
+```bash
+hookpipe connect my-service \
+  --secret my_signing_secret \
+  --to https://your-app.com/webhook
+```
+
+## The `connect` Command
+
+One-shot setup for the 80% use case (one source → one destination):
+
+```bash
+hookpipe connect <provider> \
+  --secret <signing_secret> \
+  --to <destination_url> \
+  --events <filter>           # default: "*" (all events)
+  --name <source_name>        # default: provider ID
+  --retry <strategy>          # exponential | linear | fixed (default: exponential)
+  --max-retries <n>           # default: 10
+  --json                      # structured output
+  --dry-run                   # validate without executing
+```
+
+Output includes: source ID, destination ID, subscription ID, and the **Webhook URL** to register with the provider.
+
+## Advanced: Individual Resource Commands
+
+For fan-out (one source → multiple destinations) or custom retry policies:
+
+```bash
+# Create source
+hookpipe sources create --name stripe-prod \
+  -d '{"provider":"stripe","verification":{"type":"stripe-signature","secret":"whsec_xxx"}}'
+
+# Create destinations
+hookpipe dest create --name app-primary --url https://app.com/webhook
+hookpipe dest create --name analytics --url https://analytics.com/ingest
+
+# Create subscriptions
+hookpipe subs create --source src_abc --destination dst_def --events "payment_intent.*"
+hookpipe subs create --source src_abc --destination dst_ghi --events "*"
+```
+
+### List and inspect resources
+
+```bash
+hookpipe sources ls --json
+hookpipe sources get src_abc123
+hookpipe dest ls --fields id,name,url
+hookpipe subs ls --json
+```
+
+### Delete resources
+
+```bash
+hookpipe sources rm src_abc123 --dry-run   # preview first
+hookpipe sources rm src_abc123
+hookpipe dest rm dst_def456
+hookpipe subs rm sub_ghi789
+```
+
+## Event Management
+
+```bash
+# List recent events
+hookpipe events ls --limit 20 --json
+
+# Filter by source
+hookpipe events ls --source src_abc123
+
+# Get event with full payload
+hookpipe events get evt_abc123
+
+# View delivery attempts for an event
+hookpipe events deliveries evt_abc123
+
+# Replay a failed event
+hookpipe events replay evt_abc123
+```
+
+### Batch replay failed deliveries
+
+```bash
+# View DLQ (dead letter queue) for a destination
+hookpipe dest get dst_abc123   # includes circuit breaker state
+
+# Replay all failed deliveries
+hookpipe dest replay-failed dst_abc123
+```
+
+## Real-time Streaming
+
+```bash
+# Stream events as they arrive
+hookpipe tail
+
+# NDJSON output (pipe to scripts or other agents)
+hookpipe tail --json
+
+# Filter by source
+hookpipe tail --source src_abc123
+
+# Auto-stop after N events or duration
+hookpipe tail --limit 10
+hookpipe tail --timeout 5m
+
+# Pipe to jq or another process
+hookpipe tail --json | jq '.event_type'
+```
+
+## Schema Introspection
+
+```bash
+# List all resource types and their fields
+hookpipe schema
+
+# Inspect a specific resource
+hookpipe schema sources
+hookpipe schema destinations
+hookpipe schema subscriptions
+```
+
+## Configuration
+
+```bash
+hookpipe config set api_url https://your-hookpipe.workers.dev
+hookpipe config set token hf_sk_xxx
+hookpipe config get
+```
+
+## Export / Import / Migrate
+
+```bash
+# Export current configuration
+hookpipe export -o config.json
+
+# Import into another instance
+hookpipe import -f config.json --target https://new-instance.workers.dev --target-key hf_sk_yyy
+
+# Direct migration between instances
+hookpipe migrate \
+  --from https://old.workers.dev --from-key hf_sk_old \
+  --to https://new.workers.dev --to-key hf_sk_new
+```
+
+## Global Flags
+
+All commands support:
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Machine-readable JSON output |
+| `--dry-run` | Validate mutations without executing |
+| `-d, --data <json>` | Raw JSON input for create commands |
+
+## Agent Usage Guidelines
+
+1. **Always use `--json`** for structured output parsing.
+2. **Always `--dry-run` before mutations** to validate first.
+3. **Discover before connecting**: run `hookpipe providers describe <name>` to learn available events and presets.
+4. **Use `connect` for simple setups**, individual commands for fan-out.
+5. **Never delete resources without user confirmation.**
+
+### Error codes
+
+| Code | HTTP | Meaning |
+|------|------|---------|
+| `BAD_REQUEST` | 400 | Invalid input |
+| `VALIDATION_ERROR` | 400 | Schema validation failed |
+| `UNAUTHORIZED` | 401 | Missing or invalid API key |
+| `SETUP_REQUIRED` | 401 | Instance not bootstrapped |
+| `NOT_FOUND` | 404 | Resource not found |
+| `RATE_LIMITED` | 429 | Too many requests |
+
+### Resource ID formats
+
+- Sources: `src_<hex>`
+- Destinations: `dst_<hex>`
+- Subscriptions: `sub_<hex>`
+- Events: `evt_<hex>`
+- Deliveries: `dlv_<hex>`
+- API keys: `key_<hex>`
+
+## Architecture
+
+hookpipe runs on Cloudflare Workers with zero servers to manage:
+
+```
+Provider (Stripe, GitHub, ...) → hookpipe (Cloudflare Workers, always online)
+  → Queue (Cloudflare Queues, durable)
+    → Delivery Manager (Durable Objects, per-destination)
+      → Your application (retries with exponential backoff)
+```
+
+- **Ingress latency**: ~300ms P50
+- **Retry**: exponential/linear/fixed backoff, up to 24 hours
+- **Circuit breaker**: pauses delivery to unhealthy destinations
+- **DLQ**: permanently failed deliveries stored for manual replay
+- **Idempotency**: built-in deduplication (no duplicate deliveries)
+- **Payload archive**: stored in R2, retrievable via `events get`
+
+## See Also
+
+- [Provider catalog and event types](references/providers.md)
+- [REST API reference](references/api.md)
+- GitHub: https://github.com/hookpipe/hookpipe

--- a/content/hookpipe/docs/cli/references/api.md
+++ b/content/hookpipe/docs/cli/references/api.md
@@ -1,0 +1,244 @@
+# hookpipe REST API Reference
+
+Base URL: `https://your-hookpipe.workers.dev`
+
+## Authentication
+
+All `/api/v1/*` endpoints (except bootstrap) require a Bearer token:
+
+```
+Authorization: Bearer hf_sk_xxx
+```
+
+**Bootstrap flow** (first-time setup):
+
+```bash
+curl -X POST https://your-hookpipe.workers.dev/api/v1/bootstrap
+# Returns: { "key": "hf_sk_xxx", "id": "key_abc123" }
+```
+
+Bootstrap is one-time and self-locks after first use.
+
+## Webhook Ingestion (Public)
+
+```
+POST /webhooks/:source_id
+```
+
+Accepts webhooks from providers. No authentication required. Returns `202 Accepted`.
+
+```
+GET /health
+```
+
+Returns health status with `setup_required` flag.
+
+## Sources
+
+```
+GET    /api/v1/sources           # List all sources
+GET    /api/v1/sources/:id       # Get source details
+POST   /api/v1/sources           # Create source
+PUT    /api/v1/sources/:id       # Update source
+DELETE /api/v1/sources/:id       # Delete source
+```
+
+### Create source
+
+```json
+{
+  "name": "stripe-prod",
+  "provider": "stripe",
+  "verification": {
+    "type": "stripe-signature",
+    "secret": "whsec_xxx"
+  }
+}
+```
+
+**Verification types**: `stripe-signature`, `slack-signature`, `hmac-sha256`, `hmac-sha1`
+
+Response includes the webhook ingestion URL:
+
+```json
+{
+  "id": "src_abc123",
+  "name": "stripe-prod",
+  "provider": "stripe",
+  "verification_type": "stripe-signature",
+  "verification_secret": "****wxyz",
+  "created_at": "2026-03-17T00:00:00Z",
+  "updated_at": "2026-03-17T00:00:00Z"
+}
+```
+
+Secrets are masked in GET responses (`****xxxx`). The full secret is only returned on creation.
+
+## Destinations
+
+```
+GET    /api/v1/destinations              # List all destinations
+GET    /api/v1/destinations/:id          # Get destination details
+POST   /api/v1/destinations              # Create destination
+PUT    /api/v1/destinations/:id          # Update destination
+DELETE /api/v1/destinations/:id          # Delete destination
+GET    /api/v1/destinations/:id/circuit  # Circuit breaker state
+GET    /api/v1/destinations/:id/failed   # DLQ (failed deliveries)
+POST   /api/v1/destinations/:id/replay-failed  # Replay all failed
+```
+
+### Create destination
+
+```json
+{
+  "name": "app-primary",
+  "url": "https://app.com/webhook",
+  "retry_policy": {
+    "strategy": "exponential",
+    "max_retries": 10,
+    "interval_ms": 60000,
+    "max_interval_ms": 86400000,
+    "timeout_ms": 30000,
+    "on_status": [500, 502, 503, 504]
+  }
+}
+```
+
+**Retry strategies**: `exponential` (default), `linear`, `fixed`
+
+### DLQ query parameters
+
+```
+GET /api/v1/destinations/:id/failed?limit=100&offset=0
+```
+
+## Subscriptions
+
+```
+GET    /api/v1/subscriptions      # List all subscriptions
+POST   /api/v1/subscriptions      # Create subscription
+DELETE /api/v1/subscriptions/:id  # Delete subscription
+```
+
+### Create subscription
+
+```json
+{
+  "source_id": "src_abc123",
+  "destination_id": "dst_def456",
+  "event_types": ["payment_intent.*", "charge.failed"]
+}
+```
+
+`event_types` defaults to `["*"]` (all events). Supports wildcard matching.
+
+## Events
+
+```
+GET  /api/v1/events                    # List events
+GET  /api/v1/events/:id                # Get event with full payload
+GET  /api/v1/events/:id/deliveries     # Delivery attempts for an event
+GET  /api/v1/events/deliveries         # All deliveries (for tailing)
+POST /api/v1/events/:id/replay         # Replay event
+```
+
+### List events query parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `source_id` | — | Filter by source |
+| `after` | — | Cursor for pagination |
+| `limit` | 50 | Max results |
+| `offset` | 0 | Offset |
+
+### Event object
+
+```json
+{
+  "id": "evt_abc123",
+  "source_id": "src_abc123",
+  "event_type": "payment_intent.succeeded",
+  "idempotency_key": null,
+  "payload": { "...full webhook payload from R2..." },
+  "headers": { "stripe-signature": "..." },
+  "received_at": "2026-03-17T00:00:00Z"
+}
+```
+
+Full payload is fetched from R2 only on `GET /api/v1/events/:id`.
+
+### Delivery object
+
+```json
+{
+  "id": "dlv_abc123",
+  "event_id": "evt_abc123",
+  "destination_id": "dst_def456",
+  "status": "success",
+  "attempt": 1,
+  "status_code": 200,
+  "latency_ms": 150,
+  "response_body": "OK",
+  "next_retry_at": null,
+  "created_at": "2026-03-17T00:00:00Z",
+  "updated_at": "2026-03-17T00:00:00Z"
+}
+```
+
+**Delivery statuses**: `pending`, `success`, `failed`, `dlq`
+
+## API Keys
+
+```
+GET    /api/v1/keys      # List API keys
+POST   /api/v1/keys      # Create API key
+DELETE /api/v1/keys/:id  # Revoke API key
+```
+
+### Create API key
+
+```json
+{
+  "name": "ci-deploy",
+  "scopes": ["admin"],
+  "expires_at": "2027-01-01T00:00:00Z"
+}
+```
+
+## Export / Import
+
+```
+GET  /api/v1/export   # Export all configuration (sources, destinations, subscriptions)
+POST /api/v1/import   # Import configuration (skips existing resources by name)
+```
+
+## Error Response Format
+
+All errors return:
+
+```json
+{
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Invalid URL: must use HTTPS"
+  }
+}
+```
+
+| Code | HTTP | Description |
+|------|------|-------------|
+| `BAD_REQUEST` | 400 | Invalid input |
+| `VALIDATION_ERROR` | 400 | Schema validation failed |
+| `UNAUTHORIZED` | 401 | Missing or invalid API key |
+| `SETUP_REQUIRED` | 401 | Instance not bootstrapped yet |
+| `BOOTSTRAP_COMPLETED` | 409 | Bootstrap already done |
+| `NOT_FOUND` | 404 | Resource not found |
+| `SOURCE_NOT_FOUND` | 404 | Source ID in webhook URL is invalid |
+| `RATE_LIMITED` | 429 | Too many requests |
+
+## Security
+
+- SSRF protection: destination URLs block private IPs, localhost, non-HTTPS
+- Payload size limit: 256KB max on ingestion
+- Timing-safe signature comparison for all HMAC verification
+- API key hashes stored as SHA-256 (plain text never stored)

--- a/content/hookpipe/docs/cli/references/providers.md
+++ b/content/hookpipe/docs/cli/references/providers.md
@@ -1,0 +1,215 @@
+# Built-in Provider Catalog
+
+hookpipe ships with 5 built-in providers. Each provider defines signature verification, event types, presets, and setup instructions.
+
+## Stripe
+
+**Verification**: Stripe-specific signature (`stripe-signature` header, timestamp + HMAC-SHA256)
+
+### Event types
+
+| Category | Events |
+|----------|--------|
+| Payments | `payment_intent.created`, `payment_intent.succeeded`, `payment_intent.payment_failed`, `payment_intent.canceled`, `charge.succeeded`, `charge.failed`, `charge.refunded` |
+| Disputes | `charge.dispute.created`, `charge.dispute.closed` |
+| Customers | `customer.created`, `customer.updated`, `customer.deleted` |
+| Billing | `customer.subscription.created`, `customer.subscription.updated`, `customer.subscription.deleted`, `customer.subscription.trial_will_end`, `invoice.created`, `invoice.paid`, `invoice.payment_failed`, `invoice.finalized` |
+| Checkout | `checkout.session.completed`, `checkout.session.expired` |
+
+### Presets
+
+| Preset | Events included |
+|--------|----------------|
+| `payments` | payment_intent.* + charge.* |
+| `billing` | customer.subscription.* + invoice.* |
+| `checkout` | checkout.session.* |
+| `customers` | customer.created/updated/deleted |
+| `all` | All events |
+
+### Setup
+
+```bash
+hookpipe connect stripe --secret whsec_xxx --to https://app.com/webhook --events "payment_intent.*"
+```
+
+Register the Webhook URL at: https://dashboard.stripe.com/webhooks
+
+Or via Stripe CLI:
+
+```bash
+stripe webhook_endpoints create --url <webhook_url>
+```
+
+---
+
+## GitHub
+
+**Verification**: HMAC-SHA256 (`x-hub-signature-256` header)
+
+Event type is extracted from the `x-github-event` header, not the payload body.
+
+### Event types
+
+| Category | Events |
+|----------|--------|
+| Code | `push`, `pull_request`, `pull_request.opened`, `pull_request.closed`, `pull_request.merged`, `create`, `delete` |
+| Issues | `issues`, `issues.opened`, `issues.closed`, `issue_comment` |
+| Releases | `release`, `release.published` |
+| CI | `workflow_run`, `workflow_run.completed` |
+| Social | `star`, `fork` |
+| System | `ping` |
+
+### Presets
+
+| Preset | Events included |
+|--------|----------------|
+| `code` | push, pull_request.*, create, delete |
+| `ci` | workflow_run.* |
+| `issues` | issues.*, issue_comment |
+| `releases` | release.* |
+| `all` | All events |
+
+### Setup
+
+```bash
+hookpipe connect github --secret ghsec_xxx --to https://app.com/webhook --events "pull_request.*"
+```
+
+Register the Webhook URL at: `https://github.com/{owner}/{repo}/settings/hooks`
+
+Or via GitHub CLI:
+
+```bash
+gh api repos/{owner}/{repo}/hooks \
+  -f url=<webhook_url> \
+  -f content_type=json \
+  -f secret=ghsec_xxx
+```
+
+---
+
+## Slack
+
+**Verification**: Slack-specific signature (`x-slack-signature` header, HMAC-SHA256 with timestamp)
+
+**Challenge handling**: hookpipe automatically responds to Slack's `url_verification` challenge during setup. No action needed from your application.
+
+### Event types
+
+| Category | Events |
+|----------|--------|
+| Messages | `message`, `app_mention` |
+| Reactions | `reaction_added`, `reaction_removed` |
+| Channels | `member_joined_channel`, `member_left_channel`, `channel_created`, `channel_archive` |
+| Workspace | `team_join` |
+| System | `url_verification` |
+
+### Presets
+
+| Preset | Events included |
+|--------|----------------|
+| `messages` | message, app_mention |
+| `channels` | member_joined/left_channel, channel_created/archive |
+| `all` | All events |
+
+### Setup
+
+```bash
+hookpipe connect slack --secret xoxb_xxx --to https://app.com/webhook --events "message,app_mention"
+```
+
+Register the Webhook URL at: https://api.slack.com/apps → Event Subscriptions → Request URL
+
+Note: Slack does not support CLI-based webhook setup.
+
+---
+
+## Shopify
+
+**Verification**: HMAC-SHA256 with Base64 encoding (`x-shopify-hmac-sha256` header)
+
+Event type is extracted from the `x-shopify-topic` header. Shopify uses slash-delimited topics (e.g., `orders/create`).
+
+### Event types
+
+| Category | Events |
+|----------|--------|
+| Orders | `orders/create`, `orders/updated`, `orders/cancelled`, `orders/fulfilled`, `orders/paid`, `refunds/create` |
+| Products | `products/create`, `products/update`, `products/delete` |
+| Customers | `customers/create`, `customers/update`, `customers/delete` |
+| Carts | `carts/create`, `carts/update` |
+| Checkouts | `checkouts/create`, `checkouts/update` |
+| App | `app/uninstalled` |
+
+### Presets
+
+| Preset | Events included |
+|--------|----------------|
+| `orders` | orders/* + refunds/* |
+| `products` | products/* |
+| `customers` | customers/* |
+| `all` | All events |
+
+### Setup
+
+```bash
+hookpipe connect shopify --secret shpss_xxx --to https://app.com/webhook --events "orders/*"
+```
+
+Register the Webhook URL at: `https://admin.shopify.com/store/{store}/settings/notifications`
+
+Or via Shopify CLI:
+
+```bash
+shopify app webhooks trigger --topic orders/create --address <webhook_url>
+```
+
+---
+
+## Vercel
+
+**Verification**: HMAC-SHA1 (`x-vercel-signature` header)
+
+### Event types
+
+| Category | Events |
+|----------|--------|
+| Deployments | `deployment.created`, `deployment.succeeded`, `deployment.ready`, `deployment.error`, `deployment.canceled` |
+| Projects | `project.created`, `project.removed` |
+| Domains | `domain.created` |
+| Integrations | `integration-configuration.removed` |
+
+### Presets
+
+| Preset | Events included |
+|--------|----------------|
+| `deployments` | deployment.* |
+| `all` | All events |
+
+### Setup
+
+```bash
+hookpipe connect vercel --secret vsec_xxx --to https://app.com/webhook --events "deployment.*"
+```
+
+Register the Webhook URL at: `https://vercel.com/{team}/~/settings/webhooks`
+
+Or via Vercel CLI:
+
+```bash
+vercel webhooks add <webhook_url> --events deployment.created
+```
+
+---
+
+## Custom Providers
+
+For any webhook service not in the built-in catalog, use generic HMAC verification:
+
+```bash
+hookpipe connect my-service \
+  --secret my_signing_secret \
+  --to https://app.com/webhook
+```
+
+Community providers can be published as npm packages (`hookpipe-provider-<name>`) using the `defineProvider()` API. See the [Provider Design Guide](https://github.com/hookpipe/hookpipe/blob/main/packages/providers/DESIGN.md).

--- a/content/hookpipe/skills/webhook-setup/SKILL.md
+++ b/content/hookpipe/skills/webhook-setup/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: webhook-setup
+description: "Set up durable webhook infrastructure for receiving events from Stripe, GitHub, Slack, Shopify, Vercel, or any HTTP webhook sender using hookpipe CLI"
+metadata:
+  revision: 1
+  updated-on: "2026-03-17"
+  source: maintainer
+  tags: "webhooks,webhook,infrastructure,stripe,github,slack,shopify,vercel,agent"
+---
+# Webhook Infrastructure Setup
+
+Set up durable webhook receiving with hookpipe. Webhooks are queued on Cloudflare Workers (always online) and delivered to your application with automatic retries.
+
+## Prerequisites
+
+```bash
+# Install hookpipe CLI
+npm install -g hookpipe
+# or: brew install hookpipe/hookpipe/hookpipe
+```
+
+Requires a running hookpipe instance. Deploy one to Cloudflare Workers or use an existing instance.
+
+## When to Use This Skill
+
+Use hookpipe when:
+- Your application needs to receive webhooks from Stripe, GitHub, Slack, Shopify, Vercel, or any HTTP webhook sender
+- Webhooks are being lost during application restarts or downtime
+- You need durable event buffering with guaranteed delivery
+- You need signature verification for incoming webhooks
+
+Do NOT use hookpipe for:
+- Sending outgoing webhooks to your customers (use Svix instead)
+- Direct API polling or cron-based scheduled checks
+- Internal service-to-service communication
+
+## Step-by-Step
+
+### 1. Discover the provider
+
+```bash
+hookpipe providers describe stripe --json
+```
+
+This shows available event types, presets, and setup instructions. If your service isn't in the built-in catalog, skip to step 2 — hookpipe supports generic HMAC verification.
+
+### 2. Connect the provider
+
+For built-in providers:
+
+```bash
+hookpipe connect stripe \
+  --secret whsec_xxx \
+  --to https://your-app.com/webhook \
+  --events "payment_intent.*" \
+  --json
+```
+
+For any other webhook sender:
+
+```bash
+hookpipe connect my-service \
+  --secret my_signing_secret \
+  --to https://your-app.com/webhook \
+  --json
+```
+
+The output includes a **Webhook URL**. Register this URL in the provider's dashboard or API.
+
+### 3. Verify events are flowing
+
+```bash
+hookpipe tail --json --timeout 60s
+```
+
+Trigger a test event from the provider. You should see it appear in the tail output.
+
+### 4. Handle failures
+
+```bash
+# Check circuit breaker state
+hookpipe dest ls --json
+
+# View failed deliveries
+hookpipe events ls --source src_abc123 --json
+
+# Replay a specific event
+hookpipe events replay evt_abc123
+```
+
+## Local Development
+
+For developing locally without exposing your machine to the internet:
+
+```bash
+hookpipe dev --port 3000 --provider stripe --secret whsec_xxx
+```
+
+This creates a secure Cloudflare Quick Tunnel. Paste the printed URL into the provider's webhook dashboard.
+
+## Common Patterns
+
+### Multi-provider monitoring
+
+```bash
+hookpipe connect stripe --secret whsec_xxx --to https://app.com/webhook --name stripe-prod
+hookpipe connect github --secret ghsec_xxx --to https://app.com/webhook --name github-prod
+```
+
+### Fan-out to multiple destinations
+
+```bash
+hookpipe sources create --name stripe-prod \
+  -d '{"provider":"stripe","verification":{"type":"stripe-signature","secret":"whsec_xxx"}}'
+
+hookpipe dest create --name app-primary --url https://app.com/webhook
+hookpipe dest create --name analytics --url https://analytics.com/ingest
+
+hookpipe subs create --source src_abc --destination dst_def --events "payment_intent.*"
+hookpipe subs create --source src_abc --destination dst_ghi --events "*"
+```
+
+### Pipe events to a script
+
+```bash
+hookpipe tail --json | while read -r event; do
+  echo "$event" | jq -r '.event_type'
+done
+```


### PR DESCRIPTION
## Summary

Add documentation and skill for [hookpipe](https://github.com/hookpipe/hookpipe), an open-source webhook infrastructure CLI that receives webhooks from external services, queues them durably on Cloudflare Workers, and delivers them to applications with automatic retries and signature verification.

### Why hookpipe belongs in Context Hub

- **Agent-first design**: `--json` on all commands, `--dry-run` for safe mutations, `hookpipe schema` for runtime introspection, prefixed IDs (`src_`, `dst_`, `sub_`)
- **Complements existing providers**: Context Hub already has Stripe, GitHub, Slack, Shopify documentation — hookpipe is the infrastructure layer that receives their webhooks
- **Zero-server deployment**: runs on Cloudflare Workers free tier, no Docker/PostgreSQL/Redis required

### Content added

\`\`\`
content/hookpipe/
├── docs/
│   └── cli/
│       ├── DOC.md                    # CLI usage guide (282 lines)
│       └── references/
│           ├── providers.md          # Built-in provider catalog: event types, presets, setup
│           └── api.md                # REST API reference
└── skills/
    └── webhook-setup/
        └── SKILL.md                  # Step-by-step webhook infrastructure setup skill
\`\`\`

### Content details

| File | Description |
|------|-------------|
| `DOC.md` | Installation, quick start, core concepts, all CLI commands with flags, agent usage guidelines, architecture overview |
| `references/providers.md` | Full event type catalog for Stripe (20 events), GitHub (16), Slack (10), Shopify (17), Vercel (9) with presets and setup instructions per provider |
| `references/api.md` | Complete REST API: authentication, CRUD for sources/destinations/subscriptions/events, error codes, security notes |
| `SKILL.md` | When to use hookpipe, step-by-step setup flow, local dev, common patterns (multi-provider, fan-out, pipe to script) |

### Metadata

- **Source**: `maintainer` (hookpipe team)
- **Language**: `javascript` (npm package)
- **Version**: `0.1.0`
- **Tags**: webhooks, stripe, github, slack, shopify, vercel, cloudflare-workers, cli, agent

## Checklist

- [x] YAML frontmatter with all required fields
- [x] Main DOC.md under 500 lines (282 lines)
- [x] Code-first, direct writing style for LLM consumption
- [x] Reference files for depth (providers, API)
- [x] Skill with step-by-step instructions
- [x] No marketing fluff — leads with functionality and usage