### PR TITLE
feat: add Gemini Live API docs (Python + JavaScript)

### DIFF
--- a/content/gemini/docs/live/javascript/DOC.md
+++ b/content/gemini/docs/live/javascript/DOC.md
@@ -1,0 +1,391 @@
+---
+name: live
+description: "Google Gemini Live API for real-time bidirectional voice, video, and text streaming over WebSocket in JavaScript/TypeScript"
+metadata:
+  languages: "javascript"
+  versions: "1.43.0"
+  revision: 1
+  updated-on: "2026-03-29"
+  source: community
+  tags: "gemini,google,live,realtime,voice,audio,streaming,websocket,vad,speech"
+---
+
+# Gemini Live API Coding Guidelines (JavaScript/TypeScript)
+
+You are a Gemini Live API coding expert. Help me write real-time voice and
+multimodal streaming code using the official Google Gen AI SDK.
+
+Official docs: https://ai.google.dev/gemini-api/docs/live-api
+
+## Golden Rule: Use the Correct and Current SDK
+
+Always use the Google Gen AI SDK (`@google/genai`). Do not use legacy libraries.
+
+- **Correct:** `npm install @google/genai`
+- **Incorrect:** `npm install @google/generative-ai`
+
+**Imports:**
+
+- **Correct:** `import { GoogleGenAI, Modality } from '@google/genai'`
+- **Incorrect:** `const { GenerativeModel } = require('@google/generative-ai')`
+
+## Models
+
+Use these models for the Live API as of March 2026:
+
+| Model | ID | Notes |
+|---|---|---|
+| **Gemini 3.1 Flash Live** (newest) | `gemini-3.1-flash-live-preview` | Recommended default |
+| **Gemini 2.5 Flash Live** | `gemini-2.5-flash-live-preview` | Supports async tools, proactive audio, affective dialog |
+
+**Key differences:**
+
+- **3.1 Flash Live**: Uses `thinkingLevel` (minimal/low/medium/high). `sendClientContent` only for seeding initial history. No async function calling.
+- **2.5 Flash Live**: Uses `thinkingBudget` (token count). `sendClientContent` works throughout conversation. Supports async function calling.
+
+Do not use non-Live models with `ai.live.connect`. Only `-live-preview` model IDs work.
+
+## Audio Format
+
+| Direction | Format | Sample Rate | Bit Depth | MIME Type |
+|---|---|---|---|---|
+| **Input** | Raw PCM, mono, little-endian | 16 kHz | 16-bit | `audio/pcm;rate=16000` |
+| **Output** | Raw PCM, mono, little-endian | 24 kHz | 16-bit | — |
+
+## Connecting to a Live Session
+
+The JavaScript SDK uses a callback-based connection model.
+
+```typescript
+import { GoogleGenAI, Modality } from '@google/genai';
+
+const ai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY });
+const model = 'gemini-3.1-flash-live-preview';
+
+const session = await ai.live.connect({
+    model,
+    callbacks: {
+        onopen() {
+            console.log('Session opened');
+        },
+        onmessage(message) {
+            handleServerMessage(message);
+        },
+        onerror(e) {
+            console.error('Error:', e.message);
+        },
+        onclose(e) {
+            console.log('Closed:', e.reason);
+        },
+    },
+    config: {
+        responseModalities: [Modality.AUDIO],
+    },
+});
+
+// When done:
+session.close();
+```
+
+**Important:** Unlike Python, the JS SDK is not async-iterator based. You
+handle all responses in the `onmessage` callback.
+
+## Sending Input
+
+### Audio
+
+Send base64-encoded PCM chunks (20-40ms each). Do not buffer more than 1s.
+
+```typescript
+session.sendRealtimeInput({
+    audio: {
+        data: chunk.toString('base64'),  // raw 16-bit PCM
+        mimeType: 'audio/pcm;rate=16000',
+    },
+});
+```
+
+### Text
+
+```typescript
+session.sendRealtimeInput({ text: 'Hello, how are you?' });
+```
+
+### Video (Images)
+
+Send base64-encoded JPEG frames at max 1 FPS.
+
+```typescript
+session.sendRealtimeInput({
+    video: {
+        data: jpegBuffer.toString('base64'),
+        mimeType: 'image/jpeg',
+    },
+});
+```
+
+## Receiving Responses
+
+Handle responses inside the `onmessage` callback:
+
+```typescript
+function handleServerMessage(response: any) {
+    const content = response.serverContent;
+    if (!content) return;
+
+    // Audio from the model
+    if (content.modelTurn?.parts) {
+        for (const part of content.modelTurn.parts) {
+            if (part.inlineData) {
+                const audioBase64 = part.inlineData.data;
+                // Decode and play this 24kHz PCM audio
+            }
+        }
+    }
+
+    // Transcription of what the user said
+    if (content.inputTranscription) {
+        console.log('User:', content.inputTranscription.text);
+    }
+
+    // Transcription of what the model said
+    if (content.outputTranscription) {
+        console.log('Model:', content.outputTranscription.text);
+    }
+
+    // Model was interrupted by user speech
+    if (content.interrupted) {
+        // Stop playback immediately, discard buffered audio
+    }
+
+    // Model finished its response
+    if (content.generationComplete) {
+        // Response complete
+    }
+
+    // Tool calls
+    if (response.toolCall) {
+        handleToolCall(response.toolCall);
+    }
+}
+```
+
+## Full Config Object
+
+```typescript
+import {
+    GoogleGenAI,
+    Modality,
+    StartSensitivity,
+    EndSensitivity,
+} from '@google/genai';
+
+const config = {
+    responseModalities: [Modality.AUDIO],
+
+    // Voice selection
+    speechConfig: {
+        voiceConfig: {
+            prebuiltVoiceConfig: { voiceName: 'Kore' },
+        },
+    },
+
+    // Enable transcriptions
+    outputAudioTranscription: {},
+    inputAudioTranscription: {},
+
+    // System instructions
+    systemInstruction: {
+        parts: [{ text: 'You are a helpful voice assistant.' }],
+    },
+
+    // Thinking (3.1: thinkingLevel; 2.5: thinkingBudget)
+    thinkingConfig: {
+        thinkingLevel: 'low',       // minimal, low, medium, high
+        includeThoughts: true,
+    },
+
+    // Voice Activity Detection
+    realtimeInputConfig: {
+        automaticActivityDetection: {
+            disabled: false,
+            startOfSpeechSensitivity: StartSensitivity.START_SENSITIVITY_LOW,
+            endOfSpeechSensitivity: EndSensitivity.END_SENSITIVITY_LOW,
+            prefixPaddingMs: 20,
+            silenceDurationMs: 100,
+        },
+    },
+
+    // Extend sessions beyond default limits
+    contextWindowCompression: {
+        slidingWindow: {},
+    },
+
+    // Resume after disconnection
+    sessionResumption: {
+        handle: null,  // pass previous handle to resume
+    },
+
+    // Video resolution
+    mediaResolution: 'MEDIA_RESOLUTION_LOW',
+
+    // Tools
+    tools: [
+        { functionDeclarations: [/* ... */] },
+        { googleSearch: {} },
+    ],
+};
+```
+
+## Voice Activity Detection (VAD)
+
+### Automatic VAD (default)
+
+Server detects speech start/end. Configure sensitivity:
+
+```typescript
+realtimeInputConfig: {
+    automaticActivityDetection: {
+        startOfSpeechSensitivity: StartSensitivity.START_SENSITIVITY_LOW,
+        endOfSpeechSensitivity: EndSensitivity.END_SENSITIVITY_LOW,
+        prefixPaddingMs: 20,
+        silenceDurationMs: 100,
+    },
+},
+```
+
+### Manual VAD
+
+Disable automatic detection and control turn boundaries:
+
+```typescript
+const config = {
+    responseModalities: [Modality.AUDIO],
+    realtimeInputConfig: {
+        automaticActivityDetection: { disabled: true },
+    },
+};
+
+// Mark speech boundaries manually
+session.sendRealtimeInput({ activityStart: {} });
+session.sendRealtimeInput({
+    audio: { data: base64Audio, mimeType: 'audio/pcm;rate=16000' },
+});
+session.sendRealtimeInput({ activityEnd: {} });
+```
+
+### Audio Stream Pause
+
+When the mic is off for more than 1 second (automatic VAD mode):
+
+```typescript
+session.sendRealtimeInput({ audioStreamEnd: true });
+```
+
+## Tool Calling (Function Calling)
+
+Define tools in config, handle in `onmessage`:
+
+```typescript
+const config = {
+    responseModalities: [Modality.AUDIO],
+    tools: [{
+        functionDeclarations: [{
+            name: 'get_weather',
+            description: 'Get current weather for a city',
+            parameters: {
+                type: 'object',
+                properties: {
+                    city: { type: 'string', description: 'City name' },
+                },
+                required: ['city'],
+            },
+        }],
+    }],
+};
+
+function handleToolCall(toolCall: any) {
+    const functionResponses = toolCall.functionCalls.map((fc: any) => ({
+        name: fc.name,
+        id: fc.id,
+        response: { result: myToolHandler(fc.name, fc.args) },
+    }));
+    session.sendToolResponse({ functionResponses });
+}
+```
+
+## Seeding Conversation History
+
+Pre-load context before the live session begins:
+
+```typescript
+session.sendClientContent({
+    turns: [
+        { role: 'user', parts: [{ text: 'What is Echo?' }] },
+        { role: 'model', parts: [{ text: 'Echo is a story-to-3D-world app.' }] },
+    ],
+    turnComplete: true,
+});
+```
+
+**Gemini 3.1 Flash Live:** `sendClientContent` is only for initial history
+seeding. After the first model turn, use `sendRealtimeInput({ text: ... })`.
+
+**Gemini 2.5 Flash Live:** `sendClientContent` works throughout the conversation.
+
+## Session Management
+
+### Session Duration Limits
+
+| Mode | Duration |
+|---|---|
+| Audio only | 15 min |
+| Audio + video | 2 min |
+| WebSocket connection | ~10 min |
+
+### Context Window Compression
+
+```typescript
+contextWindowCompression: { slidingWindow: {} }
+```
+
+### Session Resumption
+
+Store the handle from server updates and pass it when reconnecting:
+
+```typescript
+let sessionHandle: string | null = null;
+
+// In onmessage callback:
+if (response.sessionResumptionUpdate?.newHandle) {
+    sessionHandle = response.sessionResumptionUpdate.newHandle;
+}
+
+// When reconnecting:
+const config = {
+    responseModalities: [Modality.AUDIO],
+    sessionResumption: { handle: sessionHandle },
+};
+```
+
+## Best Practices
+
+- **Audio chunks:** Send 20-40ms chunks. Do not buffer more than 1 second.
+- **Resampling:** Browser mic input (44.1/48 kHz) must be resampled to 16 kHz. Use AudioWorklet or OfflineAudioContext.
+- **Interruption handling:** When `interrupted: true`, immediately discard buffered audio.
+- **Session management:** Always enable context window compression for production.
+- **Non-English:** Add `RESPOND IN {LANGUAGE}. YOU MUST RESPOND UNMISTAKABLY IN {LANGUAGE}.` to system instructions.
+
+## Advanced Topics
+
+See [references/advanced.md](references/advanced.md) for:
+- Raw WebSocket API (no SDK)
+- Ephemeral tokens for browser clients
+- Async function calling (Gemini 2.5 Flash Live only)
+
+## Useful Links
+
+- Live API overview: ai.google.dev/gemini-api/docs/live-api
+- JS SDK docs: googleapis.github.io/js-genai/
+- WebSocket tutorial: ai.google.dev/gemini-api/docs/live-api/get-started-websocket
+- Session management: ai.google.dev/gemini-api/docs/live-api/session-management

--- a/content/gemini/docs/live/javascript/DOC.md
+++ b/content/gemini/docs/live/javascript/DOC.md
@@ -4,7 +4,6 @@ description: "Google Gemini Live API for real-time bidirectional voice, video, a
 metadata:
   languages: "javascript"
   versions: "1.43.0"
-  revision: 1
   updated-on: "2026-03-29"
   source: community
   tags: "gemini,google,live,realtime,voice,audio,streaming,websocket,vad,speech"
@@ -126,7 +125,9 @@ session.sendRealtimeInput({
 
 ## Receiving Responses
 
-Handle responses inside the `onmessage` callback:
+Handle responses inside the `onmessage` callback. The `onerror` and `onclose`
+callbacks handle disconnects — use them to trigger reconnection with session
+resumption (see below).
 
 ```typescript
 function handleServerMessage(response: any) {
@@ -304,12 +305,14 @@ const config = {
     }],
 };
 
-function handleToolCall(toolCall: any) {
-    const functionResponses = toolCall.functionCalls.map((fc: any) => ({
-        name: fc.name,
-        id: fc.id,
-        response: { result: myToolHandler(fc.name, fc.args) },
-    }));
+async function handleToolCall(toolCall: any) {
+    const functionResponses = await Promise.all(
+        toolCall.functionCalls.map(async (fc: any) => ({
+            name: fc.name,
+            id: fc.id,
+            response: { result: await myToolHandler(fc.name, fc.args) },
+        }))
+    );
     session.sendToolResponse({ functionResponses });
 }
 ```
@@ -329,7 +332,15 @@ session.sendClientContent({
 ```
 
 **Gemini 3.1 Flash Live:** `sendClientContent` is only for initial history
-seeding. After the first model turn, use `sendRealtimeInput({ text: ... })`.
+seeding. You must enable it in the config and use `sendRealtimeInput({ text: ... })`
+for mid-conversation text:
+
+```typescript
+const config = {
+    responseModalities: [Modality.AUDIO],
+    historyConfig: { initialHistoryInClientContent: true },
+};
+```
 
 **Gemini 2.5 Flash Live:** `sendClientContent` works throughout the conversation.
 
@@ -356,16 +367,36 @@ Store the handle from server updates and pass it when reconnecting:
 ```typescript
 let sessionHandle: string | null = null;
 
-// In onmessage callback:
-if (response.sessionResumptionUpdate?.newHandle) {
-    sessionHandle = response.sessionResumptionUpdate.newHandle;
+function connectSession() {
+    const session = await ai.live.connect({
+        model,
+        callbacks: {
+            onmessage(response) {
+                // Store handle for reconnection
+                if (response.sessionResumptionUpdate?.newHandle) {
+                    sessionHandle = response.sessionResumptionUpdate.newHandle;
+                }
+                // Server about to disconnect — reconnect with stored handle
+                if (response.goAway) {
+                    session.close();
+                    connectSession();  // reconnect with updated handle
+                }
+                handleServerMessage(response);
+            },
+            onclose() {
+                // Reconnect if we have a valid handle (within 2 hours)
+                if (sessionHandle) connectSession();
+            },
+        },
+        config: {
+            responseModalities: [Modality.AUDIO],
+            sessionResumption: { handle: sessionHandle },
+            contextWindowCompression: { slidingWindow: {} },
+        },
+    });
 }
 
-// When reconnecting:
-const config = {
-    responseModalities: [Modality.AUDIO],
-    sessionResumption: { handle: sessionHandle },
-};
+connectSession();
 ```
 
 ## Best Practices

--- a/content/gemini/docs/live/javascript/references/advanced.md
+++ b/content/gemini/docs/live/javascript/references/advanced.md
@@ -6,9 +6,6 @@ For environments where the SDK is unavailable, connect directly via WebSocket.
 
 ### Endpoint
 
-**Server-side only.** Never embed your API key in client-side code. For
-browser clients, use ephemeral tokens (see below).
-
 ```
 wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent?key=YOUR_API_KEY
 ```

--- a/content/gemini/docs/live/javascript/references/advanced.md
+++ b/content/gemini/docs/live/javascript/references/advanced.md
@@ -6,6 +6,9 @@ For environments where the SDK is unavailable, connect directly via WebSocket.
 
 ### Endpoint
 
+**Server-side only.** Never embed your API key in client-side code. For
+browser clients, use ephemeral tokens (see below).
+
 ```
 wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent?key=YOUR_API_KEY
 ```
@@ -83,7 +86,7 @@ wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.
 ### Browser Usage Example
 
 ```typescript
-// Token received from your backend
+// Token received from your backend (endpoint must be authenticated + rate-limited)
 const ephemeralToken = await fetch('/api/gemini-token').then(r => r.json());
 
 const ws = new WebSocket(

--- a/content/gemini/docs/live/javascript/references/advanced.md
+++ b/content/gemini/docs/live/javascript/references/advanced.md
@@ -1,0 +1,143 @@
+# Gemini Live API — Advanced Topics (JavaScript/TypeScript)
+
+## Raw WebSocket API (No SDK)
+
+For environments where the SDK is unavailable, connect directly via WebSocket.
+
+### Endpoint
+
+```
+wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent?key=YOUR_API_KEY
+```
+
+### Setup Message (first message after connect)
+
+```json
+{
+    "config": {
+        "model": "models/gemini-3.1-flash-live-preview",
+        "responseModalities": ["AUDIO"],
+        "systemInstruction": {
+            "parts": [{"text": "You are a helpful assistant."}]
+        }
+    }
+}
+```
+
+### Sending Audio
+
+```json
+{
+    "realtimeInput": {
+        "audio": {
+            "data": "<base64-encoded-pcm-16khz>",
+            "mimeType": "audio/pcm;rate=16000"
+        }
+    }
+}
+```
+
+### Sending Text
+
+```json
+{ "realtimeInput": { "text": "Hello, how are you?" } }
+```
+
+### Tool Response
+
+```json
+{
+    "toolResponse": {
+        "functionResponses": [
+            { "name": "func_name", "id": "call_id", "response": { "result": "ok" } }
+        ]
+    }
+}
+```
+
+### Server Message Fields
+
+| Field | Description |
+|---|---|
+| `serverContent.modelTurn.parts[].inlineData.data` | Base64 audio |
+| `serverContent.inputTranscription.text` | User speech transcription |
+| `serverContent.outputTranscription.text` | Model speech transcription |
+| `serverContent.interrupted` | User interrupted the model |
+| `serverContent.turnComplete` | Model finished its turn |
+| `serverContent.generationComplete` | Generation fully complete |
+| `toolCall.functionCalls[]` | Function calls (name, id, args) |
+| `goAway.timeLeft` | Time before server disconnects |
+| `sessionResumptionUpdate.newHandle` | Handle for session resumption |
+
+## Ephemeral Tokens
+
+Short-lived tokens for direct browser-to-API connections. Created server-side
+(typically in Python or Node.js backend), passed to the browser client.
+
+### Browser WebSocket Endpoint (with ephemeral token)
+
+```
+wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContentConstrained?access_token={token}
+```
+
+### Browser Usage Example
+
+```typescript
+// Token received from your backend
+const ephemeralToken = await fetch('/api/gemini-token').then(r => r.json());
+
+const ws = new WebSocket(
+    `wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContentConstrained?access_token=${ephemeralToken.token}`
+);
+
+ws.onopen = () => {
+    ws.send(JSON.stringify({
+        config: {
+            model: 'models/gemini-3.1-flash-live-preview',
+            responseModalities: ['AUDIO'],
+        },
+    }));
+};
+```
+
+Tokens can be locked to specific configurations with `liveConnectConstraints`
+for additional security.
+
+## Async Function Calling (Gemini 2.5 Flash Live Only)
+
+**Not supported on Gemini 3.1 Flash Live.** Allows the model to continue
+interacting while a function runs in the background.
+
+Set `behavior: 'NON_BLOCKING'` on the function declaration:
+
+```typescript
+tools: [{
+    functionDeclarations: [{
+        name: 'slowLookup',
+        description: 'A slow database lookup',
+        parameters: { type: 'object', properties: { query: { type: 'string' } } },
+        behavior: 'NON_BLOCKING',
+    }],
+}]
+```
+
+When sending the function response, set `scheduling`:
+
+| Scheduling | Behavior |
+|---|---|
+| `INTERRUPT` | Model interrupts current output to address result |
+| `WHEN_IDLE` | Model addresses result after finishing current output |
+| `SILENT` | Model absorbs result silently for later use |
+
+## Model Feature Comparison
+
+| Feature | 3.1 Flash Live | 2.5 Flash Live |
+|---|---|---|
+| Thinking config | `thinkingLevel` (minimal/low/medium/high) | `thinkingBudget` (token count) |
+| Response events | Single event, multiple parts | Each event, one part |
+| `sendClientContent` | Initial history only | Throughout conversation |
+| Turn coverage default | `TURN_INCLUDES_AUDIO_ACTIVITY_AND_ALL_VIDEO` | `TURN_INCLUDES_ONLY_ACTIVITY` |
+| Async function calling | No | Yes (`NON_BLOCKING`) |
+| Proactive audio (v1alpha) | No | Yes |
+| Affective dialog (v1alpha) | No | Yes |
+| Context window | 128k tokens | 32k tokens |

--- a/content/gemini/docs/live/python/DOC.md
+++ b/content/gemini/docs/live/python/DOC.md
@@ -1,0 +1,381 @@
+---
+name: live
+description: "Google Gemini Live API for real-time bidirectional voice, video, and text streaming over WebSocket in Python"
+metadata:
+  languages: "python"
+  versions: "1.56.0"
+  revision: 1
+  updated-on: "2026-03-29"
+  source: community
+  tags: "gemini,google,live,realtime,voice,audio,streaming,websocket,vad,speech"
+---
+
+# Gemini Live API Coding Guidelines (Python)
+
+You are a Gemini Live API coding expert. Help me write real-time voice and
+multimodal streaming code using the official Google GenAI SDK.
+
+Official docs: https://ai.google.dev/gemini-api/docs/live-api
+
+## Golden Rule: Use the Correct and Current SDK
+
+Always use the Google GenAI SDK (`google-genai`). Do not use legacy libraries.
+
+- **Correct:** `pip install google-genai`
+- **Incorrect:** `pip install google-generativeai`
+
+**Imports:**
+
+- **Correct:** `from google import genai` and `from google.genai import types`
+- **Incorrect:** `import google.generativeai as genai`
+
+## Models
+
+Use these models for the Live API as of March 2026:
+
+| Model | ID | Notes |
+|---|---|---|
+| **Gemini 3.1 Flash Live** (newest) | `gemini-3.1-flash-live-preview` | Recommended default |
+| **Gemini 2.5 Flash Live** | `gemini-2.5-flash-live-preview` | Supports async tools, proactive audio, affective dialog |
+
+**Key differences:**
+
+- **3.1 Flash Live**: Uses `thinkingLevel` (minimal/low/medium/high). `send_client_content` only for seeding initial history. No async function calling.
+- **2.5 Flash Live**: Uses `thinkingBudget` (token count). `send_client_content` works throughout conversation. Supports async function calling.
+
+Do not use non-Live models (e.g., `gemini-2.5-flash`) with `client.aio.live.connect`. Only the `-live-preview` model IDs work.
+
+## Audio Format
+
+| Direction | Format | Sample Rate | Bit Depth | MIME Type |
+|---|---|---|---|---|
+| **Input** | Raw PCM, mono, little-endian | 16 kHz | 16-bit | `audio/pcm;rate=16000` |
+| **Output** | Raw PCM, mono, little-endian | 24 kHz | 16-bit | — |
+
+The API will resample if you send other rates, but 16 kHz is optimal.
+
+## Connecting to a Live Session
+
+The Live API uses an async context manager over a WebSocket connection.
+
+```python
+import asyncio
+from google import genai
+from google.genai import types
+
+client = genai.Client()  # reads GEMINI_API_KEY from env
+model = "gemini-3.1-flash-live-preview"
+
+config = types.LiveConnectConfig(
+    response_modalities=["AUDIO"],
+)
+
+async def main():
+    async with client.aio.live.connect(model=model, config=config) as session:
+        # Session is now open — send and receive here
+        pass
+
+asyncio.run(main())
+```
+
+**Important:** The connection is `client.aio.live.connect`, not
+`client.live.connect`. The Live API is async-only.
+
+## Sending Input
+
+### Audio
+
+Send small PCM chunks (20-40ms each). Do not buffer more than 1 second.
+
+```python
+await session.send_realtime_input(
+    audio=types.Blob(
+        data=audio_bytes,  # raw 16-bit PCM bytes
+        mime_type="audio/pcm;rate=16000",
+    )
+)
+```
+
+### Text
+
+```python
+await session.send_realtime_input(text="Hello, how are you?")
+```
+
+### Video (Images)
+
+Send JPEG frames at max 1 FPS.
+
+```python
+await session.send_realtime_input(
+    video=types.Blob(
+        data=jpeg_bytes,
+        mime_type="image/jpeg",
+    )
+)
+```
+
+## Receiving Responses
+
+Iterate over `session.receive()` to get server messages.
+
+```python
+async for response in session.receive():
+    content = response.server_content
+    if not content:
+        continue
+
+    # Audio from the model
+    if content.model_turn:
+        for part in content.model_turn.parts:
+            if part.inline_data:
+                pcm_24khz = part.inline_data.data
+                # Play or buffer this audio
+
+    # Transcription of what the user said
+    if content.input_transcription:
+        print(f"User: {content.input_transcription.text}")
+
+    # Transcription of what the model said
+    if content.output_transcription:
+        print(f"Model: {content.output_transcription.text}")
+
+    # Model was interrupted by user speech
+    if content.interrupted is True:
+        # Stop playback immediately, discard buffered audio
+        pass
+
+    # Model finished its response
+    if content.generation_complete is True:
+        pass
+```
+
+## Full LiveConnectConfig
+
+```python
+config = types.LiveConnectConfig(
+    response_modalities=["AUDIO"],
+
+    # Voice selection
+    speech_config={
+        "voice_config": {
+            "prebuilt_voice_config": {"voice_name": "Kore"}
+        }
+    },
+
+    # Enable transcriptions
+    output_audio_transcription={},
+    input_audio_transcription={},
+
+    # System instructions
+    system_instruction=types.Content(
+        parts=[types.Part.from_text("You are a helpful voice assistant.")]
+    ),
+
+    # Thinking (3.1: thinkingLevel; 2.5: thinkingBudget)
+    thinking_config=types.ThinkingConfig(
+        thinking_level="low",       # minimal, low, medium, high
+        include_thoughts=True,
+    ),
+
+    # Voice Activity Detection
+    realtime_input_config={
+        "automatic_activity_detection": {
+            "disabled": False,
+            "start_of_speech_sensitivity": types.StartSensitivity.START_SENSITIVITY_LOW,
+            "end_of_speech_sensitivity": types.EndSensitivity.END_SENSITIVITY_LOW,
+            "prefix_padding_ms": 20,
+            "silence_duration_ms": 100,
+        }
+    },
+
+    # Extend sessions beyond default limits
+    context_window_compression=types.ContextWindowCompressionConfig(
+        sliding_window=types.SlidingWindow(),
+    ),
+
+    # Resume after disconnection
+    session_resumption=types.SessionResumptionConfig(
+        handle=None,  # pass previous handle to resume
+    ),
+
+    # Video resolution
+    media_resolution=types.MediaResolution.MEDIA_RESOLUTION_LOW,
+
+    # Tools
+    tools=[
+        {"function_declarations": [...]},
+        {"google_search": {}},
+    ],
+)
+```
+
+## Voice Activity Detection (VAD)
+
+### Automatic VAD (default)
+
+Server detects speech start/end. When the user interrupts, ongoing generation
+is canceled. Configure sensitivity:
+
+- `start_of_speech_sensitivity`: `START_SENSITIVITY_LOW` or `START_SENSITIVITY_HIGH`
+- `end_of_speech_sensitivity`: `END_SENSITIVITY_LOW` or `END_SENSITIVITY_HIGH`
+- `prefix_padding_ms`: Audio retained before speech start (e.g., 20)
+- `silence_duration_ms`: Silence before end-of-speech (e.g., 100)
+
+### Manual VAD
+
+Disable automatic detection and control turn boundaries yourself:
+
+```python
+config = types.LiveConnectConfig(
+    response_modalities=["AUDIO"],
+    realtime_input_config={
+        "automatic_activity_detection": {"disabled": True}
+    },
+)
+
+async with client.aio.live.connect(model=model, config=config) as session:
+    await session.send_realtime_input(activity_start=types.ActivityStart())
+    await session.send_realtime_input(
+        audio=types.Blob(data=audio_bytes, mime_type="audio/pcm;rate=16000")
+    )
+    await session.send_realtime_input(activity_end=types.ActivityEnd())
+```
+
+### Audio Stream Pause
+
+When the mic is off for more than 1 second (automatic VAD mode):
+
+```python
+await session.send_realtime_input(audio_stream_end=True)
+```
+
+## Tool Calling (Function Calling)
+
+Define tools in config, handle `tool_call` responses:
+
+```python
+config = types.LiveConnectConfig(
+    response_modalities=["AUDIO"],
+    tools=[{
+        "function_declarations": [{
+            "name": "get_weather",
+            "description": "Get current weather for a city",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string", "description": "City name"}
+                },
+                "required": ["city"],
+            },
+        }]
+    }],
+)
+
+async with client.aio.live.connect(model=model, config=config) as session:
+    # ... send input, then in receive loop:
+    async for response in session.receive():
+        if response.tool_call:
+            function_responses = []
+            for fc in response.tool_call.function_calls:
+                result = await my_tool_handler(fc.name, fc.args)
+                function_responses.append(types.FunctionResponse(
+                    name=fc.name,
+                    id=fc.id,
+                    response={"result": result},
+                ))
+            await session.send_tool_response(
+                function_responses=function_responses
+            )
+```
+
+## Seeding Conversation History (send_client_content)
+
+Pre-load context before the live session begins:
+
+```python
+turns = [
+    types.Content(role="user", parts=[types.Part.from_text("What is Echo?")]),
+    types.Content(role="model", parts=[types.Part.from_text("Echo is a story-to-3D-world app.")]),
+]
+await session.send_client_content(turns=turns, turn_complete=True)
+```
+
+**Gemini 3.1 Flash Live:** `send_client_content` is only for initial history
+seeding. You must set `initial_history_in_client_content: true` in the config's
+`history_config`. After the first model turn, use `send_realtime_input(text=...)`
+for mid-conversation text.
+
+**Gemini 2.5 Flash Live:** `send_client_content` works throughout the
+conversation.
+
+## Session Management
+
+### Session Duration Limits
+
+| Mode | Duration |
+|---|---|
+| Audio only | 15 min |
+| Audio + video | 2 min |
+| WebSocket connection | ~10 min |
+
+### Context Window Compression
+
+Enable sliding window to extend sessions beyond default limits:
+
+```python
+config = types.LiveConnectConfig(
+    response_modalities=["AUDIO"],
+    context_window_compression=types.ContextWindowCompressionConfig(
+        sliding_window=types.SlidingWindow(),
+    ),
+)
+```
+
+### Session Resumption
+
+Handle server-initiated disconnects by storing the resume handle:
+
+```python
+session_handle = None
+
+config = types.LiveConnectConfig(
+    response_modalities=["AUDIO"],
+    session_resumption=types.SessionResumptionConfig(handle=session_handle),
+)
+
+async with client.aio.live.connect(model=model, config=config) as session:
+    async for response in session.receive():
+        # Store resume handle from server updates
+        if hasattr(response, 'session_resumption_update'):
+            update = response.session_resumption_update
+            if update and update.new_handle:
+                session_handle = update.new_handle
+```
+
+Tokens are valid for 2 hours after session termination. The server sends a
+`GoAway` message with `timeLeft` before disconnecting.
+
+## Best Practices
+
+- **Audio chunks:** Send 20-40ms chunks. Do not buffer more than 1 second.
+- **Resampling:** Browser mic input (44.1/48 kHz) must be resampled to 16 kHz before sending.
+- **Interruption handling:** When `interrupted: true`, immediately discard buffered audio.
+- **Session management:** Always enable context window compression for production.
+- **Non-English:** Add `RESPOND IN {LANGUAGE}. YOU MUST RESPOND UNMISTAKABLY IN {LANGUAGE}.` to system instructions.
+- **System instructions:** Use "unmistakably" for precision when defining persona or rules.
+
+## Advanced Topics
+
+See [references/advanced.md](references/advanced.md) for:
+- Raw WebSocket API (no SDK)
+- Ephemeral tokens for browser clients
+- Async function calling (Gemini 2.5 Flash Live only)
+- Model-specific feature matrix
+
+## Useful Links
+
+- Live API overview: ai.google.dev/gemini-api/docs/live-api
+- SDK tutorial: ai.google.dev/gemini-api/docs/live-api/get-started-sdk
+- Capabilities: ai.google.dev/gemini-api/docs/live-api/capabilities
+- Session management: ai.google.dev/gemini-api/docs/live-api/session-management

--- a/content/gemini/docs/live/python/DOC.md
+++ b/content/gemini/docs/live/python/DOC.md
@@ -4,7 +4,6 @@ description: "Google Gemini Live API for real-time bidirectional voice, video, a
 metadata:
   languages: "python"
   versions: "1.56.0"
-  revision: 1
   updated-on: "2026-03-29"
   source: community
   tags: "gemini,google,live,realtime,voice,audio,streaming,websocket,vad,speech"
@@ -117,7 +116,9 @@ await session.send_realtime_input(
 
 ## Receiving Responses
 
-Iterate over `session.receive()` to get server messages.
+Iterate over `session.receive()` to get server messages. In production, wrap
+this in `try/except` to handle `WebSocketError` and reconnect using session
+resumption (see below).
 
 ```python
 async for response in session.receive():
@@ -126,7 +127,7 @@ async for response in session.receive():
         continue
 
     # Audio from the model
-    if content.model_turn:
+    if content.model_turn and content.model_turn.parts:
         for part in content.model_turn.parts:
             if part.inline_data:
                 pcm_24khz = part.inline_data.data
@@ -302,9 +303,15 @@ await session.send_client_content(turns=turns, turn_complete=True)
 ```
 
 **Gemini 3.1 Flash Live:** `send_client_content` is only for initial history
-seeding. You must set `initial_history_in_client_content: true` in the config's
-`history_config`. After the first model turn, use `send_realtime_input(text=...)`
-for mid-conversation text.
+seeding. You must enable it in the config and use `send_realtime_input(text=...)`
+for mid-conversation text:
+
+```python
+config = types.LiveConnectConfig(
+    response_modalities=["AUDIO"],
+    history_config={"initial_history_in_client_content": True},
+)
+```
 
 **Gemini 2.5 Flash Live:** `send_client_content` works throughout the
 conversation.
@@ -339,22 +346,40 @@ Handle server-initiated disconnects by storing the resume handle:
 ```python
 session_handle = None
 
-config = types.LiveConnectConfig(
-    response_modalities=["AUDIO"],
-    session_resumption=types.SessionResumptionConfig(handle=session_handle),
-)
+async def run_session():
+    global session_handle
+    config = types.LiveConnectConfig(
+        response_modalities=["AUDIO"],
+        session_resumption=types.SessionResumptionConfig(handle=session_handle),
+        context_window_compression=types.ContextWindowCompressionConfig(
+            sliding_window=types.SlidingWindow(),
+        ),
+    )
+    async with client.aio.live.connect(model=model, config=config) as session:
+        async for response in session.receive():
+            # Store resume handle for reconnection
+            if hasattr(response, 'session_resumption_update'):
+                update = response.session_resumption_update
+                if update and update.new_handle:
+                    session_handle = update.new_handle
 
-async with client.aio.live.connect(model=model, config=config) as session:
-    async for response in session.receive():
-        # Store resume handle from server updates
-        if hasattr(response, 'session_resumption_update'):
-            update = response.session_resumption_update
-            if update and update.new_handle:
-                session_handle = update.new_handle
+            # Server is about to disconnect — reconnect with stored handle
+            if hasattr(response, 'go_away'):
+                break  # exit loop, then call run_session() again
+
+# Reconnect loop
+while True:
+    try:
+        await run_session()
+    except Exception:
+        if session_handle:
+            continue  # reconnect with stored handle
+        raise
 ```
 
 Tokens are valid for 2 hours after session termination. The server sends a
-`GoAway` message with `timeLeft` before disconnecting.
+`GoAway` message with `timeLeft` before disconnecting. Always handle `GoAway`
+by breaking out of the receive loop and reconnecting with the stored handle.
 
 ## Best Practices
 

--- a/content/gemini/docs/live/python/references/advanced.md
+++ b/content/gemini/docs/live/python/references/advanced.md
@@ -6,9 +6,6 @@ For environments where the SDK is unavailable, connect directly via WebSocket.
 
 ### Endpoint
 
-**Server-side only.** Never embed your API key in client-side code. For
-browser clients, use ephemeral tokens (see below).
-
 ```
 wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent?key=YOUR_API_KEY
 ```

--- a/content/gemini/docs/live/python/references/advanced.md
+++ b/content/gemini/docs/live/python/references/advanced.md
@@ -1,0 +1,157 @@
+# Gemini Live API — Advanced Topics (Python)
+
+## Raw WebSocket API (No SDK)
+
+For environments where the SDK is unavailable, connect directly via WebSocket.
+
+### Endpoint
+
+```
+wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent?key=YOUR_API_KEY
+```
+
+### Setup Message (first message after connect)
+
+```json
+{
+    "config": {
+        "model": "models/gemini-3.1-flash-live-preview",
+        "responseModalities": ["AUDIO"],
+        "systemInstruction": {
+            "parts": [{"text": "You are a helpful assistant."}]
+        }
+    }
+}
+```
+
+### Sending Audio
+
+```json
+{
+    "realtimeInput": {
+        "audio": {
+            "data": "<base64-encoded-pcm-16khz>",
+            "mimeType": "audio/pcm;rate=16000"
+        }
+    }
+}
+```
+
+### Sending Text
+
+```json
+{ "realtimeInput": { "text": "Hello, how are you?" } }
+```
+
+### Tool Response
+
+```json
+{
+    "toolResponse": {
+        "functionResponses": [
+            { "name": "func_name", "id": "call_id", "response": { "result": "ok" } }
+        ]
+    }
+}
+```
+
+### Server Message Fields
+
+Responses are `BidiGenerateContentServerMessage` JSON:
+
+| Field | Description |
+|---|---|
+| `serverContent.modelTurn.parts[].inlineData.data` | Base64 audio |
+| `serverContent.inputTranscription.text` | User speech transcription |
+| `serverContent.outputTranscription.text` | Model speech transcription |
+| `serverContent.interrupted` | User interrupted the model |
+| `serverContent.turnComplete` | Model finished its turn |
+| `serverContent.generationComplete` | Generation fully complete |
+| `toolCall.functionCalls[]` | Function calls (name, id, args) |
+| `goAway.timeLeft` | Time before server disconnects |
+| `sessionResumptionUpdate.newHandle` | Handle for session resumption |
+| `usageMetadata.totalTokenCount` | Token usage |
+
+## Ephemeral Tokens
+
+Short-lived tokens for direct browser-to-API connections without exposing the
+API key. Created server-side, passed to the client.
+
+```python
+import datetime
+from google import genai
+
+# Must use v1alpha for ephemeral tokens
+client = genai.Client(http_options={"api_version": "v1alpha"})
+
+now = datetime.datetime.now(tz=datetime.timezone.utc)
+token = client.auth_tokens.create(config={
+    "uses": 1,
+    "expire_time": now + datetime.timedelta(minutes=30),
+    "new_session_expire_time": now + datetime.timedelta(minutes=1),
+    "http_options": {"api_version": "v1alpha"},
+})
+
+# token.name is the ephemeral token string
+# Pass to client for WebSocket connection:
+# wss://...BidiGenerateContentConstrained?access_token={token.name}
+```
+
+Tokens can be locked to specific configurations with `live_connect_constraints`
+for additional security.
+
+### Ephemeral Token WebSocket Endpoint
+
+```
+wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContentConstrained?access_token={token}
+```
+
+## Async Function Calling (Gemini 2.5 Flash Live Only)
+
+**Not supported on Gemini 3.1 Flash Live.** Allows the model to continue
+interacting while a function executes in the background.
+
+Set `behavior: "NON_BLOCKING"` on the function declaration:
+
+```python
+tools = [{
+    "function_declarations": [{
+        "name": "slow_lookup",
+        "description": "A slow database lookup",
+        "parameters": {"type": "object", "properties": {"query": {"type": "string"}}},
+        "behavior": "NON_BLOCKING",
+    }]
+}]
+```
+
+When sending the `FunctionResponse`, set a `scheduling` field:
+
+| Scheduling | Behavior |
+|---|---|
+| `INTERRUPT` | Model interrupts current output to address result |
+| `WHEN_IDLE` | Model addresses result after finishing current output |
+| `SILENT` | Model absorbs result silently for later use |
+
+## Model Feature Comparison
+
+| Feature | 3.1 Flash Live | 2.5 Flash Live |
+|---|---|---|
+| Thinking config | `thinkingLevel` (minimal/low/medium/high) | `thinkingBudget` (token count) |
+| Response events | Single event, multiple parts | Each event, one part |
+| `send_client_content` | Initial history only | Throughout conversation |
+| Turn coverage default | `TURN_INCLUDES_AUDIO_ACTIVITY_AND_ALL_VIDEO` | `TURN_INCLUDES_ONLY_ACTIVITY` |
+| Async function calling | No | Yes (`NON_BLOCKING`) |
+| Proactive audio (v1alpha) | No | Yes (`proactive_audio: true`) |
+| Affective dialog (v1alpha) | No | Yes (`enable_affective_dialog: true`) |
+| Context window | 128k tokens | 32k tokens |
+
+## Session Limits
+
+| Constraint | Value |
+|---|---|
+| Audio-only session | 15 min |
+| Audio + video session | 2 min |
+| WebSocket connection | ~10 min (use session resumption) |
+| Context window (native audio) | 128k tokens |
+| Audio token accumulation | ~25 tokens/second |
+| Supported languages | 97 |

--- a/content/gemini/docs/live/python/references/advanced.md
+++ b/content/gemini/docs/live/python/references/advanced.md
@@ -6,6 +6,9 @@ For environments where the SDK is unavailable, connect directly via WebSocket.
 
 ### Endpoint
 
+**Server-side only.** Never embed your API key in client-side code. For
+browser clients, use ephemeral tokens (see below).
+
 ```
 wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent?key=YOUR_API_KEY
 ```


### PR DESCRIPTION
## Summary

Adds documentation for the **Gemini Live API** (real-time bidirectional voice/video/text streaming over WebSocket) to the content registry. This API was missing from chub — search for "gemini live" returned no results.

**Python variant** (`content/gemini/docs/live/python/DOC.md`, 406 lines):
- `client.aio.live.connect` async context manager pattern
- `send_realtime_input` for audio/text/video, `session.receive()` async iterator
- Full `LiveConnectConfig` with VAD, thinking, tools, session resumption
- Complete reconnect loop with GoAway handling

**JavaScript variant** (`content/gemini/docs/live/javascript/DOC.md`, 422 lines):
- `ai.live.connect` callback-based pattern (`onmessage`, `onerror`, `onclose`)
- `sendRealtimeInput` for audio/text/video
- Full config object with VAD, thinking, tools, session resumption
- Complete reconnect loop with GoAway handling

**Both variants include** `references/advanced.md` covering:
- Raw WebSocket API (no SDK)
- Ephemeral tokens for browser clients
- Async function calling (Gemini 2.5 Flash Live only)
- Model feature comparison (3.1 Flash Live vs 2.5 Flash Live)

## Details

- Models covered: `gemini-3.1-flash-live-preview` (recommended) and `gemini-2.5-flash-live-preview`
- Audio format: 16kHz PCM input, 24kHz PCM output
- Both docs share `name: live` for variant grouping
- `source: community`, `updated-on: 2026-03-29`
- Build validates: `chub build content/ --validate-only` passes (1554 docs, 7 skills)

## Review Notes

- Adversarial review caught a sync JS tool handler (silently serialized Promises) — fixed
- `model_turn.parts` None guard added to Python receive loop
- Session resumption examples replaced with complete reconnect loops
- `history_config` for 3.1 Flash `send_client_content` now shown in code

🤖 Generated with [Claude Code](https://claude.com/claude-code)