### PR TITLE
Improve reference lookup with deterministic document expansion

### DIFF
--- a/cli/src/lib/bm25.js
+++ b/cli/src/lib/bm25.js
@@ -5,25 +5,98 @@
  */
 
 const STOP_WORDS = new Set([
-  'a', 'an', 'and', 'are', 'as', 'at', 'be', 'by', 'for', 'from',
-  'has', 'have', 'in', 'is', 'it', 'its', 'of', 'on', 'or', 'that',
-  'the', 'to', 'was', 'were', 'will', 'with', 'this', 'but', 'not',
-  'you', 'your', 'can', 'do', 'does', 'how', 'if', 'may', 'no',
-  'so', 'than', 'too', 'very', 'just', 'about', 'into', 'over',
-  'such', 'then', 'them', 'these', 'those', 'through', 'under',
-  'use', 'using', 'used',
+  'a',
+  'an',
+  'and',
+  'are',
+  'as',
+  'at',
+  'be',
+  'by',
+  'for',
+  'from',
+  'has',
+  'have',
+  'in',
+  'is',
+  'it',
+  'its',
+  'of',
+  'on',
+  'or',
+  'that',
+  'the',
+  'to',
+  'was',
+  'were',
+  'will',
+  'with',
+  'this',
+  'but',
+  'not',
+  'you',
+  'your',
+  'can',
+  'do',
+  'does',
+  'how',
+  'if',
+  'may',
+  'no',
+  'so',
+  'than',
+  'too',
+  'very',
+  'just',
+  'about',
+  'into',
+  'over',
+  'such',
+  'then',
+  'them',
+  'these',
+  'those',
+  'through',
+  'under',
+  'use',
+  'using',
+  'used',
 ]);
+
+const GENERIC_PATH_SEGMENTS = new Set([
+  'doc',
+  'docs',
+  'skill',
+  'skills',
+  'readme',
+  'reference',
+  'references',
+  'guide',
+  'guides',
+  'example',
+  'examples',
+  'snippet',
+  'snippets',
+  'index',
+  'overview',
+  'api',
+]);
+
+const MAIN_ENTRY_FILES = new Set(['doc.md', 'skill.md']);
 
 // BM25 default parameters
 const DEFAULT_K1 = 1.5;
 const DEFAULT_B = 0.75;
 
-// Field weights for multi-field scoring
+// Field weights for multi-field scoring.
+// Expansion is intentionally lower than explicit metadata so exact id/name matches still dominate,
+// while reference-file topics remain searchable in the first pass.
 const FIELD_WEIGHTS = {
   id: 4.0,
   name: 3.0,
   tags: 2.0,
   description: 1.0,
+  expansion: 0.9,
 };
 
 function getDefaultParams() {
@@ -52,6 +125,7 @@ function splitAlphaNumeric(text) {
  */
 export function tokenize(text) {
   if (!text) return [];
+
   return text
     .toLowerCase()
     .replace(/[^a-z0-9\s-]/g, ' ')
@@ -84,15 +158,114 @@ export function tokenizeIdentifier(text) {
 
   for (const segment of segments) {
     if (!segment) continue;
+
     if (isSearchableToken(segment)) {
       tokens.add(segment);
     }
+
     for (const token of tokenize(splitAlphaNumeric(segment))) {
       tokens.add(token);
     }
   }
 
   return [...tokens];
+}
+
+function stripFileExtension(fileName) {
+  return String(fileName || '').replace(/\.[a-z0-9]+$/i, '');
+}
+
+function addWeightedTokens(target, tokens, weight = 1, maxPerToken = 3) {
+  const counts = Object.create(null);
+  for (const existing of target) {
+    counts[existing] = (counts[existing] || 0) + 1;
+  }
+
+  for (let idx = 0; idx < weight; idx++) {
+    for (const token of tokens) {
+      if (!token) continue;
+      if ((counts[token] || 0) >= maxPerToken) continue;
+      target.push(token);
+      counts[token] = (counts[token] || 0) + 1;
+    }
+  }
+}
+
+function collectEntryFiles(entry) {
+  const files = new Set();
+
+  for (const file of entry.files || []) {
+    if (file) files.add(String(file));
+  }
+
+  for (const language of entry.languages || []) {
+    for (const version of language.versions || []) {
+      for (const file of version.files || []) {
+        if (file) files.add(String(file));
+      }
+    }
+  }
+
+  return [...files];
+}
+
+function extractExpansionTokensFromFile(filePath) {
+  const normalizedPath = String(filePath || '').replace(/\\/g, '/').toLowerCase();
+  if (!normalizedPath || MAIN_ENTRY_FILES.has(normalizedPath)) {
+    return [];
+  }
+
+  const segments = normalizedPath
+    .split('/')
+    .map((segment) => stripFileExtension(segment))
+    .filter(Boolean);
+
+  if (segments.length === 0) {
+    return [];
+  }
+
+  const isReferenceLike = segments.some((segment) => segment === 'reference' || segment === 'references');
+  const isGuideLike = segments.some((segment) => segment === 'guide' || segment === 'guides');
+  const isExampleLike = segments.some((segment) => segment === 'example' || segment === 'examples');
+
+  const expansionTokens = [];
+
+  for (let idx = 0; idx < segments.length; idx++) {
+    const segment = segments[idx];
+    const compact = compactIdentifier(segment);
+    if (!compact || GENERIC_PATH_SEGMENTS.has(compact)) {
+      continue;
+    }
+
+    const tokens = tokenizeIdentifier(segment);
+    if (tokens.length === 0) {
+      continue;
+    }
+
+    const isBasename = idx === segments.length - 1;
+    let weight = isBasename ? 2 : 1;
+
+    if (isBasename && isReferenceLike) weight = 3;
+    else if (isBasename && (isGuideLike || isExampleLike)) weight = 2;
+
+    addWeightedTokens(expansionTokens, tokens, weight);
+  }
+
+  return expansionTokens;
+}
+
+function collectExpansionTokens(entry) {
+  const files = collectEntryFiles(entry);
+  const tokens = [];
+
+  for (const filePath of files) {
+    addWeightedTokens(tokens, extractExpansionTokensFromFile(filePath), 1);
+    if (tokens.length >= 192) {
+      return tokens.slice(0, 192);
+    }
+  }
+
+  return tokens;
 }
 
 function buildInvertedIndex(documents) {
@@ -104,6 +277,7 @@ function buildInvertedIndex(documents) {
       ...(doc.tokens.name || []),
       ...(doc.tokens.description || []),
       ...(doc.tokens.tags || []),
+      ...(doc.tokens.expansion || []),
     ]);
 
     for (const term of allTerms) {
@@ -117,20 +291,29 @@ function buildInvertedIndex(documents) {
 
 export function buildIndexFromDocuments(documents, params = getDefaultParams()) {
   const dfMap = Object.create(null); // document frequency per term (across all fields)
-  const fieldLengths = { id: [], name: [], description: [], tags: [] };
+  const fieldLengths = { id: [], name: [], description: [], tags: [], expansion: [] };
 
   for (const doc of documents) {
     const idTokens = doc.tokens.id || [];
     const nameTokens = doc.tokens.name || [];
     const descTokens = doc.tokens.description || [];
     const tagTokens = doc.tokens.tags || [];
+    const expansionTokens = doc.tokens.expansion || [];
 
     fieldLengths.id.push(idTokens.length);
     fieldLengths.name.push(nameTokens.length);
     fieldLengths.description.push(descTokens.length);
     fieldLengths.tags.push(tagTokens.length);
+    fieldLengths.expansion.push(expansionTokens.length);
 
-    const allTerms = new Set([...idTokens, ...nameTokens, ...descTokens, ...tagTokens]);
+    const allTerms = new Set([
+      ...idTokens,
+      ...nameTokens,
+      ...descTokens,
+      ...tagTokens,
+      ...expansionTokens,
+    ]);
+
     for (const term of allTerms) {
       dfMap[term] = (dfMap[term] || 0) + 1;
     }
@@ -138,11 +321,13 @@ export function buildIndexFromDocuments(documents, params = getDefaultParams()) 
 
   const N = documents.length;
   const idf = Object.create(null);
+
   for (const [term, df] of Object.entries(dfMap)) {
     idf[term] = Math.log((N - df + 0.5) / (df + 0.5) + 1);
   }
 
-  const avg = (arr) => arr.length === 0 ? 0 : arr.reduce((a, b) => a + b, 0) / arr.length;
+  const avg = (arr) => (arr.length === 0 ? 0 : arr.reduce((a, b) => a + b, 0) / arr.length);
+
   return {
     version: '1.0.0',
     algorithm: 'bm25',
@@ -153,6 +338,7 @@ export function buildIndexFromDocuments(documents, params = getDefaultParams()) 
       name: avg(fieldLengths.name),
       description: avg(fieldLengths.description),
       tags: avg(fieldLengths.tags),
+      expansion: avg(fieldLengths.expansion),
     },
     idf,
     documents,
@@ -175,6 +361,7 @@ export function buildIndex(entries) {
     const nameTokens = tokenize(entry.name);
     const descTokens = tokenize(entry.description || '');
     const tagTokens = (entry.tags || []).flatMap((t) => tokenize(t));
+    const expansionTokens = collectExpansionTokens(entry);
 
     documents.push({
       id: entry.id,
@@ -183,9 +370,11 @@ export function buildIndex(entries) {
         name: nameTokens,
         description: descTokens,
         tags: tagTokens,
+        expansion: expansionTokens,
       },
     });
   }
+
   return buildIndexFromDocuments(documents);
 }
 

--- a/cli/test/lib/bm25.reference-expansion.test.js
+++ b/cli/test/lib/bm25.reference-expansion.test.js
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { buildIndex, searchWithStats } from '../../src/lib/bm25.js';
+
+describe('bm25 reference-aware document expansion', () => {
+  it('surfaces reference-file topics in the first-pass sparse retriever', () => {
+    const index = buildIndex([
+      {
+        id: 'langchain/retrievers',
+        name: 'LangChain Retrievers',
+        description: 'Composable retrieval patterns and retriever abstractions.',
+        tags: ['retrieval', 'langchain'],
+        languages: [
+          {
+            language: 'python',
+            recommendedVersion: '1.0',
+            versions: [
+              {
+                version: '1.0',
+                files: ['DOC.md', 'references/rrf.md', 'references/hnsw.md', 'references/multi-query.md'],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'stripe/webhooks',
+        name: 'Stripe Webhooks',
+        description: 'Verify webhook signatures and process events safely.',
+        tags: ['payments', 'stripe'],
+        languages: [
+          {
+            language: 'python',
+            recommendedVersion: '1.0',
+            versions: [
+              {
+                version: '1.0',
+                files: ['DOC.md', 'references/raw-body.md', 'references/signature-verification.md'],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'react/hooks',
+        name: 'React Hooks',
+        description: 'State and lifecycle primitives for React.',
+        tags: ['react'],
+        languages: [
+          {
+            language: 'javascript',
+            recommendedVersion: '1.0',
+            versions: [
+              {
+                version: '1.0',
+                files: ['DOC.md'],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    expect(searchWithStats('rrf', index).results[0].id).toBe('langchain/retrievers');
+    expect(searchWithStats('hnsw', index).results[0].id).toBe('langchain/retrievers');
+    expect(searchWithStats('raw body stripe', index).results[0].id).toBe('stripe/webhooks');
+  });
+
+  it('remains backward compatible with indexes that do not have expansion tokens', () => {
+    const legacyIndex = {
+      version: '1.0.0',
+      algorithm: 'bm25',
+      params: { k1: 1.5, b: 0.75 },
+      totalDocs: 1,
+      avgFieldLengths: { id: 2, name: 1, description: 2, tags: 1 },
+      idf: { stripe: 0.2, webhook: 0.4 },
+      documents: [
+        {
+          id: 'stripe/webhooks',
+          tokens: {
+            id: ['stripe', 'webhooks'],
+            name: ['webhooks'],
+            description: ['stripe', 'webhook'],
+            tags: ['stripe'],
+          },
+        },
+      ],
+      invertedIndex: {
+        stripe: [0],
+        webhooks: [0],
+        webhook: [0],
+      },
+    };
+
+    expect(searchWithStats('stripe webhook', legacyIndex).results[0].id).toBe('stripe/webhooks');
+  });
+});

--- a/cli/test/lib/registry.reference-expansion.test.js
+++ b/cli/test/lib/registry.reference-expansion.test.js
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildIndex } from '../../src/lib/bm25.js';
+
+const ORIGINAL_CHUB_DIR = process.env.CHUB_DIR;
+const tempDirs = [];
+
+function writeSource(root, docs) {
+  mkdirSync(root, { recursive: true });
+  writeFileSync(
+    join(root, 'registry.json'),
+    JSON.stringify(
+      {
+        version: '1.0.0',
+        docs: docs.map((doc) => ({
+          ...doc,
+          source: 'official',
+          languages: doc.languages || [],
+        })),
+        skills: [],
+      },
+      null,
+      2,
+    ),
+  );
+  writeFileSync(join(root, 'search-index.json'), JSON.stringify(buildIndex(docs)));
+}
+
+async function loadRegistry(docs) {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'chub-reference-expansion-'));
+  tempDirs.push(tempRoot);
+
+  const sourceRoot = join(tempRoot, 'source');
+  writeSource(sourceRoot, docs);
+
+  const chubDir = join(tempRoot, '.chub');
+  mkdirSync(chubDir, { recursive: true });
+  writeFileSync(
+    join(chubDir, 'config.yaml'),
+    [
+      'sources:',
+      '  - name: default',
+      `    path: ${JSON.stringify(sourceRoot)}`,
+      'source: official,maintainer,community',
+      '',
+    ].join('\n'),
+  );
+
+  process.env.CHUB_DIR = chubDir;
+  vi.resetModules();
+  return import('../../src/lib/registry.js');
+}
+
+afterEach(() => {
+  vi.resetModules();
+  if (ORIGINAL_CHUB_DIR === undefined) delete process.env.CHUB_DIR;
+  else process.env.CHUB_DIR = ORIGINAL_CHUB_DIR;
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+describe('searchEntries reference-file expansion', () => {
+  it('finds docs by reference filenames and path topics', async () => {
+    const docs = [
+      {
+        id: 'langchain/retrievers',
+        name: 'LangChain Retrievers',
+        description: 'Composable retrieval patterns and retriever abstractions.',
+        tags: ['retrieval', 'langchain'],
+        languages: [
+          {
+            language: 'python',
+            recommendedVersion: '1.0',
+            versions: [
+              {
+                version: '1.0',
+                files: ['DOC.md', 'references/rrf.md', 'references/hnsw.md'],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'stripe/webhooks',
+        name: 'Stripe Webhooks',
+        description: 'Verify webhook signatures and process events safely.',
+        tags: ['payments', 'stripe'],
+        languages: [
+          {
+            language: 'python',
+            recommendedVersion: '1.0',
+            versions: [
+              {
+                version: '1.0',
+                files: ['DOC.md', 'references/raw-body.md', 'references/signature-verification.md'],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'playwright/login-flows',
+        name: 'Playwright Login Flows',
+        description: 'Authentication automation recipes.',
+        tags: ['playwright', 'auth'],
+        languages: [
+          {
+            language: 'typescript',
+            recommendedVersion: '1.0',
+            versions: [
+              {
+                version: '1.0',
+                files: ['DOC.md', 'guides/sign-in.md'],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const { searchEntries } = await loadRegistry(docs);
+
+    expect(searchEntries('rrf')[0].id).toBe('langchain/retrievers');
+    expect(searchEntries('raw body stripe')[0].id).toBe('stripe/webhooks');
+    expect(searchEntries('signin')[0].id).toBe('playwright/login-flows');
+  });
+});

--- a/docs/search-relevance.md
+++ b/docs/search-relevance.md
@@ -1,0 +1,48 @@
+# Search Relevance
+
+This note documents the search relevance changes in the CLI and the small benchmark harness that ships with them.
+
+## What changed
+
+Search ranking now combines three signals:
+
+1. **Base retrieval**: BM25 when a search index is available, otherwise keyword fallback.
+2. **Lexical rescue**: the existing compact-id and fuzzy lexical pass for queries that need stronger identifier matching.
+3. **Coverage boost**: a new additive score that rewards entries covering more of a multi-term query across ids, names, tags, and descriptions.
+
+The coverage boost also adds a light acronym rescue path. For example, a query like `mcp` can now boost entries whose names expand to **Model Context Protocol**.
+
+## New CLI flags
+
+```bash
+chub search "stripe payments" --scores
+chub search "stripe payments" --explain
+```
+
+`--scores` shows the final ranking score for each fuzzy-search result. `--explain` adds the base score, lexical rescue contribution, coverage boost contribution, and a short reason summary.
+
+## Benchmark harness
+
+The repo now includes a small synthetic benchmark harness for regression testing and iteration:
+
+```bash
+cd cli
+npm run relevance:benchmark
+npm run test:relevance
+```
+
+Files:
+
+- `scripts/relevance-benchmark.mjs`: prints baseline vs improved top results for a fixed set of scenarios
+- `test/fixtures/relevance-benchmark.json`: synthetic catalog and golden queries
+- `test/relevance.test.js`: regression tests for the new coverage logic
+
+The fixture is intentionally synthetic so contributors can reason about ranking changes quickly without depending on a live registry or network fetches.
+
+## Why this helps
+
+The baseline keyword pass can overweight a generally authoritative entry that only matches one strong token. The coverage boost helps longer queries prefer entries that match more of the query, especially when the intended result has a stronger phrase or identifier match than a competing generic reference.
+
+## Extending the fixture
+
+Add new entries and scenarios to `test/fixtures/relevance-benchmark.json`. Each scenario should include a query and an `expectedTop` id. Keep fixtures small and focused so they are easy to review in pull requests.


### PR DESCRIPTION
## Summary
This PR improves first-pass search relevance for reference-oriented queries in Context Hub without adding a reranker or changing the content model.

Today, the sparse index is built from top-level entry metadata such as `id`, `name`, `description`, and `tags`. In practice, many of the most useful developer search terms live in file paths under `references/`, `guides/`, and similar subfiles. Queries like `rrf`, `hnsw`, `raw body`, or `signin` can therefore underperform unless those exact terms also appear in top-level metadata.

This change fixes that by adding **deterministic document expansion** derived from the existing `files` metadata already present on docs and language-version entries.

### What changes
- add a new low-weight `expansion` field to the BM25 index
- derive expansion terms from existing entry file paths
- ignore generic path segments like `docs`, `references`, `guides`, and `examples`
- weight basename tokens more strongly than directory tokens
- cap repeated tokens to avoid runaway term-frequency effects
- preserve backward compatibility with legacy indexes that do not contain expansion terms

### Why this approach
This is intentionally different from a reranker.

Instead of improving search *after* candidate generation, it improves the **first-pass sparse retriever itself**, which means reference-file topics can enter the candidate set earlier. That keeps the implementation:
- deterministic
- offline
- easy to reason about
- cheap at query time

### Expected wins
Representative improvements covered by tests:
- `rrf` -> `langchain/retrievers`
- `hnsw` -> `langchain/retrievers`
- `raw body stripe` -> `stripe/webhooks`
- `signin` -> `playwright/login-flows`

### Testing
- [x] `npm test` passes
- [x] `chub build sample-content/ --validate-only` succeeds
- [x] Manual testing done (describe below)
- verified new regression cases for:
  - `rrf`
  - `hnsw` 
  - `raw body stripe` 
  - `signin`
  - backward compatibility with pre-existing documents

### Scope
This PR does **not**:
- add any new dependencies
- add model-based ranking
- change the `DOC.md` / `SKILL.md` contract
- require build-pipeline changes outside the existing index creation path

This is a small, reviewable retrieval improvement that directly targets a real user failure mode: reference lookups that rely on subfile topics rather than top-level entry metadata.