### PR TITLE
Improve CLI search relevance with coverage scoring, explain mode, and benchmark harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Chub is designed for your coding agent to use (not for you to use!). You can pro
 
 ```bash
 chub search "stripe payments"        # find relevant docs
+chub search "stripe payments" --explain
 chub get stripe/api --lang js        # fetch the doc
 # Agent reads the doc, writes correct code. Done.
 ```
@@ -88,6 +89,12 @@ Docs can have multiple reference files beyond the main entry point. Fetch only w
 ### Annotations & Feedback
 
 Annotations are local notes that agents attach to docs — they persist across sessions and appear automatically on future fetches. Feedback (up/down ratings) goes to doc authors to improve the content for everyone. See [Feedback and Annotations](docs/feedback-and-annotations.md).
+
+### Search Relevance
+
+Search ranking now combines the existing base retrieval signal (BM25 when an index is available, otherwise keyword fallback), the existing lexical rescue pass, and a new multi-term coverage boost. The coverage boost helps longer queries prefer entries that match more of the query across ids, names, tags, and descriptions, and it adds light support for acronym rescue such as `mcp`.
+
+Use `chub search "stripe payments" --scores` to inspect the final ranking scores, or `chub search "stripe payments" --explain` to inspect the ranking signals that contributed to a result. Contributors can also run `cd cli && npm run relevance:benchmark` for the synthetic benchmark harness and `cd cli && npm run test:relevance` for the fixture-backed regression tests. See [Search Relevance](docs/search-relevance.md) for details.
 
 ## Contributing
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -39,7 +39,9 @@
     "prepublish": "node bin/chub build ../content -o dist --base-url https://cdn.aichub.org/v1",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:relevance": "vitest run test/relevance.test.js",
+    "relevance:benchmark": "node scripts/relevance-benchmark.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",

--- a/cli/scripts/relevance-benchmark.mjs
+++ b/cli/scripts/relevance-benchmark.mjs
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs';
+import { scoreEntryCoverageBoost, scoreKeywordFallback } from '../src/lib/relevance.js';
+
+const fixturePath = new URL('../test/fixtures/relevance-benchmark.json', import.meta.url);
+const fixture = JSON.parse(readFileSync(fixturePath, 'utf8'));
+
+function rankEntries(catalog, query, includeCoverage) {
+  return catalog
+    .map((entry) => {
+      const base = scoreKeywordFallback(entry, query);
+      const coverage = includeCoverage ? scoreEntryCoverageBoost(entry, query).score : 0;
+      return {
+        id: entry.id,
+        base,
+        coverage,
+        total: base + coverage,
+      };
+    })
+    .filter((entry) => entry.total > 0)
+    .sort((a, b) => b.total - a.total || b.coverage - a.coverage || a.id.localeCompare(b.id));
+}
+
+let improvedPasses = 0;
+console.log('Context Hub relevance benchmark\n');
+
+for (const scenario of fixture.scenarios) {
+  const baseline = rankEntries(fixture.catalog, scenario.query, false);
+  const improved = rankEntries(fixture.catalog, scenario.query, true);
+  const baselineTop = baseline[0]?.id || '(none)';
+  const improvedTop = improved[0]?.id || '(none)';
+  const passed = improvedTop === scenario.expectedTop;
+  if (passed) improvedPasses += 1;
+
+  console.log(`query: ${scenario.query}`);
+  console.log(`  baseline top: ${baselineTop}`);
+  console.log(`  improved top: ${improvedTop}${passed ? ' ✓' : ` ✗ (expected ${scenario.expectedTop})`}`);
+  console.log(`  improved top 3: ${improved.slice(0, 3).map((entry) => entry.id).join(', ')}`);
+  console.log('');
+}
+
+console.log(`Improved pass rate: ${improvedPasses}/${fixture.scenarios.length}`);

--- a/cli/src/commands/search.js
+++ b/cli/src/commands/search.js
@@ -4,7 +4,31 @@ import { displayLanguage } from '../lib/normalize.js';
 import { output } from '../lib/output.js';
 import { trackEvent } from '../lib/analytics.js';
 
-function formatEntryList(entries) {
+function formatSearchSignals(entry, showExplain = false) {
+  const score = Number.isFinite(entry._score) ? entry._score.toFixed(1) : '0.0';
+  if (!showExplain || !entry._debug) {
+    return `score=${score}`;
+  }
+
+  const parts = [`score=${score}`];
+  if ((entry._debug.baseScore || 0) > 0) {
+    parts.push(`${entry._debug.baseKind}=${entry._debug.baseScore.toFixed(1)}`);
+  }
+  if ((entry._debug.lexicalBoost || 0) > 0) {
+    parts.push(`lexical=+${entry._debug.lexicalBoost.toFixed(1)}`);
+  }
+  if ((entry._debug.coverageBoost || 0) > 0) {
+    parts.push(`coverage=+${entry._debug.coverageBoost.toFixed(1)}`);
+  }
+  if (entry._debug.coverage?.reasons?.length) {
+    parts.push(entry._debug.coverage.reasons.join(', '));
+  }
+
+  return parts.join(' • ');
+}
+
+function formatEntryList(entries, options = {}) {
+  const { showScores = false, showExplain = false } = options;
   const multi = isMultiSource();
   for (const entry of entries) {
     const id = getDisplayId(entry);
@@ -19,6 +43,9 @@ function formatEntryList(entries) {
       : '';
     console.log(`  ${chalk.bold(id)}  ${type}  ${chalk.dim(langs)}  ${source} ${sourceName}`.trimEnd());
     if (desc) console.log(`       ${chalk.dim(desc)}`);
+    if (showScores || showExplain) {
+      console.log(`       ${chalk.dim(formatSearchSignals(entry, showExplain))}`);
+    }
   }
 }
 
@@ -54,6 +81,8 @@ export function registerSearchCommand(program) {
     .option('--tags <tags>', 'Filter by tags (comma-separated)')
     .option('--lang <language>', 'Filter by language')
     .option('--limit <n>', 'Max results', '20')
+    .option('--scores', 'Show ranking scores for fuzzy search results')
+    .option('--explain', 'Show ranking signals for fuzzy search results')
     .action((query, opts) => {
       const globalOpts = program.optsWithGlobals();
       const limit = parseInt(opts.limit, 10);
@@ -106,6 +135,8 @@ export function registerSearchCommand(program) {
         duration_ms,
         has_tags: !!opts.tags,
         has_lang: !!opts.lang,
+        has_scores: !!opts.scores,
+        has_explain: !!opts.explain,
         tags: opts.tags || undefined,
         lang: opts.lang || undefined,
       }).catch(() => {});
@@ -115,7 +146,10 @@ export function registerSearchCommand(program) {
           return;
         }
         console.log(chalk.bold(`${data.total} results for "${normalizedQuery}":\n`));
-        formatEntryList(data.results);
+        formatEntryList(data.results, {
+          showScores: !!opts.scores || !!opts.explain,
+          showExplain: !!opts.explain,
+        });
       }, globalOpts);
     });
 }

--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -29,6 +29,7 @@ ${chalk.bold.underline('Getting Started')}
   ${chalk.dim('$')} chub update                                ${chalk.dim('# download the registry')}
   ${chalk.dim('$')} chub search                                ${chalk.dim('# list everything available')}
   ${chalk.dim('$')} chub search "stripe"                       ${chalk.dim('# fuzzy search')}
+  ${chalk.dim('$')} chub search "stripe payments" --explain      ${chalk.dim('# inspect ranking signals')}
   ${chalk.dim('$')} chub search stripe/payments                ${chalk.dim('# exact id → full detail')}
   ${chalk.dim('$')} chub get stripe/api                        ${chalk.dim('# print doc to terminal')}
   ${chalk.dim('$')} chub get stripe/api -o doc.md              ${chalk.dim('# save to file')}
@@ -64,6 +65,8 @@ ${chalk.bold.underline('Flags')}
   --json                 Structured JSON output (for agents and piping)
   --tags <csv>           Filter by tags (e.g. docs, skill, openai, browser)
   --lang <language>      Language variant (required for docs): py | js | ts | rb | cs (or full name)
+  --scores               Show ranking scores for fuzzy search results
+  --explain              Show ranking signals for fuzzy search results
   --full                 Fetch all files, not just the entry point
   -o, --output <path>    Write content to file or directory
 

--- a/cli/src/lib/registry.js
+++ b/cli/src/lib/registry.js
@@ -2,6 +2,7 @@ import { loadSourceRegistry, loadSearchIndex } from './cache.js';
 import { loadConfig } from './config.js';
 import { normalizeLanguage } from './normalize.js';
 import { buildIndexFromDocuments, compactIdentifier, search as bm25Search, tokenize } from './bm25.js';
+import { scoreEntryCoverageBoost, scoreKeywordFallback } from './relevance.js';
 
 let _merged = null;
 let _searchIndex = null;
@@ -357,33 +358,29 @@ export function searchEntries(query, filters = {}) {
       const entry = entryById.get(match.id);
       if (!entry) continue;
       const key = getSearchLookupId(entry._source, entry.id);
-      resultByKey.set(key, { entry, score: match.score });
+      resultByKey.set(key, {
+        entry,
+        score: match.score,
+        baseKind: 'bm25',
+        baseScore: match.score,
+        lexicalBoost: 0,
+        coverageBoost: 0,
+      });
     }
   } else {
     // Fallback: keyword matching
-    const q = normalizedQuery.toLowerCase();
-    const words = q.split(/\s+/);
-
     for (const entry of deduped) {
-      let score = 0;
-
-      if (entry.id === q) score += 100;
-      else if (entry.id.includes(q)) score += 50;
-
-      const nameLower = entry.name.toLowerCase();
-      if (nameLower === q) score += 80;
-      else if (nameLower.includes(q)) score += 40;
-
-      for (const word of words) {
-        if (entry.id.includes(word)) score += 10;
-        if (nameLower.includes(word)) score += 10;
-        if (entry.description?.toLowerCase().includes(word)) score += 5;
-        if (entry.tags?.some((t) => t.toLowerCase().includes(word))) score += 15;
-      }
-
+      const score = scoreKeywordFallback(entry, normalizedQuery);
       if (score > 0) {
         const key = getSearchLookupId(entry._source, entry.id);
-        resultByKey.set(key, { entry, score });
+        resultByKey.set(key, {
+          entry,
+          score,
+          baseKind: 'keyword',
+          baseScore: score,
+          lexicalBoost: 0,
+          coverageBoost: 0,
+        });
       }
     }
   }
@@ -403,8 +400,42 @@ export function searchEntries(query, filters = {}) {
     const current = resultByKey.get(key);
     if (current) {
       current.score += boost;
+      current.lexicalBoost += boost;
     } else {
-      resultByKey.set(key, { entry, score: boost });
+      resultByKey.set(key, {
+        entry,
+        score: boost,
+        baseKind: 'none',
+        baseScore: 0,
+        lexicalBoost: boost,
+        coverageBoost: 0,
+      });
+    }
+  }
+
+  const queryTerms = tokenize(normalizedQuery).filter((term) => term.length >= 2);
+  if (queryTerms.length > 1) {
+    for (const entry of deduped) {
+      const { score: coverageBoost, debug } = scoreEntryCoverageBoost(entry, normalizedQuery);
+      if (coverageBoost === 0) continue;
+
+      const key = getSearchLookupId(entry._source, entry.id);
+      const current = resultByKey.get(key);
+      if (current) {
+        current.score += coverageBoost;
+        current.coverageBoost += coverageBoost;
+        if (filters.explain) current.coverageDebug = debug;
+      } else {
+        resultByKey.set(key, {
+          entry,
+          score: coverageBoost,
+          baseKind: 'none',
+          baseScore: 0,
+          lexicalBoost: 0,
+          coverageBoost,
+          coverageDebug: filters.explain ? debug : undefined,
+        });
+      }
     }
   }
 
@@ -415,7 +446,19 @@ export function searchEntries(query, filters = {}) {
   results = results.filter((r) => filteredSet.has(r.entry));
 
   results.sort((a, b) => b.score - a.score);
-  return results.map((r) => ({ ...r.entry, _score: r.score }));
+  return results.map((r) => ({
+    ...r.entry,
+    _score: r.score,
+    ...(filters.explain ? {
+      _debug: {
+        baseKind: r.baseKind || 'none',
+        baseScore: r.baseScore || 0,
+        lexicalBoost: r.lexicalBoost || 0,
+        coverageBoost: r.coverageBoost || 0,
+        coverage: r.coverageDebug || null,
+      },
+    } : {}),
+  }));
 }
 
 /**

--- a/cli/src/lib/relevance.js
+++ b/cli/src/lib/relevance.js
@@ -1,0 +1,209 @@
+import { compactIdentifier, tokenize } from './bm25.js';
+
+function normalizeText(text) {
+  return String(text || '').toLowerCase();
+}
+
+function splitCompactSegments(text) {
+  return [...new Set([
+    ...String(text || '').split('/').map((segment) => compactIdentifier(segment)),
+    ...String(text || '').split(/[\/_.\s-]+/).map((segment) => compactIdentifier(segment)),
+  ])].filter(Boolean);
+}
+
+function tokenizeQuery(query) {
+  return [...new Set(tokenize(normalizeText(query)).filter((term) => term.length >= 2))];
+}
+
+function buildAcronym(text) {
+  const words = normalizeText(text).match(/[a-z0-9]+/g) || [];
+  if (words.length < 2) return '';
+  return words.map((word) => word[0]).join('');
+}
+
+function includesInOrder(haystack, terms) {
+  let cursor = 0;
+  for (const term of terms) {
+    const next = haystack.indexOf(term, cursor);
+    if (next === -1) return false;
+    cursor = next + term.length;
+  }
+  return true;
+}
+
+function emptyCoverageResult(totalTerms = 0) {
+  return {
+    score: 0,
+    debug: {
+      matchedTerms: [],
+      matchedCount: 0,
+      totalTerms,
+      coverageRatio: 0,
+      phraseField: null,
+      orderedField: null,
+      reasons: totalTerms > 0 ? [`coverage 0/${totalTerms}`] : [],
+    },
+  };
+}
+
+export function scoreKeywordFallback(entry, normalizedQuery) {
+  const q = normalizeText(normalizedQuery).trim();
+  if (!q) return 0;
+
+  const words = q.split(/\s+/).filter(Boolean);
+  const idLower = normalizeText(entry.id);
+  const nameLower = normalizeText(entry.name);
+  const descriptionLower = normalizeText(entry.description);
+  let score = 0;
+
+  if (idLower === q) score += 100;
+  else if (idLower.includes(q)) score += 50;
+
+  if (nameLower === q) score += 80;
+  else if (nameLower.includes(q)) score += 40;
+
+  for (const word of words) {
+    if (idLower.includes(word)) score += 10;
+    if (nameLower.includes(word)) score += 10;
+    if (descriptionLower.includes(word)) score += 5;
+    if (entry.tags?.some((tag) => normalizeText(tag).includes(word))) score += 15;
+  }
+
+  return score;
+}
+
+export function scoreEntryCoverageBoost(entry, normalizedQuery) {
+  const normalized = normalizeText(normalizedQuery).trim();
+  const terms = tokenizeQuery(normalized);
+  if (terms.length === 0) return emptyCoverageResult(terms.length);
+
+  const idLower = normalizeText(entry.id);
+  const nameLower = normalizeText(entry.name);
+  const descriptionLower = normalizeText(entry.description);
+  const tagValues = (entry.tags || []).map((tag) => normalizeText(tag));
+  const idSegments = splitCompactSegments(entry.id);
+  const nameSegments = splitCompactSegments(entry.name);
+  const acronym = buildAcronym(entry.name);
+
+  let score = 0;
+  const matchedTerms = [];
+  let sawAcronymMatch = false;
+
+  for (const term of terms) {
+    const compactTerm = compactIdentifier(term);
+    const fields = new Set();
+    let termScore = 0;
+
+    if (idSegments.includes(compactTerm)) {
+      fields.add('id');
+      termScore = Math.max(termScore, 26);
+    } else if (idLower.includes(term)) {
+      fields.add('id');
+      termScore = Math.max(termScore, 18);
+    }
+
+    if (nameSegments.includes(compactTerm)) {
+      fields.add('name');
+      termScore = Math.max(termScore, 24);
+    } else if (nameLower.includes(term)) {
+      fields.add('name');
+      termScore = Math.max(termScore, 16);
+    }
+
+    if (tagValues.some((tag) => tag === term || tag.includes(term))) {
+      fields.add('tags');
+      termScore = Math.max(termScore, 14);
+    }
+
+    if (descriptionLower.includes(term)) {
+      fields.add('description');
+      termScore = Math.max(termScore, 8);
+    }
+
+    if (acronym && acronym === compactTerm && compactTerm.length >= 2 && compactTerm.length <= 6) {
+      fields.add('acronym');
+      termScore = Math.max(termScore, 28);
+      sawAcronymMatch = true;
+    }
+
+    if (termScore > 0) {
+      score += termScore;
+      matchedTerms.push(`${term}:${[...fields].join('+')}`);
+    }
+  }
+
+  const matchedCount = matchedTerms.length;
+  if (matchedCount === 0) return emptyCoverageResult(terms.length);
+
+  const coverageRatio = matchedCount / terms.length;
+  const phraseField = idLower.includes(normalized)
+    ? 'id'
+    : nameLower.includes(normalized)
+      ? 'name'
+      : descriptionLower.includes(normalized)
+        ? 'description'
+        : null;
+
+  const orderedField = includesInOrder(idLower, terms)
+    ? 'id'
+    : includesInOrder(nameLower, terms)
+      ? 'name'
+      : includesInOrder(descriptionLower, terms)
+        ? 'description'
+        : null;
+
+  if (coverageRatio > 0) {
+    score += Math.round(coverageRatio * 40);
+  }
+  if (matchedCount === terms.length) {
+    score += 35;
+  }
+
+  if (phraseField === 'id') score += 50;
+  else if (phraseField === 'name') score += 44;
+  else if (phraseField === 'description') score += 18;
+
+  if (orderedField === 'id' && phraseField !== 'id') score += 24;
+  else if (orderedField === 'name' && phraseField !== 'name') score += 20;
+  else if (orderedField === 'description' && phraseField !== 'description') score += 10;
+
+  const reasons = [`coverage ${matchedCount}/${terms.length}`];
+  if (matchedCount === terms.length) reasons.push('full coverage');
+  if (phraseField) reasons.push(`phrase:${phraseField}`);
+  if (orderedField && orderedField !== phraseField) reasons.push(`ordered:${orderedField}`);
+  if (sawAcronymMatch) reasons.push(`acronym:${acronym}`);
+
+  const needsStrongSingleTermSignal = terms.length === 1;
+  const lacksEnoughMultiTermCoverage = matchedCount < Math.min(2, terms.length)
+    && !phraseField
+    && !orderedField
+    && !sawAcronymMatch;
+
+  if ((needsStrongSingleTermSignal && !phraseField && !sawAcronymMatch) || (!needsStrongSingleTermSignal && lacksEnoughMultiTermCoverage)) {
+    return {
+      score: 0,
+      debug: {
+        matchedTerms,
+        matchedCount,
+        totalTerms: terms.length,
+        coverageRatio: Number(coverageRatio.toFixed(2)),
+        phraseField,
+        orderedField,
+        reasons,
+      },
+    };
+  }
+
+  return {
+    score,
+    debug: {
+      matchedTerms,
+      matchedCount,
+      totalTerms: terms.length,
+      coverageRatio: Number(coverageRatio.toFixed(2)),
+      phraseField,
+      orderedField,
+      reasons,
+    },
+  };
+}

--- a/cli/test/fixtures/relevance-benchmark.json
+++ b/cli/test/fixtures/relevance-benchmark.json
@@ -1,0 +1,84 @@
+{
+  "catalog": [
+    {
+      "id": "stripe/api",
+      "name": "Stripe API Reference",
+      "description": "Reference for PaymentIntents, webhooks, subscriptions, and payment methods.",
+      "tags": ["stripe", "payments", "api"]
+    },
+    {
+      "id": "stripe/payments",
+      "name": "Payments Guide",
+      "description": "Guide for checkout, subscriptions, and end to end payment flows in Stripe.",
+      "tags": ["stripe", "guide"]
+    },
+    {
+      "id": "pw-community/login-flows",
+      "name": "Login Flows Skill",
+      "description": "Reusable browser login flows and authenticated session handling for agents.",
+      "tags": ["playwright", "skill", "login"]
+    },
+    {
+      "id": "browser/login",
+      "name": "Browser Login Basics",
+      "description": "Basic browser login examples and shared auth helpers.",
+      "tags": ["browser", "login", "skill"]
+    },
+    {
+      "id": "browser/session-cookies",
+      "name": "Session Cookie Authentication",
+      "description": "Persist authenticated browser state with session cookies and auth tokens.",
+      "tags": ["auth", "cookies", "browser"]
+    },
+    {
+      "id": "protocol/mcp-overview",
+      "name": "Model Context Protocol Overview",
+      "description": "Introduction to the Model Context Protocol and MCP server basics.",
+      "tags": ["protocol", "overview"]
+    },
+    {
+      "id": "protocol/client-setup",
+      "name": "Client Setup Guide",
+      "description": "Set up a Model Context Protocol client and connect it to servers.",
+      "tags": ["mcp", "client", "setup"]
+    },
+    {
+      "id": "openai/chat",
+      "name": "OpenAI Chat API",
+      "description": "Chat completions and conversation state for chat-first integrations.",
+      "tags": ["openai", "chat"]
+    },
+    {
+      "id": "openai/responses",
+      "name": "Responses API",
+      "description": "Responses API for multimodal generation and tool use.",
+      "tags": ["openai", "responses"]
+    }
+  ],
+  "scenarios": [
+    {
+      "query": "stripe payments",
+      "expectedTop": "stripe/payments",
+      "expectedInTop3": ["stripe/api"]
+    },
+    {
+      "query": "login flows skill",
+      "expectedTop": "pw-community/login-flows",
+      "expectedInTop3": ["browser/login"]
+    },
+    {
+      "query": "session cookie auth",
+      "expectedTop": "browser/session-cookies"
+    },
+    {
+      "query": "model context protocol",
+      "expectedTop": "protocol/mcp-overview",
+      "expectedInTop3": ["protocol/client-setup"]
+    },
+    {
+      "query": "mcp",
+      "expectedTop": "protocol/mcp-overview",
+      "expectedInTop3": ["protocol/client-setup"]
+    }
+  ]
+}

--- a/cli/test/relevance.test.js
+++ b/cli/test/relevance.test.js
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { scoreEntryCoverageBoost, scoreKeywordFallback } from '../src/lib/relevance.js';
+
+const fixturePath = new URL('./fixtures/relevance-benchmark.json', import.meta.url);
+const fixture = JSON.parse(readFileSync(fixturePath, 'utf8'));
+
+function rankEntries(catalog, query, includeCoverage) {
+  return catalog
+    .map((entry) => {
+      const base = scoreKeywordFallback(entry, query);
+      const coverage = includeCoverage ? scoreEntryCoverageBoost(entry, query).score : 0;
+      return {
+        id: entry.id,
+        total: base + coverage,
+      };
+    })
+    .filter((entry) => entry.total > 0)
+    .sort((a, b) => b.total - a.total || a.id.localeCompare(b.id));
+}
+
+describe('search relevance coverage boost', () => {
+  it('prefers full multi-term coverage over single-entry authority', () => {
+    const results = rankEntries(fixture.catalog, 'stripe payments', true);
+    expect(results[0].id).toBe('stripe/payments');
+  });
+
+  it('recognizes ordered phrase matches for multi-word queries', () => {
+    const entry = fixture.catalog.find((item) => item.id === 'protocol/mcp-overview');
+    const { score, debug } = scoreEntryCoverageBoost(entry, 'model context protocol');
+    expect(score).toBeGreaterThan(0);
+    expect(debug.reasons).toContain('phrase:name');
+  });
+
+  it('supports acronym rescue for single-term queries', () => {
+    const entry = fixture.catalog.find((item) => item.id === 'protocol/mcp-overview');
+    const { score, debug } = scoreEntryCoverageBoost(entry, 'mcp');
+    expect(score).toBeGreaterThan(0);
+    expect(debug.reasons).toContain('acronym:mcp');
+  });
+
+  it('meets the expected top result for every benchmark scenario', () => {
+    for (const scenario of fixture.scenarios) {
+      const results = rankEntries(fixture.catalog, scenario.query, true);
+      expect(results[0]?.id).toBe(scenario.expectedTop);
+    }
+  });
+});

--- a/docs/search-relevance.md
+++ b/docs/search-relevance.md
@@ -1,0 +1,48 @@
+# Search Relevance
+
+This note documents the search relevance changes in the CLI and the small benchmark harness that ships with them.
+
+## What changed
+
+Search ranking now combines three signals:
+
+1. **Base retrieval**: BM25 when a search index is available, otherwise keyword fallback.
+2. **Lexical rescue**: the existing compact-id and fuzzy lexical pass for queries that need stronger identifier matching.
+3. **Coverage boost**: a new additive score that rewards entries covering more of a multi-term query across ids, names, tags, and descriptions.
+
+The coverage boost also adds a light acronym rescue path. For example, a query like `mcp` can now boost entries whose names expand to **Model Context Protocol**.
+
+## New CLI flags
+
+```bash
+chub search "stripe payments" --scores
+chub search "stripe payments" --explain
+```
+
+`--scores` shows the final ranking score for each fuzzy-search result. `--explain` adds the base score, lexical rescue contribution, coverage boost contribution, and a short reason summary.
+
+## Benchmark harness
+
+The repo now includes a small synthetic benchmark harness for regression testing and iteration:
+
+```bash
+cd cli
+npm run relevance:benchmark
+npm run test:relevance
+```
+
+Files:
+
+- `scripts/relevance-benchmark.mjs`: prints baseline vs improved top results for a fixed set of scenarios
+- `test/fixtures/relevance-benchmark.json`: synthetic catalog and golden queries
+- `test/relevance.test.js`: regression tests for the new coverage logic
+
+The fixture is intentionally synthetic so contributors can reason about ranking changes quickly without depending on a live registry or network fetches.
+
+## Why this helps
+
+The baseline keyword pass can overweight a generally authoritative entry that only matches one strong token. The coverage boost helps longer queries prefer entries that match more of the query, especially when the intended result has a stronger phrase or identifier match than a competing generic reference.
+
+## Extending the fixture
+
+Add new entries and scenarios to `test/fixtures/relevance-benchmark.json`. Each scenario should include a query and an `expectedTop` id. Keep fixtures small and focused so they are easy to review in pull requests.


### PR DESCRIPTION
## Summary

This PR improves `chub search` relevance for longer natural-language queries and adds lightweight tooling to inspect and regression-test ranking behavior.

## What changed

- adds a **coverage boost** to search ranking so entries that match more of a multi-term query across `id`, `name`, `tags`, and `description` rank more reliably
- adds light **acronym rescue** support (for example, `mcp` → `Model Context Protocol`)
- adds `chub search --scores` to show final ranking scores
- adds `chub search --explain` to show ranking signals for fuzzy-search results
- adds a small **synthetic relevance benchmark harness**
- adds **fixture-backed relevance regression tests**
- documents the approach in `docs/search-relevance.md` and updates the main README

## Why

The current search behavior is strong for exact IDs and short queries, but longer queries can still prefer a generally authoritative entry that only matches one strong token. This change keeps the existing retrieval behavior intact, then adds an additive coverage-based signal that helps multi-term queries prefer the entry that actually covers more of the user intent.

## Testing

- syntax-checked the touched CLI files
- added `npm run relevance:benchmark`
- added `npm run test:relevance`

## Example

```bash
chub search "stripe payments" --scores
chub search "stripe payments" --explain
```

This keeps the default UX unchanged while making relevance easier to inspect and iterate on.