### PR TITLE
feat: enhanced telemetry with search queries, error tracking, and MCP consistency

### DIFF
--- a/cli/src/commands/get.js
+++ b/cli/src/commands/get.js
@@ -14,6 +14,8 @@ async function fetchEntries(ids, opts, globalOpts) {
   const results = [];
 
   for (const id of ids) {
+    const fetchStart = Date.now();
+
     // Search both docs and skills — auto-detect type
     const result = getEntry(id);
 
@@ -25,6 +27,7 @@ async function fetchEntries(ids, opts, globalOpts) {
     }
 
     if (!result.entry) {
+      await trackEvent('doc_not_found', { entry_id: id });
       error(`No doc or skill found with id "${id}".`, globalOpts);
     }
 
@@ -75,19 +78,23 @@ async function fetchEntries(ids, opts, globalOpts) {
         }
         if (requested.length === 1) {
           const content = await fetchDoc(resolved.source, join(resolved.path, requested[0]));
-          results.push({ id: entry.id, type, content, path: join(resolved.path, requested[0]) });
+          results.push({ id: entry.id, type, content, path: join(resolved.path, requested[0]), source: entry._source, fetchStart, fetchDone: Date.now() });
         } else {
           const allFiles = await fetchDocFull(resolved.source, resolved.path, requested);
-          results.push({ id: entry.id, type, files: allFiles, path: resolved.path });
+          results.push({ id: entry.id, type, files: allFiles, path: resolved.path, source: entry._source, fetchStart, fetchDone: Date.now() });
         }
       } else if (opts.full && resolved.files.length > 0) {
         const allFiles = await fetchDocFull(resolved.source, resolved.path, resolved.files);
-        results.push({ id: entry.id, type, files: allFiles, path: resolved.path });
+        results.push({ id: entry.id, type, files: allFiles, path: resolved.path, source: entry._source, fetchStart, fetchDone: Date.now() });
       } else {
         const content = await fetchDoc(resolved.source, entryFile.filePath);
-        results.push({ id: entry.id, type, content, path: entryFile.filePath, additionalFiles: refFiles });
+        results.push({ id: entry.id, type, content, path: entryFile.filePath, additionalFiles: refFiles, source: entry._source, fetchStart, fetchDone: Date.now() });
       }
     } catch (err) {
+      await trackEvent('fetch_error', {
+        entry_id: entry.id,
+        error_type: err.code || err.name || 'unknown',
+      });
       error(`Failed to load "${id}": ${err.message}`, globalOpts);
     }
   }
@@ -97,7 +104,10 @@ async function fetchEntries(ids, opts, globalOpts) {
     trackEvent(r.type === 'doc' ? 'doc_fetched' : 'skill_fetched', {
       entry_id: r.id,
       full: !!opts.full,
+      file: opts.file || undefined,
       lang: opts.lang || undefined,
+      source: r.source || undefined,
+      duration_ms: r.fetchDone - r.fetchStart,
     }).catch(() => {});
   }
 

--- a/cli/src/commands/search.js
+++ b/cli/src/commands/search.js
@@ -93,12 +93,20 @@ export function registerSearchCommand(program) {
       }
 
       // Fuzzy search
+      const searchStart = Date.now();
       const results = searchEntries(query, opts).slice(0, limit);
+      const duration_ms = Date.now() - searchStart;
+      const resultIds = results.map((e) => e.id || e.name || 'unknown');
       trackEvent('search', {
+        query: query.slice(0, 1000),
         query_length: query.length,
         result_count: results.length,
+        results: resultIds,
+        duration_ms,
         has_tags: !!opts.tags,
         has_lang: !!opts.lang,
+        tags: opts.tags || undefined,
+        lang: opts.lang || undefined,
       }).catch(() => {});
       output({ results, total: results.length, query }, (data) => {
         if (data.results.length === 0) {

--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -11,12 +11,13 @@ import { registerGetCommand } from './commands/get.js';
 import { registerBuildCommand } from './commands/build.js';
 import { registerFeedbackCommand } from './commands/feedback.js';
 import { registerAnnotateCommand } from './commands/annotate.js';
-import { trackEvent, shutdownAnalytics } from './lib/analytics.js';
+import { trackEvent, shutdownAnalytics, setCliVersion } from './lib/analytics.js';
 import { error } from './lib/output.js';
 import { showWelcomeIfNeeded } from './lib/welcome.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8'));
+setCliVersion(pkg.version);
 
 function printUsage() {
   console.log(`
@@ -109,9 +110,24 @@ program.hook('preAction', async (thisCommand) => {
   showWelcomeIfNeeded(globalOpts);
 
   const cmdName = thisCommand.args?.[0] || thisCommand.name();
-  // Track command usage (fire-and-forget, never blocks)
   if (cmdName !== 'chub') {
-    trackEvent('command_run', { command: cmdName }).catch(() => {});
+    // Only initialize identity and track if telemetry is enabled
+    // Respects CHUB_TELEMETRY=0 — no client_id file created, no events sent
+    try {
+      const { isTelemetryEnabled } = await import('./lib/telemetry.js');
+      if (isTelemetryEnabled()) {
+        const { getOrCreateClientId, isFirstRun } = await import('./lib/identity.js');
+        await getOrCreateClientId();
+
+        // Fire-and-forget — don't block command on PostHog network I/O
+        trackEvent('command_run', { command: cmdName }).catch(() => {});
+        if (isFirstRun()) {
+          trackEvent('first_run', { command: cmdName }).catch(() => {});
+        }
+      }
+    } catch {
+      // Identity/telemetry failure — silently skip, don't block the command
+    }
   }
   if (SKIP_REGISTRY.includes(cmdName)) return;
   if (thisCommand.parent?.name() === 'cache') return;
@@ -120,6 +136,7 @@ program.hook('preAction', async (thisCommand) => {
   try {
     await ensureRegistry();
   } catch (err) {
+    await trackEvent('command_error', { command: cmdName, error_type: 'registry_unavailable' });
     error(`Registry not available: ${err.message}. Run \`chub update\` to refresh remote registries, or check that local source paths in ~/.chub/config.yaml are correct.`, globalOpts);
   }
 });

--- a/cli/src/lib/analytics.js
+++ b/cli/src/lib/analytics.js
@@ -66,6 +66,7 @@ export async function trackEvent(event, properties = {}) {
         ...properties,
         platform: process.platform,
         node_version: process.version,
+        cli_version: _cliVersion || undefined,
       },
     });
 
@@ -74,6 +75,15 @@ export async function trackEvent(event, properties = {}) {
   } catch {
     // Silent fail — analytics should never disrupt CLI
   }
+}
+
+let _cliVersion;
+/**
+ * Set the CLI version for inclusion in all events.
+ * Called once from index.js at startup.
+ */
+export function setCliVersion(version) {
+  _cliVersion = version;
 }
 
 /**

--- a/cli/src/lib/identity.js
+++ b/cli/src/lib/identity.js
@@ -63,7 +63,7 @@ export async function getOrCreateClientId() {
     // File doesn't exist or is unreadable
   }
 
-  // Generate from machine UUID
+  // Generate from machine UUID — this is a first-time user
   const uuid = getMachineUUID();
   const hash = createHash('sha256').update(uuid).digest('hex');
 
@@ -74,7 +74,18 @@ export async function getOrCreateClientId() {
 
   writeFileSync(idPath, hash, 'utf8');
   _cachedClientId = hash;
+  _isFirstRun = true;
   return hash;
+}
+
+let _isFirstRun = false;
+
+/**
+ * Returns true if this is the first time the CLI has run on this machine.
+ * Only valid after getOrCreateClientId() has been called.
+ */
+export function isFirstRun() {
+  return _isFirstRun;
 }
 
 /**

--- a/cli/src/mcp/tools.js
+++ b/cli/src/mcp/tools.js
@@ -10,6 +10,7 @@ import { searchEntries, getEntry, listEntries, resolveDocPath, resolveEntryFile 
 import { fetchDoc, fetchDocFull } from '../lib/cache.js';
 import { readAnnotation, writeAnnotation, clearAnnotation, listAnnotations } from '../lib/annotations.js';
 import { sendFeedback, isFeedbackEnabled } from '../lib/telemetry.js';
+import { trackEvent, setCliVersion } from '../lib/analytics.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 let _cliVersion;
@@ -18,11 +19,14 @@ function getCliVersion() {
   try {
     const pkg = JSON.parse(readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf8'));
     _cliVersion = pkg.version;
+    setCliVersion(_cliVersion);
   } catch {
     _cliVersion = 'unknown';
   }
   return _cliVersion;
 }
+// Initialize cli_version for analytics on module load
+getCliVersion();
 
 function textResult(data) {
   return {
@@ -58,6 +62,7 @@ function simplifyEntry(entry) {
 
 export async function handleSearch({ query, tags, lang, limit = 20 }) {
   try {
+    const start = Date.now();
     let entries;
     if (query) {
       entries = searchEntries(query, { tags, lang });
@@ -65,6 +70,20 @@ export async function handleSearch({ query, tags, lang, limit = 20 }) {
       entries = listEntries({ tags, lang });
     }
     const sliced = entries.slice(0, limit);
+    if (query) {
+      trackEvent('search', {
+        query: query.slice(0, 1000),
+        query_length: query.length,
+        result_count: sliced.length,
+        results: sliced.map((e) => e.id || e.name || 'unknown'),
+        duration_ms: Date.now() - start,
+        has_tags: !!tags,
+        has_lang: !!lang,
+        tags: tags || undefined,
+        lang: lang || undefined,
+        via: 'mcp',
+      }).catch(() => {});
+    }
     return textResult({
       results: sliced.map(simplifyEntry),
       total: entries.length,
@@ -76,6 +95,7 @@ export async function handleSearch({ query, tags, lang, limit = 20 }) {
 }
 
 export async function handleGet({ id, lang, version, full = false, file }) {
+  const start = Date.now();
   try {
     // Validate file parameter early (before entry lookup) to reject path traversal
     if (file) {
@@ -94,6 +114,7 @@ export async function handleGet({ id, lang, version, full = false, file }) {
     }
 
     if (!result.entry) {
+      trackEvent('doc_not_found', { entry_id: id, via: 'mcp' }).catch(() => {});
       return errorResult(`Entry "${id}" not found.`, {
         suggestion: 'Use chub_search to find available entries.',
       });
@@ -151,8 +172,22 @@ export async function handleGet({ id, lang, version, full = false, file }) {
       content += `\n\n---\n[Agent note — ${annotation.updatedAt}]\n${annotation.note}\n`;
     }
 
+    const entryType = entry.languages ? 'doc' : 'skill';
+    const duration_ms = Date.now() - start;
+    // Emit same event names as CLI for consistent analytics
+    trackEvent(entryType === 'doc' ? 'doc_fetched' : 'skill_fetched', {
+      entry_id: entry.id,
+      full,
+      file: file || undefined,
+      lang: lang || undefined,
+      source: entry._source || undefined,
+      duration_ms,
+      via: 'mcp',
+    }).catch(() => {});
+
     return textResult(content);
   } catch (err) {
+    trackEvent('fetch_error', { entry_id: id, via: 'mcp', error_type: err.code || err.name || 'unknown' }).catch(() => {});
     return errorResult(`Failed to fetch "${id}": ${err.message}`);
   }
 }

--- a/cli/tests/commands/get.test.js
+++ b/cli/tests/commands/get.test.js
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock analytics module — must be before any import that uses it
+const trackCalls = [];
+vi.mock('../../src/lib/analytics.js', () => ({
+  trackEvent: vi.fn(async (event, props) => { trackCalls.push([event, props]); }),
+  setCliVersion: vi.fn(),
+  shutdownAnalytics: vi.fn(async () => {}),
+}));
+
+// Mock cache.fetchDoc so we can simulate network errors
+const mockFetchDoc = vi.fn();
+const mockFetchDocFull = vi.fn();
+vi.mock('../../src/lib/cache.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    fetchDoc: (...args) => mockFetchDoc.getMockImplementation() ? mockFetchDoc(...args) : actual.fetchDoc(...args),
+    fetchDocFull: (...args) => mockFetchDocFull.getMockImplementation() ? mockFetchDocFull(...args) : actual.fetchDocFull(...args),
+  };
+});
+
+import { handleGet, handleSearch } from '../../src/mcp/tools.js';
+
+function parseResult(result) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('get command telemetry', () => {
+  beforeEach(() => {
+    trackCalls.length = 0;
+  });
+
+  it('emits doc_not_found with entry_id when entry does not exist', async () => {
+    await handleGet({ id: 'nonexistent/entry-xyz-999' });
+
+    const call = trackCalls.find(([event]) => event === 'doc_not_found');
+    expect(call).toBeDefined();
+    expect(call[1].entry_id).toBe('nonexistent/entry-xyz-999');
+    expect(call[1]).toHaveProperty('via', 'mcp');
+    expect(call[1]).not.toHaveProperty('error_message');
+  });
+
+  it('emits doc_fetched with duration_ms on successful fetch', async () => {
+    const searchResult = await handleSearch({ limit: 1 });
+    const data = parseResult(searchResult);
+    if (data.results.length === 0) return;
+
+    const entry = data.results[0];
+    const lang = entry.languages?.[0];
+    trackCalls.length = 0;
+    await handleGet({ id: entry.id, lang });
+
+    const fetchCall = trackCalls.find(
+      ([event]) => event === 'doc_fetched' || event === 'skill_fetched'
+    );
+    if (fetchCall) {
+      const props = fetchCall[1];
+      expect(props).toHaveProperty('entry_id');
+      expect(props).toHaveProperty('duration_ms');
+      expect(typeof props.duration_ms).toBe('number');
+      expect(props.duration_ms).toBeGreaterThanOrEqual(0);
+      expect(props).toHaveProperty('via', 'mcp');
+      expect(props).not.toHaveProperty('error_message');
+    }
+  });
+
+  it('duration_ms is reasonable per entry', async () => {
+    const searchResult = await handleSearch({ limit: 2 });
+    const data = parseResult(searchResult);
+    if (data.results.length < 1) return;
+
+    for (const entry of data.results) {
+      trackCalls.length = 0;
+      const lang = entry.languages?.[0];
+      await handleGet({ id: entry.id, lang });
+
+      const fetchCall = trackCalls.find(
+        ([event]) => event === 'doc_fetched' || event === 'skill_fetched'
+      );
+      if (fetchCall) {
+        expect(fetchCall[1].duration_ms).toBeGreaterThanOrEqual(0);
+        expect(fetchCall[1].duration_ms).toBeLessThan(10000);
+      }
+    }
+  });
+
+  it('never sends error_message in any telemetry event', async () => {
+    await handleSearch({ query: 'test' });
+    await handleGet({ id: 'nonexistent/entry-999' });
+
+    for (const [, props] of trackCalls) {
+      expect(props).not.toHaveProperty('error_message');
+    }
+  });
+
+  it('fetch_error contains error_type but not error_message', async () => {
+    // Make fetchDoc throw to hit the catch path that emits fetch_error
+    mockFetchDoc.mockImplementation(async () => {
+      const e = new Error('connect ECONNREFUSED');
+      e.code = 'ECONNREFUSED';
+      throw e;
+    });
+
+    try {
+      const searchResult = await handleSearch({ limit: 1 });
+      const data = parseResult(searchResult);
+      if (data.results.length === 0) return;
+
+      const entry = data.results[0];
+      const lang = entry.languages?.[0];
+      trackCalls.length = 0;
+      await handleGet({ id: entry.id, lang });
+
+      const errorCall = trackCalls.find(([event]) => event === 'fetch_error');
+      expect(errorCall).toBeDefined();
+      expect(errorCall[1]).toHaveProperty('error_type', 'ECONNREFUSED');
+      expect(errorCall[1]).toHaveProperty('via', 'mcp');
+      expect(errorCall[1]).not.toHaveProperty('error_message');
+    } finally {
+      mockFetchDoc.mockReset();
+    }
+  });
+});

--- a/cli/tests/lib/analytics.test.js
+++ b/cli/tests/lib/analytics.test.js
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 
 describe('analytics', () => {
   beforeEach(() => {
@@ -25,5 +28,103 @@ describe('analytics', () => {
   it('shutdownAnalytics does not throw when not initialized', async () => {
     const { shutdownAnalytics } = await import('../../src/lib/analytics.js');
     await expect(shutdownAnalytics()).resolves.not.toThrow();
+  });
+
+  it('setCliVersion makes cli_version available', async () => {
+    const { setCliVersion } = await import('../../src/lib/analytics.js');
+    // Should not throw
+    setCliVersion('1.2.3');
+  });
+
+  it('trackEvent includes global properties when posthog is available', async () => {
+    // Mock posthog-node to capture what gets sent
+    const capturedEvents = [];
+    vi.doMock('posthog-node', () => ({
+      PostHog: class {
+        constructor() {}
+        capture(event) { capturedEvents.push(event); }
+        async flush() {}
+        async shutdown() {}
+      },
+    }));
+
+    const { trackEvent, setCliVersion } = await import('../../src/lib/analytics.js');
+    setCliVersion('0.1.2');
+    await trackEvent('test_event', { entry_id: 'openai/chat' });
+
+    expect(capturedEvents.length).toBe(1);
+    const props = capturedEvents[0].properties;
+    expect(props).toHaveProperty('platform');
+    expect(props).toHaveProperty('node_version');
+    expect(props).toHaveProperty('cli_version', '0.1.2');
+    expect(props).toHaveProperty('entry_id', 'openai/chat');
+  });
+
+  it('trackEvent does not include error_message in properties', async () => {
+    const capturedEvents = [];
+    vi.doMock('posthog-node', () => ({
+      PostHog: class {
+        constructor() {}
+        capture(event) { capturedEvents.push(event); }
+        async flush() {}
+        async shutdown() {}
+      },
+    }));
+
+    const { trackEvent } = await import('../../src/lib/analytics.js');
+    await trackEvent('fetch_error', { entry_id: 'stripe/api', error_type: 'ECONNREFUSED' });
+
+    expect(capturedEvents.length).toBe(1);
+    const props = capturedEvents[0].properties;
+    expect(props).toHaveProperty('error_type', 'ECONNREFUSED');
+    expect(props).not.toHaveProperty('error_message');
+  });
+});
+
+describe('identity', () => {
+  let tempDir;
+  let origChubDir;
+
+  beforeEach(() => {
+    vi.resetModules();
+    // Isolate from real ~/.chub — use a temp directory
+    tempDir = mkdtempSync(join(tmpdir(), 'chub-test-'));
+    origChubDir = process.env.CHUB_DIR;
+    process.env.CHUB_DIR = tempDir;
+  });
+
+  afterEach(() => {
+    if (origChubDir !== undefined) {
+      process.env.CHUB_DIR = origChubDir;
+    } else {
+      delete process.env.CHUB_DIR;
+    }
+    try { rmSync(tempDir, { recursive: true }); } catch {}
+  });
+
+  it('isFirstRun returns false before getOrCreateClientId', async () => {
+    const { isFirstRun } = await import('../../src/lib/identity.js');
+    expect(isFirstRun()).toBe(false);
+  });
+
+  it('isFirstRun returns true on fresh directory', async () => {
+    const { getOrCreateClientId, isFirstRun } = await import('../../src/lib/identity.js');
+    await getOrCreateClientId();
+    // Fresh temp dir = no existing client_id = first run
+    expect(isFirstRun()).toBe(true);
+  });
+
+  it('isFirstRun returns false on second load with same dir', async () => {
+    // First call creates the client_id file
+    const mod1 = await import('../../src/lib/identity.js');
+    await mod1.getOrCreateClientId();
+    expect(mod1.isFirstRun()).toBe(true);
+
+    // Reset module to simulate a new process, same CHUB_DIR
+    vi.resetModules();
+    const mod2 = await import('../../src/lib/identity.js');
+    await mod2.getOrCreateClientId();
+    // File exists now, so not first run
+    expect(mod2.isFirstRun()).toBe(false);
   });
 });

--- a/cli/tests/mcp/tools.test.js
+++ b/cli/tests/mcp/tools.test.js
@@ -1,5 +1,6 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { handleSearch, handleGet, handleList, handleAnnotate, handleFeedback } from '../../src/mcp/tools.js';
+import * as analytics from '../../src/lib/analytics.js';
 
 /**
  * Helper to parse the JSON text from an MCP tool result.
@@ -199,6 +200,90 @@ describe('chub_annotate (handleAnnotate)', () => {
     expect(result.isError).toBe(true);
     const data = parseResult(result);
     expect(data.error).toContain('too long');
+  });
+});
+
+describe('telemetry', () => {
+  let trackSpy;
+
+  afterEach(() => {
+    trackSpy?.mockRestore();
+  });
+
+  it('emits search event with correct schema for MCP search', async () => {
+    trackSpy = vi.spyOn(analytics, 'trackEvent').mockResolvedValue();
+    await handleSearch({ query: 'stripe', tags: 'payments', lang: 'js', limit: 5 });
+
+    const searchCall = trackSpy.mock.calls.find(([event]) => event === 'search');
+    expect(searchCall).toBeDefined();
+    const [event, props] = searchCall;
+    expect(event).toBe('search');
+    expect(props).toHaveProperty('query', 'stripe');
+    expect(props).toHaveProperty('query_length', 6);
+    expect(props).toHaveProperty('result_count');
+    expect(props).toHaveProperty('results');
+    expect(props).toHaveProperty('has_tags', true);
+    expect(props).toHaveProperty('has_lang', true);
+    expect(props).toHaveProperty('tags', 'payments');
+    expect(props).toHaveProperty('lang', 'js');
+    expect(props).toHaveProperty('duration_ms');
+    expect(props).toHaveProperty('via', 'mcp');
+    // Should NOT have error_message
+    expect(props).not.toHaveProperty('error_message');
+  });
+
+  it('does not emit search event when no query', async () => {
+    trackSpy = vi.spyOn(analytics, 'trackEvent').mockResolvedValue();
+    await handleSearch({ limit: 5 });
+
+    const searchCall = trackSpy.mock.calls.find(([event]) => event === 'search');
+    expect(searchCall).toBeUndefined();
+  });
+
+  it('emits doc_not_found for missing entry', async () => {
+    trackSpy = vi.spyOn(analytics, 'trackEvent').mockResolvedValue();
+    await handleGet({ id: 'does-not-exist/xyz-99999' });
+
+    const call = trackSpy.mock.calls.find(([event]) => event === 'doc_not_found');
+    expect(call).toBeDefined();
+    expect(call[1]).toHaveProperty('entry_id', 'does-not-exist/xyz-99999');
+    expect(call[1]).toHaveProperty('via', 'mcp');
+    expect(call[1]).not.toHaveProperty('error_message');
+  });
+
+  it('emits doc_fetched/skill_fetched on successful get', async () => {
+    trackSpy = vi.spyOn(analytics, 'trackEvent').mockResolvedValue();
+
+    // Find a fetchable entry
+    const searchResult = await handleSearch({ limit: 1 });
+    const entries = parseResult(searchResult);
+    if (entries.results.length === 0) return;
+
+    const entry = entries.results[0];
+    const lang = entry.languages?.[0];
+    await handleGet({ id: entry.id, lang });
+
+    const fetchCall = trackSpy.mock.calls.find(
+      ([event]) => event === 'doc_fetched' || event === 'skill_fetched'
+    );
+    if (fetchCall) {
+      expect(fetchCall[1]).toHaveProperty('entry_id');
+      expect(fetchCall[1]).toHaveProperty('duration_ms');
+      expect(fetchCall[1]).toHaveProperty('via', 'mcp');
+      expect(fetchCall[1]).not.toHaveProperty('error_message');
+    }
+  });
+
+  it('never sends error_message in any telemetry event', async () => {
+    trackSpy = vi.spyOn(analytics, 'trackEvent').mockResolvedValue();
+
+    // Trigger various paths
+    await handleSearch({ query: 'test' });
+    await handleGet({ id: 'nonexistent/entry-999' });
+
+    for (const [, props] of trackSpy.mock.calls) {
+      expect(props).not.toHaveProperty('error_message');
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- **New events**: `first_run`, `doc_not_found`, `fetch_error`, `command_error` for tracking adoption funnel, content gaps, and errors
- **Enhanced search**: captures query text (capped 1000 chars), all result IDs, `duration_ms`, and filter values — enables zero-result analysis to identify missing docs
- **CLI/MCP consistency**: MCP handlers now emit the same event names (`doc_fetched`, `skill_fetched`, `search`) as CLI with `via: 'mcp'` tag
- **`cli_version` on all events**: added as global property, MCP initializes on module load
- **Safety hardened**: no `error_message` in any payload (only `error_type`), `CHUB_TELEMETRY=0` fully respected (no `client_id` created), unwritable `CHUB_DIR` can't crash CLI

## Event schema changes

| Event | New properties |
|-------|---------------|
| All events | `cli_version` |
| `search` | `query`, `results`, `duration_ms`, `tags`, `lang` |
| `doc_fetched` / `skill_fetched` | `duration_ms`, `source`, `file`, `via` |
| `first_run` (new) | `command` |
| `doc_not_found` (new) | `entry_id`, `via` |
| `fetch_error` (new) | `entry_id`, `error_type`, `via` |
| `command_error` (new) | `command`, `error_type` |

## Test plan

- [x] 41 tests pass (analytics, MCP tools, get command telemetry)
- [x] Hermetic identity tests with `CHUB_DIR` temp dir isolation
- [x] `fetch_error` test uses mocked `fetchDoc` to hit actual catch path
- [x] No `error_message` assertion across all telemetry events
- [x] `CHUB_TELEMETRY=0` verified: no `client_id` file created
- [x] `CHUB_DIR=/dev/null/chub` verified: CLI runs normally
- [x] Reviewed through 6 rounds of Codex automated code review

🤖 Generated with [Claude Code](https://claude.com/claude-code)