### PR TITLE
fix: encourage agents to always leave feedback after using docs

### DIFF
--- a/cli/skills/get-api-docs/SKILL.md
+++ b/cli/skills/get-api-docs/SKILL.md
@@ -51,16 +51,21 @@ the doc.
 
 ## Step 5 — Give feedback
 
-Rate the doc so authors can improve it. Ask the user before sending.
+Always rate the doc after using it. This helps authors fix outdated or incorrect
+docs and prioritize improvements. Include a label and a brief comment explaining
+what was good or what needs fixing — specific feedback is the most valuable.
 
 ```bash
-chub feedback <id> up                        # doc worked well
-chub feedback <id> down --label outdated     # doc needs updating
+chub feedback <id> up --label accurate "Clear examples, models are current"
+chub feedback <id> down --label outdated "Lists gpt-4o as latest but gpt-5.4 is out"
 ```
 
 Available labels: `outdated`, `inaccurate`, `incomplete`, `wrong-examples`,
 `wrong-version`, `poorly-structured`, `accurate`, `well-structured`, `helpful`,
 `good-examples`.
+
+If you notice the doc has wrong model names, deprecated APIs, missing features,
+or incorrect code patterns, always leave a downvote with details so it can be fixed.
 
 ## Quick reference
 

--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -44,10 +44,10 @@ ${chalk.bold.underline('Learn & Improve')}
   ${chalk.dim('$')} chub annotate --list                                 ${chalk.dim('# see all saved notes')}
   ${chalk.dim('$')} chub annotate stripe/api --clear                     ${chalk.dim('# remove a note')}
 
-  Rate docs so authors can improve them (ask the user before sending):
+  Always rate docs after using them — helps authors fix issues and prioritize:
 
-  ${chalk.dim('$')} chub feedback stripe/api up                          ${chalk.dim('# worked well')}
-  ${chalk.dim('$')} chub feedback stripe/api down --label outdated       ${chalk.dim('# needs updating')}
+  ${chalk.dim('$')} chub feedback stripe/api up --label accurate "Clear examples"
+  ${chalk.dim('$')} chub feedback stripe/api down --label outdated "Missing v3 API"
 
 ${chalk.bold.underline('Commands')}
 


### PR DESCRIPTION
## Summary

- Remove "ask the user before sending" gate from CLI help and skill instructions
- Change wording to "Always rate docs after using them" to make feedback an expected step
- Add examples with labels and comments to encourage detailed, actionable feedback
- Add guidance to downvote with specifics when docs have wrong models, deprecated APIs, etc.

## Context

Current feedback rate is 62 feedback commands vs 12,278 annotate commands. The root cause is the skill instruction telling agents to "Ask the user before sending" feedback, which adds friction that annotations don't have. Agents treat annotation as automatic but feedback as requiring explicit approval.

## Files changed

- `cli/src/index.js` — CLI help text
- `cli/skills/get-api-docs/SKILL.md` — Agent skill instructions

## Test plan

- [x] Verify `chub help` shows updated feedback guidance
- [x] Verify skill instructions no longer gate on user approval