### PR TITLE
Improve search recall and cache backfill

### DIFF
--- a/cli/src/commands/search.js
+++ b/cli/src/commands/search.js
@@ -57,9 +57,10 @@ export function registerSearchCommand(program) {
     .action((query, opts) => {
       const globalOpts = program.optsWithGlobals();
       const limit = parseInt(opts.limit, 10);
+      const normalizedQuery = typeof query === 'string' ? query.trim().replace(/\s+/g, ' ') : query;
 
       // No query: list all
-      if (!query) {
+      if (!normalizedQuery) {
         const entries = listEntries(opts).slice(0, limit);
         output({ results: entries, total: entries.length }, (data) => {
           if (data.results.length === 0) {
@@ -73,12 +74,12 @@ export function registerSearchCommand(program) {
       }
 
       // Exact id match: show detail
-      const result = getEntry(query);
+      const result = getEntry(normalizedQuery);
       if (result.ambiguous) {
         output(
           { error: 'ambiguous', alternatives: result.alternatives },
           () => {
-            console.log(chalk.yellow(`Multiple entries with id "${query}". Be specific:`));
+            console.log(chalk.yellow(`Multiple entries with id "${normalizedQuery}". Be specific:`));
             for (const alt of result.alternatives) {
               console.log(`  ${chalk.bold(alt)}`);
             }
@@ -94,12 +95,12 @@ export function registerSearchCommand(program) {
 
       // Fuzzy search
       const searchStart = Date.now();
-      const results = searchEntries(query, opts).slice(0, limit);
+      const results = searchEntries(normalizedQuery, opts).slice(0, limit);
       const duration_ms = Date.now() - searchStart;
       const resultIds = results.map((e) => e.id || e.name || 'unknown');
       trackEvent('search', {
-        query: query.slice(0, 1000),
-        query_length: query.length,
+        query: normalizedQuery.slice(0, 1000),
+        query_length: normalizedQuery.length,
         result_count: results.length,
         results: resultIds,
         duration_ms,
@@ -108,12 +109,12 @@ export function registerSearchCommand(program) {
         tags: opts.tags || undefined,
         lang: opts.lang || undefined,
       }).catch(() => {});
-      output({ results, total: results.length, query }, (data) => {
+      output({ results, total: results.length, query: normalizedQuery }, (data) => {
         if (data.results.length === 0) {
-          console.log(chalk.yellow(`No results for "${query}".`));
+          console.log(chalk.yellow(`No results for "${normalizedQuery}".`));
           return;
         }
-        console.log(chalk.bold(`${data.total} results for "${query}":\n`));
+        console.log(chalk.bold(`${data.total} results for "${normalizedQuery}":\n`));
         formatEntryList(data.results);
       }, globalOpts);
     });

--- a/cli/src/lib/bm25.js
+++ b/cli/src/lib/bm25.js
@@ -20,6 +20,7 @@ const DEFAULT_B = 0.75;
 
 // Field weights for multi-field scoring
 const FIELD_WEIGHTS = {
+  id: 4.0,
   name: 3.0,
   tags: 2.0,
   description: 1.0,
@@ -27,6 +28,22 @@ const FIELD_WEIGHTS = {
 
 function getDefaultParams() {
   return { k1: DEFAULT_K1, b: DEFAULT_B };
+}
+
+function isSearchableToken(token) {
+  return (token.length > 1 || /^\d+$/.test(token)) && !STOP_WORDS.has(token);
+}
+
+export function compactIdentifier(text) {
+  return String(text || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '');
+}
+
+function splitAlphaNumeric(text) {
+  return text
+    .replace(/([a-z])(\d)/g, '$1 $2')
+    .replace(/(\d)([a-z])/g, '$1 $2');
 }
 
 /**
@@ -39,7 +56,43 @@ export function tokenize(text) {
     .toLowerCase()
     .replace(/[^a-z0-9\s-]/g, ' ')
     .split(/[\s-]+/)
-    .filter((t) => t.length > 1 && !STOP_WORDS.has(t));
+    .filter(isSearchableToken);
+}
+
+/**
+ * Tokenize identifiers more aggressively than free text so package ids
+ * still match joined/split variants like "nodefetch" and "auth 0".
+ */
+export function tokenizeIdentifier(text) {
+  if (!text) return [];
+
+  const tokens = new Set(tokenize(text));
+  const raw = String(text);
+  const compact = compactIdentifier(raw);
+  const segments = new Set([
+    ...raw.split('/').map((segment) => compactIdentifier(segment)),
+    ...raw.split(/[\/_.\s-]+/).map((segment) => compactIdentifier(segment)),
+  ]);
+
+  if (isSearchableToken(compact)) {
+    tokens.add(compact);
+  }
+
+  for (const token of tokenize(splitAlphaNumeric(compact))) {
+    tokens.add(token);
+  }
+
+  for (const segment of segments) {
+    if (!segment) continue;
+    if (isSearchableToken(segment)) {
+      tokens.add(segment);
+    }
+    for (const token of tokenize(splitAlphaNumeric(segment))) {
+      tokens.add(token);
+    }
+  }
+
+  return [...tokens];
 }
 
 function buildInvertedIndex(documents) {
@@ -47,6 +100,7 @@ function buildInvertedIndex(documents) {
 
   for (const [docIndex, doc] of documents.entries()) {
     const allTerms = new Set([
+      ...(doc.tokens.id || []),
       ...(doc.tokens.name || []),
       ...(doc.tokens.description || []),
       ...(doc.tokens.tags || []),
@@ -63,18 +117,20 @@ function buildInvertedIndex(documents) {
 
 export function buildIndexFromDocuments(documents, params = getDefaultParams()) {
   const dfMap = Object.create(null); // document frequency per term (across all fields)
-  const fieldLengths = { name: [], description: [], tags: [] };
+  const fieldLengths = { id: [], name: [], description: [], tags: [] };
 
   for (const doc of documents) {
+    const idTokens = doc.tokens.id || [];
     const nameTokens = doc.tokens.name || [];
     const descTokens = doc.tokens.description || [];
     const tagTokens = doc.tokens.tags || [];
 
+    fieldLengths.id.push(idTokens.length);
     fieldLengths.name.push(nameTokens.length);
     fieldLengths.description.push(descTokens.length);
     fieldLengths.tags.push(tagTokens.length);
 
-    const allTerms = new Set([...nameTokens, ...descTokens, ...tagTokens]);
+    const allTerms = new Set([...idTokens, ...nameTokens, ...descTokens, ...tagTokens]);
     for (const term of allTerms) {
       dfMap[term] = (dfMap[term] || 0) + 1;
     }
@@ -93,6 +149,7 @@ export function buildIndexFromDocuments(documents, params = getDefaultParams()) 
     params,
     totalDocs: N,
     avgFieldLengths: {
+      id: avg(fieldLengths.id),
       name: avg(fieldLengths.name),
       description: avg(fieldLengths.description),
       tags: avg(fieldLengths.tags),
@@ -114,6 +171,7 @@ export function buildIndex(entries) {
   const documents = [];
 
   for (const entry of entries) {
+    const idTokens = tokenizeIdentifier(entry.id);
     const nameTokens = tokenize(entry.name);
     const descTokens = tokenize(entry.description || '');
     const tagTokens = (entry.tags || []).flatMap((t) => tokenize(t));
@@ -121,6 +179,7 @@ export function buildIndex(entries) {
     documents.push({
       id: entry.id,
       tokens: {
+        id: idTokens,
         name: nameTokens,
         description: descTokens,
         tags: tagTokens,

--- a/cli/src/lib/cache.js
+++ b/cli/src/lib/cache.js
@@ -51,10 +51,35 @@ function writeMeta(sourceName, meta) {
 
 function isSourceCacheFresh(sourceName) {
   const meta = readMeta(sourceName);
-  if (!meta.lastUpdated) return false;
+  if (!meta.lastUpdated && meta.lastUpdated !== 0) return false;
   const config = loadConfig();
   const age = (Date.now() - meta.lastUpdated) / 1000;
   return age < config.refresh_interval;
+}
+
+function isTimestampFresh(timestamp) {
+  if (timestamp === undefined || timestamp === null) return false;
+  const config = loadConfig();
+  const age = (Date.now() - timestamp) / 1000;
+  return age < config.refresh_interval;
+}
+
+function hasFreshSearchIndexState(sourceName) {
+  if (existsSync(getSourceSearchIndexPath(sourceName))) {
+    return true;
+  }
+
+  const meta = readMeta(sourceName);
+  return meta.searchIndexAvailable === false && isTimestampFresh(meta.searchIndexCheckedAt);
+}
+
+function shouldFetchRemoteRegistry(sourceName, force = false) {
+  if (force) return true;
+  return !(
+    isSourceCacheFresh(sourceName)
+    && existsSync(getSourceRegistryPath(sourceName))
+    && hasFreshSearchIndexState(sourceName)
+  );
 }
 
 async function fetchRemoteText(url) {
@@ -75,7 +100,7 @@ async function fetchRemoteText(url) {
  * Fetch registry for a single remote source.
  */
 async function fetchRemoteRegistry(source, force = false) {
-  if (!force && isSourceCacheFresh(source.name) && existsSync(getSourceRegistryPath(source.name))) {
+  if (!shouldFetchRemoteRegistry(source.name, force)) {
     return;
   }
 
@@ -92,15 +117,33 @@ async function fetchRemoteRegistry(source, force = false) {
   writeFileSync(getSourceRegistryPath(source.name), registryText);
 
   const searchIndexUrl = `${source.url}/search-index.json`;
+  const searchIndexCheckedAt = Date.now();
+  let searchIndexAvailable;
   try {
     const searchIndexText = await fetchRemoteText(searchIndexUrl);
     writeFileSync(getSourceSearchIndexPath(source.name), searchIndexText);
-  } catch {
+    searchIndexAvailable = true;
+  } catch (err) {
     // Avoid serving a stale local search index after a registry refresh.
     rmSync(getSourceSearchIndexPath(source.name), { force: true });
+    if (err.message?.startsWith('404 ')) {
+      searchIndexAvailable = false;
+    }
   }
 
-  writeMeta(source.name, { ...readMeta(source.name), lastUpdated: Date.now() });
+  const nextMeta = {
+    ...readMeta(source.name),
+    lastUpdated: Date.now(),
+  };
+  delete nextMeta.searchIndexAvailable;
+  delete nextMeta.searchIndexCheckedAt;
+
+  if (searchIndexAvailable !== undefined) {
+    nextMeta.searchIndexAvailable = searchIndexAvailable;
+    nextMeta.searchIndexCheckedAt = searchIndexCheckedAt;
+  }
+
+  writeMeta(source.name, nextMeta);
 }
 
 /**
@@ -217,7 +260,7 @@ export async function fetchDoc(source, docPath) {
   const content = await res.text();
 
   // Cache locally
-  const dir = cachedPath.substring(0, cachedPath.lastIndexOf('/'));
+  const dir = dirname(cachedPath);
   mkdirSync(dir, { recursive: true });
   writeFileSync(cachedPath, content);
 
@@ -357,7 +400,7 @@ export async function ensureRegistry() {
     // Auto-refresh stale remote registries (best-effort)
     for (const source of config.sources) {
       if (source.path) continue;
-      if (!isSourceCacheFresh(source.name)) {
+      if (shouldFetchRemoteRegistry(source.name)) {
         try { await fetchRemoteRegistry(source); } catch { /* use stale */ }
       }
     }

--- a/cli/src/lib/registry.js
+++ b/cli/src/lib/registry.js
@@ -1,13 +1,180 @@
 import { loadSourceRegistry, loadSearchIndex } from './cache.js';
 import { loadConfig } from './config.js';
 import { normalizeLanguage } from './normalize.js';
-import { buildIndexFromDocuments, search as bm25Search } from './bm25.js';
+import { buildIndexFromDocuments, compactIdentifier, search as bm25Search, tokenize } from './bm25.js';
 
 let _merged = null;
 let _searchIndex = null;
 
 function getSearchLookupId(sourceName, entryId) {
   return `${sourceName}:${entryId}`;
+}
+
+function normalizeQuery(query) {
+  return String(query || '')
+    .trim()
+    .replace(/\s+/g, ' ');
+}
+
+function splitCompactSegments(text) {
+  return [...new Set([
+    ...String(text || '').split('/').map((segment) => compactIdentifier(segment)),
+    ...String(text || '').split(/[\/_.\s-]+/).map((segment) => compactIdentifier(segment)),
+  ])].filter(Boolean);
+}
+
+function levenshteinDistance(a, b, maxDistance = Infinity) {
+  if (a === b) return 0;
+  if (!a.length) return b.length;
+  if (!b.length) return a.length;
+  if (Math.abs(a.length - b.length) > maxDistance) return maxDistance + 1;
+
+  let previous = Array.from({ length: b.length + 1 }, (_, idx) => idx);
+  let current = new Array(b.length + 1);
+
+  for (let i = 1; i <= a.length; i++) {
+    current[0] = i;
+    let rowMin = current[0];
+
+    for (let j = 1; j <= b.length; j++) {
+      const substitutionCost = a[i - 1] === b[j - 1] ? 0 : 1;
+      current[j] = Math.min(
+        previous[j] + 1,
+        current[j - 1] + 1,
+        previous[j - 1] + substitutionCost,
+      );
+      rowMin = Math.min(rowMin, current[j]);
+    }
+
+    if (rowMin > maxDistance) return maxDistance + 1;
+    [previous, current] = [current, previous];
+  }
+
+  return previous[b.length];
+}
+
+function scoreCompactCandidate(queryCompact, candidateCompact, weights) {
+  if (!queryCompact || !candidateCompact) return 0;
+  if (candidateCompact === queryCompact) return weights.exact;
+  if (queryCompact.length < 3) return 0;
+
+  const lengthPenalty = Math.abs(candidateCompact.length - queryCompact.length);
+  const lengthRatio = Math.min(candidateCompact.length, queryCompact.length)
+    / Math.max(candidateCompact.length, queryCompact.length);
+
+  if ((candidateCompact.startsWith(queryCompact) || queryCompact.startsWith(candidateCompact)) && lengthRatio >= 0.6) {
+    return Math.max(weights.prefix - lengthPenalty, 0);
+  }
+
+  if ((candidateCompact.includes(queryCompact) || queryCompact.includes(candidateCompact)) && lengthRatio >= 0.75) {
+    return Math.max(weights.contains - lengthPenalty, 0);
+  }
+
+  if (queryCompact.length < 5) return 0;
+
+  const maxDistance = queryCompact.length <= 5 ? 1 : queryCompact.length <= 8 ? 2 : 3;
+  const distance = levenshteinDistance(queryCompact, candidateCompact, maxDistance);
+  if (distance > maxDistance) return 0;
+
+  return Math.max(weights.fuzzy - (distance * 20) - lengthPenalty, 0);
+}
+
+function scoreEntryLexicalVariant(entry, queryCompact) {
+  if (queryCompact.length < 2) return 0;
+
+  const nameCompact = compactIdentifier(entry.name);
+  const idCompact = compactIdentifier(entry.id);
+  const idSegments = splitCompactSegments(entry.id);
+  const nameSegments = splitCompactSegments(entry.name);
+
+  let best = 0;
+
+  best = Math.max(best, scoreCompactCandidate(queryCompact, nameCompact, {
+    exact: 620,
+    prefix: 560,
+    contains: 520,
+    fuzzy: 500,
+  }));
+
+  best = Math.max(best, scoreCompactCandidate(queryCompact, idCompact, {
+    exact: 600,
+    prefix: 540,
+    contains: 500,
+    fuzzy: 470,
+  }));
+
+  for (let idx = 0; idx < idSegments.length; idx++) {
+    const segment = idSegments[idx];
+    const segmentScore = scoreCompactCandidate(queryCompact, segment, {
+      exact: 580,
+      prefix: 530,
+      contains: 490,
+      fuzzy: 460,
+    });
+    if (segmentScore === 0) continue;
+
+    let bonus = 0;
+    const isFirst = idx === 0;
+    const isLast = idx === idSegments.length - 1;
+    if (isFirst) bonus += 10;
+    if (isLast) bonus += 10;
+    if (queryCompact === idSegments[0]) bonus += 60;
+    if (queryCompact === idSegments[idSegments.length - 1]) bonus += 25;
+    if (idSegments.length > 1 && queryCompact === idSegments[0] && queryCompact === idSegments[idSegments.length - 1]) {
+      bonus += 40;
+    }
+
+    best = Math.max(best, segmentScore + bonus);
+  }
+
+  for (const segment of nameSegments) {
+    best = Math.max(best, scoreCompactCandidate(queryCompact, segment, {
+      exact: 560,
+      prefix: 520,
+      contains: 480,
+      fuzzy: 450,
+    }));
+  }
+
+  return best;
+}
+
+function scoreEntryLexicalBoost(entry, normalizedQuery, rescueTerms = []) {
+  const queryCompacts = [...new Set([
+    compactIdentifier(normalizedQuery),
+    ...rescueTerms.map((term) => compactIdentifier(term)),
+  ])].filter((queryCompact) => queryCompact.length >= 2);
+
+  let best = 0;
+  for (const queryCompact of queryCompacts) {
+    best = Math.max(best, scoreEntryLexicalVariant(entry, queryCompact));
+  }
+  return best;
+}
+
+function getMissingQueryTerms(normalizedQuery) {
+  if (!_searchIndex?.invertedIndex) {
+    return [];
+  }
+
+  return tokenize(normalizedQuery).filter((term) => !_searchIndex.invertedIndex[term]?.length);
+}
+
+function shouldRunGlobalLexicalScan(normalizedQuery, resultByKey) {
+  if (!_searchIndex || resultByKey.size === 0) {
+    return true;
+  }
+
+  if (!_searchIndex.invertedIndex) {
+    return false;
+  }
+
+  const queryTerms = tokenize(normalizedQuery);
+  if (queryTerms.length < 2) {
+    return false;
+  }
+
+  return getMissingQueryTerms(normalizedQuery).length > 0;
 }
 
 function namespaceSearchIndex(index, sourceName) {
@@ -158,6 +325,7 @@ export function getDisplayId(entry) {
  * Uses BM25 when a search index is available, falls back to keyword matching.
  */
 export function searchEntries(query, filters = {}) {
+  const normalizedQuery = normalizeQuery(query);
   const entries = applySourceFilter(getAllEntries());
 
   // Deduplicate: same id+source appearing as both doc and skill → show once
@@ -177,23 +345,26 @@ export function searchEntries(query, filters = {}) {
     entryById.set(getSearchLookupId(entry._source, entry.id), entry);
   }
 
-  let results;
+  if (!normalizedQuery) {
+    return applyFilters(deduped, filters).map((entry) => ({ ...entry, _score: 0 }));
+  }
+
+  const resultByKey = new Map();
 
   if (_searchIndex) {
     // BM25 search
-    const bm25Results = bm25Search(query, _searchIndex);
-    results = bm25Results
-      .map((r) => {
-        const entry = entryById.get(r.id);
-        return entry ? { entry, score: r.score } : null;
-      })
-      .filter(Boolean);
+    for (const match of bm25Search(normalizedQuery, _searchIndex)) {
+      const entry = entryById.get(match.id);
+      if (!entry) continue;
+      const key = getSearchLookupId(entry._source, entry.id);
+      resultByKey.set(key, { entry, score: match.score });
+    }
   } else {
     // Fallback: keyword matching
-    const q = query.toLowerCase();
+    const q = normalizedQuery.toLowerCase();
     const words = q.split(/\s+/);
 
-    results = deduped.map((entry) => {
+    for (const entry of deduped) {
       let score = 0;
 
       if (entry.id === q) score += 100;
@@ -210,11 +381,34 @@ export function searchEntries(query, filters = {}) {
         if (entry.tags?.some((t) => t.toLowerCase().includes(word))) score += 15;
       }
 
-      return { entry, score };
-    });
-
-    results = results.filter((r) => r.score > 0);
+      if (score > 0) {
+        const key = getSearchLookupId(entry._source, entry.id);
+        resultByKey.set(key, { entry, score });
+      }
+    }
   }
+
+  const lexicalCandidates = !shouldRunGlobalLexicalScan(normalizedQuery, resultByKey)
+    ? [...new Set([...resultByKey.values()].map(({ entry }) => entry))]
+    : deduped;
+  const rescueTerms = resultByKey.size > 0
+    ? getMissingQueryTerms(normalizedQuery).filter((term) => term.length >= 5)
+    : [];
+
+  for (const entry of lexicalCandidates) {
+    const boost = scoreEntryLexicalBoost(entry, normalizedQuery, rescueTerms);
+    if (boost === 0) continue;
+
+    const key = getSearchLookupId(entry._source, entry.id);
+    const current = resultByKey.get(key);
+    if (current) {
+      current.score += boost;
+    } else {
+      resultByKey.set(key, { entry, score: boost });
+    }
+  }
+
+  let results = [...resultByKey.values()];
 
   const filtered = applyFilters(results.map((r) => r.entry), filters);
   const filteredSet = new Set(filtered);
@@ -229,6 +423,7 @@ export function searchEntries(query, filters = {}) {
  * type: "doc" or "skill". If null, searches both.
  */
 export function getEntry(idOrNamespacedId, type = null) {
+  const normalizedId = normalizeQuery(idOrNamespacedId);
   const { docs, skills } = getMerged();
   let pool;
   if (type === 'doc') pool = applySourceFilter(docs);
@@ -236,16 +431,16 @@ export function getEntry(idOrNamespacedId, type = null) {
   else pool = applySourceFilter([...docs, ...skills]);
 
   // Check for source:id format (colon separates source from id)
-  if (idOrNamespacedId.includes(':')) {
-    const colonIdx = idOrNamespacedId.indexOf(':');
-    const sourceName = idOrNamespacedId.slice(0, colonIdx);
-    const id = idOrNamespacedId.slice(colonIdx + 1);
+  if (normalizedId.includes(':')) {
+    const colonIdx = normalizedId.indexOf(':');
+    const sourceName = normalizedId.slice(0, colonIdx);
+    const id = normalizedId.slice(colonIdx + 1);
     const entry = pool.find((e) => e._source === sourceName && e.id === id);
     return entry ? { entry, ambiguous: false } : { entry: null, ambiguous: false };
   }
 
   // Bare id (may contain slashes like author/name)
-  const matches = pool.filter((e) => e.id === idOrNamespacedId);
+  const matches = pool.filter((e) => e.id === normalizedId);
   if (matches.length === 0) return { entry: null, ambiguous: false };
   if (matches.length === 1) return { entry: matches[0], ambiguous: false };
 

--- a/cli/tests/commands/search.test.js
+++ b/cli/tests/commands/search.test.js
@@ -209,15 +209,23 @@ describe('search command', () => {
       expect(searchEntries).toHaveBeenCalledWith('widget', expect.anything());
     });
 
+    it('normalizes whitespace before lookup and search', async () => {
+      searchEntries.mockReturnValue([docEntry]);
+      await runSearch(['  widget   api  ']);
+      expect(getEntry).toHaveBeenCalledWith('widget api');
+      expect(searchEntries).toHaveBeenCalledWith('widget api', expect.anything());
+    });
+
     it('fires analytics event with correct properties', async () => {
       searchEntries.mockReturnValue([docEntry]);
       await runSearch(['widget', '--tags', 'ui']);
-      expect(trackEvent).toHaveBeenCalledWith('search', {
+      expect(trackEvent).toHaveBeenCalledWith('search', expect.objectContaining({
+        query: 'widget',
         query_length: 6,
         result_count: 1,
         has_tags: true,
         has_lang: false,
-      });
+      }));
     });
 
     it('does not fail when trackEvent rejects', async () => {

--- a/cli/tests/lib/bm25.test.js
+++ b/cli/tests/lib/bm25.test.js
@@ -69,4 +69,24 @@ describe('bm25 inverted index', () => {
     expect(result.stats.candidateDocCount).toBe(0);
     expect(result.stats.scoredDocCount).toBe(0);
   });
+
+  it('indexes identifier variants so joined and split package queries still match', () => {
+    const index = buildIndex([
+      {
+        id: 'node-fetch/node-fetch',
+        name: 'node-fetch',
+        description: 'Fetch API for Node.js',
+        tags: ['http'],
+      },
+      {
+        id: 'auth0/identity',
+        name: 'Auth0 Identity',
+        description: 'Identity toolkit',
+        tags: ['auth'],
+      },
+    ]);
+
+    expect(searchWithStats('nodefetch', index).results[0].id).toBe('node-fetch/node-fetch');
+    expect(searchWithStats('auth 0', index).results[0].id).toBe('auth0/identity');
+  });
 });

--- a/cli/tests/lib/cache.test.js
+++ b/cli/tests/lib/cache.test.js
@@ -20,6 +20,7 @@ function restoreBundledDir() {
 
 afterEach(() => {
   vi.resetModules();
+  vi.unstubAllGlobals();
   delete process.env.CHUB_DIR;
   if (tempChubDir) {
     rmSync(tempChubDir, { recursive: true, force: true });
@@ -66,5 +67,219 @@ describe('ensureRegistry', () => {
 
     const seededIndex = JSON.parse(readFileSync(seededSearchIndex, 'utf8'));
     expect(seededIndex.invertedIndex.alpha).toEqual([0]);
+  });
+
+  it('backfills a missing remote search-index.json even when registry.json is fresh', async () => {
+    tempChubDir = mkdtempSync(join(tmpdir(), 'chub-cache-test-'));
+    process.env.CHUB_DIR = tempChubDir;
+
+    mkdirSync(join(tempChubDir, 'sources', 'default'), { recursive: true });
+    writeFileSync(join(tempChubDir, 'config.yaml'), [
+      'sources:',
+      '  - name: default',
+      '    url: https://cdn.example.test/v1',
+      'refresh_interval: 21600',
+      '',
+    ].join('\n'));
+
+    writeFileSync(join(tempChubDir, 'sources', 'default', 'registry.json'), JSON.stringify({
+      version: '1.0.0',
+      docs: [],
+      skills: [],
+    }));
+    writeFileSync(join(tempChubDir, 'sources', 'default', 'meta.json'), JSON.stringify({
+      lastUpdated: Date.now(),
+    }));
+
+    const fetchMock = vi.fn(async (url) => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => JSON.stringify(url.endsWith('registry.json')
+        ? { version: '1.0.0', docs: [{ id: 'vendor/pkg', name: 'Pkg' }], skills: [] }
+        : {
+            version: '1.0.0',
+            algorithm: 'bm25',
+            params: { k1: 1.5, b: 0.75 },
+            totalDocs: 1,
+            avgFieldLengths: { id: 1, name: 1, description: 0, tags: 0 },
+            idf: { pkg: 1 },
+            documents: [{ id: 'vendor/pkg', tokens: { id: ['vendorpkg'], name: ['pkg'], description: [], tags: [] } }],
+            invertedIndex: { pkg: [0] },
+          }),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { ensureRegistry } = await import('../../src/lib/cache.js');
+    await ensureRegistry();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(existsSync(join(tempChubDir, 'sources', 'default', 'search-index.json'))).toBe(true);
+
+    const meta = JSON.parse(readFileSync(join(tempChubDir, 'sources', 'default', 'meta.json'), 'utf8'));
+    expect(meta.searchIndexAvailable).toBe(true);
+    expect(typeof meta.searchIndexCheckedAt).toBe('number');
+  });
+
+  it('does not re-fetch when the source recently confirmed that no search index exists', async () => {
+    tempChubDir = mkdtempSync(join(tmpdir(), 'chub-cache-test-'));
+    process.env.CHUB_DIR = tempChubDir;
+
+    mkdirSync(join(tempChubDir, 'sources', 'default'), { recursive: true });
+    writeFileSync(join(tempChubDir, 'config.yaml'), [
+      'sources:',
+      '  - name: default',
+      '    url: https://cdn.example.test/v1',
+      'refresh_interval: 21600',
+      '',
+    ].join('\n'));
+
+    writeFileSync(join(tempChubDir, 'sources', 'default', 'registry.json'), JSON.stringify({
+      version: '1.0.0',
+      docs: [],
+      skills: [],
+    }));
+    writeFileSync(join(tempChubDir, 'sources', 'default', 'meta.json'), JSON.stringify({
+      lastUpdated: Date.now(),
+      searchIndexAvailable: false,
+      searchIndexCheckedAt: Date.now(),
+    }));
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { fetchAllRegistries } = await import('../../src/lib/cache.js');
+    await fetchAllRegistries(false);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('retries search-index fetches after transient failures', async () => {
+    tempChubDir = mkdtempSync(join(tmpdir(), 'chub-cache-test-'));
+    process.env.CHUB_DIR = tempChubDir;
+
+    mkdirSync(join(tempChubDir, 'sources', 'default'), { recursive: true });
+    writeFileSync(join(tempChubDir, 'config.yaml'), [
+      'sources:',
+      '  - name: default',
+      '    url: https://cdn.example.test/v1',
+      'refresh_interval: 21600',
+      '',
+    ].join('\n'));
+
+    writeFileSync(join(tempChubDir, 'sources', 'default', 'registry.json'), JSON.stringify({
+      version: '1.0.0',
+      docs: [],
+      skills: [],
+    }));
+    writeFileSync(join(tempChubDir, 'sources', 'default', 'meta.json'), JSON.stringify({
+      lastUpdated: Date.now(),
+    }));
+
+    let searchIndexAttempts = 0;
+    const fetchMock = vi.fn(async (url) => {
+      if (url.endsWith('registry.json')) {
+        return {
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          text: async () => JSON.stringify({ version: '1.0.0', docs: [], skills: [] }),
+        };
+      }
+
+      searchIndexAttempts += 1;
+      if (searchIndexAttempts === 1) {
+        return {
+          ok: false,
+          status: 503,
+          statusText: 'Service Unavailable',
+          text: async () => '',
+        };
+      }
+
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: async () => JSON.stringify({
+          version: '1.0.0',
+          algorithm: 'bm25',
+          params: { k1: 1.5, b: 0.75 },
+          totalDocs: 0,
+          avgFieldLengths: { id: 0, name: 0, description: 0, tags: 0 },
+          idf: {},
+          documents: [],
+          invertedIndex: {},
+        }),
+      };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { ensureRegistry } = await import('../../src/lib/cache.js');
+    await ensureRegistry();
+    await ensureRegistry();
+
+    expect(searchIndexAttempts).toBe(2);
+    expect(existsSync(join(tempChubDir, 'sources', 'default', 'search-index.json'))).toBe(true);
+
+    const meta = JSON.parse(readFileSync(join(tempChubDir, 'sources', 'default', 'meta.json'), 'utf8'));
+    expect(meta.searchIndexAvailable).toBe(true);
+    expect(typeof meta.searchIndexCheckedAt).toBe('number');
+  });
+
+  it('clears stale negative search-index metadata after a forced refresh transient failure', async () => {
+    tempChubDir = mkdtempSync(join(tmpdir(), 'chub-cache-test-'));
+    process.env.CHUB_DIR = tempChubDir;
+
+    mkdirSync(join(tempChubDir, 'sources', 'default'), { recursive: true });
+    writeFileSync(join(tempChubDir, 'config.yaml'), [
+      'sources:',
+      '  - name: default',
+      '    url: https://cdn.example.test/v1',
+      'refresh_interval: 21600',
+      '',
+    ].join('\n'));
+
+    writeFileSync(join(tempChubDir, 'sources', 'default', 'registry.json'), JSON.stringify({
+      version: '1.0.0',
+      docs: [],
+      skills: [],
+    }));
+    writeFileSync(join(tempChubDir, 'sources', 'default', 'meta.json'), JSON.stringify({
+      lastUpdated: Date.now(),
+      searchIndexAvailable: false,
+      searchIndexCheckedAt: Date.now(),
+    }));
+
+    let searchIndexAttempts = 0;
+    const fetchMock = vi.fn(async (url) => {
+      if (url.endsWith('registry.json')) {
+        return {
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          text: async () => JSON.stringify({ version: '1.0.0', docs: [], skills: [] }),
+        };
+      }
+
+      searchIndexAttempts += 1;
+      return {
+        ok: false,
+        status: 503,
+        statusText: 'Service Unavailable',
+        text: async () => '',
+      };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { fetchAllRegistries } = await import('../../src/lib/cache.js');
+    await fetchAllRegistries(true);
+
+    const metaAfterForce = JSON.parse(readFileSync(join(tempChubDir, 'sources', 'default', 'meta.json'), 'utf8'));
+    expect(metaAfterForce.searchIndexAvailable).toBeUndefined();
+    expect(metaAfterForce.searchIndexCheckedAt).toBeUndefined();
+
+    await fetchAllRegistries(false);
+    expect(searchIndexAttempts).toBe(2);
   });
 });

--- a/cli/tests/lib/registry.search-behavior.test.js
+++ b/cli/tests/lib/registry.search-behavior.test.js
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildIndex } from '../../src/lib/bm25.js';
+
+const ORIGINAL_CHUB_DIR = process.env.CHUB_DIR;
+const tempDirs = [];
+
+function writeSource(root, docs) {
+  mkdirSync(root, { recursive: true });
+  writeFileSync(
+    join(root, 'registry.json'),
+    JSON.stringify({
+      version: '1.0.0',
+      docs: docs.map((doc) => ({
+        ...doc,
+        source: 'official',
+        languages: doc.languages || [],
+      })),
+      skills: [],
+    }, null, 2),
+  );
+
+  writeFileSync(
+    join(root, 'search-index.json'),
+    JSON.stringify(buildIndex(docs)),
+  );
+}
+
+async function loadRegistry(docs) {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'chub-search-behavior-'));
+  tempDirs.push(tempRoot);
+
+  const sourceRoot = join(tempRoot, 'source');
+  writeSource(sourceRoot, docs);
+
+  const chubDir = join(tempRoot, '.chub');
+  mkdirSync(chubDir, { recursive: true });
+  writeFileSync(join(chubDir, 'config.yaml'), [
+    'sources:',
+    `  - name: default`,
+    `    path: ${JSON.stringify(sourceRoot)}`,
+    'source: official,maintainer,community',
+    '',
+  ].join('\n'));
+
+  process.env.CHUB_DIR = chubDir;
+  vi.resetModules();
+  return import('../../src/lib/registry.js');
+}
+
+afterEach(() => {
+  vi.resetModules();
+  if (ORIGINAL_CHUB_DIR === undefined) delete process.env.CHUB_DIR;
+  else process.env.CHUB_DIR = ORIGINAL_CHUB_DIR;
+
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+describe('searchEntries normalization and typo handling', () => {
+  it('recovers common typos and joined/split identifier forms', async () => {
+    const docs = [
+      {
+        id: 'playwright/playwright',
+        name: 'Playwright',
+        description: 'Browser automation library',
+        tags: ['testing'],
+      },
+      {
+        id: 'react/react',
+        name: 'React',
+        description: 'React UI library',
+        tags: ['react'],
+      },
+      {
+        id: 'node-fetch/node-fetch',
+        name: 'node-fetch',
+        description: 'Fetch API for Node.js',
+        tags: ['http'],
+      },
+      {
+        id: 'typescript/node-fetch',
+        name: 'node-fetch types',
+        description: 'TypeScript support for node-fetch',
+        tags: ['typescript'],
+      },
+      {
+        id: 'auth0/identity',
+        name: 'Auth0 Identity',
+        description: 'Authentication and identity toolkit',
+        tags: ['auth'],
+      },
+      {
+        id: 'next/next',
+        name: 'Next.js',
+        description: 'React framework for production',
+        tags: ['react'],
+      },
+      {
+        id: 'eslint/eslint-config-next',
+        name: 'eslint-config-next',
+        description: 'ESLint preset for Next.js apps',
+        tags: ['eslint'],
+      },
+      {
+        id: 'openai/chat',
+        name: 'OpenAI Chat',
+        description: 'OpenAI chat docs',
+        tags: ['ai'],
+      },
+      {
+        id: 'openapi/package',
+        name: 'OpenAPI',
+        description: 'OpenAPI tooling docs',
+        tags: ['api'],
+      },
+    ];
+
+    const { searchEntries, getEntry } = await loadRegistry(docs);
+
+    expect(searchEntries('playwrite')[0].id).toBe('playwright/playwright');
+    expect(searchEntries('play wright')[0].id).toBe('playwright/playwright');
+    expect(searchEntries('nodefetch')[0].id).toBe('node-fetch/node-fetch');
+    expect(searchEntries('node-fetch')[0].id).toBe('node-fetch/node-fetch');
+    expect(searchEntries('auth 0')[0].id).toBe('auth0/identity');
+    expect(searchEntries('nextjs')[0].id).toBe('next/next');
+    expect(searchEntries('open ai')[0].id).toBe('openai/chat');
+    expect(searchEntries('react playwrite').slice(0, 5).map((entry) => entry.id)).toContain('playwright/playwright');
+    expect(getEntry('  openai/chat  ').entry?.id).toBe('openai/chat');
+  });
+});


### PR DESCRIPTION
## Summary
- improve search recall for typoed and joined/split identifier queries
- normalize exact-id lookup and add stronger search regression coverage
- backfill missing remote search indexes and retry transient fetch failures

## Testing
- ../node_modules/.bin/vitest run tests/lib/bm25.test.js tests/lib/cache.test.js tests/lib/registry.multisource.test.js tests/lib/registry.search-behavior.test.js tests/commands/search.test.js
- CHUB_TELEMETRY=0 CHUB_FEEDBACK=0 node ./cli/bin/chub build ./content -o /tmp/chub-search-followups-dist

## Notes
- Full `vitest run` still has the preexisting unrelated failures in `tests/mcp/tools.test.js` on this branch, same as current main.