### PR TITLE
Add Flutter networking and state-management docs with Bloc/Cubit and Riverpod skills

### DIFF
--- a/content/flutter/docs/networking-clients-core/DOC.md
+++ b/content/flutter/docs/networking-clients-core/DOC.md
@@ -1,0 +1,280 @@
+---
+name: networking-clients-core
+description: "Flutter networking guide for HTTP requests, authenticated calls, CRUD patterns, WebSocket usage, and network debugging."
+metadata:
+  languages: "dart"
+  versions: "3.41.6"
+  revision: 1
+  updated-on: "2026-04-04"
+  source: official
+  tags: "flutter,dart,networking,http,dio,websocket,devtools"
+---
+
+# Flutter Networking And HTTP Core Guide
+
+## Version Scope
+
+This doc is written for:
+
+- Flutter `3.41.6` (stable)
+- Dart `3.11.4` (bundled with Flutter 3.41.6)
+- `http` package `1.6.0`
+- `dio` package `5.9.2`
+- `web_socket_channel` package `3.0.3`
+
+If your project pins older versions, adjust API usage and dependency constraints accordingly.
+
+## Choose One HTTP Client (Independent Usage)
+
+`http` and `dio` are alternatives for HTTP calls. You can use either one independently.
+
+- Use `http` for simpler REST flows.
+- Use `dio` for interceptors, richer request config, and centralized error handling.
+- Do not install both unless your project has a specific migration or mixed-client reason.
+
+## Install Dependencies
+
+Pick one HTTP client setup below.
+
+Option A: `http` only
+
+```yaml
+dependencies:
+  flutter:
+    sdk: flutter
+  http: 1.6.0
+  web_socket_channel: 3.0.3
+```
+
+Option B: `dio` only
+
+```yaml
+dependencies:
+  flutter:
+    sdk: flutter
+  dio: 5.9.2
+  web_socket_channel: 3.0.3
+```
+
+Then run:
+
+```bash
+flutter pub get
+```
+
+## Basic GET With http
+
+Use `http` for straightforward REST calls.
+
+```dart
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+class Todo {
+  final int id;
+  final String title;
+  final bool completed;
+
+  const Todo({
+    required this.id,
+    required this.title,
+    required this.completed,
+  });
+
+  factory Todo.fromJson(Map<String, dynamic> json) {
+    return Todo(
+      id: json['id'] as int,
+      title: json['title'] as String,
+      completed: json['completed'] as bool,
+    );
+  }
+}
+
+Future<Todo> fetchTodo(http.Client client) async {
+  final uri = Uri.parse('https://jsonplaceholder.typicode.com/todos/1');
+  final response = await client.get(uri).timeout(const Duration(seconds: 10));
+
+  if (response.statusCode != 200) {
+    throw Exception('GET failed: ${response.statusCode}');
+  }
+
+  final map = jsonDecode(response.body) as Map<String, dynamic>;
+  return Todo.fromJson(map);
+}
+```
+
+## Authenticated Request
+
+Set auth and content headers explicitly.
+
+```dart
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+Future<Map<String, dynamic>> fetchProfile({
+  required http.Client client,
+  required String token,
+}) async {
+  final uri = Uri.parse('https://api.example.com/profile');
+
+  final response = await client.get(
+    uri,
+    headers: {
+      'Authorization': 'Bearer $token',
+      'Accept': 'application/json',
+    },
+  );
+
+  if (response.statusCode != 200) {
+    throw Exception('Profile request failed: ${response.statusCode}');
+  }
+
+  return jsonDecode(response.body) as Map<String, dynamic>;
+}
+```
+
+## Send, Update, Delete Data
+
+Common CRUD flows with JSON payloads.
+
+```dart
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+Future<void> createPost(http.Client client) async {
+  final uri = Uri.parse('https://api.example.com/posts');
+
+  final response = await client.post(
+    uri,
+    headers: {'Content-Type': 'application/json'},
+    body: jsonEncode({'title': 'Hello', 'body': 'World'}),
+  );
+
+  if (response.statusCode != 201) {
+    throw Exception('Create failed: ${response.statusCode}');
+  }
+}
+
+Future<void> updatePost(http.Client client, int id) async {
+  final uri = Uri.parse('https://api.example.com/posts/$id');
+
+  final response = await client.put(
+    uri,
+    headers: {'Content-Type': 'application/json'},
+    body: jsonEncode({'title': 'Updated title'}),
+  );
+
+  if (response.statusCode != 200) {
+    throw Exception('Update failed: ${response.statusCode}');
+  }
+}
+
+Future<void> deletePost(http.Client client, int id) async {
+  final uri = Uri.parse('https://api.example.com/posts/$id');
+  final response = await client.delete(uri);
+
+  if (response.statusCode != 200 && response.statusCode != 204) {
+    throw Exception('Delete failed: ${response.statusCode}');
+  }
+}
+```
+
+## When To Use Dio
+
+Use `dio` when you choose `dio` as your single HTTP client and need interceptors, richer request options, or centralized error mapping.
+
+```dart
+import 'package:dio/dio.dart';
+
+Dio buildApiClient(String token) {
+  final dio = Dio(
+    BaseOptions(
+      baseUrl: 'https://api.example.com',
+      connectTimeout: const Duration(seconds: 10),
+      receiveTimeout: const Duration(seconds: 10),
+      headers: {'Authorization': 'Bearer $token'},
+    ),
+  );
+
+  dio.interceptors.add(
+    InterceptorsWrapper(
+      onError: (error, handler) {
+        handler.next(error);
+      },
+    ),
+  );
+
+  return dio;
+}
+
+Future<Map<String, dynamic>> fetchMe(Dio dio) async {
+  final response = await dio.get('/me');
+  return response.data as Map<String, dynamic>;
+}
+```
+
+## WebSocket For Realtime
+
+Use WebSocket for push updates such as chat, notifications, and live status.
+
+```dart
+import 'dart:convert';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+class RealtimeClient {
+  final WebSocketChannel channel;
+
+  RealtimeClient(String url) : channel = WebSocketChannel.connect(Uri.parse(url));
+
+  Stream<Map<String, dynamic>> messages() {
+    return channel.stream.map((event) {
+      return jsonDecode(event as String) as Map<String, dynamic>;
+    });
+  }
+
+  void send(Map<String, dynamic> payload) {
+    channel.sink.add(jsonEncode(payload));
+  }
+
+  void dispose() {
+    channel.sink.close();
+  }
+}
+```
+
+## Debugging Network Calls In DevTools
+
+Use Flutter DevTools Network view to inspect:
+
+- request URL, method, and headers
+- response status and timing
+- payload size and sequence
+
+Practical workflow:
+
+1. Reproduce the failing screen or action.
+2. Open the request in Network view.
+3. Verify status code, headers, and body shape.
+4. Match failures to app-side error handling.
+
+## Pitfalls And Safe Defaults
+
+- Reuse one client where practical; close it when no longer needed.
+- Always set request timeouts.
+- Check non-2xx responses before decoding.
+- In widgets, guard post-await UI updates with `mounted` checks.
+- Keep parsing typed and explicit.
+- Avoid logging tokens or sensitive request payloads.
+
+## References
+
+- https://docs.flutter.dev/data-and-backend/networking
+- https://docs.flutter.dev/cookbook/networking/fetch-data
+- https://docs.flutter.dev/cookbook/networking/authenticated-requests
+- https://docs.flutter.dev/cookbook/networking/send-data
+- https://docs.flutter.dev/cookbook/networking/update-data
+- https://docs.flutter.dev/cookbook/networking/delete-data
+- https://docs.flutter.dev/cookbook/networking/web-sockets
+- https://docs.flutter.dev/tools/devtools/network
+- https://pub.dev/packages/http
+- https://pub.dev/packages/dio

--- a/content/flutter/docs/state-management-bloc/DOC.md
+++ b/content/flutter/docs/state-management-bloc/DOC.md
@@ -1,0 +1,468 @@
+---
+name: state-management-bloc
+description: "Flutter state management using bloc and cubit patterns with flutter_bloc. Covers bloc vs cubit selection, event-driven architecture, listeners, and bloc testing."
+metadata:
+  languages: "dart"
+  versions: "3.41.6"
+  revision: 1
+  updated-on: "2026-04-04"
+  source: official
+  tags: "flutter,dart,bloc,cubit,state-management,flutter_bloc,events,architecture"
+---
+
+# Flutter State Management: Bloc and Cubit
+
+## Version Scope
+
+This doc is written for:
+
+- Flutter `3.41.6` (stable)
+- Dart `3.11.4` (bundled with Flutter 3.41.6)
+- `bloc` package `9.2.0`
+- `flutter_bloc` package `9.1.1`
+
+All examples follow this architecture. Adjust versions if using newer bloc releases, which maintain API compatibility within the 9.x series.
+
+## Package Distinction: `bloc` vs `flutter_bloc`
+
+The `bloc` package provides **core, framework-agnostic** state management logic (Bloc, Cubit, Event classes, state streams). The `flutter_bloc` package provides **Flutter-specific widgets and helpers** (BlocProvider, BlocBuilder, BlocListener, MultiBlocProvider).
+
+**Use them based on your project type:**
+- Dart-only project: add `bloc`
+- Flutter app: add `flutter_bloc` and let it bring `bloc` transitively
+
+In non-Flutter Dart projects, use `bloc` alone.
+
+## Cubit vs Bloc: When to Use Each
+
+**Cubit** — Simple state mutations with method calls (no external events):
+- State changes via direct method calls (e.g., `cubit.increment()`)
+- Fewer moving parts, suitable for simple features (theme toggle, counter, form state)
+- Single responsibility: one cubit = one state source
+- Preferred for 60% of UI state needs
+
+**Bloc** — Event-driven state machine with explicit transitions:
+- State changes via events (e.g., `bloc.add(LoginEvent(email, password))`)
+- Clear event → processing → state flow (great for debugging)
+- Recoverable: events can be replayed for state restoration
+- Preferred for complex flows (authentication, data sync, undo/redo)
+
+**Decision rule:**
+- No events needed? → Use Cubit
+- Events, state transitions, or replay? → Use Bloc
+
+## Install Dependencies
+
+Add the package that matches your project:
+
+Option A: Dart-only project
+
+```yaml
+dependencies:
+  bloc: ^9.2.0
+```
+
+Option B: Flutter app using Bloc widgets
+
+```yaml
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_bloc: ^9.1.1
+```
+
+Run:
+
+```bash
+flutter pub get
+```
+
+## Cubit: Direct State Mutations
+
+Cubit emits state via method calls (no events). Use for simple state changes.
+
+```dart
+import 'package:bloc/bloc.dart';
+
+// Define state
+class CounterState {
+  final int count;
+  CounterState({required this.count});
+  
+  CounterState copyWith({int? count}) {
+    return CounterState(count: count ?? this.count);
+  }
+}
+
+// Cubit: state emission via methods
+class CounterCubit extends Cubit<CounterState> {
+  CounterCubit() : super(CounterState(count: 0));
+
+  void increment() {
+    emit(state.copyWith(count: state.count + 1));
+  }
+
+  void decrement() {
+    emit(state.copyWith(count: state.count - 1));
+  }
+}
+
+// Use in Flutter
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) => CounterCubit(),
+      child: MaterialApp(
+        home: const CounterPage(),
+      ),
+    );
+  }
+}
+
+class CounterPage extends StatelessWidget {
+  const CounterPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Counter (Cubit)')),
+      body: Center(
+        child: BlocBuilder<CounterCubit, CounterState>(
+          builder: (context, state) {
+            return Text(
+              'Count: ${state.count}',
+              style: const TextStyle(fontSize: 28),
+            );
+          },
+        ),
+      ),
+      floatingActionButton: Row(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: [
+          FloatingActionButton(
+            onPressed: () => context.read<CounterCubit>().increment(),
+            child: const Icon(Icons.add),
+          ),
+          const SizedBox(width: 8),
+          FloatingActionButton(
+            onPressed: () => context.read<CounterCubit>().decrement(),
+            child: const Icon(Icons.remove),
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+## Bloc: Event-Driven State Machine
+
+Bloc emits state through events and explicit event handlers. Use for complex flows with state transitions.
+
+```dart
+import 'package:bloc/bloc.dart';
+
+// Define event
+abstract class AuthEvent {}
+
+class LoginEvent extends AuthEvent {
+  final String email;
+  final String password;
+  LoginEvent(this.email, this.password);
+}
+
+class LogoutEvent extends AuthEvent {}
+
+// Define state
+abstract class AuthState {}
+
+class AuthInitial extends AuthState {}
+
+class AuthLoading extends AuthState {}
+
+class AuthSuccess extends AuthState {
+  final String userId;
+  AuthSuccess(this.userId);
+}
+
+class AuthFailure extends AuthState {
+  final String error;
+  AuthFailure(this.error);
+}
+
+// Bloc: event-driven state transitions
+class AuthBloc extends Bloc<AuthEvent, AuthState> {
+  AuthBloc() : super(AuthInitial()) {
+    // Register event handlers
+    on<LoginEvent>((event, emit) async {
+      emit(AuthLoading());
+      
+      try {
+        // Simulate API call
+        await Future.delayed(const Duration(seconds: 2));
+        
+        if (event.email.isEmpty || event.password.isEmpty) {
+          emit(AuthFailure('Email and password required'));
+        } else if (!event.email.contains('@')) {
+          emit(AuthFailure('Invalid email format'));
+        } else {
+          emit(AuthSuccess('user_${event.email}'));
+        }
+      } catch (e) {
+        emit(AuthFailure(e.toString()));
+      }
+    });
+
+    on<LogoutEvent>((event, emit) {
+      emit(AuthInitial());
+    });
+  }
+}
+
+// Use in Flutter
+class LoginPage extends StatefulWidget {
+  const LoginPage({Key? key}) : super(key: key);
+
+  @override
+  State<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+  late TextEditingController emailController;
+  late TextEditingController passwordController;
+
+  @override
+  void initState() {
+    super.initState();
+    emailController = TextEditingController();
+    passwordController = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    emailController.dispose();
+    passwordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login (Bloc)')),
+      body: BlocListener<AuthBloc, AuthState>(
+        listener: (context, state) {
+          if (state is AuthSuccess) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text('Logged in: ${state.userId}')),
+            );
+          } else if (state is AuthFailure) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text('Error: ${state.error}')),
+            );
+          }
+        },
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              TextField(
+                controller: emailController,
+                decoration: const InputDecoration(hintText: 'Email'),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: passwordController,
+                decoration: const InputDecoration(hintText: 'Password'),
+                obscureText: true,
+              ),
+              const SizedBox(height: 24),
+              BlocBuilder<AuthBloc, AuthState>(
+                builder: (context, state) {
+                  if (state is AuthLoading) {
+                    return const CircularProgressIndicator();
+                  }
+                  
+                  return ElevatedButton(
+                    onPressed: () {
+                      context.read<AuthBloc>().add(
+                        LoginEvent(
+                          emailController.text,
+                          passwordController.text,
+                        ),
+                      );
+                    },
+                    child: const Text('Login'),
+                  );
+                },
+              ),
+              if (context.read<AuthBloc>().state is AuthSuccess)
+                Padding(
+                  padding: const EdgeInsets.only(top: 16),
+                  child: ElevatedButton.icon(
+                    onPressed: () {
+                      context.read<AuthBloc>().add(LogoutEvent());
+                    },
+                    icon: const Icon(Icons.logout),
+                    label: const Text('Logout'),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+```
+
+## Bloc Lifecycle and Closing
+
+Always close blocs and cubits when they are no longer needed to free resources:
+
+```dart
+// Bloc closes itself when disposed via BlocProvider
+// Manual close when managing blocs directly:
+final authBloc = AuthBloc();
+// ... use bloc ...
+await authBloc.close(); // Free event listener and close stream
+
+// Using try-finally to ensure close:
+final counterCubit = CounterCubit();
+try {
+  // Use cubit
+} finally {
+  await counterCubit.close();
+}
+```
+
+## BlocListener for Side Effects
+
+Use `BlocListener` for side effects (navigation, snackbars, analytics) that should not rebuild:
+
+```dart
+BlocListener<AuthBloc, AuthState>(
+  listenWhen: (previous, current) {
+    // Only listen to failure state changes
+    return current is AuthFailure;
+  },
+  listener: (context, state) {
+    if (state is AuthFailure) {
+      // Show error snackbar
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(state.error)),
+      );
+    }
+  },
+  child: BlocBuilder<AuthBloc, AuthState>(
+    builder: (context, state) {
+      // Build UI based on state
+      return const Text('UI');
+    },
+  ),
+);
+```
+
+## MultiBlocProvider for Multiple State Sources
+
+Provide multiple blocs at the same level to avoid deep nesting:
+
+```dart
+MultiBlocProvider(
+  providers: [
+    BlocProvider(create: (context) => AuthBloc()),
+    BlocProvider(create: (context) => UserBloc()),
+    BlocProvider(create: (context) => ThemeCubit()),
+  ],
+  child: MaterialApp(
+    home: const HomePage(),
+  ),
+);
+```
+
+## Testing Blocs
+
+Test blocs by adding events and asserting emitted states:
+
+```dart
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('CounterCubit', () {
+    test('increments count', () async {
+      final cubit = CounterCubit();
+      
+      await expectLater(
+        cubit.stream,
+        emits(isA<CounterState>().having(
+          (state) => state.count,
+          'count',
+          1,
+        )),
+      );
+      
+      cubit.increment();
+      await cubit.close();
+    });
+  });
+
+  group('AuthBloc', () {
+    blocTest<AuthBloc, AuthState>(
+      'emits [AuthLoading, AuthSuccess] on LoginEvent',
+      build: () => AuthBloc(),
+      act: (bloc) => bloc.add(LoginEvent('test@example.com', 'password123')),
+      expect: () => [
+        isA<AuthLoading>(),
+        isA<AuthSuccess>(),
+      ],
+    );
+
+    blocTest<AuthBloc, AuthState>(
+      'emits [AuthLoading, AuthFailure] on invalid email',
+      build: () => AuthBloc(),
+      act: (bloc) => bloc.add(LoginEvent('invalid', 'password123')),
+      expect: () => [
+        isA<AuthLoading>(),
+        isA<AuthFailure>(),
+      ],
+    );
+  });
+}
+```
+
+Add `bloc_test` to `pubspec.yaml` for testing utilities:
+
+```yaml
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  bloc_test: ^9.1.0
+```
+
+## Pitfalls and Safe Defaults
+
+- **Do not** emit state synchronously in event handlers — always use `emit()` which respects equality checks and prevents unnecessary rebuilds
+- **Do not** forget to call `await bloc.close()` when manually managing blocs — use `BlocProvider` for automatic closure
+- **Do not** use `context.read()` outside of `build` methods — use `context.watch()` in build, `context.read()` in event handlers
+- **Do** use sealed classes (Dart 3.0+) for events and states to ensure exhaustive pattern matching
+- **Do** add `equatable` mixin or override `==` and `hashCode` for state comparison (bloc uses `==` to skip duplicate emissions)
+- **Do** test bloc/cubit side effects separately using `BlocListener` tests or mock dependencies
+
+## References
+
+- [Bloc Package](https://pub.dev/packages/bloc)
+- [Flutter Bloc Package](https://pub.dev/packages/flutter_bloc)
+- [Official Flutter State Management Guide](https://docs.flutter.dev/data-and-backend/state-mgmt/intro)
+- [Bloc Package GitHub](https://github.com/felangel/bloc)
+- [Flutter Bloc YouTube Intro](https://www.youtube.com/watch?v=hTExltbRoYs)

--- a/content/flutter/docs/state-management-riverpod/DOC.md
+++ b/content/flutter/docs/state-management-riverpod/DOC.md
@@ -1,0 +1,412 @@
+---
+name: state-management-riverpod
+description: "Flutter state management with Riverpod. Covers providers, consumers, refs, overrides, scoping, async state, code generation, and testing."
+metadata:
+  languages: "dart"
+  versions: "3.2.1"
+  revision: 1
+  updated-on: "2026-04-04"
+  source: official
+  tags: "flutter,dart,riverpod,flutter_riverpod,providers,async,testing,codegen"
+---
+
+# Flutter State Management: Riverpod
+
+## Version Scope
+
+This doc is written for:
+
+- Flutter `3.41.6` (stable)
+- Dart `3.11.4` (bundled with Flutter 3.41.6)
+- `flutter_riverpod` package `3.3.1`
+- `riverpod` package `3.2.1`
+
+This draft assumes Riverpod 3.x APIs. If your project uses a newer 3.x release, keep the same structure and update package versions in `pubspec.yaml`.
+
+## Package Distinction: `riverpod` vs `flutter_riverpod`
+
+The `riverpod` package provides the core provider system. The `flutter_riverpod` package adds Flutter widgets and integration helpers.
+
+Use them like this:
+- Dart-only project: add `riverpod`
+- Flutter app: add `flutter_riverpod`
+- If you use `flutter_riverpod`, you usually do not add `riverpod` separately because it comes through the Flutter package
+
+## Choose the Right Primitive
+
+Use these defaults:
+- `Provider` for read-only dependencies and derived values
+- `StateProvider` for simple mutable state
+- `FutureProvider` for one-shot async loading
+- `StreamProvider` for reactive streams
+- `Notifier` or `AsyncNotifier` for feature state and mutations
+- `StateNotifier` only if you are maintaining legacy Riverpod 1.x style or a codebase that already uses it
+
+## Install Dependencies
+
+For a Flutter app using Riverpod:
+
+```yaml
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_riverpod: ^3.3.1
+```
+
+If you use code generation, add these too:
+
+```yaml
+dependencies:
+  riverpod_annotation: ^4.0.2
+
+dev_dependencies:
+  build_runner: ^2.4.0
+  riverpod_generator: ^4.0.3
+```
+
+Run:
+
+```bash
+flutter pub get
+```
+
+## ProviderScope and Consumer Widgets
+
+Wrap the app in `ProviderScope` once at the root. Use `ConsumerWidget`, `Consumer`, or `ConsumerStatefulWidget` to read providers.
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final greetingProvider = Provider<String>((ref) => 'Hello Riverpod');
+
+void main() {
+  runApp(const ProviderScope(child: MyApp()));
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(home: HomePage());
+  }
+}
+
+class HomePage extends ConsumerWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final greeting = ref.watch(greetingProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Riverpod')),
+      body: Center(
+        child: Text(greeting),
+      ),
+    );
+  }
+}
+```
+
+## Simple Mutable State with StateProvider
+
+Use `StateProvider` for small local state.
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final countProvider = StateProvider<int>((ref) => 0);
+
+class CounterPage extends ConsumerWidget {
+  const CounterPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final count = ref.watch(countProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Counter')),
+      body: Center(
+        child: Text('Count: $count', style: const TextStyle(fontSize: 28)),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          ref.read(countProvider.notifier).state++;
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}
+```
+
+## Async Data with FutureProvider
+
+Use `FutureProvider` when the state is loading/data/error.
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final todosProvider = FutureProvider<List<String>>((ref) async {
+  await Future.delayed(const Duration(seconds: 1));
+  return ['Buy milk', 'Write docs', 'Review PR'];
+});
+
+class TodosPage extends ConsumerWidget {
+  const TodosPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final todosAsync = ref.watch(todosProvider);
+
+    return todosAsync.when(
+      data: (todos) => ListView.builder(
+        itemCount: todos.length,
+        itemBuilder: (context, index) => ListTile(title: Text(todos[index])),
+      ),
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (error, stackTrace) => Center(child: Text('Error: $error')),
+    );
+  }
+}
+```
+
+## StreamProvider for Live Updates
+
+Use `StreamProvider` for realtime data.
+
+```dart
+final clockProvider = StreamProvider<DateTime>((ref) async* {
+  while (true) {
+    yield DateTime.now();
+    await Future.delayed(const Duration(seconds: 1));
+  }
+});
+```
+
+## family for Parameterized State
+
+Use `.family` when the provider depends on an argument.
+
+```dart
+final userProvider = FutureProvider.family<Map<String, dynamic>, int>(
+  (ref, userId) async {
+    await Future.delayed(const Duration(milliseconds: 500));
+    return {
+      'id': userId,
+      'name': 'User $userId',
+    };
+  },
+);
+
+class UserPage extends ConsumerWidget {
+  final int userId;
+
+  const UserPage({super.key, required this.userId});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final userAsync = ref.watch(userProvider(userId));
+
+    return userAsync.when(
+      data: (user) => Text('Name: ${user['name']}'),
+      loading: () => const CircularProgressIndicator(),
+      error: (error, stackTrace) => Text('Error: $error'),
+    );
+  }
+}
+```
+
+## autoDispose for Short-Lived State
+
+Use `autoDispose` for search screens, transient requests, or state that should reset when unused.
+
+```dart
+final searchResultsProvider = FutureProvider.autoDispose<List<String>>((ref) async {
+  await Future.delayed(const Duration(milliseconds: 300));
+  return ['Result A', 'Result B'];
+});
+```
+
+Use `ref.keepAlive()` only when you explicitly want to keep the state cached.
+
+## refs and Containers
+
+Use `Ref` inside providers and `WidgetRef` in Flutter widgets. Use `ProviderContainer` in non-UI code or tests.
+
+```dart
+final apiBaseUrlProvider = Provider<String>((ref) => 'https://api.example.com');
+
+final apiClientProvider = Provider<ApiClient>((ref) {
+  final baseUrl = ref.watch(apiBaseUrlProvider);
+  return ApiClient(baseUrl: baseUrl);
+});
+
+class ApiClient {
+  final String baseUrl;
+  ApiClient({required this.baseUrl});
+}
+```
+
+`ProviderContainer` is the headless equivalent of a widget tree.
+
+## Mutations and Imperative Updates
+
+Use `Notifier` or `AsyncNotifier` when a feature needs mutation methods.
+
+```dart
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final counterProvider = NotifierProvider<Counter, int>(Counter.new);
+
+class Counter extends Notifier<int> {
+  @override
+  int build() => 0;
+
+  void increment() {
+    state++;
+  }
+
+  void decrement() {
+    state--;
+  }
+}
+```
+
+For async mutation flows, use `AsyncNotifier` and expose loading/error states through `AsyncValue`.
+
+## Overrides and Scoping
+
+Use overrides for testing, previews, and environment-specific configuration.
+
+```dart
+final container = ProviderContainer(
+  overrides: [
+    apiBaseUrlProvider.overrideWithValue('https://mock.example.com'),
+  ],
+);
+
+final value = container.read(apiBaseUrlProvider);
+```
+
+Use scoped providers when different parts of the tree need different values.
+
+## select for Rebuild Control
+
+Use `select` when only one field should trigger rebuilds.
+
+```dart
+final profileProvider = Provider<Profile>((ref) => Profile(name: 'Ada', age: 30));
+
+class Profile {
+  final String name;
+  final int age;
+  Profile({required this.name, required this.age});
+}
+
+class ProfileName extends ConsumerWidget {
+  const ProfileName({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final name = ref.watch(profileProvider.select((profile) => profile.name));
+    return Text(name);
+  }
+}
+```
+
+## Eager Initialization and Refresh
+
+Use `ref.read(provider.future)` or `ref.refresh(provider)` when you need to prefetch or reload data.
+
+```dart
+class RefreshButton extends ConsumerWidget {
+  const RefreshButton({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ElevatedButton(
+      onPressed: () {
+        ref.refresh(todosProvider);
+      },
+      child: const Text('Refresh'),
+    );
+  }
+}
+```
+
+## Pull to Refresh and Cancel
+
+For pull-to-refresh, call `ref.refresh(provider)` from the refresh handler.
+For cancellation, use `autoDispose` so unused requests are disposed, or structure async work so it stops when the provider is disposed.
+
+## Offline and Retry
+
+Use provider overrides and cached state to model offline-first behavior. Use retry logic in the data layer, not inside the UI.
+
+## Testing Riverpod Code
+
+Test providers with `ProviderContainer` and overrides.
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+void main() {
+  test('counterProvider increments', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    expect(container.read(counterProvider), 0);
+    container.read(counterProvider.notifier).increment();
+    expect(container.read(counterProvider), 1);
+  });
+}
+```
+
+Use provider overrides to isolate dependencies and assert side effects separately.
+
+## Code Generation
+
+Use `@riverpod` when you want generated providers and less boilerplate.
+
+```dart
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'counter.g.dart';
+
+@riverpod
+int counter(CounterRef ref) {
+  return 0;
+}
+```
+
+Generated providers are useful when you want type-safe naming, auto-dispose defaults, and a consistent provider style.
+
+## Pitfalls and Safe Defaults
+
+- Do not call `ref.watch` inside callbacks; use `ref.read` there.
+- Do not skip `ProviderScope` at the root.
+- Do not use `StateProvider` for large feature state.
+- Do not rebuild the whole widget tree when one field changes; use `select`.
+- Do not put business logic in widgets.
+- Do not model async loading manually if `FutureProvider` or `AsyncNotifier` fits.
+- Do not reach for `Notifier` if a simple `Provider` or `StateProvider` is enough.
+
+## References
+
+- [Getting Started](https://riverpod.dev/docs/introduction/getting_started)
+- [Providers](https://riverpod.dev/docs/concepts2/providers)
+- [Consumers](https://riverpod.dev/docs/concepts2/consumers)
+- [Containers](https://riverpod.dev/docs/concepts2/containers)
+- [Refs](https://riverpod.dev/docs/concepts2/refs)
+- [Auto Dispose](https://riverpod.dev/docs/concepts2/auto_dispose)
+- [Family](https://riverpod.dev/docs/concepts2/family)
+- [Mutations](https://riverpod.dev/docs/concepts2/mutations)
+- [Testing](https://riverpod.dev/docs/how_to/testing)
+- [Select](https://riverpod.dev/docs/how_to/select)
+- [Code Generation](https://riverpod.dev/docs/concepts/about_code_generation)

--- a/content/flutter/skills/state-management/bloc-cubit/SKILL.md
+++ b/content/flutter/skills/state-management/bloc-cubit/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: bloc-cubit
+description: "Use when working with Flutter Bloc/Cubit state management. Covers when to choose Bloc vs Cubit, how to use bloc and flutter_bloc together, lifecycle, testing, and safe defaults."
+metadata:
+  revision: 1
+  updated-on: "2026-04-04"
+  source: official
+  tags: "flutter,dart,bloc,cubit,flutter_bloc,state-management,testing,architecture"
+---
+
+# Flutter Bloc/Cubit State Management
+
+Use this skill when building Flutter state management with `bloc` and `flutter_bloc`.
+
+## Core Rule
+
+- Use `Cubit` for simple, direct state updates.
+- Use `Bloc` for event-driven flows, transitions, and replayable business logic.
+- Use `bloc` in Dart-only projects.
+- Use `flutter_bloc` in Flutter apps when you need widgets like `BlocProvider`, `BlocBuilder`, or `BlocListener`.
+- If you install `flutter_bloc`, you do not need to add `bloc` separately in a Flutter app because `flutter_bloc` depends on it.
+
+## Decision Guide
+
+Choose `Cubit` when:
+- state changes are simple method calls
+- you do not need events
+- the feature is local and low complexity
+- examples include counters, toggles, filters, form flags, and theme mode
+
+Choose `Bloc` when:
+- user actions should be modeled as explicit events
+- the flow has loading, success, and failure transitions
+- the logic benefits from clear state machines
+- examples include auth, pagination, checkout, sync, and multi-step workflows
+
+## Required Project Setup
+
+For Dart-only code:
+- add `bloc`
+- do not add `flutter_bloc` unless Flutter widgets are needed
+
+For Flutter UI code:
+- add `flutter_bloc`
+- let it bring `bloc` transitively
+- use `BlocProvider` at the feature boundary
+- use `BlocBuilder` for rebuilds and `BlocListener` for side effects
+
+## Implementation Pattern
+
+Prefer this structure:
+- repository or service owns I/O
+- bloc/cubit owns state and orchestration
+- UI only dispatches actions and renders state
+
+Keep state immutable.
+Keep events explicit when using `Bloc`.
+Keep one bloc or cubit per feature responsibility.
+
+## Lifecycle Rules
+
+- Close manually created blocs and cubits with `close()`.
+- Do not manually close instances owned by `BlocProvider`.
+- Use `BlocProvider` or `MultiBlocProvider` to let Flutter manage disposal.
+- If you create a bloc/cubit with `new` or a constructor outside the widget tree, you own its lifecycle.
+
+## UI Binding Rules
+
+Use `BlocBuilder` when the widget should rebuild from state.
+Use `BlocListener` when the widget should react without rebuilding.
+Use `BlocConsumer` only when both are needed in one place.
+Use `buildWhen` and `listenWhen` when rebuilds or listeners need narrowing.
+Use `BlocSelector` when only one field should drive rebuilds.
+
+## Testing Rules
+
+- Test `Cubit` by calling methods and asserting emitted states.
+- Test `Bloc` by adding events and asserting the transition sequence.
+- Mock repositories at the boundary, not inside the bloc logic.
+- Test side effects separately from rendering logic.
+
+## Common Pitfalls
+
+- Do not put network calls directly in widgets.
+- Do not use `Bloc` for trivial local state.
+- Do not add both `bloc` and `flutter_bloc` in a Flutter app when only `flutter_bloc` is needed.
+- Do not forget `close()` for manually managed instances.
+- Do not emit duplicate states unless the transition is meaningful.
+- Do not let a single bloc grow into an app-wide dumping ground.
+
+## What To Prefer In Answers
+
+When writing code or advising on design:
+- show the smallest working Bloc or Cubit first
+- mention why Bloc or Cubit was chosen
+- mention whether the dependency should be `bloc` or `flutter_bloc`
+- include cleanup and testing notes if lifecycle is manual
+- keep examples aligned with the current Flutter state management docs and the bloc package docs
+
+## Minimal Reference Checklist
+
+- `bloc` = core logic package
+- `flutter_bloc` = Flutter UI integration package
+- `Cubit` = method-based updates
+- `Bloc` = event-based transitions
+- manual creation = manual `close()`
+- provider-owned instance = no manual `close()`

--- a/content/flutter/skills/state-management/riverpod/SKILL.md
+++ b/content/flutter/skills/state-management/riverpod/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: riverpod
+description: "Use when working with Flutter Riverpod state management. Covers providers, consumers, refs, containers, overrides, async state, code generation, testing, and safe defaults."
+metadata:
+  revision: 1
+  updated-on: "2026-04-04"
+  source: official
+  tags: "flutter,dart,riverpod,flutter_riverpod,providers,async,testing,codegen"
+---
+
+# Flutter Riverpod State Management
+
+Use this skill when building Flutter state management with `riverpod` and `flutter_riverpod`.
+
+## Core Rule
+
+- Use `Provider` for read-only values and dependency wiring.
+- Use `StateProvider` for small mutable state.
+- Use `FutureProvider` for one-shot async loading.
+- Use `StreamProvider` for reactive streams.
+- Use `Notifier` or `AsyncNotifier` for feature state that needs mutation methods.
+- Use `autoDispose` for short-lived state.
+- Use `family` when provider output depends on an argument.
+- Use `flutter_riverpod` in Flutter apps.
+- If you use `flutter_riverpod`, you usually do not add `riverpod` separately because the Flutter package brings it in transitively.
+- Current stable line is Riverpod 3.x (`riverpod` 3.2.1, `flutter_riverpod` 3.3.1).
+
+## Decision Guide
+
+Choose Riverpod when:
+- you want provider-based dependency injection and reactive state in one model
+- state should be derived from other providers
+- async data is a major part of the feature
+- test overrides and scoped state matter
+- you want fewer classes than a Bloc-heavy approach
+
+Choose a different pattern when:
+- the feature is a tiny local state toggle and a simple widget would be enough
+- the logic is better expressed as an explicit event machine
+
+## Required Project Setup
+
+For Dart-only code:
+- add `riverpod`
+
+For Flutter UI code:
+- add `flutter_riverpod`
+- wrap the app in `ProviderScope`
+- use `ConsumerWidget`, `Consumer`, or `ConsumerStatefulWidget` where `ref` is needed
+
+If code generation is used:
+- add `riverpod_annotation`
+- add `riverpod_generator`
+- add `build_runner`
+
+## Implementation Pattern
+
+Prefer this structure:
+- providers own state, dependencies, and derived values
+- repositories and APIs stay outside widgets
+- UI reads state with `ref.watch`
+- UI performs imperative reads with `ref.read`
+- container-level overrides are used for tests, demos, and environment-specific wiring
+
+Keep providers small and composable.
+Keep state immutable unless the provider type is specifically meant for mutation.
+Keep feature logic in providers or notifiers, not in widgets.
+
+## Lifecycle Rules
+
+- Use `autoDispose` for short-lived screens and transient queries.
+- Use `ref.keepAlive()` only when you want cached state to survive temporarily.
+- Prefer provider disposal over manual cleanup.
+- In tests and pure Dart code, dispose `ProviderContainer` when finished.
+
+## UI Binding Rules
+
+Use `ConsumerWidget` when the whole widget depends on providers.
+Use `Consumer` when only a small subtree needs access to `ref`.
+Use `ConsumerStatefulWidget` when you need widget lifecycle plus `ref`.
+Use `select` to reduce rebuilds.
+Use `ProviderListener` or `ref.listen` for side effects.
+
+## Testing Rules
+
+- Test providers through `ProviderContainer`.
+- Override dependencies instead of mocking provider internals.
+- Assert `AsyncValue` states directly for async providers.
+- Dispose containers in tests.
+
+## Common Pitfalls
+
+- Do not call `ref.watch` inside callbacks; use `ref.read` there.
+- Do not skip `ProviderScope` at the app root.
+- Do not use `StateProvider` for large feature state.
+- Do not put business logic in widgets.
+- Do not rebuild the whole tree when a single field changes; use `select`.
+- Do not model async loading manually when `FutureProvider` or `AsyncNotifier` fits.
+- Do not forget provider overrides for tests and previews.
+
+## What To Prefer In Answers
+
+When writing code or advising on design:
+- show the smallest working provider first
+- mention whether `ProviderScope` is required
+- mention whether the provider should be `autoDispose` or cached
+- mention whether a `family` is needed for arguments
+- include test override notes when dependencies are external
+- keep examples aligned with the current Riverpod docs and Flutter integration patterns
+- if code generation is involved, prefer matching `riverpod_annotation` / `riverpod_generator` versions from the same 3.x release line
+
+## Minimal Reference Checklist
+
+- `ProviderScope` = app root setup
+- `ref.watch` = rebuild on change
+- `ref.read` = imperative access
+- `select` = narrower rebuilds
+- `autoDispose` = short-lived state
+- `family` = parameterized provider
+- `ProviderContainer` = test/headless container


### PR DESCRIPTION
## Summary

This PR adds initial Flutter coverage for networking and state management in Context Hub.

Added:
- `networking-clients-core` doc:
  - clarifies `http` and `dio` as alternatives
  - keeps WebSocket guidance via `web_socket_channel`
- `state-management-bloc` doc:
  - clarifies `bloc` vs `flutter_bloc`
  - explains Bloc vs Cubit decision rules
  - includes lifecycle and testing guidance
- `state-management-riverpod` doc:
  - updated to current line (`riverpod` 3.2.1, `flutter_riverpod` 3.3.1)
  - includes providers/consumers/refs/overrides/scoping/testing/codegen
- State-management skills:
  - `bloc-cubit` skill
  - `riverpod` skill

## Validation

- Ran: `node cli/bin/chub build content/ --validate-only`
- Result: `Valid: 1556 docs, 9 skills, 2 warnings`
- Existing warnings are unrelated ADE skill warnings.

## Next Actions (follow-up PRs)

- Add `ui-widgets-core` doc
- Add `platform-channels-core` doc
- Add `testing-core` doc
- Add skill: `error-handling-strategies`
- Add skill: `dependency-injection`
- Add skill: `testing-strategies`
- Add skill: `performance-profiling-optimization`