### PR TITLE
fix: use path.dirname for cross-platform cache directory extraction

### DIFF
--- a/cli/src/lib/cache.js
+++ b/cli/src/lib/cache.js
@@ -186,8 +186,8 @@ export async function fetchDoc(source, docPath) {
 
   const content = await res.text();
 
-  // Cache locally
-  const dir = cachedPath.substring(0, cachedPath.lastIndexOf('/'));
+  // Cache locally - use path.dirname for cross-platform compatibility
+  const dir = dirname(cachedPath);
   mkdirSync(dir, { recursive: true });
   writeFileSync(cachedPath, content);
 


### PR DESCRIPTION
On Windows, paths use backslash (\) instead of forward slash (/). The previous code used lastIndexOf('/') which returns -1 on Windows, causing mkdirSync('') to fail with 'ENOENT: no such file or directory'.

This fix uses Node.js dirname() which handles both path separators correctly across all platforms.

## Related Issue
Fixes #144