### PR TITLE
Add Bitwarden Public API and Vault Management API docs

### DIFF
--- a/content/bitwarden/docs/public-api/DOC.md
+++ b/content/bitwarden/docs/public-api/DOC.md
@@ -1,0 +1,133 @@
+---
+name: public-api
+description: "Bitwarden Public API for managing organization members, collections, groups, event logs, and policies"
+metadata:
+  languages: "rest"
+  versions: "1.0.0"
+  revision: 1
+  updated-on: "2026-03-20"
+  source: community
+  tags: "bitwarden,api,rest,password-manager,organization,security"
+---
+
+# Bitwarden Public API
+
+RESTful API for managing Bitwarden organizations: members, collections, groups, event logs, and policies. Requires a Teams or Enterprise plan.
+
+> This API does not manage individual vault items. Use the Vault Management API for that.
+
+## Authentication
+
+Uses OAuth2 Client Credentials flow. Get your organization API key from **Admin Console → Settings → Organization info → API key**.
+
+The `client_id` format is `"organization.ClientId"` (not the same as a personal API key which uses `"user.clientId"`).
+
+> **Warning:** Your organization API key enables full access to your organization. If compromised, rotate it immediately via **Settings → Organization info → Rotate API key**. All existing implementations will need the new key. To share the key with other admins, use [Bitwarden Send](https://bitwarden.com/help/about-send/).
+
+### Get a bearer token
+
+```bash
+curl -X POST \
+  https://identity.bitwarden.com/connect/token \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d 'grant_type=client_credentials&scope=api.organization&client_id=<ID>&client_secret=<SECRET>'
+```
+
+Response:
+
+```json
+{
+  "access_token": "<TOKEN>",
+  "expires_in": 3600,
+  "token_type": "Bearer"
+}
+```
+
+Token expires in 3600 seconds (60 minutes). Expired tokens return `401 Unauthorized`.
+
+## Base URLs
+
+| Environment | API Base | Auth Endpoint |
+|---|---|---|
+| US Cloud | `https://api.bitwarden.com` | `https://identity.bitwarden.com/connect/token` |
+| EU Cloud | `https://api.bitwarden.eu` | `https://identity.bitwarden.eu/connect/token` |
+| Self-hosted | `https://your.domain.com/api` | `https://your.domain.com/identity/connect/token` |
+
+## Making requests
+
+All requests use `Authorization: Bearer <TOKEN>` header and return `application/json`. The only exception is the auth endpoint, which expects `application/x-www-form-urlencoded` requests (but still returns JSON).
+
+```bash
+curl -X GET \
+  https://api.bitwarden.com/public/collections \
+  -H 'Authorization: Bearer <TOKEN>'
+```
+
+## Key endpoints
+
+| Method | Endpoint | Description |
+|---|---|---|
+| GET | `/public/members` | List organization members |
+| GET | `/public/members/{id}` | Get a member |
+| POST | `/public/members` | Invite a member |
+| PUT | `/public/members/{id}` | Update a member |
+| DELETE | `/public/members/{id}` | Remove a member |
+| GET | `/public/collections` | List collections |
+| GET | `/public/collections/{id}` | Get a collection |
+| POST | `/public/collections` | Create a collection |
+| PUT | `/public/collections/{id}` | Update a collection |
+| DELETE | `/public/collections/{id}` | Delete a collection |
+| GET | `/public/groups` | List groups |
+| POST | `/public/groups` | Create a group |
+| PUT | `/public/groups/{id}` | Update a group |
+| DELETE | `/public/groups/{id}` | Delete a group |
+| GET | `/public/events` | List event logs |
+| GET | `/public/policies` | List policies |
+| PUT | `/public/policies/{type}` | Update a policy |
+
+## Pagination
+
+Queries returning over 50 results include a `continuationToken` in the response:
+
+```json
+{
+  "object": "list",
+  "data": [...],
+  "continuationToken": "token_value"
+}
+```
+
+Append it as a query parameter to get the next page:
+
+```
+https://api.bitwarden.com/public/events?continuationToken=<token_value>
+```
+
+Paginated endpoints: `/public/collections`, `/public/events`, `/public/groups`, `/public/members`, `/public/policies`.
+
+## Response codes
+
+| Code | Meaning |
+|---|---|
+| `200` | Success |
+| `400` | Bad request (missing/malformed parameters) |
+| `401` | Unauthorized (missing/invalid/expired token) |
+| `404` | Resource not found |
+| `429` | Rate limited |
+| `500/502/503/504` | Server error |
+
+## OpenAPI spec
+
+The API is compatible with OpenAPI Specification (OAS3) and publishes a compliant `swagger.json`. Explore via Swagger UI:
+- Cloud: `https://bitwarden.com/help/api/`
+- Self-hosted: `https://your.domain.com/api/docs/`
+
+## Status
+
+Service health: [https://status.bitwarden.com](https://status.bitwarden.com)
+
+## Further reading
+
+- [Bitwarden Public API docs](https://bitwarden.com/help/public-api/)
+- [API Specification (Swagger UI)](https://bitwarden.com/help/api/)
+- [Event logs](https://bitwarden.com/help/event-logs/)

--- a/content/bitwarden/docs/vault-management-api/DOC.md
+++ b/content/bitwarden/docs/vault-management-api/DOC.md
@@ -1,0 +1,171 @@
+---
+name: vault-management-api
+description: "Bitwarden Vault Management API for managing vault items via RESTful HTTP calls through the CLI serve command"
+metadata:
+  languages: "rest"
+  versions: "1.0.0"
+  revision: 1
+  updated-on: "2026-03-20"
+  source: community
+  tags: "bitwarden,api,rest,vault,password-manager,cli,security"
+---
+
+# Bitwarden Vault Management API
+
+RESTful API for managing Bitwarden vault items (logins, notes, cards, identities, folders, Send, attachments), including items owned by organizations if you have the appropriate permissions. Works by running `bw serve` from the Bitwarden CLI, which starts a local Express web server.
+
+> This is not a cloud API. It controls a locally-running, authenticated Bitwarden CLI instance. The CLI must be logged in and the vault unlocked before making API calls.
+
+## Setup
+
+### 1. Install the CLI
+
+```bash
+npm install -g @bitwarden/cli
+```
+
+### 2. Log in
+
+```bash
+bw login <email>
+# or with API key:
+bw login --apikey
+```
+
+### 3. Unlock the vault
+
+```bash
+bw unlock
+# Returns a session key — export it:
+export BW_SESSION="<session_key>"
+```
+
+### 4. Start the API server
+
+```bash
+bw serve
+# Default: http://localhost:8087
+
+bw serve --port 8080
+# Custom port
+
+bw serve --hostname 0.0.0.0
+# Listen on all interfaces (use with caution)
+```
+
+## Making requests
+
+All requests go to `http://localhost:8087` (or your configured port). JSON request/response format.
+
+```bash
+# List all items
+curl http://localhost:8087/list/object/items
+
+# Get a specific item by ID
+curl http://localhost:8087/object/item/<item_id>
+
+# Sync the vault
+curl -X POST http://localhost:8087/sync
+```
+
+## Key endpoints
+
+### Vault status
+
+| Method | Endpoint | Description |
+|---|---|---|
+| GET | `/status` | Vault status (locked/unlocked/unauthenticated) |
+| POST | `/sync` | Sync vault with server |
+| POST | `/lock` | Lock the vault |
+| POST | `/unlock` | Unlock the vault (body: `{"password": "<master_password>"}`) |
+
+### Items (logins, notes, cards, identities)
+
+| Method | Endpoint | Description |
+|---|---|---|
+| GET | `/list/object/items` | List all items |
+| GET | `/list/object/items?search=<query>` | Search items |
+| GET | `/list/object/items?folderid=<id>` | Items in a folder |
+| GET | `/list/object/items?collectionid=<id>` | Items in a collection |
+| GET | `/object/item/<id>` | Get item by ID |
+| POST | `/object/item` | Create an item |
+| PUT | `/object/item/<id>` | Update an item |
+| DELETE | `/object/item/<id>` | Delete an item (soft delete) |
+| POST | `/restore/item/<id>` | Restore a deleted item |
+
+### Folders
+
+| Method | Endpoint | Description |
+|---|---|---|
+| GET | `/list/object/folders` | List all folders |
+| GET | `/object/folder/<id>` | Get folder by ID |
+| POST | `/object/folder` | Create a folder |
+| PUT | `/object/folder/<id>` | Update a folder |
+| DELETE | `/object/folder/<id>` | Delete a folder |
+
+### Send
+
+| Method | Endpoint | Description |
+|---|---|---|
+| GET | `/list/object/send` | List all Sends |
+| GET | `/object/send/<id>` | Get Send by ID |
+| POST | `/object/send` | Create a Send |
+| DELETE | `/object/send/<id>` | Delete a Send |
+
+### Attachments
+
+| Method | Endpoint | Description |
+|---|---|---|
+| GET | `/object/attachment?id=<attachment_id>&itemid=<item_id>` | Get attachment |
+| POST | `/attachment?itemid=<item_id>` | Create attachment (multipart form) |
+| DELETE | `/object/attachment/<attachment_id>?itemid=<item_id>` | Delete attachment |
+
+### Generate
+
+| Method | Endpoint | Description |
+|---|---|---|
+| GET | `/generate` | Generate a password |
+| GET | `/generate?length=20&uppercase&lowercase&number&special` | Custom password options |
+| GET | `/generate?passphrase&words=4&separator=-` | Generate a passphrase |
+
+### Collections & Organizations
+
+| Method | Endpoint | Description |
+|---|---|---|
+| GET | `/list/object/collections` | List collections |
+| GET | `/list/object/org-collections?organizationid=<id>` | Org collections |
+| GET | `/list/object/org-members?organizationid=<id>` | Org members |
+| GET | `/list/object/organizations` | List organizations |
+
+## Creating an item
+
+```bash
+# Encode the item JSON as base64 (required by the API)
+ITEM=$(echo '{"type":1,"name":"My Login","login":{"username":"<username>","password":"<password>","uris":[{"uri":"https://example.com"}]}}' | base64)
+
+curl -X POST http://localhost:8087/object/item \
+  -H 'Content-Type: application/json' \
+  -d "$ITEM"
+```
+
+Item types: `1` = Login, `2` = Secure Note, `3` = Card, `4` = Identity.
+
+## Confirm the vault is unlocked
+
+```bash
+curl -s http://localhost:8087/status | jq '.data.status'
+# Should return "unlocked"
+```
+
+## Security considerations
+
+- `bw serve` runs an unauthenticated HTTP server — anyone with network access to the port can read your vault
+- Default binding is `localhost` only — keep it that way unless you understand the risks
+- The vault must already be unlocked, meaning the master password has been provided at least once
+- Consider using `--hostname 127.0.0.1` explicitly and firewall rules in production scripts
+
+## Further reading
+
+- [Vault Management API docs](https://bitwarden.com/help/vault-management-api/)
+- [Bitwarden CLI serve command](https://bitwarden.com/help/cli/#serve)
+- [Password Manager APIs overview](https://bitwarden.com/help/bitwarden-apis/)


### PR DESCRIPTION
## Summary

Adds two new documentation entries for Bitwarden:

### `bitwarden/docs/public-api/DOC.md`
Bitwarden Public API — RESTful API for managing organization members, collections, groups, event logs, and policies. Covers:
- OAuth2 Client Credentials authentication flow
- Base URLs (US Cloud, EU Cloud, self-hosted)
- All key endpoints (members, collections, groups, events, policies)
- Pagination with continuation tokens
- Response codes, OpenAPI/OAS3 spec links, API key rotation

### `bitwarden/docs/vault-management-api/DOC.md`
Bitwarden Vault Management API — local RESTful API for managing vault items via the CLI `bw serve` command. Covers:
- Full setup flow (install CLI → login → unlock → serve)
- All endpoints: items, folders, Send, attachments, generate, collections, status/sync/lock/unlock
- Creating items with examples
- Security considerations (unauthenticated local HTTP server)

## Validation

```
$ node cli/bin/chub build content/ --validate-only
Valid: 1555 docs, 6 skills, 0 warnings
```

## Sources

- https://bitwarden.com/help/public-api/
- https://bitwarden.com/help/bitwarden-apis/
- https://bitwarden.com/help/vault-management-api/
- https://bitwarden.com/help/cli/#serve