### PR TITLE
Add Cortex Agents REST API and managed MCP server documentation

### DIFF
--- a/content/snowflake/docs/cortex-agents-mcp/DOC.md
+++ b/content/snowflake/docs/cortex-agents-mcp/DOC.md
@@ -1,0 +1,215 @@
+---
+name: cortex-agents-mcp
+description: "Snowflake-managed MCP Server — expose Cortex Analyst, Cortex Search, Cortex Agents, SQL execution, and custom UDF/SP tools via the Model Context Protocol standard"
+metadata:
+  languages: "sql,python"
+  versions: "2026-03"
+  revision: 1
+  updated-on: "2026-03-24"
+  source: community
+  tags: "snowflake,mcp,model-context-protocol,agents,cortex,tools,oauth,agentic-ai"
+---
+
+# Snowflake-Managed MCP Server
+
+Snowflake hosts a managed MCP (Model Context Protocol) server that lets external AI agents discover and invoke Snowflake tools — Cortex Analyst, Cortex Search, Cortex Agents, SQL execution, and custom UDFs/SPs — over a standardized interface. No separate infrastructure to deploy.
+
+Supports MCP revision 2025-06-18.
+
+## What You Get
+
+- **Standardized integration**: One interface for tool discovery and invocation across any MCP client
+- **Built-in OAuth**: Snowflake's OAuth service handles auth for MCP connections
+- **RBAC governance**: Separate permissions for the MCP server object and each individual tool
+
+## Create an MCP Server
+
+```sql
+CREATE OR REPLACE MCP SERVER my_mcp_server
+FROM SPECIFICATION $$
+tools:
+  - name: "product-search"
+    type: "CORTEX_SEARCH_SERVICE_QUERY"
+    identifier: "mydb.myschema.product_search_service"
+    description: "Search product catalog"
+    title: "Product Search"
+
+  - name: "revenue-analyst"
+    type: "CORTEX_ANALYST_MESSAGE"
+    identifier: "mydb.myschema.revenue_semantic_view"
+    description: "Revenue analytics via natural language"
+    title: "Revenue Analyst"
+$$;
+```
+
+## Tool Types
+
+### Cortex Analyst
+
+Generates SQL from natural language. Only supports semantic views (not semantic model YAML files).
+
+```yaml
+tools:
+  - name: "revenue-analyst"
+    type: "CORTEX_ANALYST_MESSAGE"
+    identifier: "db.schema.semantic_view_name"
+    description: "Revenue data queries"
+    title: "Revenue Analyst"
+```
+
+### Cortex Search
+
+Hybrid (vector + keyword) search over unstructured data.
+
+```yaml
+tools:
+  - name: "product-search"
+    type: "CORTEX_SEARCH_SERVICE_QUERY"
+    identifier: "db.schema.search_service_name"
+    description: "Search product catalog"
+    title: "Product Search"
+```
+
+### SQL Execution
+
+Run arbitrary SQL queries against Snowflake.
+
+```yaml
+tools:
+  - name: "sql_exec_tool"
+    type: "SYSTEM_EXECUTE_SQL"
+    description: "Execute SQL queries against the connected Snowflake database"
+    title: "SQL Execution Tool"
+```
+
+### Cortex Agent
+
+Pass messages to an existing Cortex Agent object.
+
+```yaml
+tools:
+  - name: "agent_1"
+    type: "CORTEX_AGENT_RUN"
+    identifier: "db.schema.my_agent"
+    description: "Agent that answers data questions"
+    title: "My Agent"
+```
+
+### Custom Tools (UDFs and Stored Procedures)
+
+Invoke UDFs or stored procedures as MCP tools. Specify `type: "function"` for UDFs, `type: "procedure"` for SPs.
+
+```yaml
+tools:
+  - name: "multiply_ten"
+    type: "GENERIC"
+    identifier: "mydb.myschema.MULTIPLY_BY_TEN"
+    description: "Multiplies input by ten"
+    title: "Multiply by Ten"
+    config:
+      type: "function"
+      warehouse: "MY_WH"
+      input_schema:
+        type: "object"
+        properties:
+          x:
+            type: "number"
+            description: "Value to multiply"
+        required:
+          - "x"
+```
+
+For stored procedures, use `type: "procedure"` in the config block.
+
+## Authentication
+
+### OAuth (Recommended)
+
+Set up a Snowflake security integration for OAuth:
+
+```sql
+CREATE OR REPLACE SECURITY INTEGRATION my_mcp_oauth
+  TYPE = API_AUTHENTICATION
+  AUTH_TYPE = OAUTH2
+  ENABLED = TRUE
+  OAUTH_CLIENT_ID = 'your-client-id'
+  OAUTH_CLIENT_SECRET = 'your-secret'
+  OAUTH_TOKEN_ENDPOINT = 'https://your-idp.com/oauth/token'
+  OAUTH_ALLOWED_SCOPES = ('session:role:MY_ROLE');
+```
+
+### Programmatic Access Token (PAT)
+
+Use least-privilege role to minimize risk if leaked.
+
+## Permissions
+
+Access to the MCP server does **not** grant access to tools. Grant separately:
+
+```sql
+-- Grant usage on the MCP server
+GRANT USAGE ON MCP SERVER my_mcp_server TO ROLE analyst_role;
+
+-- Grant usage on underlying objects (search service, semantic view, etc.)
+GRANT USAGE ON CORTEX SEARCH SERVICE mydb.myschema.product_search_service TO ROLE analyst_role;
+```
+
+## Connecting MCP Clients
+
+### Cortex Code CLI
+
+```bash
+cortex mcp add snowflake-mcp https://<account>.snowflakecomputing.com/api/v2/databases/<db>/schemas/<schema>/mcp-servers/<server>/sse --transport http
+```
+
+### Generic MCP Client Config
+
+```json
+{
+  "mcpServers": {
+    "snowflake": {
+      "url": "https://<account>.snowflakecomputing.com/api/v2/databases/<db>/schemas/<schema>/mcp-servers/<server>/sse",
+      "transport": "sse",
+      "headers": {
+        "Authorization": "Bearer <token>"
+      }
+    }
+  }
+}
+```
+
+## Manage MCP Servers
+
+```sql
+-- List
+SHOW MCP SERVERS;
+
+-- Describe
+DESCRIBE MCP SERVER my_mcp_server;
+
+-- Update (full replace)
+CREATE OR REPLACE MCP SERVER my_mcp_server
+FROM SPECIFICATION $$
+tools:
+  - name: "updated-tool"
+    type: "SYSTEM_EXECUTE_SQL"
+    description: "Updated SQL tool"
+    title: "SQL Tool"
+$$;
+
+-- Drop
+DROP MCP SERVER my_mcp_server;
+```
+
+## Security Recommendations
+
+- Use hyphens (`-`) not underscores (`_`) in hostnames — underscores cause connection issues
+- Verify all third-party MCP servers and their tools before connecting
+- Prefer OAuth over hardcoded tokens
+- For PATs, use the least-privileged role
+- Grant tool-level permissions individually (MCP server access alone is not enough)
+- Audit MCP server tools from untrusted sources to avoid tool poisoning or shadowing
+
+## Lifecycle
+
+MCP servers follow standard Snowflake object lifecycle: create, alter, describe, show, drop. They live in a database and schema, and are governed by RBAC like any other Snowflake object.

--- a/content/snowflake/docs/cortex-agents-rest-api/DOC.md
+++ b/content/snowflake/docs/cortex-agents-rest-api/DOC.md
@@ -1,0 +1,269 @@
+---
+name: cortex-agents-rest-api
+description: "Snowflake Cortex Agents REST API — create, manage, and run agentic AI workflows with built-in tools (Cortex Analyst, Cortex Search, web search, SQL exec) and custom UDF/SP tools"
+metadata:
+  languages: "sql,python,curl"
+  versions: "2026-03"
+  revision: 1
+  updated-on: "2026-03-24"
+  source: community
+  tags: "snowflake,cortex,agents,rest-api,agentic-ai,tools,orchestration,llm"
+---
+
+# Cortex Agents REST API
+
+Cortex Agents are Snowflake-native agentic AI objects. You define tools, instructions, and an orchestration model — the agent reasons over user queries and invokes the right tools autonomously. Manage them via the REST API at `/api/v2/databases/{db}/schemas/{schema}/agents`.
+
+Requests time out after 15 minutes.
+
+## Authentication
+
+All requests require a `Authorization` header with a Snowflake bearer token (OAuth, key-pair JWT, or PAT). Set `Content-Type: application/json`.
+
+## Create an Agent
+
+```
+POST /api/v2/databases/{database}/schemas/{schema}/agents?createMode=errorIfExists
+```
+
+`createMode` options: `errorIfExists` (default), `orReplace`, `ifNotExists`.
+
+### Request Body
+
+```json
+{
+  "name": "MY_AGENT",
+  "comment": "An agent to answer questions about all my data",
+  "profile": {
+    "display_name": "My Agent"
+  },
+  "models": {
+    "orchestration": "claude-4-sonnet"
+  },
+  "instructions": {
+    "response": "You will respond in a friendly but concise manner",
+    "orchestration": "For revenue questions use Analyst; for policy use Search",
+    "system": "You are a friendly data assistant.",
+    "sample_questions": [
+      {"question": "What was Q1 revenue?"},
+      {"question": "Show me our return policy"}
+    ]
+  },
+  "orchestration": {
+    "budget": {
+      "seconds": 30,
+      "tokens": 16000
+    }
+  },
+  "tools": [
+    {
+      "tool_spec": {
+        "type": "cortex_analyst_text_to_sql",
+        "name": "Analyst1",
+        "description": "Revenue data via semantic view"
+      }
+    },
+    {
+      "tool_spec": {
+        "type": "cortex_search",
+        "name": "Search1"
+      }
+    }
+  ],
+  "tool_resources": {
+    "Analyst1": {
+      "semantic_view": "DB.SCHEMA.REVENUE_SV"
+    },
+    "Search1": {
+      "name": "DB.SCHEMA.POLICY_SEARCH",
+      "max_results": "5"
+    }
+  }
+}
+```
+
+### Key Fields
+
+| Field | Description |
+|-------|-------------|
+| `models.orchestration` | LLM for reasoning (e.g. `claude-4-sonnet`, `llama3.1-70b`) |
+| `instructions.response` | Controls tone of final answers |
+| `instructions.orchestration` | Routing hints — which tool for which query type |
+| `instructions.system` | System prompt for the agent |
+| `orchestration.budget` | Limits on seconds and tokens per request |
+| `tools[].tool_spec.type` | One of: `cortex_analyst_text_to_sql`, `cortex_analyst_sql_exec`, `cortex_search`, `web_search`, `generic` |
+| `tool_resources` | Config per tool — keys must match tool names |
+
+## Built-in Tool Types
+
+### Cortex Analyst (text-to-SQL)
+
+```json
+{
+  "tool_spec": {"type": "cortex_analyst_text_to_sql", "name": "analyst", "description": "Revenue queries"},
+  "tool_resources": {"analyst": {"semantic_view": "DB.SCHEMA.MY_VIEW"}}
+}
+```
+
+Resource can also use `"semantic_model_file": "@STAGE/model.yaml"` instead of `semantic_view`.
+
+### Cortex Analyst (SQL execution)
+
+```json
+{
+  "tool_spec": {"type": "cortex_analyst_sql_exec", "name": "sql_exec"},
+  "tool_resources": {"sql_exec": {"name": "MY_WAREHOUSE", "timeout": "30", "auto_execute": "true"}}
+}
+```
+
+### Cortex Search
+
+```json
+{
+  "tool_spec": {"type": "cortex_search", "name": "search"},
+  "tool_resources": {
+    "search": {
+      "name": "DB.SCHEMA.SEARCH_SERVICE",
+      "max_results": "5",
+      "filter": {"@eq": {"region": "North America"}},
+      "title_column": "TITLE",
+      "id_column": "DOC_ID"
+    }
+  }
+}
+```
+
+### Web Search
+
+```json
+{
+  "tool_spec": {"type": "web_search", "name": "web"},
+  "tool_resources": {"web": {"name": "web_search_1", "function": "DB.SCHEMA.SEARCH_WEB"}}
+}
+```
+
+### Generic (UDF / Stored Procedure)
+
+```json
+{
+  "tool_spec": {
+    "type": "generic",
+    "name": "get_weather",
+    "description": "Get weather for a city",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "location": {"type": "string", "description": "City and state"}
+      }
+    },
+    "required": ["location"]
+  },
+  "tool_resources": {
+    "get_weather": {
+      "type": "function",
+      "execution_environment": {"type": "warehouse", "warehouse": "MY_WH"},
+      "identifier": "DB.SCHEMA.GET_WEATHER_UDF"
+    }
+  }
+}
+```
+
+## Run an Agent (Chat)
+
+```
+POST /api/v2/databases/{database}/schemas/{schema}/agents/{name}:run
+```
+
+### Request Body
+
+```json
+{
+  "model": "claude-4-sonnet",
+  "messages": [
+    {"role": "user", "content": [{"type": "text", "text": "What was Q1 revenue by region?"}]}
+  ],
+  "tools": [],
+  "tool_resources": {},
+  "stream": true
+}
+```
+
+Set `stream: true` for server-sent events (SSE). The response streams `event: message.delta` with incremental content, tool invocations, and citations. Final event is `event: message.stop`.
+
+### Streamed Response Events
+
+```
+event: message.delta
+data: {"delta": {"content": [{"type": "text", "text": "Based on the data..."}]}}
+
+event: message.delta
+data: {"delta": {"content": [{"type": "tool_use", "name": "analyst", ...}]}}
+
+event: message.delta
+data: {"delta": {"content": [{"type": "tool_results", ...}]}}
+
+event: message.stop
+data: {}
+```
+
+## Other Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `.../agents` | List agents in schema |
+| `GET` | `.../agents/{name}` | Describe an agent |
+| `PUT` | `.../agents/{name}` | Update agent (full replace of spec) |
+| `DELETE` | `.../agents/{name}` | Drop an agent |
+
+## Python Example (snowflake-connector)
+
+```python
+import json, requests
+from snowflake.connector import connect
+
+conn = connect(
+    account=os.environ["SNOWFLAKE_ACCOUNT"],
+    user=os.environ["SNOWFLAKE_USER"],
+    authenticator="externalbrowser",
+)
+token = conn.rest.token
+
+url = f"https://{os.environ['SNOWFLAKE_ACCOUNT']}.snowflakecomputing.com"
+resp = requests.post(
+    f"{url}/api/v2/databases/MYDB/schemas/PUBLIC/agents/MY_AGENT:run",
+    headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+    json={
+        "messages": [{"role": "user", "content": [{"type": "text", "text": "Q1 revenue?"}]}],
+        "stream": True,
+    },
+    stream=True,
+)
+
+for line in resp.iter_lines():
+    if line:
+        print(line.decode())
+```
+
+## SQL Management
+
+You can also manage agents via SQL:
+
+```sql
+-- Create
+CREATE OR REPLACE CORTEX AGENT my_agent ...;
+
+-- Describe
+DESCRIBE CORTEX AGENT my_agent;
+
+-- List
+SHOW CORTEX AGENTS;
+
+-- Drop
+DROP CORTEX AGENT my_agent;
+```
+
+## Limits
+
+- Request timeout: 15 minutes
+- Budget constraints via `orchestration.budget` (seconds and tokens)
+- `tool_resources` keys must exactly match tool `name` values

--- a/content/snowflake/docs/cortex-analyst/DOC.md
+++ b/content/snowflake/docs/cortex-analyst/DOC.md
@@ -1,16 +1,18 @@
 ---
 name: cortex-analyst
-description: "Snowflake Cortex Analyst — natural language to SQL engine powered by semantic views for self-serve analytics, REST API integration, and multi-turn conversations"
+description: "Snowflake Cortex Analyst (being superseded by Cortex Agents) — natural language to SQL engine powered by semantic views for self-serve analytics, REST API integration, and multi-turn conversations"
 metadata:
   languages: "sql,python"
   versions: "2026-03"
-  revision: 1
-  updated-on: "2026-03-17"
+  revision: 2
+  updated-on: "2026-03-24"
   source: community
-  tags: "snowflake,cortex,analyst,natural-language,sql,semantic-model,analytics,rest-api"
+  tags: "snowflake,cortex,analyst,natural-language,sql,semantic-model,analytics,rest-api,deprecated"
 ---
 
 # Cortex Analyst
+
+> **Deprecation Notice**: Cortex Analyst is being superseded by **Cortex Agents**, which provide the same text-to-SQL capabilities plus multi-tool orchestration, Cortex Search integration, web search, custom UDF/SP tools, and agentic reasoning. New projects should use Cortex Agents. See [cortex-agents-rest-api](../cortex-agents-rest-api/DOC.md) for the REST API reference and [cortex-agents-mcp](../cortex-agents-mcp/DOC.md) for the managed MCP server.
 
 Cortex Analyst is a fully managed Snowflake Cortex feature that converts natural language questions into accurate SQL queries against your structured data. Business users ask questions in plain English and get direct answers — no SQL required.
 


### PR DESCRIPTION
## Summary

Adds two new Snowflake documentation entries under `content/snowflake/docs/`:

- **cortex-agents-rest-api** — REST API for creating, managing, and running Cortex Agent objects with built-in tools (Cortex Analyst, Cortex Search, web search, SQL execution) and custom UDF/stored procedure tools
- **cortex-agents-mcp** — Snowflake-managed MCP (Model Context Protocol) server for exposing Cortex Analyst, Cortex Search, Cortex Agents, SQL execution, and custom tools over the MCP standard with OAuth auth and RBAC governance

### Directory structure

```
content/snowflake/docs/
├── cortex-agents-rest-api/DOC.md   (269 lines)
└── cortex-agents-mcp/DOC.md        (215 lines)
```

### Validation

```
$ chub build content/ --validate-only
Valid: 1555 docs, 7 skills, 2 warnings
```

(2 pre-existing warnings from landingai skills — 0 new warnings from this PR)

## Test plan

- [ ] Verify `node cli/bin/chub build content/ --validate-only` passes with 0 new warnings
- [ ] Confirm YAML frontmatter matches expected schema (name, description, metadata fields)
- [ ] Check each DOC.md is under 500 lines (269 + 215 = 484 total)
- [ ] Verify directory structure follows `content/<company>/docs/<product>/DOC.md` convention
