### PR TITLE
feat: Add PowerShell language alias (pwsh)

### DIFF
--- a/cli/src/commands/get.js
+++ b/cli/src/commands/get.js
@@ -202,7 +202,7 @@ export function registerGetCommand(program) {
   program
     .command('get <ids...>')
     .description('Fetch docs or skills by ID (auto-detects type)')
-    .option('--lang <language>', 'Language variant (required for docs): py, js, ts, rb, cs (or full names: python, javascript, typescript, ruby, csharp)')
+    .option('--lang <language>', 'Language variant (required for docs): py, js, ts, rb, cs, pwsh (or full names: python, javascript, typescript, ruby, csharp, powershell)')
     .option('--version <version>', 'Specific version (for docs)')
     .option('-o, --output <path>', 'Write to file or directory')
     .option('--full', 'Fetch all files (not just entry point)')

--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -63,7 +63,7 @@ ${chalk.bold.underline('Flags')}
 
   --json                 Structured JSON output (for agents and piping)
   --tags <csv>           Filter by tags (e.g. docs, skill, openai, browser)
-  --lang <language>      Language variant (required for docs): py | js | ts | rb | cs (or full name)
+  --lang <language>      Language variant (required for docs): py | js | ts | rb | cs | pwsh (or full name)
   --full                 Fetch all files, not just the entry point
   -o, --output <path>    Write content to file or directory
 

--- a/cli/src/lib/normalize.js
+++ b/cli/src/lib/normalize.js
@@ -4,6 +4,7 @@ const ALIASES = {
   py: 'python',
   rb: 'ruby',
   cs: 'csharp',
+  pwsh: 'powershell',
 };
 
 const DISPLAY = {
@@ -12,6 +13,7 @@ const DISPLAY = {
   python: 'py',
   ruby: 'rb',
   csharp: 'cs',
+  powershell: 'pwsh',
 };
 
 export function normalizeLanguage(lang) {

--- a/cli/tests/lib/normalize.test.js
+++ b/cli/tests/lib/normalize.test.js
@@ -22,10 +22,15 @@ describe('normalizeLanguage', () => {
     expect(normalizeLanguage('cs')).toBe('csharp');
   });
 
+  it('maps pwsh to powershell', () => {
+    expect(normalizeLanguage('pwsh')).toBe('powershell');
+  });
+
   it('is case-insensitive', () => {
     expect(normalizeLanguage('JS')).toBe('javascript');
     expect(normalizeLanguage('Py')).toBe('python');
     expect(normalizeLanguage('TS')).toBe('typescript');
+    expect(normalizeLanguage('PWSH')).toBe('powershell');
   });
 
   it('passes through unknown languages unchanged (lowercased)', () => {
@@ -60,6 +65,10 @@ describe('displayLanguage', () => {
 
   it('maps csharp to cs', () => {
     expect(displayLanguage('csharp')).toBe('cs');
+  });
+
+  it('maps powershell to pwsh', () => {
+    expect(displayLanguage('powershell')).toBe('pwsh');
   });
 
   it('passes through unknown languages unchanged', () => {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -35,7 +35,7 @@ Fetch one or more docs or skills by ID. Auto-detects type (doc vs skill). Auto-i
 
 | Flag | Purpose |
 |------|---------|
-| `--lang <language>` | Language variant (js, py, ts, etc.) |
+| `--lang <language>` | Language variant (js, py, ts, pwsh, etc.) |
 | `--version <version>` | Specific doc version |
 | `--full` | Fetch all files, not just the entry point |
 | `--file <paths>` | Fetch specific file(s) by path (comma-separated) |


### PR DESCRIPTION
## Summary

- Add `pwsh` as a first-class language alias (like `py` → `python`, `js` → `javascript`)
- Users can now use `chub get microsoft/pwsh-core --lang pwsh`
- Display name maps `powershell` → `pwsh` in search results

## Changes

| File | Change |
|------|--------|
| `cli/src/lib/normalize.js` | Add `pwsh: 'powershell'` alias + display mapping |
| `cli/src/index.js` | Add `pwsh` to `--lang` help text |
| `cli/src/commands/get.js` | Add `pwsh` to `--lang` option description |
| `docs/cli-reference.md` | Add `pwsh` to language table |
| `cli/tests/lib/normalize.test.js` | Add alias + display unit tests |

## Test plan

- [x] All 233 existing tests pass (`npm test`)
- [x] New tests verify `pwsh` → `powershell` normalization
- [x] New tests verify `powershell` → `pwsh` display

🤖 Generated with [Claude Code](https://claude.com/claude-code)