### PR TITLE
fix: Use dirname() for cross-platform path handling in cache.js

### DIFF
--- a/cli/src/lib/cache.js
+++ b/cli/src/lib/cache.js
@@ -186,8 +186,8 @@ export async function fetchDoc(source, docPath) {
 
   const content = await res.text();
 
-  // Cache locally
-  const dir = cachedPath.substring(0, cachedPath.lastIndexOf('/'));
+  // Cache locally - use path.dirname for cross-platform compatibility
+  const dir = dirname(cachedPath);
   mkdirSync(dir, { recursive: true });
   writeFileSync(cachedPath, content);
 


### PR DESCRIPTION
## Summary

On Windows, `path.join()` uses backslashes, but the previous code used `lastIndexOf('/')` to find the directory. This caused two issues:

1. On Windows, `lastIndexOf('/')` returns -1 since paths use backslashes
2. When `docPath` has no directory (e.g., 'DOC.md'), `lastIndexOf('/')` returns -1 and `cachedPath.substring(0, -1)` returns an empty string

This resulted in `ENOENT: no such file or directory, mkdir ''` errors on Windows when running `chub get openai/package`.

## Fix

Replace the manual substring calculation with Node.js's built-in `dirname()` function which is platform-aware and handles edge cases correctly.

## Testing

The fix ensures:
- Cross-platform compatibility (works on both Windows and Unix)
- Handles files without directory components correctly
- Uses standard library instead of manual string manipulation

Fixes: andrewyng/context-hub#144