### PR TITLE
feat: add Langdock agent completions docs

### DIFF
--- a/content/langdock/docs/agent-completions/DOC.md
+++ b/content/langdock/docs/agent-completions/DOC.md
@@ -2,7 +2,7 @@
 name: agent-completions
 description: "Langdock Agents Completions API for Vercel AI SDK-style chat requests, attachments, temporary agents, and structured output handling"
 metadata:
-  languages: "http"
+  languages: "python"
   versions: "v1"
   revision: 1
   updated-on: "2026-03-26"
@@ -15,8 +15,8 @@ metadata:
 Use this doc when you need to call Langdock agents over HTTP, including structured output, attachments, tool-enabled agents, and temporary inline agent configs.
 
 Official docs:
-- https://docs.langdock.com/de/api-endpoints/api-introduction
-- https://docs.langdock.com/de/api-endpoints/agent/agent
+- https://docs.langdock.com/api-endpoints/api-introduction
+- https://docs.langdock.com/api-endpoints/agent/agent
 
 ## Base URL and Authentication
 
@@ -60,7 +60,7 @@ payload = {
             ],
         }
     ],
-    "stream": True,
+    "stream": False,
 }
 
 headers = {
@@ -74,6 +74,8 @@ print(response.text)
 ```
 
 The important part is the payload shape: `agentId`, `messages`, and message `parts` follow Langdock's Vercel AI SDK-compatible format rather than OpenAI chat-completions message objects.
+
+If you do not already have an `agentId`, you can typically find it in the Langdock UI for that agent, such as in the agent settings or the agent URL.
 
 ## Request Shape
 
@@ -197,6 +199,12 @@ Treat structured output as best-effort model output, not as guaranteed parser-sa
 
 See `references/production-notes.md` for observed response behavior that matters in batch pipelines.
 
+## Streaming
+
+Keep the minimal example non-streaming while you are getting started. Streaming responses require SSE-capable client handling rather than a simple `response.text` flow.
+
+When you do enable streaming, build your client to handle incremental message parts instead of assuming a single plain-text string.
+
 ## Response Handling
 
 For non-streaming requests, expect a Vercel AI SDK-style assistant response with `parts` and output data. Keep the full assistant message when continuing the same conversation.
@@ -224,7 +232,6 @@ These headers are useful for logging, rate-limit handling, and debugging which u
 
 ## Official Sources
 
-- https://docs.langdock.com/de/api-endpoints/api-introduction
-- https://docs.langdock.com/de/api-endpoints/agent/agent
-- https://docs.langdock.com/de/api-endpoints/agent/attachments
-
+- https://docs.langdock.com/api-endpoints/api-introduction
+- https://docs.langdock.com/api-endpoints/agent/agent
+- https://docs.langdock.com/api-endpoints/agent/attachments

--- a/content/langdock/docs/agent-completions/DOC.md
+++ b/content/langdock/docs/agent-completions/DOC.md
@@ -1,0 +1,217 @@
+---
+name: agent-completions
+description: "Langdock Agents Completions API for Vercel AI SDK-style chat requests, attachments, temporary agents, and structured output handling"
+metadata:
+  languages: "http"
+  versions: "v1"
+  revision: 1
+  updated-on: "2026-03-26"
+  source: community
+  tags: "langdock,agents,chat,api,vercel-ai-sdk,structured-output"
+---
+
+# Langdock Agents Completions API
+
+Use this doc when you need to call Langdock agents over HTTP, including structured output, attachments, tool-enabled agents, and temporary inline agent configs.
+
+Official docs:
+- https://docs.langdock.com/de/api-endpoints/api-introduction
+- https://docs.langdock.com/de/api-endpoints/agent/agent
+
+## Base URL and Authentication
+
+Cloud endpoint:
+
+```text
+POST https://api.langdock.com/agent/v1/chat/completions
+```
+
+Required headers:
+
+```http
+Authorization: Bearer <LANGDOCK_API_KEY>
+Content-Type: application/json
+```
+
+Dedicated deployments do not use `api.langdock.com`. Replace it with your deployment base URL and append `/api/public`.
+
+```text
+https://<deployment-url>/api/public/agent/v1/chat/completions
+```
+
+## Minimal Request
+
+```bash
+curl -X POST "https://api.langdock.com/agent/v1/chat/completions" \
+  -H "Authorization: Bearer $LANGDOCK_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agentId": "agent_123",
+    "messages": [
+      {
+        "id": "msg_1",
+        "role": "user",
+        "parts": [
+          {
+            "type": "text",
+            "text": "Summarize this document."
+          }
+        ]
+      }
+    ],
+    "stream": false
+  }'
+```
+
+## Request Shape
+
+Important request fields:
+
+- `agentId` or `agent`: one of these is required
+- `messages`: required array of Vercel AI SDK `UIMessage` objects
+- `stream`: optional, defaults to `false`
+- `output`: optional structured output specification
+- `maxSteps`: optional tool-step cap from `1` to `20`
+- `imageResponseFormat`: optional, `"url"` or `"b64_json"`
+
+Use `agentId` when you already have a persistent agent in Langdock. Use `agent` when you want to define a temporary inline agent configuration for a single request.
+
+## UIMessage Format
+
+Langdock's Agents Completions API uses the Vercel AI SDK `UIMessage` format rather than OpenAI chat-completions message objects.
+
+Each message should include:
+
+- `id`
+- `role`: `system`, `user`, or `assistant`
+- `parts`: array of message parts
+- `metadata`: optional, including attachments
+
+Common user message parts:
+
+- `type: "text"` with `text`
+- `type: "file"` with inline file metadata for inline file references
+
+Common agent response parts:
+
+- `type: "text"`
+- `type: "reasoning"`
+- `type: "tool-{name}"`
+- `type: "source-url"`
+- `type: "source-document"`
+
+For follow-up turns, preserve the returned assistant message parts in the conversation history instead of flattening them to plain text. Tool call state lives inside those parts.
+
+## Attachments
+
+For uploaded files, use the Upload Attachment API first, then reference the returned UUIDs in `message.metadata.attachments`.
+
+```json
+{
+  "id": "msg_2",
+  "role": "user",
+  "parts": [
+    {
+      "type": "text",
+      "text": "Analyze the attached transcript."
+    }
+  ],
+  "metadata": {
+    "attachments": ["550e8400-e29b-41d4-a716-446655440000"]
+  }
+}
+```
+
+Do not use `type: "file"` for files uploaded through the attachment upload endpoint. Langdock documents that uploaded attachments should be passed through `metadata.attachments`.
+
+Important current limitation: `agent.attachmentIds` in inline temporary agent configs is documented as not currently functional. For request-scoped file access, prefer `metadata.attachments` on individual messages.
+
+## Temporary Agent Configs
+
+When using the inline `agent` field, Langdock accepts fields such as:
+
+- `name`
+- `instructions`
+- `description`
+- `temperature`
+- `model`
+- `capabilities`
+- `knowledgeFolderIds`
+- `attachmentIds`
+
+Do not assume these field names match the create/update agent APIs. Langdock documents that the completions endpoint uses:
+
+- `instructions` instead of CRUD `instruction`
+- `temperature` instead of CRUD `creativity`
+- nested `capabilities` instead of CRUD-style flat booleans
+
+## Structured Output
+
+Langdock documents an optional `output` field for structured output. A minimal request shape looks like this:
+
+```json
+{
+  "agentId": "agent_123",
+  "messages": [
+    {
+      "id": "system_1",
+      "role": "system",
+      "parts": [
+        {
+          "type": "text",
+          "text": "Return valid JSON only."
+        }
+      ]
+    },
+    {
+      "id": "user_1",
+      "role": "user",
+      "parts": [
+        {
+          "type": "text",
+          "text": "Extract the key themes from this interview."
+        }
+      ]
+    }
+  ],
+  "stream": false,
+  "output": {
+    "type": "object"
+  }
+}
+```
+
+Treat structured output as best-effort model output, not as guaranteed parser-safe JSON. In observed production usage, responses intended as JSON may still arrive wrapped in Markdown code fences. Strip fences and validate before decoding.
+
+See `references/production-notes.md` for observed response behavior that matters in batch pipelines.
+
+## Response Handling
+
+For non-streaming requests, expect a Vercel AI SDK-style assistant response with `parts` and output data. Keep the full assistant message when continuing the same conversation.
+
+For streaming requests, build your client to handle incremental message parts instead of assuming a single plain-text string.
+
+Useful response metadata observed in successful requests includes:
+
+- `ld-model-id`
+- `x-usage-input-tokens`
+- `x-usage-output-tokens`
+- `x-ratelimit-limit-requests`
+- `x-ratelimit-remaining-requests`
+
+These headers are useful for logging, rate-limit handling, and debugging which underlying model served the request.
+
+## Common Pitfalls
+
+- Sending OpenAI chat-completions message objects instead of Langdock/Vercel `UIMessage` objects.
+- Dropping assistant tool parts from conversation history before the next turn.
+- Using uploaded files as `type: "file"` parts instead of `metadata.attachments`.
+- Assuming inline `agent.attachmentIds` works for temporary agents.
+- Assuming "JSON only" instructions guarantee raw JSON without code fences.
+- Forgetting to swap the base URL for dedicated deployments.
+
+## Official Sources
+
+- https://docs.langdock.com/de/api-endpoints/api-introduction
+- https://docs.langdock.com/de/api-endpoints/agent/agent
+- https://docs.langdock.com/de/api-endpoints/agent/attachments

--- a/content/langdock/docs/agent-completions/DOC.md
+++ b/content/langdock/docs/agent-completions/DOC.md
@@ -41,27 +41,39 @@ https://<deployment-url>/api/public/agent/v1/chat/completions
 
 ## Minimal Request
 
-```bash
-curl -X POST "https://api.langdock.com/agent/v1/chat/completions" \
-  -H "Authorization: Bearer $LANGDOCK_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
+```python
+import requests
+
+url = "https://api.langdock.com/agent/v1/chat/completions"
+
+payload = {
     "agentId": "agent_123",
     "messages": [
-      {
-        "id": "msg_1",
-        "role": "user",
-        "parts": [
-          {
-            "type": "text",
-            "text": "Summarize this document."
-          }
-        ]
-      }
+        {
+            "id": "msg_1",
+            "role": "user",
+            "parts": [
+                {
+                    "type": "text",
+                    "text": "Hello, how can you help me?",
+                }
+            ],
+        }
     ],
-    "stream": false
-  }'
+    "stream": True,
+}
+
+headers = {
+    "Authorization": "Bearer <token>",
+    "Content-Type": "application/json",
+}
+
+response = requests.post(url, json=payload, headers=headers, timeout=60)
+response.raise_for_status()
+print(response.text)
 ```
+
+The important part is the payload shape: `agentId`, `messages`, and message `parts` follow Langdock's Vercel AI SDK-compatible format rather than OpenAI chat-completions message objects.
 
 ## Request Shape
 
@@ -215,3 +227,4 @@ These headers are useful for logging, rate-limit handling, and debugging which u
 - https://docs.langdock.com/de/api-endpoints/api-introduction
 - https://docs.langdock.com/de/api-endpoints/agent/agent
 - https://docs.langdock.com/de/api-endpoints/agent/attachments
+

--- a/content/langdock/docs/agent-completions/references/production-notes.md
+++ b/content/langdock/docs/agent-completions/references/production-notes.md
@@ -1,0 +1,53 @@
+# Production Notes for Agent Completions
+
+These notes summarize sanitized observed behavior from a successful production-style request to Langdock's Agents Completions API. Treat them as implementation guidance, not stronger contract guarantees than the official docs.
+
+## Observed Structured Output Caveat
+
+A request that asked for valid JSON only and set:
+
+```json
+{
+  "stream": false,
+  "output": {
+    "type": "object"
+  }
+}
+```
+
+still returned assistant text wrapped in Markdown code fences. For production parsing:
+
+1. read the assistant text as text first,
+2. strip surrounding triple-backtick fences if present,
+3. parse JSON,
+4. validate the parsed object against your expected schema.
+
+Do not assume `output.type = "object"` guarantees directly parseable JSON text.
+
+## Observed Useful Headers
+
+Successful requests returned headers including:
+
+- `ld-model-id`
+- `x-usage-input-tokens`
+- `x-usage-output-tokens`
+- `x-ratelimit-limit-requests`
+- `x-ratelimit-remaining-requests`
+
+Capture these for:
+
+- cost and token accounting,
+- identifying the routed model actually used,
+- adaptive throttling in batch jobs.
+
+## Batch Workflow Guidance
+
+For batch analysis pipelines, make the response path defensive:
+
+- keep raw assistant text for debugging,
+- normalize fenced JSON before parsing,
+- validate required fields before writing results,
+- log request latency and token headers,
+- retry transient failures separately from schema-validation failures.
+
+This matters because a single formatting surprise can otherwise break a large batch run.

--- a/content/langdock/docs/agent-completions/references/production-notes.md
+++ b/content/langdock/docs/agent-completions/references/production-notes.md
@@ -1,6 +1,6 @@
 # Production Notes for Agent Completions
 
-These notes summarize sanitized observed behavior from a successful production-style request to Langdock's Agents Completions API. Treat them as implementation guidance, not stronger contract guarantees than the official docs.
+These notes summarize sanitized observed behavior from a successful production-style request to Langdock's Agents Completions API in a batch analysis workflow with structured JSON output requirements. Treat them as implementation guidance, not stronger contract guarantees than the official docs.
 
 ## Observed Structured Output Caveat
 
@@ -51,3 +51,4 @@ For batch analysis pipelines, make the response path defensive:
 - retry transient failures separately from schema-validation failures.
 
 This matters because a single formatting surprise can otherwise break a large batch run.
+


### PR DESCRIPTION
## What

Adds a new community-maintained Context Hub entry for Langdock Agents Completions. This includes:

- a Python-focused `DOC.md`
- request format guidance for Langdock's Vercel AI SDK-compatible `UIMessage` structure
- attachment handling notes
- temporary agent config caveats
- structured output guidance
- a reference note for observed production parsing behavior

## Why

Langdock does not currently appear in the public `context-hub` content tree, and its Agents Completions API has a few integration details that are easy for coding agents to get wrong:

- request messages use Langdock/Vercel-style `UIMessage` objects rather than OpenAI chat-completions message objects
- uploaded attachments should be referenced via `metadata.attachments`
- structured output may still return fenced JSON, so production parsers should handle that defensively
- dedicated deployments use a different base URL shape

## Testing

- [ ] `npm test` passes
- [x] `chub build sample-content/ --validate-only` succeeds
- [x] Manual testing done (describe below)

Manual testing:
- validated the new content locally with `CHUB_TELEMETRY=0 node cli/bin/chub build content --validate-only`
- reviewed the doc structure against existing Context Hub entries
- based implementation details on official Langdock docs plus sanitized observed API behavior from successful Agent Completions usage

## Notes

Official sources used:
- https://docs.langdock.com/api-endpoints/api-introduction
- https://docs.langdock.com/api-endpoints/agent/agent
- https://docs.langdock.com/api-endpoints/agent/attachments

The production-notes reference file documents observed behavior from a sanitized real-world batch workflow, but it is phrased as implementation guidance rather than stronger contract guarantees than the official docs