### PR TITLE
fix: auto-select language when doc has only one variant

### DIFF
--- a/cli/src/lib/registry.js
+++ b/cli/src/lib/registry.js
@@ -492,6 +492,8 @@ export function resolveDocPath(entry, language, version) {
   let langObj = null;
   if (lang) {
     langObj = entry.languages.find((l) => l.language === lang);
+  } else if (entry.languages.length === 1) {
+    langObj = entry.languages[0];
   } else {
     return {
       needsLanguage: true,

--- a/cli/test/e2e.test.js
+++ b/cli/test/e2e.test.js
@@ -143,9 +143,9 @@ describe('chub CLI e2e', () => {
       expect(out).toContain('npm install @acme/widgets');
     });
 
-    itCli('errors on single-lang doc without --lang', () => {
-      const out = chub(['get', 'acme/widgets'], { expectError: true });
-      expect(out).toContain('--lang');
+    itCli('auto-selects language for single-lang doc without --lang', () => {
+      const out = chub(['get', 'acme/widgets']);
+      expect(out).toContain('npm install @acme/widgets');
     });
 
     itCli('fetches multi-language doc with --lang', () => {

--- a/cli/tests/lib/registry.test.js
+++ b/cli/tests/lib/registry.test.js
@@ -102,6 +102,19 @@ describe('resolveDocPath', () => {
     expect(result.available).toEqual(['python', 'javascript']);
   });
 
+  it('auto-selects language when only one variant exists', () => {
+    const entry = {
+      name: 'single-lang',
+      languages: [
+        { language: 'python', versions: [{ version: '1.0', path: 'p/python', files: ['DOC.md'] }], recommendedVersion: '1.0' },
+      ],
+      _sourceObj: { name: 'default', url: 'http://example.com' },
+    };
+    const result = resolveDocPath(entry, null, null);
+    expect(result.needsLanguage).toBeUndefined();
+    expect(result.path).toBe('p/python');
+  });
+
   it('selects the correct language', () => {
     const entry = {
       name: 'multi-lang',


### PR DESCRIPTION
## What

When a doc entry has only one language variant, `resolveDocPath()` now auto-selects it instead of requiring `--lang`. Multi-language docs still prompt for language selection as before.

## Why

The MCP tool description for `chub_get` already documents this behavior (`server.js` line 57: "Auto-selected if only one"), but it was never implemented. Most docs in the registry have only one language variant, making the common case unnecessarily verbose.

Before:
```bash
chub get stripe/api --lang python   # required even though python is the only option
```

After:
```bash
chub get stripe/api                 # auto-selects python (the only variant)
chub get stripe/api --lang python   # still works explicitly
```

Fixes #49

## Testing

- [x] `npm test` - all 232 tests pass
- [x] `chub build content/ --validate-only` - 1553 docs, 7 skills validated
- [x] New unit test covers single-language auto-selection
- [x] Updated e2e test to verify auto-selection works end-to-end
- [x] Existing multi-language tests continue to pass (no behavior change for multi-lang docs)

## Notes

- 3 files changed, 18 insertions, 3 deletions
- The fix is a 2-line `else if` branch in `resolveDocPath()` in `cli/src/lib/registry.js`
- Backward compatible - explicit `--lang` still works for all entries