### PR TITLE
Add Responses API structured outputs, function calling, and Conversations API

### DIFF
--- a/content/openai/docs/chat/go/DOC.md
+++ b/content/openai/docs/chat/go/DOC.md
@@ -4,8 +4,8 @@ description: "OpenAI API for text generation, chat completions, streaming, funct
 metadata:
   languages: "go"
   versions: "1.3.0"
-  revision: 1
-  updated-on: "2026-03-09"
+  revision: 2
+  updated-on: "2026-03-27"
   source: community
   tags: "openai,chat,llm,ai"
 ---
@@ -195,6 +195,44 @@ if err := stream.Err(); err != nil {
 
 ## Function Calling (Tools)
 
+### Responses API (Recommended)
+
+```go
+response, err := client.Responses.New(context.Background(), responses.ResponseNewParams{
+    Model: "gpt-5.4",
+    Input: responses.ResponseNewParamsInputUnion{
+        OfString: openai.String("What's the weather in Paris?"),
+    },
+    Tools: []responses.ToolUnionParam{{
+        OfFunction: &responses.FunctionToolParam{
+            Name:        "get_weather",
+            Description: openai.String("Get current weather for a city"),
+            Parameters: map[string]any{
+                "type": "object",
+                "properties": map[string]any{
+                    "location": map[string]string{
+                        "type":        "string",
+                        "description": "City name",
+                    },
+                },
+                "required": []string{"location"},
+            },
+        },
+    }},
+})
+if err != nil {
+    panic(err)
+}
+for _, item := range response.Output {
+    if item.Type == "function_call" {
+        toolCall := item.AsFunctionCall()
+        fmt.Printf("Function: %s, Args: %s\n", toolCall.Name, toolCall.Arguments)
+    }
+}
+```
+
+### Chat Completions (Legacy)
+
 ```go
 tools := []openai.ChatCompletionToolParam{
     {
@@ -226,7 +264,6 @@ resp, err := client.Chat.Completions.New(context.Background(), openai.ChatComple
 if err != nil {
     panic(err)
 }
-// Inspect resp.Choices[0].Message.ToolCalls for the model's invocation
 for _, tc := range resp.Choices[0].Message.ToolCalls {
     fmt.Printf("Function: %s, Args: %s\n", tc.Function.Name, tc.Function.Arguments)
 }
@@ -234,15 +271,53 @@ for _, tc := range resp.Choices[0].Message.ToolCalls {
 
 ## Structured Outputs (JSON Schema)
 
+### Responses API (Recommended)
+
 ```go
 import "encoding/json"
 
-type Step struct {
-    Explanation string `json:"explanation"`
-    Output      string `json:"output"`
+type HistoricalComputer struct {
+    Origin string `json:"origin"`
+    Name   string `json:"full_name"`
 }
+
+// GenerateSchema uses github.com/invopop/jsonschema to produce a JSON Schema from a Go struct.
+// See the openai-go README for the full helper implementation.
+var schema = GenerateSchema[HistoricalComputer]()
+
+response, err := client.Responses.New(context.Background(), responses.ResponseNewParams{
+    Model: "gpt-5.4",
+    Input: responses.ResponseNewParamsInputUnion{
+        OfString: openai.String("What computer ran the first neural network?"),
+    },
+    Text: responses.ResponseTextConfigParam{
+        Format: responses.ResponseFormatTextConfigParamOfJSONSchema(
+            "historical_computer",
+            schema,
+        ),
+    },
+})
+if err != nil {
+    panic(err)
+}
+
+var computer HistoricalComputer
+json.Unmarshal([]byte(response.OutputText()), &computer)
+fmt.Println(computer.Name)
+```
+
+Note: Go SDK uses `response.OutputText()` + manual `json.Unmarshal` instead of auto-parsed results like Python/JS. The `GenerateSchema` helper is defined in the [openai-go README](https://github.com/openai/openai-go). Import paths use `github.com/openai/openai-go/v3` and subpackages like `github.com/openai/openai-go/v3/responses`.
+
+### Chat Completions (Legacy)
+
+```go
+import "encoding/json"
+
 type MathReasoning struct {
-    Steps       []Step `json:"steps"`
+    Steps       []struct {
+        Explanation string `json:"explanation"`
+        Output      string `json:"output"`
+    } `json:"steps"`
     FinalAnswer string `json:"final_answer"`
 }
 
@@ -269,6 +344,50 @@ resp, err := client.Chat.Completions.New(context.Background(), openai.ChatComple
 var result MathReasoning
 json.Unmarshal([]byte(resp.Choices[0].Message.Content), &result)
 fmt.Println(result.FinalAnswer)
+```
+
+## Conversations API
+
+Import `github.com/openai/openai-go/v3/conversations` for the conversations package.
+
+```go
+conv, err := client.Conversations.New(context.Background(), conversations.ConversationNewParams{})
+if err != nil {
+    panic(err)
+}
+
+response, err := client.Responses.New(context.Background(), responses.ResponseNewParams{
+    Model: "gpt-5.4",
+    Input: responses.ResponseNewParamsInputUnion{
+        OfString: openai.String("Tell me a joke about programming."),
+    },
+    Conversation: responses.ResponseNewParamsConversationUnion{
+        OfConversationObject: &responses.ResponseConversationParam{
+            ID: conv.ID,
+        },
+    },
+})
+if err != nil {
+    panic(err)
+}
+fmt.Println(response.OutputText())
+
+// Follow-up — context preserved automatically
+followUp, err := client.Responses.New(context.Background(), responses.ResponseNewParams{
+    Model: "gpt-5.4",
+    Input: responses.ResponseNewParamsInputUnion{
+        OfString: openai.String("Explain why that's funny."),
+    },
+    Conversation: responses.ResponseNewParamsConversationUnion{
+        OfConversationObject: &responses.ResponseConversationParam{
+            ID: conv.ID,
+        },
+    },
+})
+if err != nil {
+    panic(err)
+}
+fmt.Println(followUp.OutputText())
 ```
 
 ## Vision (Multimodal)

--- a/content/openai/docs/chat/javascript/DOC.md
+++ b/content/openai/docs/chat/javascript/DOC.md
@@ -1,11 +1,12 @@
 ---
 name: chat
-description: "OpenAI API for text generation, chat completions, streaming, function calling, vision, embeddings, and assistants"
+description: "OpenAI API for text generation, responses, conversations, streaming, function calling, vision, structured outputs, embeddings, and assistants"
 metadata:
   languages: "javascript"
   versions: "6.27.0"
-  updated-on: "2026-03-06"
-  source: maintainer
+  revision: 1
+  updated-on: "2026-03-27"
+  source: community
   tags: "openai,chat,llm,ai"
 ---
 
@@ -257,33 +258,48 @@ await client.files.create({
 
 ### Function Calling (Tools)
 
+#### Responses API (Recommended)
+
 ```typescript
-const completion = await client.chat.completions.create({
-  model: 'gpt-5.4',
-  messages: [{ role: 'user', content: 'What is the weather like today?' }],
-  tools: [
-    {
-      type: 'function',
-      function: {
-        name: 'get_current_weather',
-        description: 'Get the current weather in a given location',
-        parameters: {
-          type: 'object',
-          properties: {
-            location: {
-              type: 'string',
-              description: 'The city and state, e.g. San Francisco, CA',
-            },
-            unit: { type: 'string', enum: ['celsius', 'fahrenheit'] },
-          },
-          required: ['location'],
-        },
+const tools = [
+  {
+    type: 'function',
+    name: 'get_weather',
+    description: 'Get the current weather in a given location',
+    parameters: {
+      type: 'object',
+      properties: {
+        location: { type: 'string', description: 'City and state' },
+        unit: { type: 'string', enum: ['celsius', 'fahrenheit'] },
       },
+      required: ['location'],
+      additionalProperties: false,
     },
-  ],
-  tool_choice: 'auto',
+    strict: true,
+  },
+];
+
+let input = [{ role: 'user', content: 'What is the weather like in Paris?' }];
+
+const response = await client.responses.create({
+  model: 'gpt-5.4',
+  tools,
+  input,
 });
+
+// Handle tool calls
+for (const item of response.output) {
+  if (item.type === 'function_call') {
+    const args = JSON.parse(item.arguments);
+    console.log(`Call ${item.name} with`, args);
+    // Return results: input.push({ type: 'function_call_output', call_id: item.call_id, output: result })
+  }
+}
 ```
+
+Note: Responses API uses `name` at the top level of each tool, not nested under `function`. Tool call results use `type: 'function_call_output'` with `call_id`.
+
+For legacy Chat Completions function calling, see [references/additional-apis.md](references/additional-apis.md).
 
 ### Temperature and Sampling Parameters
 
@@ -301,102 +317,88 @@ const completion = await client.chat.completions.create({
 });
 ```
 
-### Structured Outputs (JSON Mode)
+### Structured Outputs
+
+#### Responses API with Zod (Recommended)
 
 ```typescript
-const completion = await client.chat.completions.create({
+import { zodTextFormat } from 'openai/helpers/zod';
+import { z } from 'zod';
+
+const PersonSchema = z.object({
+  name: z.string(),
+  age: z.number(),
+});
+
+const response = await client.responses.parse({
   model: 'gpt-5.4',
-  messages: [
-    { role: 'user', content: 'Extract the name and age from: "John is 30 years old"' }
+  input: [
+    { role: 'user', content: 'Extract the name and age from: "John is 30 years old"' },
   ],
-  response_format: {
-    type: 'json_object'
+  text: {
+    format: zodTextFormat(PersonSchema, 'person'),
   },
 });
 
-const result = JSON.parse(completion.choices[0].message.content);
+const person = response.output_parsed;
+console.log(person.name, person.age);
 ```
 
-## Error Handling
+Key differences from Chat Completions:
+- Use `client.responses.parse()` instead of `client.chat.completions.parse()`
+- Use `text: { format: zodTextFormat(Schema, 'name') }` instead of `response_format: zodResponseFormat(Schema, 'name')`
+- Access result via `response.output_parsed` instead of `message.parsed`
 
-The library provides specific error types for different failure scenarios:
+For legacy Chat Completions structured outputs (JSON mode), see [references/additional-apis.md](references/additional-apis.md).
+
+### Conversations API
+
+Persistent multi-turn conversations managed server-side. Two approaches:
+
+#### Using `previous_response_id` (simpler)
 
 ```typescript
-import OpenAI from 'openai';
+const response = await client.responses.create({
+  model: 'gpt-5.4',
+  input: 'Tell me a joke about programming.',
+  store: true,
+});
+console.log(response.output_text);
 
-const client = new OpenAI();
-
-try {
-  const completion = await client.chat.completions.create({
-    model: 'gpt-5.4',
-    messages: [{ role: 'user', content: 'Hello!' }],
-  });
-} catch (error) {
-  if (error instanceof OpenAI.RateLimitError) {
-    console.log('Rate limit exceeded');
-  } else if (error instanceof OpenAI.AuthenticationError) {
-    console.log('Invalid API key');
-  } else if (error instanceof OpenAI.APIError) {
-    console.log(error.status);  // HTTP status code
-    console.log(error.name);    // Error name
-    console.log(error.headers); // Response headers
-  } else {
-    console.log('Unexpected error:', error);
-  }
-}
+// Follow-up — chain using previous response ID
+const followUp = await client.responses.create({
+  model: 'gpt-5.4',
+  previous_response_id: response.id,
+  input: [{ role: 'user', content: 'Explain why that was funny.' }],
+  store: true,
+});
+console.log(followUp.output_text);
 ```
 
-## Common Patterns
-
-### Retry Logic with Exponential Backoff
+#### Using Conversations (persistent sessions)
 
 ```typescript
-async function createCompletionWithRetry(messages: any[], maxRetries = 3) {
-  for (let attempt = 1; attempt <= maxRetries; attempt++) {
-    try {
-      return await client.chat.completions.create({
-        model: 'gpt-5.4',
-        messages,
-      });
-    } catch (error) {
-      if (error instanceof OpenAI.RateLimitError && attempt < maxRetries) {
-        const delay = Math.pow(2, attempt) * 1000; // Exponential backoff
-        await new Promise(resolve => setTimeout(resolve, delay));
-        continue;
-      }
-      throw error;
-    }
-  }
-}
+const conversation = await client.conversations.create();
+
+const response = await client.responses.create({
+  model: 'gpt-5.4',
+  input: 'Tell me a joke about programming.',
+  conversation: conversation.id,
+});
+console.log(response.output_text);
+
+// Follow-up — context preserved automatically
+const followUp = await client.responses.create({
+  model: 'gpt-5.4',
+  input: 'Explain why that was funny.',
+  conversation: conversation.id,
+});
+console.log(followUp.output_text);
 ```
 
-### Conversation Management
+Use `previous_response_id` for simple chains. Use Conversations API for persistent multi-session state.
 
-```typescript
-class ChatSession {
-  private messages: OpenAI.Chat.ChatCompletionMessageParam[] = [];
-
-  constructor(private client: OpenAI, systemPrompt?: string) {
-    if (systemPrompt) {
-      this.messages.push({ role: 'system', content: systemPrompt });
-    }
-  }
-
-  async sendMessage(content: string) {
-    this.messages.push({ role: 'user', content });
-
-    const completion = await this.client.chat.completions.create({
-      model: 'gpt-5.4',
-      messages: this.messages,
-    });
-
-    const response = completion.choices[0].message;
-    this.messages.push(response);
-
-    return response.content;
-  }
-}
-```
+For error handling, retry logic, and legacy conversation management patterns, see [references/additional-apis.md](references/additional-apis.md).
 
 ## Useful Links
 

--- a/content/openai/docs/chat/javascript/references/additional-apis.md
+++ b/content/openai/docs/chat/javascript/references/additional-apis.md
@@ -1,0 +1,125 @@
+# Additional APIs and Legacy Patterns (JavaScript/TypeScript)
+
+## Legacy Chat Completions Function Calling
+
+```typescript
+const completion = await client.chat.completions.create({
+  model: 'gpt-5.4',
+  messages: [{ role: 'user', content: 'What is the weather like today?' }],
+  tools: [
+    {
+      type: 'function',
+      function: {
+        name: 'get_weather',
+        description: 'Get the current weather in a given location',
+        parameters: {
+          type: 'object',
+          properties: {
+            location: { type: 'string', description: 'City and state' },
+            unit: { type: 'string', enum: ['celsius', 'fahrenheit'] },
+          },
+          required: ['location'],
+        },
+      },
+    },
+  ],
+  tool_choice: 'auto',
+});
+```
+
+## Legacy Chat Completions Structured Outputs (JSON Mode)
+
+```typescript
+const completion = await client.chat.completions.create({
+  model: 'gpt-5.4',
+  messages: [
+    { role: 'user', content: 'Extract the name and age from: "John is 30 years old"' },
+  ],
+  response_format: { type: 'json_object' },
+});
+
+const result = JSON.parse(completion.choices[0].message.content);
+```
+
+## Error Handling
+
+The library provides specific error types for different failure scenarios:
+
+```typescript
+import OpenAI from 'openai';
+
+const client = new OpenAI();
+
+try {
+  const completion = await client.chat.completions.create({
+    model: 'gpt-5.4',
+    messages: [{ role: 'user', content: 'Hello!' }],
+  });
+} catch (error) {
+  if (error instanceof OpenAI.RateLimitError) {
+    console.log('Rate limit exceeded');
+  } else if (error instanceof OpenAI.AuthenticationError) {
+    console.log('Invalid API key');
+  } else if (error instanceof OpenAI.APIError) {
+    console.log(error.status);  // HTTP status code
+    console.log(error.name);    // Error name
+    console.log(error.headers); // Response headers
+  } else {
+    console.log('Unexpected error:', error);
+  }
+}
+```
+
+## Common Patterns
+
+### Retry Logic with Exponential Backoff
+
+```typescript
+async function createCompletionWithRetry(messages: any[], maxRetries = 3) {
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      return await client.chat.completions.create({
+        model: 'gpt-5.4',
+        messages,
+      });
+    } catch (error) {
+      if (error instanceof OpenAI.RateLimitError && attempt < maxRetries) {
+        const delay = Math.pow(2, attempt) * 1000; // Exponential backoff
+        await new Promise(resolve => setTimeout(resolve, delay));
+        continue;
+      }
+      throw error;
+    }
+  }
+}
+```
+
+### Conversation Management (Legacy)
+
+For manual conversation management with Chat Completions. Prefer the Conversations API for new code.
+
+```typescript
+class ChatSession {
+  private messages: OpenAI.Chat.ChatCompletionMessageParam[] = [];
+
+  constructor(private client: OpenAI, systemPrompt?: string) {
+    if (systemPrompt) {
+      this.messages.push({ role: 'system', content: systemPrompt });
+    }
+  }
+
+  async sendMessage(content: string) {
+    this.messages.push({ role: 'user', content });
+
+    const completion = await this.client.chat.completions.create({
+      model: 'gpt-5.4',
+      messages: this.messages,
+    });
+
+    const response = completion.choices[0].message;
+    this.messages.push(response);
+
+    return response.content;
+  }
+}
+```

--- a/content/openai/docs/chat/python/DOC.md
+++ b/content/openai/docs/chat/python/DOC.md
@@ -1,11 +1,12 @@
 ---
 name: chat
-description: "OpenAI API for text generation, chat completions, streaming, function calling, vision, embeddings, and assistants"
+description: "OpenAI API for text generation, responses, conversations, streaming, function calling, vision, structured outputs, embeddings, and assistants"
 metadata:
   languages: "python"
   versions: "2.26.0"
-  updated-on: "2026-03-06"
-  source: maintainer
+  revision: 1
+  updated-on: "2026-03-27"
+  source: community
   tags: "openai,chat,llm,ai"
 ---
 
@@ -124,23 +125,7 @@ response = client.responses.create(
 print(response.output_text)
 ```
 
-### Legacy Method: Chat Completions API
-
-```python
-from openai import OpenAI
-
-client = OpenAI()
-
-completion = client.chat.completions.create(
-    model="gpt-4.1",
-    messages=[
-        {"role": "system", "content": "You are a helpful assistant."},
-        {"role": "user", "content": "How do I reverse a string in Python?"},
-    ],
-)
-
-print(completion.choices[0].message.content)
-```
+For the legacy Chat Completions approach, see [references/additional-apis.md](references/additional-apis.md).
 
 ## Vision (Multimodal Inputs)
 
@@ -227,57 +212,58 @@ for event in stream:
     print(event)
 ```
 
-### Chat Completions Streaming
-
-```python
-from openai import OpenAI
-client = OpenAI()
-
-stream = client.chat.completions.create(
-    model="gpt-4.1",
-    messages=[{"role": "user", "content": "Tell me a joke"}],
-    stream=True,
-)
-
-for chunk in stream:
-    if chunk.choices[0].delta.content is not None:
-        print(chunk.choices[0].delta.content, end="")
-```
+For Chat Completions streaming, see [references/additional-apis.md](references/additional-apis.md).
 
 ## Function Calling (Tools)
 
-Type-safe function calling with Pydantic helpers.
+### Primary Method: Responses API (Recommended)
 
 ```python
-from pydantic import BaseModel
+import json
 from openai import OpenAI
-import openai
-
-class WeatherQuery(BaseModel):
-    """Get the current weather for a location"""
-    location: str
-    unit: str = "celsius"
 
 client = OpenAI()
 
-completion = client.chat.completions.parse(
-    model="gpt-4.1",
-    messages=[{"role": "user", "content": "What's the weather like in Paris?"}],
-    tools=[openai.pydantic_function_tool(WeatherQuery)],
+tools = [
+    {
+        "type": "function",
+        "name": "get_weather",
+        "description": "Get the current weather for a location",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "location": {"type": "string", "description": "City name"},
+                "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+            },
+            "required": ["location"],
+        },
+    },
+]
+
+response = client.responses.create(
+    model="gpt-5.4",
+    tools=tools,
+    input=[{"role": "user", "content": "What's the weather like in Paris?"}],
 )
 
-if completion.choices[0].message.tool_calls:
-    for tool_call in completion.choices[0].message.tool_calls:
-        if getattr(tool_call, "parsed_arguments", None):
-            print(tool_call.parsed_arguments.location)
+# Handle tool calls
+for item in response.output:
+    if item.type == "function_call":
+        args = json.loads(item.arguments)
+        print(f"Call {item.name} with {args}")
+        # Execute your function, then return results:
+        # input.append({"type": "function_call_output", "call_id": item.call_id, "output": result})
 ```
+
+For legacy Chat Completions function calling with Pydantic, see [references/additional-apis.md](references/additional-apis.md).
 
 ## Structured Outputs
 
 Auto-parse JSON into Pydantic models.
 
+### Primary Method: Responses API (Recommended)
+
 ```python
-from typing import List
 from pydantic import BaseModel
 from openai import OpenAI
 
@@ -286,278 +272,87 @@ class Step(BaseModel):
     output: str
 
 class MathResponse(BaseModel):
-    steps: List[Step]
+    steps: list[Step]
     final_answer: str
 
 client = OpenAI()
-completion = client.chat.completions.parse(
-    model="gpt-4.1",
-    messages=[
+response = client.responses.parse(
+    model="gpt-5.4",
+    input=[
         {"role": "system", "content": "You are a helpful math tutor."},
         {"role": "user", "content": "solve 8x + 31 = 2"},
     ],
-    response_format=MathResponse,
+    text_format=MathResponse,
 )
 
-message = completion.choices[0].message
-if message.parsed:
-    print(message.parsed.final_answer)
+if response.output_parsed:
+    print(response.output_parsed.final_answer)
 ```
 
-## Audio Capabilities
+Key differences from Chat Completions:
+- Use `client.responses.parse()` instead of `client.chat.completions.parse()`
+- Use `text_format=` instead of `response_format=`
+- Access result via `response.output_parsed` instead of `message.parsed`
+- Use `input=` instead of `messages=`
 
-### Speech Synthesis (Text-to-Speech)
+For legacy Chat Completions structured outputs, see [references/additional-apis.md](references/additional-apis.md).
+
+## Conversations API
+
+Persistent multi-turn conversations managed server-side by OpenAI. No need to manually pass message history — the API tracks it automatically.
 
 ```python
 from openai import OpenAI
+
 client = OpenAI()
 
-response = client.audio.speech.create(
-    model="gpt-4o-mini-tts",
-    voice="alloy",
-    input="Hello, this is a test of the text to speech API."
-)
+# Create a conversation (once per session)
+conversation = client.conversations.create()
 
-with open("output.mp3", "wb") as f:
-    f.write(response.content)
-```
-
-### Audio Transcription
-
-```python
-from openai import OpenAI
-client = OpenAI()
-
-with open("audio.mp3", "rb") as audio_file:
-    transcription = client.audio.transcriptions.create(
-        model="gpt-4o-transcribe",
-        file=audio_file
-    )
-print(transcription.text)
-```
-
-### Audio Translation
-
-```python
-from openai import OpenAI
-client = OpenAI()
-
-with open("audio.mp3", "rb") as audio_file:
-    translation = client.audio.translations.create(
-        model="whisper-1",
-        file=audio_file
-    )
-print(translation.text)
-```
-
-## File Operations
-
-### Upload Files
-
-```python
-from pathlib import Path
-from openai import OpenAI
-client = OpenAI()
-
-file_response = client.files.create(
-    file=Path("training_data.jsonl"),
-    purpose="fine-tune"
-)
-
-print(f"File ID: {file_response.id}")
-```
-
-### Retrieve, Download, Delete Files
-
-```python
-from openai import OpenAI
-client = OpenAI()
-
-# List files
-files = client.files.list()
-
-# Retrieve a specific file
-file_info = client.files.retrieve("file-abc123")
-
-# Download file content
-file_content = client.files.content("file-abc123")
-
-# Delete a file
-client.files.delete("file-abc123")
-```
-
-## Embeddings
-
-```python
-from openai import OpenAI
-client = OpenAI()
-
-response = client.embeddings.create(
-    model="text-embedding-3-small",
-    input="The quick brown fox jumps over the lazy dog."
-)
-
-embeddings = response.data[0].embedding
-print(f"Embedding dimensions: {len(embeddings)}")
-```
-
-## Image Generation
-
-```python
-from openai import OpenAI
-client = OpenAI()
-
-response = client.images.generate(
-    model="gpt-image-1.5",
-    prompt="A futuristic city skyline at sunset",
-    size="1024x1024",
-    quality="standard",
-    n=1,
-)
-
-image_url = response.data[0].url
-print(f"Generated image: {image_url}")
-```
-
-## Error Handling
-
-```python
-import openai
-from openai import OpenAI
-client = OpenAI()
-
-try:
-    response = client.responses.create(model="gpt-5.4", input="Hello, world!")
-except openai.RateLimitError:
-    print("Rate limit exceeded. Please wait before retrying.")
-except openai.APIConnectionError:
-    print("Failed to connect to OpenAI API.")
-except openai.AuthenticationError:
-    print("Invalid API key provided.")
-except openai.APIStatusError as e:
-    print(f"API error occurred: {e.status_code}")
-    print(f"Error response: {e.response}")
-```
-
-## Request IDs and Debugging
-
-```python
-from openai import OpenAI
-client = OpenAI()
-
-response = client.responses.create(model="gpt-5.4", input="Test message")
-print(f"Request ID: {response._request_id}")
-```
-
-## Retries and Timeouts
-
-```python
-from openai import OpenAI
-
-# Configure retries
-client = OpenAI(max_retries=5)
-
-# Configure timeouts
-client = OpenAI(timeout=30.0)
-
-# Per-request configuration
-response = client.with_options(
-    max_retries=3,
-    timeout=60.0
-).responses.create(
+# First turn
+response = client.responses.create(
     model="gpt-5.4",
-    input="Hello"
+    input="Tell me a joke about programming.",
+    conversation=conversation.id,
 )
+print(response.output_text)
+
+# Follow-up — context is preserved automatically
+response = client.responses.create(
+    model="gpt-5.4",
+    input="Explain why that's funny.",
+    conversation=conversation.id,
+)
+print(response.output_text)
 ```
 
-## Realtime API
+Works with `responses.parse()` for structured outputs in multi-turn conversations:
 
 ```python
-import asyncio
-from openai import AsyncOpenAI
-
-async def main():
-    client = AsyncOpenAI()
-
-    async with client.realtime.connect(model="gpt-realtime") as connection:
-        await connection.session.update(session={'modalities': ['text']})
-
-        await connection.conversation.item.create(
-            item={
-                "type": "message",
-                "role": "user",
-                "content": [{"type": "input_text", "text": "Say hello!"}],
-            }
-        )
-        await connection.response.create()
-
-        async for event in connection:
-            if event.type == "response.output_text.delta":
-                print(event.delta, end="")
-            elif event.type == "response.done":
-                break
-
-asyncio.run(main())
-```
-
-## Microsoft Azure OpenAI
-
-```python
-from openai import AzureOpenAI
-
-client = AzureOpenAI(
-    azure_endpoint="https://your-endpoint.openai.azure.com",
-)
-
-completion = client.chat.completions.create(
-    model="deployment-name",  # Your deployment name
-    messages=[{"role": "user", "content": "Hello, Azure OpenAI!"}],
-)
-print(completion.choices[0].message.content)
-```
-
-## Webhook Verification
-
-```python
-from flask import Flask, request
+from pydantic import BaseModel
 from openai import OpenAI
 
-app = Flask(__name__)
-client = OpenAI()  # Uses OPENAI_WEBHOOK_SECRET environment variable
-
-@app.route("/webhook", methods=["POST"])
-def webhook():
-    request_body = request.get_data(as_text=True)
-
-    try:
-        event = client.webhooks.unwrap(request_body, request.headers)
-
-        if event.type == "response.completed":
-            print("Response completed:", event.data)
-
-        return "ok"
-    except Exception as e:
-        print("Invalid signature:", e)
-        return "Invalid signature", 400
-```
-
-## Pagination
-
-```python
-from openai import OpenAI
+class EditResult(BaseModel):
+    modified_text: str
+    explanation: str
 
 client = OpenAI()
+conversation = client.conversations.create()
 
-# Automatic pagination
-all_files = []
-for file in client.files.list(limit=20):
-    all_files.append(file)
-
-# Manual pagination
-first_page = client.files.list(limit=20)
-if first_page.has_next_page():
-    next_page = first_page.get_next_page()
+response = client.responses.parse(
+    model="gpt-5.4",
+    input="Make the first paragraph bold.",
+    text_format=EditResult,
+    conversation=conversation.id,
+)
+print(response.output_parsed.explanation)
 ```
+
+Use Conversations API when building multi-turn chat UIs or agents that need persistent context. Use manual message history (`input=[...]`) for simple single-request interactions.
+
+## Additional APIs
+
+For audio, files, embeddings, image generation, error handling, retries, realtime API, Azure, webhooks, and pagination, see [references/additional-apis.md](references/additional-apis.md).
 
 ## Notes
 

--- a/content/openai/docs/chat/python/references/additional-apis.md
+++ b/content/openai/docs/chat/python/references/additional-apis.md
@@ -1,0 +1,293 @@
+# Additional OpenAI APIs and Legacy Patterns (Python)
+
+## Legacy Chat Completions Examples
+
+### Basic Inference (Legacy)
+
+```python
+from openai import OpenAI
+
+client = OpenAI()
+
+completion = client.chat.completions.create(
+    model="gpt-4.1",
+    messages=[
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "How do I reverse a string in Python?"},
+    ],
+)
+
+print(completion.choices[0].message.content)
+```
+
+### Streaming (Legacy)
+
+```python
+from openai import OpenAI
+client = OpenAI()
+
+stream = client.chat.completions.create(
+    model="gpt-4.1",
+    messages=[{"role": "user", "content": "Tell me a joke"}],
+    stream=True,
+)
+
+for chunk in stream:
+    if chunk.choices[0].delta.content is not None:
+        print(chunk.choices[0].delta.content, end="")
+```
+
+### Function Calling with Pydantic (Legacy)
+
+```python
+from pydantic import BaseModel
+from openai import OpenAI
+import openai
+
+class WeatherQuery(BaseModel):
+    """Get the current weather for a location"""
+    location: str
+    unit: str = "celsius"
+
+client = OpenAI()
+
+completion = client.chat.completions.parse(
+    model="gpt-4.1",
+    messages=[{"role": "user", "content": "What's the weather like in Paris?"}],
+    tools=[openai.pydantic_function_tool(WeatherQuery)],
+)
+
+if completion.choices[0].message.tool_calls:
+    for tool_call in completion.choices[0].message.tool_calls:
+        if getattr(tool_call, "parsed_arguments", None):
+            print(tool_call.parsed_arguments.location)
+```
+
+### Structured Outputs (Legacy)
+
+```python
+from pydantic import BaseModel
+from openai import OpenAI
+
+class MathResponse(BaseModel):
+    steps: list[str]
+    final_answer: str
+
+client = OpenAI()
+completion = client.chat.completions.parse(
+    model="gpt-4.1",
+    messages=[
+        {"role": "system", "content": "You are a helpful math tutor."},
+        {"role": "user", "content": "solve 8x + 31 = 2"},
+    ],
+    response_format=MathResponse,
+)
+
+message = completion.choices[0].message
+if message.parsed:
+    print(message.parsed.final_answer)
+```
+
+## Audio Capabilities
+
+### Speech Synthesis (Text-to-Speech)
+
+```python
+from openai import OpenAI
+client = OpenAI()
+
+response = client.audio.speech.create(
+    model="gpt-4o-mini-tts",
+    voice="alloy",
+    input="Hello, this is a test of the text to speech API."
+)
+
+with open("output.mp3", "wb") as f:
+    f.write(response.content)
+```
+
+### Audio Transcription
+
+```python
+from openai import OpenAI
+client = OpenAI()
+
+with open("audio.mp3", "rb") as audio_file:
+    transcription = client.audio.transcriptions.create(
+        model="gpt-4o-transcribe",
+        file=audio_file
+    )
+print(transcription.text)
+```
+
+### Audio Translation
+
+```python
+from openai import OpenAI
+client = OpenAI()
+
+with open("audio.mp3", "rb") as audio_file:
+    translation = client.audio.translations.create(
+        model="whisper-1",
+        file=audio_file
+    )
+print(translation.text)
+```
+
+## File Operations
+
+### Upload Files
+
+```python
+from pathlib import Path
+from openai import OpenAI
+client = OpenAI()
+
+file_response = client.files.create(
+    file=Path("training_data.jsonl"),
+    purpose="fine-tune"
+)
+
+print(f"File ID: {file_response.id}")
+```
+
+### Retrieve, Download, Delete Files
+
+```python
+from openai import OpenAI
+client = OpenAI()
+
+# List files
+files = client.files.list()
+
+# Retrieve a specific file
+file_info = client.files.retrieve("file-abc123")
+
+# Download file content
+file_content = client.files.content("file-abc123")
+
+# Delete a file
+client.files.delete("file-abc123")
+```
+
+## Embeddings
+
+```python
+from openai import OpenAI
+client = OpenAI()
+
+response = client.embeddings.create(
+    model="text-embedding-3-small",
+    input="The quick brown fox jumps over the lazy dog."
+)
+
+embeddings = response.data[0].embedding
+print(f"Embedding dimensions: {len(embeddings)}")
+```
+
+## Image Generation
+
+```python
+from openai import OpenAI
+client = OpenAI()
+
+response = client.images.generate(
+    model="gpt-image-1.5",
+    prompt="A futuristic city skyline at sunset",
+    size="1024x1024",
+    quality="standard",
+    n=1,
+)
+
+image_url = response.data[0].url
+print(f"Generated image: {image_url}")
+```
+
+## Realtime API
+
+```python
+import asyncio
+from openai import AsyncOpenAI
+
+async def main():
+    client = AsyncOpenAI()
+
+    async with client.realtime.connect(model="gpt-realtime") as connection:
+        await connection.session.update(session={'modalities': ['text']})
+
+        await connection.conversation.item.create(
+            item={
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "Say hello!"}],
+            }
+        )
+        await connection.response.create()
+
+        async for event in connection:
+            if event.type == "response.output_text.delta":
+                print(event.delta, end="")
+            elif event.type == "response.done":
+                break
+
+asyncio.run(main())
+```
+
+## Microsoft Azure OpenAI
+
+```python
+from openai import AzureOpenAI
+
+client = AzureOpenAI(
+    azure_endpoint="https://your-endpoint.openai.azure.com",
+)
+
+completion = client.chat.completions.create(
+    model="deployment-name",  # Your deployment name
+    messages=[{"role": "user", "content": "Hello, Azure OpenAI!"}],
+)
+print(completion.choices[0].message.content)
+```
+
+## Webhook Verification
+
+```python
+from flask import Flask, request
+from openai import OpenAI
+
+app = Flask(__name__)
+client = OpenAI()  # Uses OPENAI_WEBHOOK_SECRET environment variable
+
+@app.route("/webhook", methods=["POST"])
+def webhook():
+    request_body = request.get_data(as_text=True)
+
+    try:
+        event = client.webhooks.unwrap(request_body, request.headers)
+
+        if event.type == "response.completed":
+            print("Response completed:", event.data)
+
+        return "ok"
+    except Exception as e:
+        print("Invalid signature:", e)
+        return "Invalid signature", 400
+```
+
+## Pagination
+
+```python
+from openai import OpenAI
+
+client = OpenAI()
+
+# Automatic pagination
+all_files = []
+for file in client.files.list(limit=20):
+    all_files.append(file)
+
+# Manual pagination
+first_page = client.files.list(limit=20)
+if first_page.has_next_page():
+    next_page = first_page.get_next_page()
+```

--- a/content/openai/docs/package/python/DOC.md
+++ b/content/openai/docs/package/python/DOC.md
@@ -4,9 +4,9 @@ description: "openai package guide for Python with OpenAI(), AsyncOpenAI(), Resp
 metadata:
   languages: "python"
   versions: "2.26.0"
-  revision: 1
-  updated-on: "2026-03-12"
-  source: maintainer
+  revision: 2
+  updated-on: "2026-03-27"
+  source: community
   tags: "openai,python,sdk,llm,responses,chat,streaming,webhooks"
 ---
 
@@ -205,7 +205,35 @@ print(response.output_text)
 
 ### Structured Outputs With Pydantic
 
-The SDK's documented auto-parsing helper is on Chat Completions, not on the Responses API. Use it when you want parsed Pydantic output.
+Auto-parsing helpers are available on both the Responses API and Chat Completions.
+
+#### Responses API (Recommended)
+
+```python
+from pydantic import BaseModel
+from openai import OpenAI
+
+class Summary(BaseModel):
+    title: str
+    bullets: list[str]
+
+client = OpenAI()
+
+response = client.responses.parse(
+    model="gpt-5.4",
+    input=[
+        {"role": "system", "content": "Return a short structured summary."},
+        {"role": "user", "content": "Summarize how Python context managers work."},
+    ],
+    text_format=Summary,
+)
+
+if response.output_parsed:
+    print(response.output_parsed.title)
+    print(response.output_parsed.bullets)
+```
+
+#### Chat Completions (Legacy)
 
 ```python
 from pydantic import BaseModel


### PR DESCRIPTION
## Summary

The OpenAI docs currently only show Chat Completions for structured outputs and function calling, despite recommending the Responses API as primary. This PR adds the missing Responses API equivalents and the Conversations API across Python, JavaScript, and Go.

**Note on diff size:** The large number of additions/deletions is mostly from moving legacy Chat Completions examples and additional API sections (audio, files, embeddings, etc.) out of the main DOC.md files into `references/additional-apis.md` files to comply with the 500-line guideline. The actual new content added is the Responses API structured outputs, function calling, and Conversations API sections.

## Changes

### New content added (all three languages — Python, JS, Go):
- `responses.parse()` / `responses.create()` as primary method for structured outputs
- Responses API function calling as primary method  
- Conversations API section (persistent multi-turn sessions)

### Refactored (Python & JavaScript):
- Moved legacy Chat Completions examples to `references/additional-apis.md`
- Moved additional API sections (audio, files, embeddings, image gen, realtime, Azure, webhooks, pagination) to `references/additional-apis.md`
- Main DOC.md files now link to reference files for these sections
- This brings Python from 694 → 363 lines and JavaScript from 527 → 409 lines

### Fix (package/python):
- Corrected incorrect claim: "The SDK's documented auto-parsing helper is on Chat Completions, not on the Responses API" — `responses.parse()` with `text_format` exists now

### Existing content preserved:
- All Chat Completions examples kept as "Legacy" subsections or moved to reference files with links
- No model names changed in existing examples

## Verification

- Python examples verified by testing against live OpenAI API
- JavaScript examples verified against official OpenAI structured outputs guide
- Go examples verified via Codex code review against `openai-go` v3 SDK
- All files pass `chub build content/ --validate-only`
- All DOC.md files under 500 lines

## Related

- #202 — Consider renaming `openai/chat` since it now covers the full API (Responses, Conversations, etc.), not just Chat Completions