### PR TITLE
Add Meridian CLI documentation

### DIFF
--- a/content/meridian/docs/cli/python/DOC.md
+++ b/content/meridian/docs/cli/python/DOC.md
@@ -1,0 +1,235 @@
+---
+name: cli
+description: "Meridian CLI for deploying censorship-resistant VLESS+Reality proxy servers — one command deploys Xray, HAProxy, Caddy, and firewall on any VPS"
+metadata:
+  languages: "python"
+  versions: "3.8.1"
+  updated-on: "2026-03-25"
+  source: official
+  tags: "meridian,vpn,proxy,censorship,vless,reality,xray,deployment,cli"
+---
+
+# Meridian CLI Guide
+
+Meridian is a Python CLI tool that deploys censorship-resistant VLESS+Reality proxy servers on any VPS. It orchestrates Docker, Xray, HAProxy, Caddy, firewall, and TLS — you run one command and share VPN access via QR codes.
+
+- **Package:** `meridian-vpn` on PyPI
+- **Install:** `uv tool install meridian-vpn` or `pipx install meridian-vpn`
+- **Docs:** https://getmeridian.org
+- **GitHub:** https://github.com/uburuntu/meridian
+- **llms.txt:** https://getmeridian.org/llms.txt
+
+## Install
+
+```bash
+curl -sSf https://getmeridian.org/install.sh | bash
+```
+
+Or manually:
+
+```bash
+uv tool install meridian-vpn    # recommended
+pipx install meridian-vpn       # alternative
+```
+
+Requires Python 3.10+. Update with `meridian update`.
+
+## Deploy a Proxy Server
+
+Interactive wizard:
+
+```bash
+meridian deploy
+```
+
+Non-interactive:
+
+```bash
+meridian deploy 1.2.3.4 --sni www.microsoft.com --name alice --yes
+```
+
+Local deployment (on the VPS itself, no SSH):
+
+```bash
+meridian deploy local
+```
+
+### What deploy does
+
+1. Installs Docker, deploys Xray via 3x-ui management panel
+2. Generates x25519 keypair for Reality authentication
+3. Hardens server — UFW firewall, SSH key-only auth, BBR congestion control
+4. Configures VLESS+Reality on port 443 (impersonates a real TLS server)
+5. Enables XHTTP transport (additional stealth, routed through Caddy)
+6. Deploys connection pages with QR codes and shareable URLs
+
+### Deploy flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--sni HOST` | www.microsoft.com | Site that Reality impersonates |
+| `--domain DOMAIN` | (none) | Enable domain mode with CDN fallback |
+| `--email EMAIL` | (none) | Email for TLS certificates |
+| `--xhttp / --no-xhttp` | enabled | XHTTP transport |
+| `--name NAME` | default | Name for the first client |
+| `--user USER` | root | SSH user (non-root gets sudo) |
+| `--harden / --no-harden` | enabled | Server hardening: SSH key-only + firewall |
+| `--server NAME` | | Target a specific named server |
+| `--yes` | | Skip confirmation prompts |
+
+## Client Management
+
+```bash
+meridian client add alice          # generate keys + connection page
+meridian client list               # show all clients
+meridian client remove alice       # revoke access
+```
+
+Each client gets a unique UUID, QR code, and hosted connection page. Use `--server NAME` to target a specific server.
+
+## Relay Nodes
+
+A relay is a lightweight TCP forwarder (Realm) on a domestic server that forwards traffic to the exit server abroad. Useful when the exit IP gets blocked.
+
+```bash
+meridian relay deploy RELAY_IP --exit EXIT_IP    # deploy relay
+meridian relay list                               # list relays
+meridian relay remove RELAY_IP                    # remove relay
+meridian relay check RELAY_IP                     # health check
+```
+
+All protocols (Reality, XHTTP, WSS) work through the relay with end-to-end encryption.
+
+### Relay flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--exit/-e EXIT` | (required) | Exit server IP or name |
+| `--name NAME` | (auto) | Friendly name for the relay |
+| `--port/-p PORT` | 443 | Listen port on relay server |
+| `--user/-u USER` | root | SSH user on relay |
+
+## Server Management
+
+Manage multiple VPS deployments from one machine:
+
+```bash
+meridian server list             # view all managed servers (name, IP, user)
+meridian server add [IP]         # register an existing server + fetch its credentials
+meridian server remove NAME      # remove from local registry
+```
+
+Use `--server NAME` with any command to target a specific server:
+
+```bash
+meridian client add alice --server finland
+meridian doctor --server finland
+```
+
+If you have only one server registered, it's auto-selected.
+
+## Diagnostics
+
+```bash
+meridian preflight [IP]          # pre-flight check (SNI, ports, DNS, OS, disk)
+meridian scan [IP]               # find optimal SNI targets on server's network
+meridian test [IP]               # test proxy reachability (no SSH needed)
+meridian doctor [IP]             # collect system diagnostics for debugging
+meridian teardown [IP]           # remove proxy from server
+```
+
+Add `--ai` to `preflight` or `doctor` to generate an AI-ready diagnostic prompt.
+
+## Global Flags
+
+| Flag | Description |
+|------|-------------|
+| `--server NAME` | Target a specific named server |
+
+Server resolution priority: explicit IP > `--server` flag > local mode detection > single server auto-select > interactive prompt.
+
+## Domain Mode
+
+Adds CDN fallback via Cloudflare (VLESS+WSS). Deploy with:
+
+```bash
+meridian deploy 1.2.3.4 --domain proxy.example.com
+```
+
+Cloudflare setup order:
+1. Create A record pointing to server IP (grey cloud — DNS only)
+2. Run `meridian deploy` — Caddy obtains TLS certificate
+3. Switch to orange cloud (Proxied)
+4. SSL/TLS → Full (Strict), Network → Enable WebSockets
+
+Users get three connection options: Reality (primary), XHTTP (alternative), WSS (CDN backup).
+
+## Architecture
+
+All modes deploy HAProxy (port 443, SNI routing) + Caddy (TLS + web serving):
+
+- **HAProxy** — TCP-level SNI router on port 443. Does NOT terminate TLS. Routes by SNI hostname.
+- **Caddy** — reverse proxy with auto-TLS. Handles connection pages, panel, XHTTP, and WSS traffic.
+- **Xray** — runs inside 3x-ui Docker container. Handles Reality, XHTTP, and WSS inbounds.
+
+### Port assignments
+
+| Port | Service | Mode |
+|------|---------|------|
+| 443 | HAProxy (SNI router) | All |
+| 80 | Caddy (ACME challenges) | All |
+| 10443 | Xray Reality (internal) | All |
+| 8443 | Caddy TLS (internal) | All |
+| localhost | Xray XHTTP | When XHTTP enabled |
+| localhost | Xray WSS | Domain mode |
+| 2053 | 3x-ui panel (internal) | All |
+
+### How Reality protocol works
+
+1. Server generates x25519 keypair. Public key shared with clients.
+2. Client sends TLS Client Hello with camouflage domain as SNI.
+3. Observers see normal HTTPS to the camouflage site.
+4. Probers get proxied to the real site — valid certificate returned.
+5. Authenticated clients (x25519 key) get the VLESS tunnel.
+6. uTLS makes Client Hello identical to Chrome's.
+
+### File locations
+
+On server:
+- `/etc/meridian/proxy.yml` — credentials and client list
+- `/etc/caddy/conf.d/meridian.caddy` — Caddy config
+- `/etc/haproxy/haproxy.cfg` — HAProxy config
+
+On local machine:
+- `~/.meridian/credentials/<IP>/proxy.yml` — cached credentials
+- `~/.meridian/servers` — server registry
+
+### Credential lifecycle
+
+1. Generated randomly on first deploy (panel password, x25519 keys, client UUID)
+2. Saved locally BEFORE applying to server (prevents lockout on failure)
+3. Applied to server (panel password, inbounds)
+4. Synced to `/etc/meridian/proxy.yml` on server
+5. On re-runs: loaded from cache, not regenerated (idempotent)
+
+## SNI Target Selection
+
+Default `www.microsoft.com` works well. For optimal stealth, run `meridian scan` to find same-ASN targets.
+
+**Good:** `www.microsoft.com`, `www.twitch.tv`, `dl.google.com`, `github.com` (global CDN).
+**Bad:** `apple.com`, `icloud.com` (Apple-owned ASN — instant detection).
+
+## Client Apps
+
+| Platform | App |
+|----------|-----|
+| iOS | v2RayTun |
+| Android | v2rayNG |
+| Windows | v2rayN |
+| All platforms | Hiddify |
+
+## Reference Files
+
+For detailed content, see the reference files in this directory:
+- [Troubleshooting](references/troubleshooting.md) — common issues, fixes, diagnostic tool interpretation
+- [Architecture](references/architecture.md) — full service topology, Docker internals, Caddy config, provisioning pipeline

--- a/content/meridian/docs/cli/python/references/architecture.md
+++ b/content/meridian/docs/cli/python/references/architecture.md
@@ -1,0 +1,156 @@
+
+## Technology stack
+
+- **VLESS+Reality** (Xray-core) — proxy protocol that impersonates a legitimate TLS website. Censors probing the server see a real certificate (e.g., from microsoft.com). Only clients with the correct private key can connect.
+- **3x-ui** — web panel for managing Xray, deployed as a Docker container. Meridian controls it entirely via REST API.
+- **HAProxy** — TCP-level SNI router on port 443. Routes traffic by SNI hostname without terminating TLS.
+- **Caddy** — reverse proxy with automatic TLS. In standalone mode, requests a Let's Encrypt IP certificate via ACME `shortlived` profile (6-day validity). Serves connection pages, reverse-proxies the panel, and proxies XHTTP/WSS traffic to Xray.
+- **Docker** — runs 3x-ui (which contains Xray). All proxy traffic flows through the container.
+- **Pure-Python provisioner** — `src/meridian/provision/` executes deployment steps via SSH. Each step gets `(conn, ctx)` and returns a `StepResult`.
+- **uTLS** — impersonates Chrome's TLS Client Hello fingerprint, making connections indistinguishable from real browser traffic.
+
+## Service topology
+
+### Standalone mode (no domain)
+
+```mermaid
+flowchart TD
+    Internet((Internet)) -->|Port 443| HAProxy[HAProxy<br>SNI Router]
+    HAProxy -->|"SNI = reality_sni"| Xray["Xray Reality<br>:10443"]
+    HAProxy -->|"SNI = server IP"| Caddy["Caddy TLS<br>:8443"]
+    Caddy -->|/info-path| Page[Connection Page]
+    Caddy -->|/panel-path| Panel[3x-ui Panel]
+    Caddy -->|/xhttp-path| XrayXHTTP["Xray XHTTP<br>localhost"]
+    Internet -->|Port 80| CaddyACME["Caddy<br>ACME challenges"]
+```
+
+HAProxy does **not** terminate TLS. It reads the SNI hostname from the TLS Client Hello and forwards the raw TCP stream to the appropriate backend.
+
+Caddy requests a Let's Encrypt IP certificate via the ACME `shortlived` profile (6-day validity, auto-renewed). Falls back to self-signed if IP cert issuance is not supported.
+
+XHTTP runs on a localhost-only port and is reverse-proxied by Caddy — no extra external port exposed.
+
+### Domain mode
+
+```mermaid
+flowchart TD
+    Internet((Internet)) -->|Port 443| HAProxy[HAProxy<br>SNI Router]
+    HAProxy -->|"SNI = reality_sni"| Xray["Xray Reality<br>:10443"]
+    HAProxy -->|"SNI = domain"| Caddy["Caddy TLS<br>:8443"]
+    Caddy -->|/info-path| Page[Connection Page]
+    Caddy -->|/panel-path| Panel[3x-ui Panel]
+    Caddy -->|/xhttp-path| XrayXHTTP["Xray XHTTP<br>localhost"]
+    Caddy -->|/ws-path| XrayWSS["Xray WSS<br>localhost"]
+    Internet -->|Port 80| CaddyACME["Caddy<br>ACME challenges"]
+    Internet -.->|"CDN (Cloudflare)"| Caddy
+```
+
+Domain mode adds VLESS+WSS as a CDN fallback path. Traffic flows through Cloudflare's CDN via WebSocket, making the connection work even if the server's IP is blocked.
+
+### Relay topology
+
+```mermaid
+flowchart LR
+    Client([Client]) -->|Port 443| Relay["Relay<br>(Realm TCP)"]
+    Relay -->|Port 443| Exit["Exit Server<br>(abroad)"]
+    Exit --> Internet((Internet))
+```
+
+A relay node is a lightweight TCP forwarder running [Realm](https://github.com/zhboner/realm). The client connects to the relay's domestic IP, which forwards raw TCP to the exit server abroad. All encryption is end-to-end between client and exit — the relay never sees plaintext.
+
+## How Reality protocol works
+
+1. Server generates an **x25519 keypair**. Public key is shared with clients, private key stays on server.
+2. Client connects on port 443 with a TLS Client Hello containing the camouflage domain (e.g., `www.microsoft.com`) as SNI.
+3. To any observer, this looks like a normal HTTPS connection to microsoft.com.
+4. If a **prober** sends their own Client Hello, the server proxies the connection to the real microsoft.com — the prober sees a valid certificate.
+5. If the client includes valid authentication (derived from the x25519 key), the server establishes the VLESS tunnel.
+6. **uTLS** makes the Client Hello byte-for-byte identical to Chrome's, defeating TLS fingerprinting.
+
+## Docker container structure
+
+The `3x-ui` Docker container contains:
+- **3x-ui web panel** — REST API on port 2053 (internal)
+- **Xray binary** at `/app/bin/xray-linux-*` (architecture-dependent path)
+- **Database** at `/etc/x-ui/x-ui.db` (SQLite, stores inbound configs and clients)
+- **Xray config** managed by 3x-ui (not a static file)
+
+Meridian manages 3x-ui entirely via its REST API:
+- `POST /login` — authenticate (form-urlencoded, returns session cookie)
+- `POST /panel/api/inbounds/add` — create VLESS inbound
+- `GET /panel/api/inbounds/list` — list inbounds (check before creating)
+- `POST /panel/setting/update` — configure panel settings
+- `POST /panel/setting/updateUser` — change panel credentials
+
+## Caddy configuration pattern
+
+Meridian writes to `/etc/caddy/conf.d/meridian.caddy` (never the main Caddyfile). The main Caddyfile gets a single line added: `import /etc/caddy/conf.d/*.caddy`. This allows Meridian to coexist with user's own Caddy configuration.
+
+Caddy handles:
+- Auto-TLS certificate (domain cert or Let's Encrypt IP cert via ACME `shortlived` profile)
+- Reverse proxy for the 3x-ui panel (at a random web base path)
+- Connection info page serving (hosted pages with shareable URLs)
+- Reverse proxy for XHTTP traffic to Xray (path-based routing, all modes when XHTTP enabled)
+- Reverse proxy for WSS traffic to Xray (domain mode only)
+
+## Port assignments
+
+| Port | Service | Mode |
+|------|---------|------|
+| 443 | HAProxy (SNI router) | All |
+| 80 | Caddy (ACME challenges) | All |
+| 10443 | Xray Reality (internal) | All |
+| 8443 | Caddy TLS (internal) | All |
+| localhost | Xray XHTTP | When XHTTP enabled |
+| localhost | Xray WSS | Domain mode |
+| 2053 | 3x-ui panel (internal) | All |
+
+XHTTP and WSS ports are localhost-only — Caddy reverse-proxies to them on port 443.
+
+## Provisioning pipeline
+
+Steps execute sequentially via `build_setup_steps()`. Each step gets `(conn, ctx)` and returns a `StepResult`.
+
+| # | Step | Module | Purpose |
+|---|------|--------|---------|
+| 1 | InstallPackages | `common.py` | OS packages |
+| 2 | EnableAutoUpgrades | `common.py` | Unattended upgrades |
+| 3 | SetTimezone | `common.py` | UTC |
+| 4 | HardenSSH | `common.py` | Key-only auth |
+| 5 | ConfigureBBR | `common.py` | TCP congestion control |
+| 6 | ConfigureFirewall | `common.py` | UFW: 22 + 80 + 443 |
+| 7 | InstallDocker | `docker.py` | Docker CE |
+| 8 | Deploy3xui | `docker.py` | 3x-ui container |
+| 9 | ConfigurePanel | `panel.py` | Panel credentials |
+| 10 | LoginToPanel | `panel.py` | API auth |
+| 11 | CreateRealityInbound | `xray.py` | VLESS+Reality |
+| 12 | CreateXHTTPInbound | `xray.py` | VLESS+XHTTP |
+| 13 | CreateWSSInbound | `xray.py` | VLESS+WSS (domain) |
+| 14 | VerifyXray | `xray.py` | Health check |
+| 15 | InstallHAProxy | `services.py` | SNI routing |
+| 16 | InstallCaddy | `services.py` | TLS + reverse proxy |
+| 17 | DeployConnectionPage | `services.py` | QR codes + page |
+
+## Credential lifecycle
+
+1. **Generate**: random credentials (panel password, x25519 keys, client UUID)
+2. **Save locally**: `~/.meridian/credentials/<IP>/proxy.yml` — saved BEFORE applying to server
+3. **Apply**: panel password changed, inbounds created
+4. **Sync**: credentials copied to `/etc/meridian/proxy.yml` on server
+5. **Re-runs**: loaded from cache, not regenerated (idempotent)
+6. **Cross-machine**: `meridian server add IP` fetches from server via SSH
+7. **Uninstall**: deleted from both server and local machine
+
+## File locations
+
+### On the server
+- `/etc/meridian/proxy.yml` — credentials and client list
+- `/etc/caddy/conf.d/meridian.caddy` — Caddy config
+- `/etc/haproxy/haproxy.cfg` — HAProxy config
+- Docker container `3x-ui` — Xray + panel
+
+### On the local machine
+- `~/.meridian/credentials/<IP>/` — cached credentials per server
+- `~/.meridian/servers` — server registry
+- `~/.meridian/cache/` — update check throttle cache
+- `~/.local/bin/meridian` — CLI entry point (installed via uv/pipx)

--- a/content/meridian/docs/cli/python/references/troubleshooting.md
+++ b/content/meridian/docs/cli/python/references/troubleshooting.md
@@ -1,0 +1,189 @@
+
+## Which tool to use
+
+```
+BEFORE INSTALL           → meridian preflight IP
+  "Will this server work for Meridian?"
+  Tests: SNI reachability, port 443, DNS, OS, disk space.
+
+AFTER INSTALL, CAN'T CONNECT → meridian test IP
+  "Is the proxy reachable from where I am right now?"
+  Tests: TCP port 443, TLS handshake (Reality), domain HTTPS.
+  No SSH needed — runs from the client device.
+
+AFTER INSTALL, SOMETHING BROKE → meridian doctor IP
+  "Collect everything for debugging."
+  Collects: server OS, Docker, 3x-ui logs, ports, firewall, SNI, DNS.
+```
+
+Add `--ai` to preflight or doctor for an AI-ready diagnostic prompt.
+
+## Can't connect at all
+
+### Port 443 not reachable
+
+**Causes:**
+1. Cloud provider firewall / security group blocks port 443 inbound
+2. ISP or network blocks the server IP entirely
+3. Server is down or proxy is not running
+4. UFW on the server doesn't allow port 443
+
+**Fixes:**
+1. Check cloud provider console — ensure port 443/TCP is allowed inbound
+2. Try from a different network (mobile data, another Wi-Fi)
+3. SSH in and check: `docker ps` (is 3x-ui running?), `ss -tlnp sport = :443`
+4. Check UFW: `ufw status` — should show 443/tcp ALLOW
+
+### TLS handshake fails
+
+**Causes:**
+1. Xray is not running inside the Docker container
+2. Port 443 is occupied by another service
+3. Reality SNI target is unreachable from the server
+
+**Fixes:**
+1. Check Xray: `docker logs 3x-ui --tail 20`
+2. Check port: `ss -tlnp sport = :443` — should be haproxy
+3. Test SNI: `meridian preflight IP`
+
+### Domain not reachable
+
+**Causes:**
+1. DNS not pointing to server IP
+2. Caddy not running or failed to get TLS certificate
+3. HAProxy not routing domain SNI correctly
+
+**Fixes:**
+1. Check DNS: `dig +short yourdomain.com @8.8.8.8`
+2. Check Caddy: `systemctl status caddy`
+3. Check HAProxy: `/etc/haproxy/haproxy.cfg`
+
+## Connection drops after seconds
+
+**Causes:**
+1. System clock skew >30 seconds between client and server
+2. MTU issues on the network path
+3. ISP resetting long-lived TLS sessions
+
+**Fixes:**
+1. Server: `timedatectl set-ntp true`. Client: enable automatic date/time
+2. Try a different network
+3. Use WSS/CDN connection (domain mode)
+
+## Setup fails
+
+### Port 443 conflict
+
+Another service (Apache, Nginx) is using port 443. Stop it or use a clean server. `meridian preflight` will tell you what's using the port.
+
+### Docker installation fails
+
+Conflicting Docker packages from distro repos. Meridian auto-removes them, but if Docker is already running with containers, it skips to avoid disruption.
+
+### SSH connection errors
+
+Test SSH manually: `ssh root@SERVER_IP`. Ensure you have key-based access. Use `--user` flag if not root.
+
+### Xray fails to start (invalid JSON / MarshalJSON error)
+
+The 3x-ui inbound `settings` or `streamSettings` fields contain corrupted JSON. This happens when `settings` is sent as a nested object instead of a JSON string — the 3x-ui Go struct expects a `string` type. The API returns `success: true` but stores only the first key name instead of the full JSON.
+
+**Fix:** Uninstall and reinstall: `meridian teardown IP && meridian deploy IP`. To verify the database: `sqlite3 /opt/3x-ui/db/x-ui.db "SELECT settings FROM inbounds;"` — each field should be valid JSON.
+
+### XHTTP inbound creation fails (port conflict)
+
+In older versions (pre-v3.6.0), both Reality and XHTTP tried to use port 443. 3x-ui rejects duplicate ports.
+
+**Fix:** Update to v3.6.0+. XHTTP now runs on a localhost-only port, routed through Caddy.
+
+### Disk space insufficient
+
+Less than 2GB free. Free up space: `docker system prune -af`, `journalctl --vacuum-time=1d`, check `/var/log/`.
+
+### DNS resolution fails (domain mode)
+
+Domain doesn't resolve to server IP yet. Update the DNS A record. Propagation is usually 5-15 minutes (up to 48 hours). Meridian warns if DNS doesn't resolve but lets you proceed.
+
+## Was working, now stopped
+
+**Most common cause:** Server IP got blocked. This is very common in censored regions.
+
+**Fixes:**
+1. Run `meridian test IP` — if TCP fails, the IP is likely blocked
+2. Use the WSS/CDN link (domain mode)
+3. Deploy a new server: get a new IP and re-run `meridian deploy`
+
+Other causes:
+- Server rebooted and Docker didn't auto-start → `docker start 3x-ui`
+- Disk full → `df -h /`, `docker system prune -af`
+
+## Slow speeds
+
+1. Choose a server geographically closer (Finland, Netherlands, Sweden for Europe/Middle East)
+2. Check server load: `htop` or `uptime`
+3. Try WSS/CDN link — may have better routing through Cloudflare
+4. Verify BBR is enabled: `sysctl net.ipv4.tcp_congestion_control`
+
+**Do NOT** run other protocols (OpenVPN, WireGuard) on the same server — it flags the IP.
+
+## AI-powered help
+
+```
+meridian doctor --ai
+```
+
+Copies a diagnostic prompt to your clipboard for use with any AI assistant.
+
+Or collect diagnostics for a [GitHub issue](https://github.com/uburuntu/meridian/issues):
+
+```
+meridian doctor
+```
+
+## Relay not working
+
+**Check relay health:**
+```bash
+meridian relay check RELAY_IP
+```
+
+**Common issues:**
+- **Port conflict** — Another service is using port 443 on the relay server. Check with `ss -tlnp sport = :443` and stop the conflicting service.
+- **Firewall blocking** — Ensure port 443 is open on the relay's cloud provider firewall / security group.
+- **Exit server unreachable** — The relay must be able to reach the exit server on port 443. Test with `curl -I https://EXIT_IP`.
+- **Relay not started** — Check the Realm service: `systemctl status meridian-relay`.
+
+## Interpreting preflight output
+
+| Check | What It Tests | If It Fails |
+|-------|--------------|-------------|
+| SNI target reachability | Can the server reach the camouflage site? | Server's outbound is restricted. Try a different SNI with `--sni` |
+| SNI ASN match | Does the SNI target share a CDN/ASN with the server? | Use a global CDN domain. Avoid apple.com (Apple-owned ASN) |
+| Port 443 availability | Is port 443 free or used by Meridian? | Another service is on 443. Stop it or use a clean server |
+| Port 443 external reachability | Can the outside world reach port 443? | Cloud firewall blocks it. Open port 443/TCP inbound |
+| Domain DNS | Does the domain resolve to server IP? | Update DNS A record |
+| Server OS | Is it Ubuntu/Debian? | Other distros may work but are untested |
+| Disk space | At least 2GB free? | Free up space |
+
+## Interpreting doctor output
+
+| Section | What to Look For |
+|---------|-----------------|
+| Local Machine | OS compatibility |
+| Server | OS version, uptime (recent reboot?), disk/memory usage |
+| Docker | Is 3x-ui container running? Status should be "Up" |
+| 3x-ui Logs | Error messages, "failed to start" entries, certificate issues |
+| Listening Ports | Port 443 should show haproxy. If missing, proxy isn't running |
+| Firewall (UFW) | Port 443/tcp should be ALLOW. If not listed, it's blocked |
+| SNI Target | Should show CONNECTED with a certificate chain |
+| Domain DNS | Should resolve to server IP |
+
+## Interpreting test output
+
+| Check | Pass | Fail |
+|-------|------|------|
+| TCP port 443 | Server is network-reachable | Firewall, ISP block, or server down |
+| TLS handshake | Reality protocol is working | Xray not running, port conflict, or SNI issue |
+| Domain HTTPS | Caddy + HAProxy working | DNS, Caddy, or HAProxy issue |
+
+If all checks pass but the VPN client still can't connect: re-scan the QR code, check device clock is accurate (within 30 seconds), or try a different app (v2rayNG, Hiddify).


### PR DESCRIPTION
## Summary

Adds documentation for [Meridian](https://github.com/uburuntu/meridian) — a Python CLI tool for deploying censorship-resistant VLESS+Reality proxy servers on any VPS.

- **DOC.md** (224 lines): install, deploy, all CLI commands & flags, architecture overview, SNI selection, client apps
- **references/troubleshooting.md**: diagnostic tools, common issues & fixes, output interpretation tables
- **references/architecture.md**: service topology, Docker internals, Caddy config pattern, provisioning pipeline, file locations

## About Meridian

- **PyPI:** [meridian-vpn](https://pypi.org/project/meridian-vpn/)
- **GitHub:** https://github.com/uburuntu/meridian (MIT, 490+ tests)
- **Website:** https://getmeridian.org
- **Source:** official (project maintainer)

## Validation

```
$ chub build content/ --validate-only
Valid: 1554 docs, 7 skills, 2 warnings
```

No new warnings introduced — the 2 existing warnings are from `landingai/skills/ade/`.