### PR TITLE
fix: resolve Windows path separator issues across CLI (#144)

### DIFF
--- a/cli/src/commands/build.js
+++ b/cli/src/commands/build.js
@@ -1,10 +1,18 @@
 import { existsSync, readFileSync, readdirSync, statSync, writeFileSync, mkdirSync, cpSync } from 'node:fs';
-import { join, relative, dirname } from 'node:path';
+import { join, relative, dirname, basename } from 'node:path';
 import chalk from 'chalk';
 import { parseFrontmatter } from '../lib/frontmatter.js';
 import { info } from '../lib/output.js';
 import { trackEvent } from '../lib/analytics.js';
 import { buildIndex } from '../lib/bm25.js';
+
+/**
+ * Normalize a path to use forward slashes so registry.json is
+ * consistent regardless of which OS ran the build.
+ */
+function toPosix(p) {
+  return p.split('\\').join('/');
+}
 
 /**
  * Recursively find all DOC.md and SKILL.md files under a directory.
@@ -31,7 +39,7 @@ function listDirFiles(dir) {
     for (const entry of readdirSync(d, { withFileTypes: true })) {
       const full = join(d, entry.name);
       if (entry.isDirectory()) walk(full);
-      else results.push(relative(dir, full));
+      else results.push(toPosix(relative(dir, full)));
     }
   };
   walk(dir);
@@ -83,7 +91,7 @@ function discoverAuthor(authorDir, authorName, contentDir) {
     const tags = meta.tags ? meta.tags.split(',').map((t) => t.trim()) : [];
     const updatedOn = meta['updated-on'] || new Date().toISOString().split('T')[0];
     const entryDir = dirname(ef.path);
-    const entryPath = relative(contentDir, entryDir);
+    const entryPath = toPosix(relative(contentDir, entryDir));
     const files = listDirFiles(entryDir);
     const size = dirSize(entryDir);
 
@@ -317,7 +325,7 @@ export function registerBuildCommand(program) {
         // Skip registry.json in author dirs
         cpSync(src, dest, {
           recursive: true,
-          filter: (s) => !s.endsWith('/registry.json'),
+          filter: (s) => basename(s) !== 'registry.json',
         });
       }
 

--- a/cli/src/commands/get.js
+++ b/cli/src/commands/get.js
@@ -122,7 +122,7 @@ async function fetchEntries(ids, opts, globalOpts) {
         }
       }
     } else {
-      const isDir = opts.output.endsWith('/');
+      const isDir = opts.output.endsWith('/') || opts.output.endsWith('\\');
       if (isDir && results.length > 1) {
         mkdirSync(opts.output, { recursive: true });
         for (const r of results) {

--- a/cli/src/lib/cache.js
+++ b/cli/src/lib/cache.js
@@ -187,8 +187,7 @@ export async function fetchDoc(source, docPath) {
   const content = await res.text();
 
   // Cache locally
-  const dir = cachedPath.substring(0, cachedPath.lastIndexOf('/'));
-  mkdirSync(dir, { recursive: true });
+  mkdirSync(dirname(cachedPath), { recursive: true });
   writeFileSync(cachedPath, content);
 
   return content;

--- a/cli/tests/lib/welcome.test.js
+++ b/cli/tests/lib/welcome.test.js
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { existsSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
 import { showWelcomeIfNeeded } from '../../src/lib/welcome.js';
+
+const TEST_DIR = join('/tmp', 'test-chub');
 
 vi.mock('node:fs', () => ({
   existsSync: vi.fn(),
@@ -8,9 +11,10 @@ vi.mock('node:fs', () => ({
   mkdirSync: vi.fn(),
 }));
 
-vi.mock('../../src/lib/config.js', () => ({
-  getChubDir: () => '/tmp/test-chub',
-}));
+vi.mock('../../src/lib/config.js', async () => {
+  const { join } = await import('node:path');
+  return { getChubDir: () => join('/tmp', 'test-chub') };
+});
 
 describe('showWelcomeIfNeeded', () => {
   let consoleSpy;
@@ -46,7 +50,7 @@ describe('showWelcomeIfNeeded', () => {
     expect(output).toContain('Welcome to Context Hub (chub)!');
     expect(output).toContain('Terms of Service');
     expect(output).toContain('feedback: false');
-    expect(output).toContain('/tmp/test-chub/config.yaml');
+    expect(output).toContain(join(TEST_DIR, 'config.yaml'));
   });
 
   it('creates marker file after showing message', () => {
@@ -56,9 +60,9 @@ describe('showWelcomeIfNeeded', () => {
 
     // Called twice: once for marker check, once for dir check
     expect(existsSync).toHaveBeenCalledTimes(2);
-    expect(mkdirSync).toHaveBeenCalledWith('/tmp/test-chub', { recursive: true });
+    expect(mkdirSync).toHaveBeenCalledWith(TEST_DIR, { recursive: true });
     expect(writeFileSync).toHaveBeenCalledWith(
-      '/tmp/test-chub/.welcome_shown',
+      join(TEST_DIR, '.welcome_shown'),
       expect.any(String),
       'utf8'
     );


### PR DESCRIPTION
## What

Fixes multiple places where forward-slash (`/`) separators are hardcoded, causing failures on Windows where `path.join()` and `path.relative()` produce backslash (`\`) separators.

- **cache.js**: Replace manual `lastIndexOf('/')` slicing with `dirname()` (already imported) to fix ENOENT when caching fetched docs
- **build.js**: Add `toPosix()` helper to normalize `path.relative()` output so `registry.json` paths use forward slashes regardless of build OS
- **build.js**: Use `basename()` in `cpSync` filter instead of `endsWith('/registry.json')` so author-level registry files are correctly excluded
- **get.js**: Accept both `/` and `\` as trailing separators in `--output` path detection
- **welcome.test.js**: Use `path.join()` in mock and assertions so the test passes on both Windows and Unix

## Why

On Windows, `chub get` crashes with:

```
ENOENT: no such file or directory, mkdir ''
```

The root cause is `cachedPath.substring(0, cachedPath.lastIndexOf('/'))` in `cache.js` — when `cachedPath` uses backslashes (produced by `path.join()` on Windows), `lastIndexOf('/')` returns `-1`, and `substring(0, -1)` yields an empty string. `mkdirSync('')` then throws ENOENT.

The same class of bug affects `build.js` (registry paths baked with backslashes make the registry non-portable) and `get.js` (`--output mydir\` not recognised as a directory).

## Testing

- [x] `npm test` passes — 171/174 (3 remaining failures are pre-existing timeouts unrelated to this change)
- [x] `welcome.test.js` now passes 6/6 on Windows (was 4/6 before this fix)
- [x] Verified `dirname()` correctly resolves the parent directory for Windows-style paths
- [x] Verified `toPosix()` normalizes backslash paths in generated `registry.json`

## Notes

The 3 remaining test timeouts (`go-lang build`, `--list annotations`, `--json annotation get`) are pre-existing on Windows and reproduce on an unmodified `main` checkout. They are caused by slow `execFileSync` calls exceeding the default 5 000 ms timeout, not by assertion failures.

