### PR TITLE
feat(build): add content freshness detection warnings

### DIFF
--- a/cli/src/commands/build.js
+++ b/cli/src/commands/build.js
@@ -89,7 +89,10 @@ function discoverAuthor(authorDir, authorName, contentDir) {
     const description = attributes.description || '';
     const source = meta.source || 'community';
     const tags = meta.tags ? meta.tags.split(',').map((t) => t.trim()) : [];
-    const updatedOn = meta['updated-on'] || new Date().toISOString().split('T')[0];
+    const updatedOn = meta['updated-on'] || null;
+    if (!updatedOn) {
+      warnings.push(`${ef.relPath}: missing 'metadata.updated-on', add updated-on: "${new Date().toISOString().split('T')[0]}" to metadata`);
+    }
     const entryDir = dirname(ef.path);
     const entryPath = toPosix(relative(contentDir, entryDir));
     const files = listDirFiles(entryDir);
@@ -272,6 +275,30 @@ export function registerBuildCommand(program) {
         skillIds.set(skill.id, true);
       }
 
+      // Content freshness check
+      const STALE_THRESHOLD_DAYS = 180;
+      const now = new Date();
+      const staleIds = new Set();
+      const checkFreshness = (id, lastUpdated) => {
+        if (!lastUpdated) return;
+        const updated = new Date(lastUpdated);
+        if (isNaN(updated.getTime())) return;
+        const ageDays = Math.floor((now - updated) / (1000 * 60 * 60 * 24));
+        if (ageDays > STALE_THRESHOLD_DAYS) {
+          staleIds.add(id);
+        }
+      };
+      for (const doc of allDocs) {
+        for (const lang of doc.languages || []) {
+          for (const ver of lang.versions || []) {
+            checkFreshness(doc.id, ver.lastUpdated);
+          }
+        }
+      }
+      for (const skill of allSkills) {
+        checkFreshness(skill.id, skill.lastUpdated);
+      }
+      const staleCount = staleIds.size;
       // Print warnings
       for (const w of allWarnings) {
         process.stderr.write(chalk.yellow(`Warning: ${w}\n`));
@@ -297,11 +324,14 @@ export function registerBuildCommand(program) {
       }
 
       if (opts.validateOnly) {
-        const summary = { docs: allDocs.length, skills: allSkills.length, warnings: allWarnings.length };
+        const summary = { docs: allDocs.length, skills: allSkills.length, warnings: allWarnings.length, stale: staleCount };
         if (globalOpts.json) {
           console.log(JSON.stringify(summary));
         } else {
           console.log(chalk.green(`Valid: ${summary.docs} docs, ${summary.skills} skills, ${summary.warnings} warnings`));
+          if (staleCount > 0) {
+            console.log(chalk.yellow(`Freshness: ${staleCount} entries not updated in ${STALE_THRESHOLD_DAYS}+ days`));
+          }
         }
         return;
       }
@@ -329,12 +359,15 @@ export function registerBuildCommand(program) {
         });
       }
 
-      const summary = { docs: allDocs.length, skills: allSkills.length, warnings: allWarnings.length };
+      const summary = { docs: allDocs.length, skills: allSkills.length, warnings: allWarnings.length, stale: staleCount };
       trackEvent('build', { doc_count: allDocs.length, skill_count: allSkills.length }).catch(() => {});
       if (globalOpts.json) {
         console.log(JSON.stringify({ ...summary, output: outputDir }));
       } else {
         console.log(chalk.green(`Built: ${summary.docs} docs, ${summary.skills} skills → ${outputDir}`));
+        if (staleCount > 0) {
+          console.log(chalk.yellow(`Freshness: ${staleCount} entries not updated in ${STALE_THRESHOLD_DAYS}+ days`));
+        }
       }
     });
 }


### PR DESCRIPTION
Stop silently defaulting missing `updated-on` to today's date. Instead,
emit an actionable warning and set `lastUpdated` to `null` in the registry.

Add a staleness summary that counts entries not updated in 180+ days,
shown as an info line in human output and a `stale` field in JSON output.
Both validate-only and full build paths report consistently.

Closes #186

## What

Two non-breaking additions to `chub build`:
1. Missing `metadata.updated-on` now emits a warning with a suggested fix instead of silently defaulting to today's date
2. A freshness summary counts entries older than 180 days and reports it in both human and JSON output

## Why

Context Hub's value depends on content being current. Currently, missing `updated-on` is silently backfilled with today's date, masking the problem. There's also no visibility into how many entries in the registry are going stale. This change surfaces both issues as non-blocking warnings so contributors and maintainers can act on them.

Related: #106, #107

## Testing

- [x] `npm test` passes (231/231)
- [x] `chub build content/ --validate-only` succeeds
- [x] Manual testing done:
  - Verified missing `updated-on` emits actionable warning with suggested date
  - Verified `--json` output includes `stale` field
  - Verified freshness line only appears when stale entries exist (real content shows 0, test fixtures with old dates trigger correctly)
  - Verified no existing test assertions broken

## Notes

- Only one file changed: `cli/src/commands/build.js`
- No new dependencies
- `lastUpdated` is set to `null` (not `"unknown"`) when missing — cleaner for JSON consumers
- Staleness uses a `Set` to deduplicate by doc ID so multi-language/version docs aren't double-counted
- This is purely additive — no builds break, no new errors, just warnings and info
