### PR TITLE
Add Zuora subscription billing platform documentation (maintainer)

### DIFF
--- a/content/zuora/docs/api/DOC.md
+++ b/content/zuora/docs/api/DOC.md
@@ -1,0 +1,570 @@
+---
+name: api
+description: "Subscription billing and revenue management platform with comprehensive REST APIs for accounts, subscriptions, orders, invoicing, payments, product catalog, usage, and Object Query"
+metadata:
+  languages: "javascript"
+  versions: "2025-08-12"
+  revision: 1
+  updated-on: "2026-03-31"
+  source: maintainer
+  tags: "zuora,api,billing,subscriptions,payments,invoicing,revenue"
+---
+# Zuora API Coding Guide
+
+## 1. Golden Rules
+
+**Always use the official Zuora SDK packages:**
+- Python: `zuora-sdk` (PyPI)
+- JavaScript: `zuora-sdk-js` (npm)
+- Java: `zuora-sdk-java` (Maven Central)
+- C#: `ZuoraSDK` (NuGet)
+
+**Never call the REST API directly when an SDK is available.** The SDKs handle authentication, token refresh, retries, and serialization automatically.
+
+**Current API Version:** `2025-08-12` (date-based versioning). Specify via the `Zuora-Version` header or SDK configuration.
+
+**Always use ZuoraClient with auto-auth.** The `ZuoraClient` class manages OAuth2 token lifecycle automatically, including background refresh and thread-safe access.
+
+## 2. Environments
+
+Zuora provides multiple environments across regions:
+
+| Environment | Base URL |
+|---|---|
+| US Developer & Central Sandbox | `https://rest.test.zuora.com` |
+| US API Sandbox (Cloud 1) | `https://rest.sandbox.na.zuora.com` |
+| US API Sandbox (Cloud 2) | `https://rest.apisandbox.zuora.com` |
+| US Production (Cloud 1) | `https://rest.na.zuora.com` |
+| US Production (Cloud 2) | `https://rest.zuora.com` |
+| EU Developer & Central Sandbox | `https://rest.test.eu.zuora.com` |
+| EU API Sandbox | `https://rest.sandbox.eu.zuora.com` |
+| EU Production | `https://rest.eu.zuora.com` |
+| APAC Developer & Central Sandbox | `https://rest.test.ap.zuora.com` |
+| APAC Production | `https://rest.ap.zuora.com` |
+
+All SDKs support environment selection via enum constants (e.g., `ZuoraClient.SBX`, `ZuoraClient.PROD`).
+
+## 3. Authentication
+
+Zuora uses **OAuth 2.0 Client Credentials** flow exclusively.
+
+### Environment Variables
+
+```bash
+# Required
+ZUORA_CLIENT_ID=your-client-id        # OAuth client ID from Zuora Admin
+ZUORA_CLIENT_SECRET=your-client-secret  # OAuth client secret
+
+# Optional
+ZUORA_BASE_URL=https://rest.apisandbox.zuora.com  # Override environment URL
+ZUORA_ENTITY_IDS=entity-id-1,entity-id-2          # Multi-entity scoping
+ZUORA_ORG_IDS=org-id-1                             # Multi-org scoping
+```
+
+**CRITICAL:** Never commit client secrets to version control. Use environment variables or secure secret management.
+
+### Authentication Flow
+
+1. SDK sends `POST /oauth/token` with `client_id`, `client_secret`, and `grant_type=client_credentials`
+2. Zuora returns a Bearer token (valid ~60 minutes)
+3. SDK auto-refreshes tokens in the background (every 10 minutes by default)
+4. All subsequent API calls include `Authorization: Bearer {token}` header
+
+### Initialization
+
+```javascript
+const { ZuoraClient, ZuoraAPI } = require('zuora-sdk-js');
+
+(async () => {
+    const client = new ZuoraClient({
+        clientId: process.env.ZUORA_CLIENT_ID,
+        clientSecret: process.env.ZUORA_CLIENT_SECRET,
+        env: ZuoraClient.SBX,
+    });
+    client.debug(true);  // Enable request/response logging (disable in production)
+    await client.initialize();  // Authenticates and starts background token refresh
+
+    // API calls here...
+})();
+```
+
+### Available Environment Constants
+
+| Constant | Environment |
+|---|---|
+| `ZuoraClient.SBX` | US Sandbox (Cloud 2) |
+| `ZuoraClient.CSBX` | US Central Sandbox |
+| `ZuoraClient.PROD` | US Production (Cloud 2) |
+
+## 4. Core API Surfaces
+
+### 4.1 Accounts
+
+Create and manage customer billing accounts.
+
+**Create Account:**
+
+```javascript
+// Create a basic account
+let createAccountRequest = new ZuoraAPI.CreateAccountRequest();
+createAccountRequest.Name = 'Acme Corp';
+createAccountRequest.Currency = 'USD';
+createAccountRequest.BillCycleDay = 1;
+createAccountRequest.AutoPay = false;
+createAccountRequest.BillToContact = {
+    FirstName: 'Jane',
+    LastName: 'Doe',
+    State: 'California',
+    Country: 'USA'
+};
+
+const account = await client.accountsApi.createAccount(createAccountRequest);
+console.log('Account Number:', account.AccountNumber);
+```
+
+**Get Account:**
+
+```javascript
+const accountDetail = await client.accountsApi.getAccount(account.AccountId);
+console.log(JSON.stringify(accountDetail, null, 2));
+```
+
+### 4.2 Product Catalog
+
+Build your product catalog with Products, Rate Plans, and Charges.
+
+**Create Product:**
+
+```javascript
+let productReq = new ZuoraAPI.CreateProductRequest();
+productReq.Name = 'Gold Membership';
+productReq.Description = 'Premium subscription tier';
+productReq.EffectiveStartDate = '2024-01-01';
+productReq.EffectiveEndDate = '2034-01-01';
+
+const product = await client.productsApi.createProduct(productReq);
+console.log('Product ID:', product.Id);
+```
+
+**Create Rate Plan:**
+
+```javascript
+let planReq = new ZuoraAPI.CreateProductRatePlanRequest();
+planReq.Name = 'Monthly Plan';
+planReq.ProductId = product.Id;
+planReq.Description = 'Monthly billing plan';
+planReq.EffectiveStartDate = '2024-01-01';
+planReq.EffectiveEndDate = '2034-01-01';
+planReq.activeCurrencies = ['USD'];
+
+const ratePlan = await client.productRatePlansApi
+    .createProductRatePlan(planReq, {});
+```
+
+**Create Charge with Pricing Tier:**
+
+```javascript
+let chargeReq = new ZuoraAPI.CreateProductRatePlanChargeRequest();
+chargeReq.Name = 'Monthly Fee';
+chargeReq.ChargeModel = 'Flat Fee Pricing';
+chargeReq.ChargeType = 'Recurring';
+chargeReq.TriggerEvent = 'ContractEffective';
+chargeReq.ProductRatePlanId = ratePlan.Id;
+chargeReq.BillCycleType = 'DefaultFromCustomer';
+chargeReq.BillingPeriod = 'Monthly';
+chargeReq.UseDiscountSpecificAccountingCode = false;
+
+let tierData = new ZuoraAPI.ProductRatePlanChargeTierData();
+tierData.ProductRatePlanChargeTier = [{ Currency: 'USD', price: 29.99 }];
+chargeReq.ProductRatePlanChargeTierData = tierData;
+
+const charge = await client.productRatePlanChargesApi
+    .createProductRatePlanCharge(chargeReq, {});
+```
+
+**Verify Product:**
+
+```javascript
+const productDetail = await client.productsApi.getProduct(product.Id);
+console.log(JSON.stringify(productDetail, (k, v) => v ?? undefined, 2));
+```
+
+### 4.3 Orders & Subscriptions
+
+Use the Orders API to create, amend, renew, and cancel subscriptions.
+
+**Create Subscription via Order:**
+
+```javascript
+const orderReq = new ZuoraAPI.CreateOrderRequest();
+orderReq.OrderDate = new Date().toISOString().split('T')[0];
+orderReq.ExistingAccountNumber = 'A00000001';
+orderReq.Subscriptions = [{
+    OrderActions: [{
+        Type: 'CreateSubscription',
+        CreateSubscription: {
+            Terms: {
+                InitialTerm: { TermType: 'EVERGREEN' }
+            },
+            SubscribeToRatePlans: [
+                { ProductRatePlanNumber: 'PRP-00000151' }
+            ]
+        }
+    }]
+}];
+orderReq.ProcessingOptions = {
+    RunBilling: true,
+    BillingOptions: {
+        TargetDate: new Date().toISOString().split('T')[0]
+    }
+};
+
+const order = await client.ordersApi.createOrder(orderReq);
+console.log('Order:', order.OrderNumber);
+console.log('Subscriptions:', order.SubscriptionNumbers);
+```
+
+**Preview Order (dry run):**
+
+```javascript
+const previewReq = new ZuoraAPI.PreviewOrderRequest();
+previewReq.OrderDate = new Date().toISOString().split('T')[0];
+previewReq.ExistingAccountNumber = 'A00000001';
+previewReq.Subscriptions = [{
+    OrderActions: [{
+        Type: 'CreateSubscription',
+        CreateSubscription: {
+            Terms: {
+                InitialTerm: { TermType: 'EVERGREEN' }
+            },
+            SubscribeToRatePlans: [
+                { ProductRatePlanNumber: 'PRP-00000151' }
+            ]
+        }
+    }]
+}];
+previewReq.PreviewOptions = {
+    PreviewThruType: 'NumberOfPeriods',
+    PreviewNumberOfPeriods: 1,
+    PreviewTypes: ['BillingDocs']
+};
+
+const preview = await client.ordersApi.previewOrder(previewReq);
+console.log(JSON.stringify(preview, null, 2));
+```
+
+### 4.4 Invoicing
+
+**Create Standalone Invoice:**
+
+```javascript
+const invoiceReq = new ZuoraAPI.CreateInvoiceRequest();
+invoiceReq.AccountNumber = 'A00000001';
+invoiceReq.AutoPay = false;
+invoiceReq.InvoiceDate = '2024-01-01';
+invoiceReq.Status = 'Posted';
+invoiceReq.InvoiceItems = [{
+    Amount: 100.0,
+    ChargeName: 'Set Up Fee',
+    Description: 'One-time setup charge',
+    Quantity: 1.0,
+    ServiceStartDate: '2024-01-01',
+    UOM: 'Each'
+}];
+
+const invoice = await client.invoicesApi.createStandaloneInvoice(invoiceReq);
+console.log(`Invoice ${invoice.InvoiceNumber}: $${invoice.Balance}`);
+```
+
+### 4.5 Payments
+
+**Create Payment and Apply to Invoice:**
+
+```javascript
+const paymentReq = new ZuoraAPI.CreatePaymentRequest();
+paymentReq.AccountNumber = 'A00000001';
+paymentReq.Amount = 100.0;
+paymentReq.Currency = 'USD';
+paymentReq.EffectiveDate = '2024-11-30';
+paymentReq.Type = 'External';
+paymentReq.PaymentMethodType = 'Check';
+paymentReq.Invoices = [{
+    Amount: 100.0,
+    InvoiceId: invoice.Id
+}];
+
+const payment = await client.paymentsApi.createPayment(paymentReq);
+console.log('Payment:', payment.Number);
+```
+
+### 4.6 Bill Runs
+
+**Create Bill Run for Specific Account:**
+
+```javascript
+const billRunFilter = new ZuoraAPI.BillRunFilter();
+billRunFilter.filterType = 'Account';
+billRunFilter.accountId = 'A00000001';
+
+const billRunReq = new ZuoraAPI.CreateBillRunRequest();
+billRunReq.billRunFilters = [billRunFilter];
+billRunReq.targetDate = '2025-01-31';
+
+const billRun = await client.billRunApi.createBillRun(billRunReq);
+console.log('Bill Run Created:', billRun);
+```
+
+## 5. Object Query API
+
+The Object Query API provides a powerful, consistent way to query 40+ Zuora object types with filtering, sorting, expansion, and pagination.
+
+### Endpoint Pattern
+
+```
+GET /object-query/{objectType}           # List objects
+GET /object-query/{objectType}/{key}     # Get by key
+```
+
+### Filtering
+
+Use dot-notation operators in the `filter` parameter:
+
+| Operator | Description | Example |
+|---|---|---|
+| `EQ` | Equal | `currency.EQ:EUR` |
+| `NE` | Not equal | `status.NE:Draft` |
+| `LT` | Less than | `amount.LT:100` |
+| `GT` | Greater than | `amount.GT:0` |
+| `LE` | Less than or equal | `balance.LE:500` |
+| `GE` | Greater than or equal | `createdDate.GE:2024-01-01` |
+| `SW` | Starts with | `name.SW:Test` |
+| `IN` | In set | `status.IN:Active,Cancelled` |
+
+```javascript
+// Filter accounts by currency (via REST — SDKs wrap this)
+// GET /object-query/accounts?filter[]=currency.EQ:USD&filter[]=status.EQ:Active&sort[]=accountNumber.ASC&pageSize=20
+const accounts = await client.objectQueriesApi.queryAccounts({
+    filter: ['currency.EQ:USD', 'status.EQ:Active'],
+    sort: ['accountNumber.ASC'],
+    pageSize: 20
+});
+```
+
+### Expansion (Joins)
+
+Include related objects in a single response using `expand`:
+
+```javascript
+// Get account with billing contact and subscriptions
+// GET /object-query/accounts/{key}?expand[]=billTo&expand[]=subscriptions
+const account = await client.objectQueriesApi.queryAccountByKey('A00000001', {
+    expand: ['billTo', 'subscriptions', 'subscriptions.rateplans']
+});
+
+// Get invoice with line items
+const invoice = await client.objectQueriesApi.queryInvoiceByKey('INV00000315', {
+    expand: ['invoiceItems']
+});
+
+// Get product catalog with full charge details
+const ratePlans = await client.objectQueriesApi.queryProductRatePlans({
+    filter: ['productId.EQ:prod-id'],
+    expand: ['productrateplancharges',
+             'productrateplancharges.productrateplanchargetiers']
+});
+```
+
+### Pagination
+
+Object Query uses cursor-based pagination:
+
+```javascript
+// First page
+let response = await client.objectQueriesApi.queryAccounts({ pageSize: 20 });
+console.log(`Page 1: ${response.data.length} accounts`);
+
+// Next page (if available)
+if (response.nextPage) {
+    response = await client.objectQueriesApi.queryAccounts({
+        pageSize: 20,
+        cursor: response.nextPage
+    });
+}
+```
+
+### Field Selection
+
+Reduce response payload by selecting specific fields:
+
+```javascript
+const accounts = await client.objectQueriesApi.queryAccounts({
+    fields: ['id', 'accountNumber', 'name', 'balance']
+});
+```
+
+## 6. Common Request Headers
+
+| Header | Purpose | Example |
+|---|---|---|
+| `Authorization` | Bearer token (auto-managed by SDK) | `Bearer eyJ...` |
+| `Zuora-Version` | API version override | `2025-08-12` |
+| `Zuora-Track-Id` | Custom request tracing ID | `my-trace-123` |
+| `Zuora-Entity-Ids` | Multi-entity scoping | `entity-uuid-1` |
+| `Zuora-Org-Ids` | Multi-org scoping | `org-uuid-1` |
+| `Idempotency-Key` | Idempotent POST/PATCH operations | `uuid-v4` |
+
+## 7. Error Handling
+
+### Error Response Structure
+
+All Zuora API errors return a consistent structure:
+
+```json
+{
+  "reasons": [
+    {
+      "code": 53100020,
+      "message": "The account number A99999999 is invalid."
+    }
+  ]
+}
+```
+
+### Error Handling Pattern
+
+```javascript
+try {
+    const result = await client.productsApi.createProduct(request);
+    if (result.Success) {
+        console.log('Created:', result.Id);
+    } else {
+        console.log('Operation failed:', result);
+    }
+} catch (error) {
+    console.error('HTTP Status:', error.status);
+
+    // Parse structured error response
+    if (error.response && error.response.body) {
+        const body = error.response.body;
+        if (body.reasons) {
+            body.reasons.forEach(reason => {
+                console.error(`  [${reason.code}] ${reason.message}`);
+            });
+        }
+    }
+
+    // Handle specific HTTP status codes
+    if (error.status === 401) {
+        // Token expired — re-initialize client
+        await client.initialize();
+    } else if (error.status === 429) {
+        // Rate limited — back off and retry
+    }
+}
+```
+
+## 8. Best Practices
+
+### Idempotency
+
+Use the `Idempotency-Key` header for POST/PATCH requests to prevent duplicate operations. The SDK supports setting custom headers per request.
+
+### Rate Limiting
+
+- Zuora enforces rate limits per tenant
+- SDKs include built-in retry with exponential backoff
+- Monitor `429 Too Many Requests` responses
+- Use bulk/async endpoints for high-volume operations
+
+### Multi-Entity & Multi-Org
+
+For multi-entity tenants, scope API calls using headers:
+
+```javascript
+// Set entity/org context — check SDK docs for per-request header options
+// Zuora-Entity-Ids: entity-uuid-1
+// Zuora-Org-Ids: org-uuid-1
+```
+
+### Async Operations
+
+For long-running operations (bill runs, large orders), use async endpoints:
+
+```javascript
+// Async order creation
+const asyncResponse = await client.ordersApi.createOrderAsync(orderReq);
+// Poll for completion using the job ID
+```
+
+### Custom Fields
+
+Zuora supports custom fields (suffix `__c`) on most objects:
+
+```javascript
+// Include custom fields via additional properties
+createAccountRequest.salesRegion__c = 'West';
+createAccountRequest.industry__c = 'Technology';
+```
+
+## 9. Charge Models
+
+Zuora supports 16 charge models for flexible pricing:
+
+| Category | Models |
+|---|---|
+| **Recurring** | Flat Fee, Per Unit, Tiered, Volume |
+| **One-Time** | Flat Fee, Tiered, Volume |
+| **Usage-Based** | Per Unit, Flat Fee, Tiered, Volume, Tiered with Overage, Overage |
+| **Discount** | Fixed Amount, Percentage |
+| **Custom** | Multi-Attribute Pricing |
+
+### Charge Types
+
+- **Recurring** — Billed on a regular schedule (monthly, annual, etc.)
+- **OneTime** — Billed once at subscription start
+- **Usage** — Billed based on consumption data
+
+## 10. Production Checklist
+
+### Pre-Launch Verification
+
+- [ ] Switch from Sandbox to Production environment URL
+- [ ] Replace sandbox OAuth credentials with production credentials
+- [ ] Set `ZUORA_CLIENT_ID` and `ZUORA_CLIENT_SECRET` via secure secret management
+- [ ] Verify API version is explicitly set (`Zuora-Version` header)
+- [ ] Enable auto-auth with token refresh (use `client.initialize()`)
+- [ ] Implement error handling for all API calls with proper logging
+- [ ] Use `Idempotency-Key` headers for all mutating POST/PATCH requests
+- [ ] Set up `Zuora-Track-Id` headers for request tracing
+- [ ] Configure rate limit handling with exponential backoff
+- [ ] Test webhook endpoints receive and process events correctly
+- [ ] Verify multi-entity/multi-org headers if applicable
+- [ ] Review custom field mappings (`__c` fields)
+- [ ] Validate product catalog (products, rate plans, charges) exists in production
+- [ ] Test full order-to-cash flow: account creation, order, invoice, payment
+- [ ] Disable SDK debug mode in production
+
+### Monitoring
+
+- Track API response times and error rates
+- Monitor OAuth token refresh cycles
+- Alert on consecutive 401/403 errors (credential issues)
+- Alert on 429 responses (rate limiting)
+- Monitor billing run completion times
+- Track payment success/failure rates
+
+### Security
+
+- **NEVER** expose OAuth client secrets in client-side code
+- Rotate OAuth credentials periodically
+- Use separate OAuth clients for different environments
+- Restrict OAuth client permissions to minimum required scopes
+- Audit API access logs in Zuora Admin
+
+## 11. Key Resources
+
+- **Developer Portal:** https://developer.zuora.com/
+- **API Reference:** https://developer.zuora.com/v1-api-reference/introduction/
+- **SDKs:** Python (`zuora-sdk`), JavaScript (`zuora-sdk-js`), Java (`zuora-sdk-java`), C# (`ZuoraSDK`)
+- **MCP Server:** `npx zuora-mcp` for AI-assisted Zuora development
+- **Knowledge Center:** https://knowledgecenter.zuora.com/

--- a/content/zuora/docs/order-to-cash/DOC.md
+++ b/content/zuora/docs/order-to-cash/DOC.md
@@ -1,0 +1,541 @@
+---
+name: order-to-cash
+description: "Zuora order-to-cash lifecycle guide: product catalog setup, subscription creation via Orders API, billing runs, invoicing, payments, and revenue recognition"
+metadata:
+  languages: "javascript"
+  versions: "2025-08-12"
+  revision: 1
+  updated-on: "2026-03-31"
+  source: maintainer
+  tags: "zuora,subscriptions,billing,orders,invoices,payments,revenue"
+---
+# Zuora Subscription Billing Guide
+
+## 1. Golden Rules
+
+**Use the Orders API for all subscription operations.** The Orders API is the modern, recommended approach for creating, amending, renewing, and canceling subscriptions. It replaces the legacy Subscribe and Amend calls.
+
+**Always preview before creating.** Use `previewOrder()` to validate your order and see projected billing documents before committing.
+
+**Follow the order-to-cash flow:** Product Catalog -> Account -> Order (Subscription) -> Bill Run -> Invoice -> Payment.
+
+## 2. Order-to-Cash Overview
+
+```
+Product Catalog          Account              Order
+┌──────────────┐    ┌──────────────┐    ┌──────────────────┐
+│ Product       │    │ Name         │    │ Order Date       │
+│  └─ Rate Plan │    │ Bill-To      │    │ Account          │
+│     └─ Charge │    │ Currency     │    │ Subscriptions    │
+│       └─ Tier │    │ Payment Info │    │  └─ Order Actions│
+└──────────────┘    └──────────────┘    └──────────────────┘
+                                              │
+                    ┌─────────────────────────┘
+                    ▼
+              Bill Run / Invoice              Payment
+         ┌──────────────────────┐     ┌──────────────────┐
+         │ Invoice Number       │     │ Amount           │
+         │ Invoice Items        │     │ Payment Method   │
+         │ Amount / Balance     │     │ Applied Invoices │
+         └──────────────────────┘     └──────────────────┘
+```
+
+## 3. Product Catalog Setup
+
+Before creating subscriptions, you need a product catalog: **Product > Rate Plan > Charge > Tier**.
+
+### Create a Product
+
+```javascript
+const { ZuoraClient, ZuoraAPI } = require('zuora-sdk-js');
+
+(async () => {
+    const client = new ZuoraClient({
+        clientId: process.env.ZUORA_CLIENT_ID,
+        clientSecret: process.env.ZUORA_CLIENT_SECRET,
+        env: ZuoraClient.SBX,
+    });
+    await client.initialize();
+
+    let productReq = new ZuoraAPI.CreateProductRequest();
+    productReq.Name = 'Gold Membership';
+    productReq.Description = 'Premium subscription tier';
+    productReq.EffectiveStartDate = '2024-01-01';
+    productReq.EffectiveEndDate = '2034-01-01';
+
+    const product = await client.productsApi.createProduct(productReq);
+    console.log('Product ID:', product.Id);
+})();
+```
+
+### Create a Rate Plan
+
+```javascript
+let planReq = new ZuoraAPI.CreateProductRatePlanRequest();
+planReq.Name = 'Monthly Plan';
+planReq.ProductId = product.Id;
+planReq.Description = 'Monthly billing plan';
+planReq.EffectiveStartDate = '2024-01-01';
+planReq.EffectiveEndDate = '2034-01-01';
+planReq.activeCurrencies = ['USD'];
+
+const ratePlan = await client.productRatePlansApi
+    .createProductRatePlan(planReq, {});
+console.log('Rate Plan ID:', ratePlan.Id);
+```
+
+### Create a Charge with Pricing Tiers
+
+```javascript
+let chargeReq = new ZuoraAPI.CreateProductRatePlanChargeRequest();
+chargeReq.Name = 'Monthly Fee';
+chargeReq.ChargeModel = 'Flat Fee Pricing';
+chargeReq.ChargeType = 'Recurring';
+chargeReq.TriggerEvent = 'ContractEffective';
+chargeReq.ProductRatePlanId = ratePlan.Id;
+chargeReq.BillCycleType = 'DefaultFromCustomer';
+chargeReq.BillingPeriod = 'Monthly';
+chargeReq.UseDiscountSpecificAccountingCode = false;
+
+let tierData = new ZuoraAPI.ProductRatePlanChargeTierData();
+tierData.ProductRatePlanChargeTier = [{ Currency: 'USD', price: 29.99 }];
+chargeReq.ProductRatePlanChargeTierData = tierData;
+
+const charge = await client.productRatePlanChargesApi
+    .createProductRatePlanCharge(chargeReq, {});
+console.log('Charge created:', charge.Id);
+```
+
+### Verify Product Catalog
+
+```javascript
+const productDetail = await client.productsApi.getProduct(product.Id);
+console.log(JSON.stringify(productDetail, (k, v) => v ?? undefined, 2));
+```
+
+## 4. Account Management
+
+### Create a Billing Account
+
+```javascript
+let accountReq = new ZuoraAPI.CreateAccountRequest();
+accountReq.Name = 'Acme Corp';
+accountReq.Currency = 'USD';
+accountReq.BillCycleDay = 1;
+accountReq.AutoPay = false;
+accountReq.BillToContact = {
+    FirstName: 'Jane',
+    LastName: 'Doe',
+    State: 'California',
+    Country: 'USA'
+};
+
+const account = await client.accountsApi.createAccount(accountReq);
+const accountNumber = account.AccountNumber;
+console.log('Account:', accountNumber);
+```
+
+### Create Account with Payment Method
+
+```javascript
+let accountReq = new ZuoraAPI.CreateAccountRequest();
+accountReq.Name = 'Acme Corp';
+accountReq.Currency = 'USD';
+accountReq.BillCycleDay = 1;
+accountReq.AutoPay = false;
+accountReq.SoldToSameAsBillTo = true;
+accountReq.BillToContact = {
+    FirstName: 'Jane',
+    LastName: 'Doe',
+    WorkEmail: 'jane@acme.com',
+    Country: 'United States',
+    State: 'CA'
+};
+accountReq.PaymentMethod = {
+    Type: 'CreditCard',
+    CardType: 'Visa',
+    CardNumber: '4111111111111111',
+    ExpirationMonth: 10,
+    ExpirationYear: 2030,
+    SecurityCode: '123',
+    CardHolderInfo: { CardHolderName: 'Jane Doe' }
+};
+
+const account = await client.accountsApi.createAccount(accountReq);
+console.log('Account:', JSON.stringify(account, null, 2));
+```
+
+### Get and Delete Account
+
+```javascript
+// Get account details
+const accountDetail = await client.accountsApi.getAccount(account.AccountId);
+console.log(accountDetail);
+
+// Delete account
+const deleteResponse = await client.accountsApi.deleteAccount(account.AccountId);
+console.log(deleteResponse);
+```
+
+## 5. Subscription Operations
+
+### Create Subscription (Evergreen)
+
+An evergreen subscription has no end date and continues until explicitly canceled.
+
+```javascript
+const today = new Date().toISOString().split('T')[0];
+
+const orderReq = new ZuoraAPI.CreateOrderRequest();
+orderReq.OrderDate = today;
+orderReq.ExistingAccountNumber = 'A00000001';
+orderReq.Subscriptions = [{
+    OrderActions: [{
+        Type: 'CreateSubscription',
+        CreateSubscription: {
+            Terms: {
+                InitialTerm: { TermType: 'EVERGREEN' }
+            },
+            SubscribeToRatePlans: [
+                { ProductRatePlanNumber: 'PRP-00000151' }
+            ]
+        }
+    }]
+}];
+orderReq.ProcessingOptions = {
+    RunBilling: true,
+    BillingOptions: { TargetDate: today }
+};
+
+const order = await client.ordersApi.createOrder(orderReq);
+console.log('Order:', order.OrderNumber);
+console.log('Subscriptions:', order.SubscriptionNumbers);
+```
+
+### Create Subscription (Termed)
+
+A termed subscription has a fixed duration.
+
+```javascript
+const orderReq = new ZuoraAPI.CreateOrderRequest();
+orderReq.OrderDate = today;
+orderReq.ExistingAccountNumber = 'A00000001';
+orderReq.Subscriptions = [{
+    OrderActions: [{
+        Type: 'CreateSubscription',
+        CreateSubscription: {
+            Terms: {
+                InitialTerm: {
+                    TermType: 'TERMED',
+                    Period: 12,
+                    PeriodType: 'Month'
+                },
+                RenewalTerms: [{
+                    Period: 12,
+                    PeriodType: 'Month'
+                }],
+                AutoRenew: true
+            },
+            SubscribeToRatePlans: [
+                { ProductRatePlanNumber: 'PRP-00000151' }
+            ]
+        }
+    }]
+}];
+
+const order = await client.ordersApi.createOrder(orderReq);
+```
+
+### Preview Order
+
+**ALWAYS preview before creating** to validate and see projected billing:
+
+```javascript
+const previewReq = new ZuoraAPI.PreviewOrderRequest();
+previewReq.OrderDate = today;
+previewReq.ExistingAccountNumber = 'A00000001';
+previewReq.Subscriptions = [{
+    OrderActions: [{
+        Type: 'CreateSubscription',
+        CreateSubscription: {
+            Terms: {
+                InitialTerm: { TermType: 'EVERGREEN' }
+            },
+            SubscribeToRatePlans: [
+                { ProductRatePlanNumber: 'PRP-00000151' }
+            ]
+        }
+    }]
+}];
+previewReq.PreviewOptions = {
+    PreviewThruType: 'NumberOfPeriods',
+    PreviewNumberOfPeriods: 3,
+    PreviewTypes: ['BillingDocs', 'ChargeMetrics']
+};
+
+const preview = await client.ordersApi.previewOrder(previewReq);
+// Inspect projected invoices before committing
+console.log(JSON.stringify(preview, null, 2));
+```
+
+### Cancel Subscription
+
+```javascript
+const cancelReq = new ZuoraAPI.CreateOrderRequest();
+cancelReq.OrderDate = today;
+cancelReq.ExistingAccountNumber = 'A00000001';
+cancelReq.Subscriptions = [{
+    SubscriptionNumber: 'A-S00000001',
+    OrderActions: [{
+        Type: 'CancelSubscription',
+        CancelSubscription: {
+            CancelDate: today,
+            CancelPolicy: 'SpecificDate'
+        }
+    }]
+}];
+
+const cancelOrder = await client.ordersApi.createOrder(cancelReq);
+```
+
+### Renew Subscription
+
+```javascript
+const renewReq = new ZuoraAPI.CreateOrderRequest();
+renewReq.OrderDate = today;
+renewReq.ExistingAccountNumber = 'A00000001';
+renewReq.Subscriptions = [{
+    SubscriptionNumber: 'A-S00000001',
+    OrderActions: [{
+        Type: 'RenewSubscription',
+        RenewSubscription: {
+            Terms: {
+                RenewalTerms: [{
+                    Period: 12,
+                    PeriodType: 'Month'
+                }]
+            }
+        }
+    }]
+}];
+
+const renewOrder = await client.ordersApi.createOrder(renewReq);
+```
+
+## 6. Invoicing
+
+### Standalone Invoices
+
+Create invoices directly without a subscription:
+
+```javascript
+const invoiceReq = new ZuoraAPI.CreateInvoiceRequest();
+invoiceReq.AccountNumber = 'A00000001';
+invoiceReq.AutoPay = false;
+invoiceReq.InvoiceDate = '2024-01-01';
+invoiceReq.Status = 'Posted';
+invoiceReq.InvoiceItems = [{
+    Amount: 100.0,
+    ChargeName: 'Set Up Fee',
+    Description: 'One-time setup charge',
+    Quantity: 1.0,
+    ServiceStartDate: '2024-01-01',
+    UOM: 'Each'
+}];
+
+const invoice = await client.invoicesApi.createStandaloneInvoice(invoiceReq);
+console.log(`Invoice ${invoice.InvoiceNumber}: $${invoice.Balance}`);
+```
+
+### Bill Runs
+
+Generate invoices for subscriptions in bulk:
+
+```javascript
+const billRunFilter = new ZuoraAPI.BillRunFilter();
+billRunFilter.filterType = 'Account';
+billRunFilter.accountId = 'A00000001';
+
+const billRunReq = new ZuoraAPI.CreateBillRunRequest();
+billRunReq.billRunFilters = [billRunFilter];
+billRunReq.targetDate = '2025-01-31';
+
+const billRun = await client.billRunApi.createBillRun(billRunReq);
+console.log('Bill Run Created:', billRun);
+```
+
+## 7. Payments
+
+### Create Payment and Apply to Invoice
+
+```javascript
+const paymentReq = new ZuoraAPI.CreatePaymentRequest();
+paymentReq.AccountNumber = 'A00000001';
+paymentReq.Amount = 100.0;
+paymentReq.Currency = 'USD';
+paymentReq.EffectiveDate = '2024-11-30';
+paymentReq.Type = 'External';
+paymentReq.PaymentMethodType = 'Check';
+paymentReq.Invoices = [{
+    Amount: 100.0,
+    InvoiceId: invoice.Id
+}];
+
+const payment = await client.paymentsApi.createPayment(paymentReq);
+console.log('Payment:', payment.Number);
+```
+
+### Payment Types
+
+| Type | Description |
+|---|---|
+| **External** | Payment processed outside Zuora (check, wire, etc.) |
+| **Electronic** | Payment processed through Zuora payment gateway |
+
+### Payment Method Types
+
+Common payment methods: `CreditCard`, `DebitCard`, `ACH`, `PayPal`, `Check`, `WireTransfer`, `Other`
+
+## 8. Credit & Debit Memos
+
+### Credit Memo
+
+Apply credits to customer accounts for refunds, adjustments, or corrections.
+
+### Debit Memo
+
+Create additional charges outside the normal billing cycle.
+
+Both support async operations for large volumes:
+- `POST /v1/creditmemos` — Create credit memo
+- `POST /v1/debitmemos` — Create debit memo
+- Async variants available for bulk operations
+
+## 9. Usage-Based Billing
+
+Submit usage records for consumption-based charges:
+
+```javascript
+const usageData = [{
+    Quantity: 150,
+    StartDateTime: '2024-01-01T00:00:00',
+    UOM: 'GB',
+    SubscriptionNumber: 'A-S00000001',
+    ChargeNumber: 'C-00000001'
+}];
+
+const usage = await client.usageApi.postUsage('A00000001', usageData);
+```
+
+## 10. Order Actions Summary
+
+| Action Type | Description |
+|---|---|
+| `CreateSubscription` | Create a new subscription |
+| `AddProduct` | Add a rate plan to existing subscription |
+| `RemoveProduct` | Remove a rate plan |
+| `UpdateProduct` | Modify charge quantities/pricing |
+| `RenewSubscription` | Renew a termed subscription |
+| `CancelSubscription` | Cancel a subscription |
+| `TermsAndConditions` | Update subscription terms |
+| `OwnerTransfer` | Transfer subscription ownership |
+| `Suspend` | Temporarily suspend a subscription |
+| `Resume` | Resume a suspended subscription |
+
+## 11. Complete Order-to-Cash Example
+
+```javascript
+const { ZuoraClient, ZuoraAPI } = require('zuora-sdk-js');
+
+(async () => {
+    try {
+        // 1. Initialize client
+        const client = new ZuoraClient({
+            clientId: process.env.ZUORA_CLIENT_ID,
+            clientSecret: process.env.ZUORA_CLIENT_SECRET,
+            env: ZuoraClient.SBX,
+        });
+        await client.initialize();
+
+        const today = new Date().toISOString().split('T')[0];
+
+        // 2. Create account
+        let accountReq = new ZuoraAPI.CreateAccountRequest();
+        accountReq.Name = 'Acme Corp';
+        accountReq.Currency = 'USD';
+        accountReq.BillCycleDay = 1;
+        accountReq.AutoPay = false;
+        accountReq.BillToContact = {
+            FirstName: 'Jane', LastName: 'Doe',
+            State: 'California', Country: 'USA'
+        };
+        const account = await client.accountsApi.createAccount(accountReq);
+        console.log('Account:', account.AccountNumber);
+
+        // 3. Create subscription via order
+        const orderReq = new ZuoraAPI.CreateOrderRequest();
+        orderReq.OrderDate = today;
+        orderReq.ExistingAccountNumber = account.AccountNumber;
+        orderReq.Subscriptions = [{
+            OrderActions: [{
+                Type: 'CreateSubscription',
+                CreateSubscription: {
+                    Terms: { InitialTerm: { TermType: 'EVERGREEN' } },
+                    SubscribeToRatePlans: [
+                        { ProductRatePlanNumber: 'PRP-00000151' }
+                    ]
+                }
+            }]
+        }];
+        orderReq.ProcessingOptions = {
+            RunBilling: true,
+            BillingOptions: { TargetDate: today }
+        };
+        const order = await client.ordersApi.createOrder(orderReq);
+        console.log('Order:', order.OrderNumber);
+
+        // 4. Create standalone invoice
+        const invoiceReq = new ZuoraAPI.CreateInvoiceRequest();
+        invoiceReq.AccountNumber = account.AccountNumber;
+        invoiceReq.AutoPay = false;
+        invoiceReq.InvoiceDate = today;
+        invoiceReq.Status = 'Posted';
+        invoiceReq.InvoiceItems = [{
+            Amount: 100.0,
+            ChargeName: 'Set Up Fee',
+            Quantity: 1.0,
+            ServiceStartDate: today,
+            UOM: 'Each'
+        }];
+        const invoice = await client.invoicesApi
+            .createStandaloneInvoice(invoiceReq);
+        console.log(`Invoice: ${invoice.InvoiceNumber}, Balance: $${invoice.Balance}`);
+
+        // 5. Apply payment
+        const paymentReq = new ZuoraAPI.CreatePaymentRequest();
+        paymentReq.AccountNumber = account.AccountNumber;
+        paymentReq.Amount = 100.0;
+        paymentReq.Currency = 'USD';
+        paymentReq.EffectiveDate = today;
+        paymentReq.Type = 'External';
+        paymentReq.PaymentMethodType = 'Check';
+        paymentReq.Invoices = [{ Amount: 100.0, InvoiceId: invoice.Id }];
+        const payment = await client.paymentsApi.createPayment(paymentReq);
+        console.log('Payment:', payment.Number);
+
+    } catch (error) {
+        console.error(error);
+    }
+})();
+```
+
+## 12. Best Practices
+
+- **Always preview orders** before creating to catch validation errors early
+- **Use ProcessingOptions** to control whether billing runs immediately or is deferred
+- **Prefer account numbers** over account IDs for readability in order requests
+- **Use ProductRatePlanNumber** (not ID) for portability across environments
+- **Handle partial failures** — some order actions may succeed while others fail
+- **Use async endpoints** for bulk bill runs and large order batches
+- **Set up webhooks** for billing events (invoice posted, payment received, etc.)
+- **Test the full flow** in Sandbox before Production: catalog -> account -> order -> bill -> pay

--- a/content/zuora/docs/package/csharp/DOC.md
+++ b/content/zuora/docs/package/csharp/DOC.md
@@ -1,0 +1,463 @@
+---
+name: package
+description: "Zuora C# SDK (ZuoraSDK) for subscription billing, invoicing, payments, and product catalog management with auto-authentication and async support on .NET 8+"
+metadata:
+  languages: "csharp"
+  versions: "1.7.0"
+  revision: 1
+  updated-on: "2026-03-31"
+  source: maintainer
+  tags: "zuora,csharp,dotnet,sdk,billing,subscriptions,payments"
+---
+# Zuora C# SDK Guide
+
+## 1. Golden Rules
+
+**Always use `ZuoraClient` with auto-auth.** The `ZuoraClient` class manages OAuth2 authentication and token refresh automatically. Never manage tokens manually.
+
+**Always call `zuoraClient.Initialize()`** after creating the client.
+
+**Use both sync and async methods.** The SDK provides synchronous methods and `Async` variants for non-blocking operations.
+
+**Current SDK Version:** 1.7.0 | **API Version:** 2024-05-20 | **.NET:** 8.0+
+
+## 2. Installation
+
+### NuGet
+
+```bash
+dotnet add package ZuoraSDK
+```
+
+```powershell
+Install-Package ZuoraSDK
+```
+
+### Key Dependencies
+
+- RestSharp 112.0.0 (HTTP client)
+- Newtonsoft.Json 13.0.3 (JSON serialization)
+- Polly 8.1.0 (resilience/retry policies)
+- System.Text.Json 8.0.6
+
+## 3. Initialization
+
+### Basic Setup
+
+```csharp
+using ZuoraSDK.Client;
+
+var zuoraClient = new ZuoraClient(
+    Environment.GetEnvironmentVariable("ZUORA_CLIENT_ID"),
+    Environment.GetEnvironmentVariable("ZUORA_CLIENT_SECRET"),
+    ZuoraEnv.SBX
+);
+zuoraClient.Initialize();
+```
+
+### With Debug Mode
+
+```csharp
+var zuoraClient = new ZuoraClient(
+    Environment.GetEnvironmentVariable("ZUORA_CLIENT_ID"),
+    Environment.GetEnvironmentVariable("ZUORA_CLIENT_SECRET"),
+    ZuoraEnv.SBX
+);
+zuoraClient.SetDebugging(true);
+// zuoraClient.SetHttpTimeout(110000);  // Optional timeout in ms
+zuoraClient.Initialize();
+```
+
+### Available Environments
+
+| Enum | Environment |
+|---|---|
+| `ZuoraEnv.SBX` | US Sandbox (Cloud 2) |
+| `ZuoraEnv.PROD` | US Production (Cloud 2) |
+
+## 4. API Client Properties
+
+The `ZuoraClient` exposes typed API accessors:
+
+| Property | API Surface |
+|---|---|
+| `zuoraClient.AccountsApi` | Account CRUD |
+| `zuoraClient.OrdersApi` | Order & subscription lifecycle |
+| `zuoraClient.InvoicesApi` | Invoice management |
+| `zuoraClient.PaymentsApi` | Payment processing |
+| `zuoraClient.ProductsApi` | Product catalog CRUD |
+| `zuoraClient.ProductRatePlansApi` | Rate plan management |
+| `zuoraClient.ProductRatePlanChargesApi` | Charge management |
+| `zuoraClient.ObjectQueriesApi` | Object Query API |
+
+### Sync vs Async
+
+Most API methods have both synchronous and async variants:
+
+```csharp
+// Synchronous
+CreateAccountResponse response = zuoraClient.AccountsApi.CreateAccount(request);
+
+// Asynchronous
+CreateAccountResponse response = await zuoraClient.AccountsApi.CreateAccountAsync(request);
+```
+
+## 5. Core Usage
+
+### Accounts
+
+```csharp
+using ZuoraSDK.Client;
+using ZuoraSDK.Model;
+
+// Create account with payment method
+var contact = new CreateAccountContact(
+    firstName: "Jane",
+    lastName: "Doe",
+    country: "United States",
+    state: "CA"
+);
+
+var paymentMethod = new CreateAccountPaymentMethod(
+    type: "CreditCard",
+    cardType: "Visa",
+    cardNumber: "4111111111111111",
+    expirationMonth: 10,
+    expirationYear: 2030,
+    securityCode: "123",
+    cardHolderInfo: new CreatePaymentMethodCardholderInfo(
+        cardHolderName: "Jane Doe"
+    )
+);
+
+var createAccountRequest = new CreateAccountRequest(
+    name: "Acme Corp",
+    billToContact: contact,
+    paymentMethod: paymentMethod,
+    billCycleDay: 1,
+    soldToSameAsBillTo: true,
+    autoPay: false,
+    currency: "USD"
+);
+
+// Custom fields
+createAccountRequest.AdditionalProperties.Add("salesRegion__c", "West");
+
+CreateAccountResponse response = zuoraClient.AccountsApi.CreateAccount(createAccountRequest);
+Console.WriteLine(response.ToJson());
+```
+
+```csharp
+// Update account
+var updateRequest = new UpdateAccountRequest(name: "Acme Corporation", billCycleDay: 15);
+CommonResponse updateResponse = zuoraClient.AccountsApi.UpdateAccount(
+    response.AccountId, updateRequest);
+
+// Get account
+AccountDetailResponse account = zuoraClient.AccountsApi.GetAccount(response.AccountId);
+
+// Delete account
+DeleteAccountResponse deleteResponse = zuoraClient.AccountsApi.DeleteAccount(
+    response.AccountId);
+```
+
+### Orders & Subscriptions
+
+```csharp
+using ZuoraSDK.Model;
+
+// Preview order (async)
+PreviewOrderResponse preview = await zuoraClient.OrdersApi.PreviewOrderAsync(
+    new PreviewOrderRequest(
+        orderDate: DateOnly.FromDateTime(DateTime.Today),
+        existingAccountNumber: "A00000001",
+        subscriptions: [
+            new PreviewOrderSubscriptions(
+                orderActions: [
+                    new PreviewOrderOrderAction(
+                        type: OrderActionType.CreateSubscription,
+                        createSubscription: new PreviewOrderCreateSubscription(
+                            terms: new PreviewOrderCreateSubscriptionTerms(
+                                initialTerm: new InitialTerm(
+                                    termType: TermType.EVERGREEN)),
+                            subscribeToRatePlans: [
+                                new PreviewOrderRatePlanOverride(
+                                    productRatePlanId: "rate-plan-id")]))])],
+        previewOptions: new PreviewOptions(
+            previewThruType: PreviewOptionsPreviewThruType.NumberOfPeriods,
+            previewNumberOfPeriods: 1,
+            previewTypes: [PreviewOptions.PreviewTypesEnum.BillingDocs])));
+Console.WriteLine(preview.ToJson());
+```
+
+```csharp
+// Create order (subscription)
+CreateOrderResponse order = zuoraClient.OrdersApi.CreateOrder(
+    new CreateOrderRequest(
+        orderDate: DateOnly.FromDateTime(DateTime.Today),
+        existingAccountNumber: "A00000001",
+        subscriptions: [
+            new CreateOrderSubscription(
+                orderActions: [
+                    new CreateOrderAction(
+                        type: OrderActionType.CreateSubscription,
+                        createSubscription: new CreateOrderCreateSubscription(
+                            terms: new OrderActionCreateSubscriptionTerms(
+                                initialTerm: new InitialTerm(
+                                    termType: TermType.EVERGREEN)),
+                            subscribeToRatePlans: [
+                                new CreateOrderRatePlanOverride(
+                                    productRatePlanNumber: "PRP-00000774")]))])],
+        processingOptions: new ProcessingOptionsWithDelayedCapturePayment(
+            runBilling: true,
+            billingOptions: new BillingOptions(
+                targetDate: DateOnly.FromDateTime(DateTime.Today)))));
+Console.WriteLine(order.ToJson());
+```
+
+### Invoices
+
+```csharp
+// Create standalone invoice
+InvoiceResponse invoice = zuoraClient.InvoicesApi.CreateStandaloneInvoice(
+    new CreateInvoiceRequest(
+        accountNumber: "A00000001",
+        autoPay: false,
+        invoiceDate: DateOnly.Parse("2024-01-01"),
+        status: BillingDocumentStatus.Posted,
+        invoiceItems: [
+            new CreateInvoiceItem(
+                amount: 100,
+                chargeName: "Set Up Fee",
+                description: "One-time setup charge",
+                quantity: 1.0m,
+                serviceStartDate: DateOnly.Parse("2024-01-01"),
+                uom: "Each")]));
+Console.WriteLine(invoice.ToJson());
+```
+
+### Object Query
+
+```csharp
+// Query invoice by key
+var inv = zuoraClient.ObjectQueriesApi.QueryInvoiceByKey(invoice.InvoiceNumber);
+Console.WriteLine(inv.ToJson());
+
+// Query invoices by account
+var invoices = zuoraClient.ObjectQueriesApi.QueryInvoices(
+    filter: [$"accountId.EQ:{invoice.AccountId}"]);
+Console.WriteLine(invoices.Data[0].ToJson());
+
+// Query rate plan by key
+ExpandedProductRatePlan ratePlan = zuoraClient.ObjectQueriesApi
+    .QueryProductRatePlanByKey("rate-plan-id");
+```
+
+### Payments
+
+```csharp
+// Create payment and apply to invoice
+var payment = zuoraClient.PaymentsApi.CreatePayment(
+    new CreatePaymentRequest(
+        accountNumber: "A00000001",
+        amount: 100.0,
+        currency: "USD",
+        effectiveDate: "2024-11-30",
+        type: PaymentType.External,
+        paymentMethodType: "Check",
+        invoices: [
+            new CreatePaymentInvoiceApplication(
+                amount: 100.0,
+                invoiceId: invoice.Id)]));
+Console.WriteLine(payment.ToJson());
+```
+
+## 6. Error Handling
+
+```csharp
+using ZuoraSDK.Client;
+
+try
+{
+    var response = zuoraClient.AccountsApi.CreateAccount(request);
+    Console.WriteLine(response.ToJson());
+}
+catch (ApiException e)
+{
+    Console.Error.WriteLine($"HTTP Status: {e.ErrorCode}");
+    Console.Error.WriteLine($"Error: {e.Message}");
+    Console.Error.WriteLine($"Response Body: {e.ErrorContent}");
+}
+```
+
+## 7. Enum Reference
+
+### Order Action Types
+
+| Enum | Description |
+|---|---|
+| `OrderActionType.CreateSubscription` | Create new subscription |
+| `OrderActionType.CancelSubscription` | Cancel subscription |
+| `OrderActionType.RenewSubscription` | Renew subscription |
+| `OrderActionType.AddProduct` | Add rate plan |
+| `OrderActionType.RemoveProduct` | Remove rate plan |
+| `OrderActionType.UpdateProduct` | Modify charges |
+
+### Term Types
+
+| Enum | Description |
+|---|---|
+| `TermType.EVERGREEN` | No end date, renews indefinitely |
+| `TermType.TERMED` | Fixed duration |
+
+### Billing Document Status
+
+| Enum | Description |
+|---|---|
+| `BillingDocumentStatus.Draft` | Draft status |
+| `BillingDocumentStatus.Posted` | Posted/finalized |
+
+### Payment Types
+
+| Enum | Description |
+|---|---|
+| `PaymentType.External` | External payment (check, wire, etc.) |
+| `PaymentType.Electronic` | Gateway-processed payment |
+
+## 8. Advanced Features
+
+### JSON Serialization
+
+All model objects support:
+
+```csharp
+string json = response.ToJson();  // Serialize to JSON string
+```
+
+### Custom Fields
+
+```csharp
+// Add custom fields via AdditionalProperties dictionary
+var request = new CreateAccountRequest(name: "Acme Corp", ...);
+request.AdditionalProperties.Add("salesRegion__c", "West");
+request.AdditionalProperties.Add("industry__c", "Technology");
+```
+
+### HTTP Timeout
+
+```csharp
+zuoraClient.SetHttpTimeout(110000);  // 110 seconds
+```
+
+### Resilience (Polly)
+
+The C# SDK includes Polly for retry policies. The SDK handles retries automatically for transient failures.
+
+### Collection Initializer Syntax
+
+C# 12+ supports collection expressions for cleaner request construction:
+
+```csharp
+// Clean array syntax with []
+subscribeToRatePlans: [
+    new CreateOrderRatePlanOverride(productRatePlanNumber: "PRP-00000774")
+]
+
+invoiceItems: [
+    new CreateInvoiceItem(amount: 100, chargeName: "Fee", ...)
+]
+```
+
+## 9. Complete Example: Order-to-Cash
+
+```csharp
+using ZuoraSDK.Client;
+using ZuoraSDK.Model;
+
+class Program
+{
+    static async Task Main(string[] args)
+    {
+        // 1. Initialize client
+        var zuoraClient = new ZuoraClient(
+            Environment.GetEnvironmentVariable("ZUORA_CLIENT_ID"),
+            Environment.GetEnvironmentVariable("ZUORA_CLIENT_SECRET"),
+            ZuoraEnv.SBX);
+        zuoraClient.Initialize();
+
+        // 2. Create account
+        var accountResponse = zuoraClient.AccountsApi.CreateAccount(
+            new CreateAccountRequest(
+                name: "Acme Corp",
+                billToContact: new CreateAccountContact(
+                    firstName: "Jane", lastName: "Doe",
+                    country: "United States", state: "CA"),
+                billCycleDay: 1,
+                soldToSameAsBillTo: true,
+                autoPay: false,
+                currency: "USD"));
+        Console.WriteLine($"Account: {accountResponse.AccountNumber}");
+
+        // 3. Create subscription via order
+        var orderResponse = zuoraClient.OrdersApi.CreateOrder(
+            new CreateOrderRequest(
+                orderDate: DateOnly.FromDateTime(DateTime.Today),
+                existingAccountNumber: accountResponse.AccountNumber,
+                subscriptions: [
+                    new CreateOrderSubscription(
+                        orderActions: [
+                            new CreateOrderAction(
+                                type: OrderActionType.CreateSubscription,
+                                createSubscription: new CreateOrderCreateSubscription(
+                                    terms: new OrderActionCreateSubscriptionTerms(
+                                        initialTerm: new InitialTerm(
+                                            termType: TermType.EVERGREEN)),
+                                    subscribeToRatePlans: [
+                                        new CreateOrderRatePlanOverride(
+                                            productRatePlanNumber: "PRP-00000774")]))])]));
+        Console.WriteLine($"Order: {orderResponse.OrderNumber}");
+
+        // 4. Create standalone invoice
+        var invoiceResponse = zuoraClient.InvoicesApi.CreateStandaloneInvoice(
+            new CreateInvoiceRequest(
+                accountNumber: accountResponse.AccountNumber,
+                autoPay: false,
+                invoiceDate: DateOnly.FromDateTime(DateTime.Today),
+                status: BillingDocumentStatus.Posted,
+                invoiceItems: [
+                    new CreateInvoiceItem(
+                        amount: 100, chargeName: "Set Up Fee",
+                        quantity: 1.0m,
+                        serviceStartDate: DateOnly.FromDateTime(DateTime.Today),
+                        uom: "Each")]));
+        Console.WriteLine($"Invoice: {invoiceResponse.InvoiceNumber}");
+
+        // 5. Apply payment
+        var paymentResponse = zuoraClient.PaymentsApi.CreatePayment(
+            new CreatePaymentRequest(
+                accountNumber: accountResponse.AccountNumber,
+                amount: 100.0, currency: "USD",
+                effectiveDate: DateTime.Today.ToString("yyyy-MM-dd"),
+                type: PaymentType.External,
+                paymentMethodType: "Check",
+                invoices: [
+                    new CreatePaymentInvoiceApplication(
+                        amount: 100.0,
+                        invoiceId: invoiceResponse.Id)]));
+        Console.WriteLine($"Payment: {paymentResponse.Number}");
+    }
+}
+```
+
+## 10. Production Checklist
+
+- [ ] Switch `ZuoraEnv.SBX` to `ZuoraEnv.PROD`
+- [ ] Use environment variables or secure vault for credentials
+- [ ] Call `zuoraClient.Initialize()` at application startup
+- [ ] Wrap all API calls in try/catch for `ApiException`
+- [ ] Disable debugging in production (`SetDebugging(false)`)
+- [ ] Use async methods (`*Async`) for non-blocking operations
+- [ ] Configure appropriate HTTP timeout for your use case
+- [ ] Test full order-to-cash flow in Sandbox before Production
+- [ ] Monitor error rates and handle 429 rate limiting
+- [ ] Ensure .NET 8.0+ runtime is available in production

--- a/content/zuora/docs/package/java/DOC.md
+++ b/content/zuora/docs/package/java/DOC.md
@@ -1,0 +1,383 @@
+---
+name: package
+description: "Zuora Java SDK (zuora-sdk-java) for subscription billing, invoicing, payments, and product catalog management with auto-authentication and fluent builder API"
+metadata:
+  languages: "java"
+  versions: "3.15.0"
+  revision: 1
+  updated-on: "2026-03-31"
+  source: maintainer
+  tags: "zuora,java,sdk,billing,subscriptions,payments"
+---
+# Zuora Java SDK Guide
+
+## 1. Golden Rules
+
+**Always use `ZuoraClient` with auto-auth.** The `ZuoraClient` class manages OAuth2 authentication and token refresh automatically. Never manage tokens manually.
+
+**Always call `zuoraClient.initialize()`** after creating the client. This authenticates with Zuora and prepares the client for API calls.
+
+**Use the fluent builder pattern.** All request models support method chaining for readable, type-safe request construction.
+
+**Always catch `ApiException`.** Parse `getResponseBody()` with `CommonResponse.fromJson()` for structured error details.
+
+**Current SDK Version:** 3.15.0 | **API Version:** 2025-08-12 | **Java:** 11+
+
+## 2. Installation
+
+### Maven
+
+```xml
+<dependency>
+    <groupId>com.zuora.sdk</groupId>
+    <artifactId>zuora-sdk-java</artifactId>
+    <version>3.15.0</version>
+</dependency>
+```
+
+### Gradle
+
+```groovy
+implementation 'com.zuora.sdk:zuora-sdk-java:3.15.0'
+```
+
+### Key Dependencies
+
+- OkHttp 4.10.0 (HTTP client)
+- Gson 2.10.1 (JSON serialization)
+- Jackson 2.16.1 (alternative serialization)
+
+### Build Requirements
+
+- Java 11+
+- Maven 3.8.3+ (if using Maven)
+
+## 3. Initialization
+
+### Basic Setup
+
+```java
+import com.zuora.ZuoraClient;
+
+ZuoraClient zuoraClient = new ZuoraClient(
+    System.getenv("ZUORA_CLIENT_ID"),
+    System.getenv("ZUORA_CLIENT_SECRET"),
+    ZuoraClient.ZuoraEnv.SBX
+);
+zuoraClient.initialize();
+```
+
+### With Debug Mode
+
+```java
+ZuoraClient zuoraClient = new ZuoraClient(
+    System.getenv("ZUORA_CLIENT_ID"),
+    System.getenv("ZUORA_CLIENT_SECRET"),
+    ZuoraClient.ZuoraEnv.SBX
+);
+zuoraClient.setDebugging(true);  // Log full request/response
+zuoraClient.initialize();
+```
+
+### Available Environments
+
+| Enum | Environment |
+|---|---|
+| `ZuoraClient.ZuoraEnv.SBX` | US Sandbox (Cloud 2) |
+| `ZuoraClient.ZuoraEnv.PROD` | US Production (Cloud 2) |
+
+## 4. API Client Methods
+
+The `ZuoraClient` exposes typed API accessors:
+
+| Method | API Surface |
+|---|---|
+| `zuoraClient.accountsApi()` | Account CRUD |
+| `zuoraClient.ordersApi()` | Order & subscription lifecycle |
+| `zuoraClient.invoicesApi()` | Invoice management |
+| `zuoraClient.paymentsApi()` | Payment processing |
+| `zuoraClient.productsApi()` | Product catalog CRUD |
+| `zuoraClient.productRatePlansApi()` | Rate plan management |
+| `zuoraClient.productRatePlanChargesApi()` | Charge management |
+| `zuoraClient.objectQueriesApi()` | Object Query API |
+| `zuoraClient.usageApi()` | Usage records |
+| `zuoraClient.billRunApi()` | Bill run operations |
+
+### Execution Pattern
+
+All API methods return a request builder. Call `.execute()` to send the request:
+
+```java
+// Standard execution
+CreateAccountResponse response = zuoraClient.accountsApi()
+    .createAccountApi(request)
+    .execute();
+
+// With HTTP info (headers, status code, request ID)
+ApiResponse<CreateAccountResponse> response = zuoraClient.accountsApi()
+    .createAccountApi(request)
+    .executeWithHttpInfo();
+
+String requestId = response.getZuoraRequestId();
+```
+
+## 5. Core Usage
+
+### Accounts
+
+```java
+import com.zuora.model.*;
+
+// Create account with payment method
+CreateAccountContact contact = new CreateAccountContact()
+    .firstName("Jane").lastName("Doe")
+    .workEmail("jane@acme.com")
+    .country("United States").state("CA");
+
+CreateAccountPaymentMethod paymentMethod = new CreateAccountPaymentMethod()
+    .type("CreditCard").cardType("Visa")
+    .cardNumber("4111111111111111")
+    .expirationMonth(10).expirationYear(2030)
+    .securityCode("123")
+    .cardHolderInfo(new CreatePaymentMethodCardholderInfo()
+        .cardHolderName("Jane Doe"));
+
+CreateAccountRequest request = new CreateAccountRequest()
+    .name("Acme Corp")
+    .billToContact(contact)
+    .paymentMethod(paymentMethod)
+    .billCycleDay(1)
+    .soldToSameAsBillTo(true)
+    .autoPay(false)
+    .currency("USD");
+
+ApiResponse<CreateAccountResponse> response = zuoraClient.accountsApi()
+    .createAccountApi(request)
+    .executeWithHttpInfo();
+
+System.out.println("Request ID: " + response.getZuoraRequestId());
+System.out.println("Account ID: " + response.getData().getAccountId());
+```
+
+```java
+// Custom fields
+CreateAccountRequest request = new CreateAccountRequest()
+    .name("Acme Corp")
+    .billToContact(contact)
+    .putAdditionalProperty("salesRegion__c", "West");
+```
+
+### Product Catalog
+
+```java
+import com.zuora.model.*;
+import java.time.LocalDate;
+import java.util.List;
+
+// Create product
+CreateProductRequest productRequest = new CreateProductRequest()
+    .name("Gold Membership")
+    .effectiveStartDate(LocalDate.of(2024, 1, 1))
+    .effectiveEndDate(LocalDate.of(2034, 1, 1))
+    .SKU("SKU-GOLD-001")
+    .description("Premium subscription tier");
+
+ProxyCreateOrModifyResponse productResponse = zuoraClient.productsApi()
+    .createProductApi(productRequest).execute();
+
+if (productResponse.getSuccess()) {
+    String productId = productResponse.getId();
+
+    // Create rate plan
+    CreateProductRatePlanRequest planRequest = new CreateProductRatePlanRequest()
+        .name("Monthly Plan")
+        .productId(productId)
+        .effectiveStartDate(LocalDate.of(2024, 1, 1))
+        .effectiveEndDate(LocalDate.of(2034, 1, 1))
+        .description("Monthly billing plan")
+        .activeCurrencies(List.of("USD"));
+
+    ProxyCreateOrModifyResponse planResponse = zuoraClient.productRatePlansApi()
+        .createProductRatePlanApi(planRequest).execute();
+
+    if (planResponse.getSuccess()) {
+        // Create charge with pricing tier
+        CreateProductRatePlanChargeRequest chargeRequest =
+            new CreateProductRatePlanChargeRequest()
+                .name("Monthly Fee")
+                .chargeModel(ChargeModelProductRatePlanChargeRest.FLAT_FEE_PRICING)
+                .chargeType(ChargeType.RECURRING)
+                .triggerEvent(TriggerEventProductRatePlanChargeRest.CONTRACTEFFECTIVE)
+                .productRatePlanId(planResponse.getId())
+                .billCycleType(BillCycleType.DEFAULTFROMCUSTOMER)
+                .billingPeriod(BillingPeriodProductRatePlanChargeRest.MONTHLY)
+                .useDiscountSpecificAccountingCode(false)
+                .productRatePlanChargeTierData(new ProductRatePlanChargeTierData()
+                    .addProductRatePlanChargeTierItem(
+                        new ProductRatePlanChargeTier()
+                            .currency("USD")
+                            .price(29.99)));
+
+        zuoraClient.productRatePlanChargesApi()
+            .createProductRatePlanChargeApi(chargeRequest).execute();
+    }
+}
+
+// Verify product
+GetProductResponse product = zuoraClient.productsApi()
+    .getProductApi(productResponse.getId()).execute();
+```
+
+### Orders & Subscriptions
+
+```java
+import com.zuora.model.*;
+
+// Create subscription via Order API
+CreateOrderRequest orderRequest = new CreateOrderRequest()
+    .orderDate(LocalDate.now())
+    .existingAccountNumber("A00000001")
+    .addSubscriptionsItem(new CreateOrderSubscription()
+        .addOrderActionsItem(new CreateOrderAction()
+            .type(OrderActionType.CREATESUBSCRIPTION)
+            .createSubscription(new CreateOrderCreateSubscription()
+                .terms(new OrderActionCreateSubscriptionTerms()
+                    .initialTerm(new InitialTerm()
+                        .termType(TermType.EVERGREEN)))
+                .addSubscribeToRatePlansItem(
+                    new CreateOrderRatePlanOverride()
+                        .productRatePlanNumber("PRP-00000151")))))
+    .processingOptions(new ProcessingOptionsWithDelayedCapturePayment()
+        .runBilling(true)
+        .billingOptions(new BillingOptions()
+            .targetDate(LocalDate.now())));
+
+CreateOrderResponse orderResponse = zuoraClient.ordersApi()
+    .createOrderApi(orderRequest).execute();
+```
+
+### Object Query
+
+```java
+// Query accounts with subscriptions
+ExpandedAccount account = zuoraClient.objectQueriesApi()
+    .queryAccountByKeyApi("A00000001")
+    .expand(List.of("billTo", "subscriptions"))
+    .execute();
+
+// Query with filters
+QueryAccountsResponse accounts = zuoraClient.objectQueriesApi()
+    .queryAccountsApi()
+    .filter(List.of("currency.EQ:USD", "status.EQ:Active"))
+    .sort(List.of("accountNumber.ASC"))
+    .pageSize(20)
+    .execute();
+```
+
+## 6. Error Handling
+
+```java
+import com.zuora.ApiException;
+import com.zuora.model.CommonResponse;
+
+try {
+    CreateAccountResponse response = zuoraClient.accountsApi()
+        .createAccountApi(request).execute();
+} catch (ApiException e) {
+    System.err.println("HTTP Status: " + e.getCode());
+
+    CommonResponse errorResponse = CommonResponse.fromJson(e.getResponseBody());
+    if (errorResponse.getReasons() != null) {
+        errorResponse.getReasons().forEach(reason ->
+            System.err.printf("Code: %s, Message: %s%n",
+                reason.getCode(), reason.getMessage()));
+    }
+}
+```
+
+### Common Patterns
+
+```java
+// Check for 401 (unauthorized) — re-initialize client
+try {
+    zuoraClient.accountsApi().createAccountApi(request).execute();
+} catch (ApiException e) {
+    if (e.getCode() == 401) {
+        zuoraClient.initialize();  // Re-authenticate
+        // Retry the operation
+    }
+}
+```
+
+## 7. Charge Models (Enum Reference)
+
+| Enum | Description |
+|---|---|
+| `ChargeModelProductRatePlanChargeRest.FLAT_FEE_PRICING` | Fixed price per period |
+| `ChargeModelProductRatePlanChargeRest.PER_UNIT_PRICING` | Price per unit |
+| `ChargeModelProductRatePlanChargeRest.TIERED_PRICING` | Volume tiers (each tier priced separately) |
+| `ChargeModelProductRatePlanChargeRest.VOLUME_PRICING` | Total volume determines single price |
+| `ChargeModelProductRatePlanChargeRest.OVERAGE_PRICING` | Charges for usage over included units |
+| `ChargeModelProductRatePlanChargeRest.DISCOUNT_FIXED_AMOUNT` | Fixed discount |
+| `ChargeModelProductRatePlanChargeRest.DISCOUNT_PERCENTAGE` | Percentage discount |
+
+| Enum | Description |
+|---|---|
+| `ChargeType.RECURRING` | Billed on regular schedule |
+| `ChargeType.ONETIME` | Billed once |
+| `ChargeType.USAGE` | Billed based on consumption |
+
+| Enum | Description |
+|---|---|
+| `BillingPeriodProductRatePlanChargeRest.MONTHLY` | Monthly billing |
+| `BillingPeriodProductRatePlanChargeRest.ANNUAL` | Annual billing |
+| `BillingPeriodProductRatePlanChargeRest.QUARTERLY` | Quarterly billing |
+
+## 8. Advanced Features
+
+### HTTP Response Details
+
+```java
+ApiResponse<CreateAccountResponse> response = zuoraClient.accountsApi()
+    .createAccountApi(request)
+    .executeWithHttpInfo();
+
+int statusCode = response.getStatusCode();
+String requestId = response.getZuoraRequestId();
+Map<String, List<String>> headers = response.getHeaders();
+CreateAccountResponse data = response.getData();
+```
+
+### JSON Serialization
+
+```java
+// Serialize any model to JSON
+String json = response.toJson();
+
+// Deserialize from JSON
+CommonResponse errorResponse = CommonResponse.fromJson(jsonString);
+```
+
+### Custom Fields
+
+```java
+// Add custom fields via putAdditionalProperty
+CreateAccountRequest request = new CreateAccountRequest()
+    .name("Acme Corp")
+    .putAdditionalProperty("salesRegion__c", "West")
+    .putAdditionalProperty("industry__c", "Technology");
+```
+
+## 9. Production Checklist
+
+- [ ] Switch `ZuoraClient.ZuoraEnv.SBX` to `ZuoraClient.ZuoraEnv.PROD`
+- [ ] Use environment variables or secure vault for credentials
+- [ ] Call `zuoraClient.initialize()` at application startup
+- [ ] Wrap all API calls in try/catch for `ApiException`
+- [ ] Parse `CommonResponse.fromJson()` for structured error handling
+- [ ] Check `response.getSuccess()` for create/update operations
+- [ ] Disable debugging in production (`setDebugging(false)`)
+- [ ] Use `executeWithHttpInfo()` for operations needing request tracing
+- [ ] Handle rate limiting (429) with exponential backoff
+- [ ] Test full order-to-cash flow in Sandbox before Production
+- [ ] Configure appropriate JVM connection pool settings for OkHttp

--- a/content/zuora/docs/package/javascript/DOC.md
+++ b/content/zuora/docs/package/javascript/DOC.md
@@ -1,0 +1,345 @@
+---
+name: package
+description: "Zuora JavaScript/Node.js SDK (zuora-sdk-js) for subscription billing, invoicing, payments, and product catalog management with auto-authentication"
+metadata:
+  languages: "javascript"
+  versions: "3.15.0"
+  revision: 1
+  updated-on: "2026-03-31"
+  source: maintainer
+  tags: "zuora,javascript,nodejs,sdk,billing,subscriptions,payments"
+---
+# Zuora JavaScript SDK Guide
+
+## 1. Golden Rules
+
+**Always use `ZuoraClient` with auto-auth.** The `ZuoraClient` class manages OAuth2 tokens automatically, including authentication and refresh. Never manage tokens manually.
+
+**Always call `await client.initialize()`** after creating the client. This authenticates with Zuora and prepares the client for API calls.
+
+**Always use async/await.** All SDK methods return Promises.
+
+**Current SDK Version:** 3.15.0 | **API Version:** 2025-08-12 | **Node.js:** 16+
+
+## 2. Installation
+
+```bash
+npm install zuora-sdk-js
+```
+
+```bash
+yarn add zuora-sdk-js
+```
+
+```bash
+pnpm add zuora-sdk-js
+```
+
+### Dependencies
+
+Core dependency: `superagent` 5.3.0+ (HTTP client)
+
+### Environment Variables
+
+```bash
+# Required
+ZUORA_CLIENT_ID=your-client-id
+ZUORA_CLIENT_SECRET=your-client-secret
+
+# Optional
+ZUORA_ENV=SBX  # SBX, PROD, etc.
+```
+
+**CRITICAL:** Never commit credentials to version control or expose them in client-side code.
+
+## 3. Initialization
+
+### Basic Setup
+
+```javascript
+const { ZuoraClient, ZuoraAPI } = require('zuora-sdk-js');
+
+(async () => {
+    const client = new ZuoraClient({
+        clientId: process.env.ZUORA_CLIENT_ID,
+        clientSecret: process.env.ZUORA_CLIENT_SECRET,
+        env: ZuoraClient.SBX,
+    });
+    await client.initialize();
+
+    // API calls here...
+})();
+```
+
+### With Debug Mode
+
+```javascript
+const { ZuoraClient, ZuoraAPI } = require('zuora-sdk-js');
+
+(async () => {
+    const client = new ZuoraClient({
+        clientId: process.env.ZUORA_CLIENT_ID,
+        clientSecret: process.env.ZUORA_CLIENT_SECRET,
+        env: ZuoraClient.SBX,
+    });
+    client.debug(true);  // Log request/response details
+    await client.initialize();
+
+    // API calls here...
+})();
+```
+
+### Available Environments
+
+| Constant | Environment |
+|---|---|
+| `ZuoraClient.SBX` | US Sandbox (Cloud 2) |
+| `ZuoraClient.CSBX` | US Central Sandbox |
+| `ZuoraClient.PROD` | US Production (Cloud 2) |
+
+## 4. API Client Properties
+
+The `ZuoraClient` exposes typed API accessors as properties:
+
+| Property | API Surface |
+|---|---|
+| `client.accountsApi` | Account CRUD operations |
+| `client.ordersApi` | Order & subscription lifecycle |
+| `client.invoicesApi` | Invoice creation & management |
+| `client.paymentsApi` | Payment processing |
+| `client.productsApi` | Product catalog CRUD |
+| `client.productRatePlansApi` | Rate plan management |
+| `client.productRatePlanChargesApi` | Charge management |
+| `client.objectQueriesApi` | Object Query (search/filter/expand) |
+| `client.billRunApi` | Bill run operations |
+
+## 5. Core Usage
+
+### Products
+
+```javascript
+// Create product
+let createProductRequest = new ZuoraAPI.CreateProductRequest();
+createProductRequest.Name = 'Gold Membership';
+createProductRequest.Description = 'Premium subscription tier';
+createProductRequest.EffectiveStartDate = '2024-01-01';
+createProductRequest.EffectiveEndDate = '2034-01-01';
+
+let product = await client.productsApi.createProduct(createProductRequest);
+console.log('Product:', JSON.stringify(product, null, 2));
+```
+
+```javascript
+// Get product by ID
+let productDetail = await client.productsApi.getProduct(product.Id);
+console.log('Product:', JSON.stringify(productDetail, (k, v) => v ?? undefined, 2));
+```
+
+### Rate Plans & Charges
+
+```javascript
+// Create rate plan
+let ratePlanRequest = new ZuoraAPI.CreateProductRatePlanRequest();
+ratePlanRequest.Name = 'Monthly Plan';
+ratePlanRequest.ProductId = product.Id;
+ratePlanRequest.Description = 'Monthly billing plan';
+ratePlanRequest.EffectiveStartDate = '2024-01-01';
+ratePlanRequest.EffectiveEndDate = '2034-01-01';
+ratePlanRequest.activeCurrencies = ['USD'];
+
+let ratePlan = await client.productRatePlansApi
+    .createProductRatePlan(ratePlanRequest, {});
+```
+
+```javascript
+// Create charge with pricing tier
+let chargeRequest = new ZuoraAPI.CreateProductRatePlanChargeRequest();
+chargeRequest.Name = 'Monthly Fee';
+chargeRequest.ChargeModel = 'Flat Fee Pricing';
+chargeRequest.ChargeType = 'Recurring';
+chargeRequest.TriggerEvent = 'ContractEffective';
+chargeRequest.ProductRatePlanId = ratePlan.Id;
+chargeRequest.BillCycleType = 'DefaultFromCustomer';
+chargeRequest.BillingPeriod = 'Monthly';
+chargeRequest.UseDiscountSpecificAccountingCode = false;
+
+let tierData = new ZuoraAPI.ProductRatePlanChargeTierData();
+tierData.ProductRatePlanChargeTier = [{ Currency: 'USD', price: 29.99 }];
+chargeRequest.ProductRatePlanChargeTierData = tierData;
+
+let charge = await client.productRatePlanChargesApi
+    .createProductRatePlanCharge(chargeRequest, {});
+```
+
+### Bill Runs
+
+```javascript
+// Create bill run for specific account
+const billRunFilter = new ZuoraAPI.BillRunFilter();
+billRunFilter.filterType = 'Account';
+billRunFilter.accountId = 'A00000001';
+
+const billRunRequest = new ZuoraAPI.CreateBillRunRequest();
+billRunRequest.billRunFilters = [billRunFilter];
+billRunRequest.targetDate = '2025-01-31';
+
+try {
+    const billRun = await client.billRunApi.createBillRun(billRunRequest);
+    console.log('Bill Run Created:', billRun);
+} catch (error) {
+    console.error('Error creating bill run:', error);
+}
+```
+
+### Contacts
+
+```javascript
+// Contact management is available through the accounts API
+// Contacts are typically created as part of account creation
+// via billToContact and soldToContact fields
+```
+
+## 6. Error Handling
+
+```javascript
+try {
+    const result = await client.productsApi.createProduct(request);
+    if (result.Success) {
+        console.log('Created:', result.Id);
+    } else {
+        console.log('Failed:', result);
+    }
+} catch (error) {
+    console.error('API Error:', error);
+    // error.status - HTTP status code
+    // error.response.body - Error response body with reasons array
+}
+```
+
+### Pattern: Wrap in Async IIFE
+
+```javascript
+(async () => {
+    try {
+        const client = new ZuoraClient({
+            clientId: process.env.ZUORA_CLIENT_ID,
+            clientSecret: process.env.ZUORA_CLIENT_SECRET,
+            env: ZuoraClient.SBX,
+        });
+        await client.initialize();
+
+        // API calls here...
+        const products = await client.productsApi.getProducts();
+        console.log('Products:', JSON.stringify(products, null, 2));
+    } catch (error) {
+        console.error(error);
+    }
+})();
+```
+
+## 7. Request/Response Notes
+
+### Property Naming
+
+The JavaScript SDK uses **PascalCase** for request model properties (matching the Zuora API):
+
+```javascript
+// Correct: PascalCase
+request.Name = 'Gold';
+request.EffectiveStartDate = '2024-01-01';
+request.ProductRatePlanId = 'id';
+
+// Response properties may also be PascalCase
+if (response.Success) {
+    console.log(response.Id);
+}
+```
+
+### JSON Serialization
+
+```javascript
+// Pretty-print response
+console.log(JSON.stringify(response, null, 2));
+
+// Remove null values from output
+console.log(JSON.stringify(response, (k, v) => v ?? undefined, 2));
+```
+
+## 8. Complete Example: Product Catalog Setup
+
+```javascript
+const { ZuoraClient, ZuoraAPI } = require('zuora-sdk-js');
+
+(async () => {
+    try {
+        const client = new ZuoraClient({
+            clientId: process.env.ZUORA_CLIENT_ID,
+            clientSecret: process.env.ZUORA_CLIENT_SECRET,
+            env: ZuoraClient.SBX,
+        });
+        client.debug(true);
+        await client.initialize();
+
+        // 1. Create product
+        let productReq = new ZuoraAPI.CreateProductRequest();
+        productReq.Name = 'Gold Membership';
+        productReq.Description = 'Premium subscription tier';
+        productReq.EffectiveStartDate = '2024-01-01';
+        productReq.EffectiveEndDate = '2034-01-01';
+        let product = await client.productsApi.createProduct(productReq);
+
+        if (product.Success) {
+            // 2. Create rate plan
+            let planReq = new ZuoraAPI.CreateProductRatePlanRequest();
+            planReq.Name = 'Monthly Plan';
+            planReq.ProductId = product.Id;
+            planReq.Description = 'Monthly billing';
+            planReq.EffectiveStartDate = '2024-01-01';
+            planReq.EffectiveEndDate = '2034-01-01';
+            planReq.activeCurrencies = ['USD'];
+            let plan = await client.productRatePlansApi.createProductRatePlan(planReq, {});
+
+            if (plan.Success) {
+                // 3. Create charge
+                let chargeReq = new ZuoraAPI.CreateProductRatePlanChargeRequest();
+                chargeReq.Name = 'Monthly Fee';
+                chargeReq.ChargeModel = 'Flat Fee Pricing';
+                chargeReq.ChargeType = 'Recurring';
+                chargeReq.TriggerEvent = 'ContractEffective';
+                chargeReq.ProductRatePlanId = plan.Id;
+                chargeReq.BillCycleType = 'DefaultFromCustomer';
+                chargeReq.BillingPeriod = 'Monthly';
+                chargeReq.UseDiscountSpecificAccountingCode = false;
+
+                let tierData = new ZuoraAPI.ProductRatePlanChargeTierData();
+                tierData.ProductRatePlanChargeTier = [
+                    { Currency: 'USD', price: 29.99 }
+                ];
+                chargeReq.ProductRatePlanChargeTierData = tierData;
+
+                let charge = await client.productRatePlanChargesApi
+                    .createProductRatePlanCharge(chargeReq, {});
+                console.log('Catalog created successfully');
+
+                // 4. Verify
+                let result = await client.productsApi.getProduct(product.Id);
+                console.log(JSON.stringify(result, (k, v) => v ?? undefined, 2));
+            }
+        }
+    } catch (error) {
+        console.error(error);
+    }
+})();
+```
+
+## 9. Production Checklist
+
+- [ ] Switch `ZuoraClient.SBX` to `ZuoraClient.PROD`
+- [ ] Use environment variables for credentials
+- [ ] Call `await client.initialize()` at application startup
+- [ ] Wrap all API calls in try/catch
+- [ ] Check `response.Success` for create/update operations
+- [ ] Disable debug mode in production
+- [ ] Handle rate limiting (429 responses) with backoff
+- [ ] Use `Zuora-Track-Id` headers for request tracing
+- [ ] Test full flow in Sandbox before Production

--- a/content/zuora/docs/package/python/DOC.md
+++ b/content/zuora/docs/package/python/DOC.md
@@ -1,0 +1,471 @@
+---
+name: package
+description: "Zuora Python SDK (zuora-sdk) for subscription billing, invoicing, payments, and product catalog management with auto-authentication and thread-safe token refresh"
+metadata:
+  languages: "python"
+  versions: "3.15.0"
+  revision: 1
+  updated-on: "2026-03-31"
+  source: maintainer
+  tags: "zuora,python,sdk,billing,subscriptions,payments"
+---
+# Zuora Python SDK Guide
+
+## 1. Golden Rules
+
+**Always use the `ZuoraClient` class** — it handles OAuth2 authentication, automatic token refresh (every 10 minutes), and thread-safe access. Never manage tokens manually.
+
+**Always call `client.initialize()`** after creating the client. This authenticates and starts the background token refresh daemon thread.
+
+**Always catch `ApiException`** for API errors. Parse `e.body` as JSON to get structured error codes and messages.
+
+**Current SDK Version:** 3.15.0 | **API Version:** 2025-08-12 | **Python:** 3.9+
+
+## 2. Installation
+
+```bash
+pip install zuora-sdk
+```
+
+```bash
+poetry add zuora-sdk
+```
+
+```bash
+uv add zuora-sdk
+```
+
+### Dependencies
+
+The SDK depends on: `urllib3`, `python-dateutil`, `pydantic>=2.6`, `typing-extensions`, `certifi`
+
+### Environment Variables
+
+```bash
+# Required
+ZUORA_CLIENT_ID=your-client-id
+ZUORA_CLIENT_SECRET=your-client-secret
+
+# Optional
+ZUORA_BASE_URL=https://rest.apisandbox.zuora.com
+```
+
+**CRITICAL:** Never commit credentials to version control. Use `.env` files with `python-dotenv` or secure secret managers.
+
+## 3. Initialization
+
+### Basic Setup
+
+```python
+import os
+from zuora_sdk.zuora_client import ZuoraClient, ZuoraEnvironment
+
+client = ZuoraClient(
+    client_id=os.environ['ZUORA_CLIENT_ID'],
+    client_secret=os.environ['ZUORA_CLIENT_SECRET'],
+    env=ZuoraEnvironment.SBX
+)
+client.initialize()  # Authenticates and starts background token refresh
+```
+
+### With dotenv
+
+```python
+import os
+from dotenv import load_dotenv
+from zuora_sdk.zuora_client import ZuoraClient, ZuoraEnvironment
+from zuora_sdk.rest import ApiException
+
+load_dotenv()
+
+def get_client():
+    try:
+        client = ZuoraClient(
+            client_id=os.environ.get('ZUORA_CLIENT_ID'),
+            client_secret=os.environ.get('ZUORA_CLIENT_SECRET'),
+            env=ZuoraEnvironment.SBX
+        )
+        client.set_debug(True)  # Enable request/response logging
+        client.initialize()
+        return client
+    except ApiException as ex:
+        print(f"Failed to initialize client: {ex}")
+        raise
+```
+
+### Available Environments
+
+| Enum | Environment |
+|---|---|
+| `ZuoraEnvironment.SBX` | US Sandbox (Cloud 2) |
+| `ZuoraEnvironment.SBX_NA` | US Sandbox (Cloud 1) |
+| `ZuoraEnvironment.SBX_EU` | EU Sandbox |
+| `ZuoraEnvironment.CSBX` | US Central Sandbox |
+| `ZuoraEnvironment.CSBX_EU` | EU Central Sandbox |
+| `ZuoraEnvironment.CSBX_AP` | AP Central Sandbox |
+| `ZuoraEnvironment.PROD` | US Production (Cloud 2) |
+| `ZuoraEnvironment.PROD_NA` | US Production (Cloud 1) |
+| `ZuoraEnvironment.PROD_EU` | EU Production |
+| `ZuoraEnvironment.PROD_AP` | AP Production |
+
+## 4. API Client Methods
+
+The `ZuoraClient` exposes typed API accessors:
+
+| Method | API Surface |
+|---|---|
+| `client.accounts_api()` | Account CRUD operations |
+| `client.orders_api()` | Order & subscription lifecycle |
+| `client.invoices_api()` | Invoice creation & management |
+| `client.payments_api()` | Payment processing |
+| `client.products_api()` | Product catalog CRUD |
+| `client.product_rate_plans_api()` | Rate plan management |
+| `client.product_rate_plan_charges_api()` | Charge management |
+| `client.object_queries_api()` | Object Query (search/filter/expand) |
+| `client.usage_api()` | Usage record submission |
+| `client.bill_run_api()` | Bill run operations |
+| `client.credit_memos_api()` | Credit memo operations |
+| `client.debit_memos_api()` | Debit memo operations |
+
+## 5. Core Usage
+
+### Accounts
+
+```python
+from zuora_sdk import CreateAccountRequest
+from zuora_sdk.rest import ApiException
+
+# Create account
+try:
+    account = client.accounts_api().create_account(
+        CreateAccountRequest(
+            name='Acme Corp',
+            bill_to_contact={
+                'first_name': 'Jane',
+                'last_name': 'Doe',
+                'state': 'California',
+                'country': 'USA'
+            },
+            auto_pay=False,
+            currency='USD',
+            bill_cycle_day='1'
+        ))
+    print(f"Account created: {account.account_number}")
+except ApiException as e:
+    print(f"Error: {e.status} {e.reason}")
+```
+
+```python
+# Query account with expansion
+account = client.object_queries_api().query_account_by_key(
+    'A00000001',
+    expand=['billTo'])
+print(account.to_json())
+```
+
+```python
+# Query accounts with filters
+accounts = client.object_queries_api().query_accounts(
+    filter=['currency.EQ:USD'],
+    sort=['accountNumber.ASC'],
+    page_size=20)
+```
+
+### Products
+
+```python
+from zuora_sdk import CreateProductRequest
+
+# Create product
+product = client.products_api().create_product(
+    CreateProductRequest(
+        name='Gold Membership',
+        description='Premium tier',
+        effective_start_date='2024-01-01',
+        effective_end_date='2034-01-01'
+    ))
+if product.success:
+    print(f"Product ID: {product.id}")
+```
+
+```python
+# Query products
+products = client.object_queries_api().query_products()
+for prod in products.data:
+    print(f"{prod.product_number}: {prod.name}")
+```
+
+```python
+# Query rate plans with charge details
+rate_plans = client.object_queries_api().query_product_rate_plans(
+    filter=['productId.EQ:' + product_id],
+    expand=['productrateplancharges',
+            'productrateplancharges.productrateplanchargetiers'])
+```
+
+```python
+# Get and delete product
+product_detail = client.products_api().get_product(product_id)
+client.products_api().delete_product(product_id)
+```
+
+### Orders & Subscriptions
+
+```python
+from datetime import date
+from zuora_sdk import (
+    CreateOrderRequest, PreviewOrderRequest,
+    ProcessingOptionsWithDelayedCapturePayment
+)
+
+# Preview order (dry run)
+preview = client.orders_api().preview_order(
+    PreviewOrderRequest(
+        order_date=date.today().strftime('%Y-%m-%d'),
+        existing_account_number='A00000001',
+        subscriptions=[{
+            'order_actions': [{
+                'type': 'CreateSubscription',
+                'create_subscription': {
+                    'terms': {'initial_term': {'term_type': 'EVERGREEN'}},
+                    'subscribe_to_rate_plans': [
+                        {'product_rate_plan_number': 'PRP-00000151'}
+                    ]
+                }
+            }]
+        }],
+        preview_options={
+            'preview_thru_type': 'NumberOfPeriods',
+            'preview_number_of_periods': 1,
+            'preview_types': ['BillingDocs']
+        }
+    ))
+print(preview.to_json())
+```
+
+```python
+# Create order (subscription)
+order = client.orders_api().create_order(
+    CreateOrderRequest(
+        order_date=date.today().strftime('%Y-%m-%d'),
+        existing_account_number='A00000001',
+        subscriptions=[{
+            'order_actions': [{
+                'type': 'CreateSubscription',
+                'create_subscription': {
+                    'terms': {'initial_term': {'term_type': 'EVERGREEN'}},
+                    'subscribe_to_rate_plans': [
+                        {'product_rate_plan_number': 'PRP-00000151'}
+                    ]
+                }
+            }]
+        }],
+        processing_options=ProcessingOptionsWithDelayedCapturePayment(
+            run_billing=False,
+            billing_options={'target_date': date.today().strftime('%Y-%m-%d')}
+        )
+    ))
+print(order.to_json())
+```
+
+### Invoices
+
+```python
+from zuora_sdk import CreateInvoiceRequest, CreateInvoiceItem
+
+# Create standalone invoice
+invoice = client.invoices_api().create_standalone_invoice(
+    CreateInvoiceRequest(
+        account_number='A00000001',
+        auto_pay=False,
+        invoice_date='2024-01-01',
+        status='Posted',
+        invoice_items=[
+            CreateInvoiceItem(
+                amount=100.0,
+                charge_name='Set Up Fee',
+                description='One-time setup charge',
+                quantity=1.0,
+                service_start_date='2024-01-01',
+                uom='Each'
+            )
+        ]
+    ))
+print(f"Invoice {invoice.invoice_number}: ${invoice.balance:.2f}")
+```
+
+```python
+# Query invoices
+inv = client.object_queries_api().query_invoice_by_key(
+    'INV00000315', expand=['invoiceItems'])
+
+invoices = client.object_queries_api().query_invoices(
+    filter=['accountId.EQ:account-uuid'])
+```
+
+### Payments
+
+```python
+import json
+from zuora_sdk import CreatePaymentRequest, CreatePaymentInvoiceApplication
+from zuora_sdk.rest import ApiException
+
+try:
+    payment = client.payments_api().create_payment(
+        CreatePaymentRequest(
+            account_number='A00000001',
+            amount=100.0,
+            currency='USD',
+            effective_date='2024-11-30',
+            type='External',
+            payment_method_type='Check',
+            invoices=[
+                CreatePaymentInvoiceApplication(
+                    amount=100.0,
+                    invoice_id=invoice_id
+                )
+            ]
+        ))
+    print(f"Payment created: {payment.number}")
+except ApiException as e:
+    error_details = json.loads(e.body)
+    error_code = error_details['reasons'][0]['code']
+    error_msg = error_details['reasons'][0]['message']
+    print(f"Error: {error_code} - {error_msg}")
+```
+
+## 6. Object Query API
+
+The Object Query API provides consistent querying across all Zuora objects.
+
+### Filtering Operators
+
+```python
+# Equality
+accounts = client.object_queries_api().query_accounts(
+    filter=['currency.EQ:USD'])
+
+# Comparison
+invoices = client.object_queries_api().query_invoices(
+    filter=['amount.GT:100', 'status.EQ:Posted'])
+
+# Starts with
+products = client.object_queries_api().query_products(
+    filter=['name.SW:Gold'])
+
+# In set
+subscriptions = client.object_queries_api().query_subscriptions(
+    filter=['status.IN:Active,Suspended'])
+```
+
+### Sorting & Pagination
+
+```python
+# Sort ascending
+accounts = client.object_queries_api().query_accounts(
+    sort=['accountNumber.ASC'],
+    page_size=20)
+
+# Cursor-based pagination
+if accounts.next_page:
+    next_page = client.object_queries_api().query_accounts(
+        page_size=20, cursor=accounts.next_page)
+```
+
+### Expansion (Joins)
+
+```python
+# Account with contacts and subscriptions
+account = client.object_queries_api().query_account_by_key(
+    'A00000001',
+    expand=['billTo', 'soldTo', 'subscriptions'])
+
+# Catalog hierarchy
+rate_plans = client.object_queries_api().query_product_rate_plans(
+    filter=['productId.EQ:prod-id'],
+    expand=['productrateplancharges',
+            'productrateplancharges.productrateplanchargetiers'])
+```
+
+## 7. Error Handling
+
+```python
+import json
+from zuora_sdk.rest import ApiException
+
+try:
+    result = client.accounts_api().create_account(request)
+except ApiException as e:
+    print(f"HTTP {e.status}: {e.reason}")
+
+    if e.body:
+        error = json.loads(e.body)
+        for reason in error.get('reasons', []):
+            print(f"  [{reason['code']}] {reason['message']}")
+
+    if e.status == 401:
+        client.initialize()  # Re-authenticate
+    elif e.status == 404:
+        print("Resource not found")
+    elif e.status == 429:
+        print("Rate limited — back off and retry")
+```
+
+### Common Error Codes
+
+| HTTP Status | Meaning |
+|---|---|
+| 400 | Bad request — validation error in request body |
+| 401 | Unauthorized — invalid or expired token |
+| 404 | Not found — resource doesn't exist |
+| 429 | Rate limited — too many requests |
+| 500 | Server error — retry with backoff |
+
+## 8. Advanced Features
+
+### Debug Mode
+
+```python
+client.set_debug(True)  # Logs full request/response details
+```
+
+### Response Serialization
+
+All response objects support:
+
+```python
+response.to_json()   # JSON string
+response.to_dict()   # Python dict
+```
+
+### Custom Fields
+
+```python
+# Access custom fields via additional_properties
+account = CreateAccountRequest(name='Acme Corp', ...)
+account.additional_properties = {'salesRegion__c': 'West'}
+```
+
+### Thread Safety
+
+The `ZuoraClient` is thread-safe. The background token refresh runs in a daemon thread with proper locking. You can safely share a single client instance across threads.
+
+### Retry Logic
+
+The SDK includes built-in exponential backoff retry:
+- 3 retry attempts
+- Delays: 1 second, 2 seconds, 4 seconds
+- Retries on network errors and 5xx responses
+
+## 9. Production Checklist
+
+- [ ] Switch `ZuoraEnvironment.SBX` to appropriate production environment
+- [ ] Use environment variables for credentials (never hardcode)
+- [ ] Call `client.initialize()` at application startup
+- [ ] Implement `ApiException` handling on all API calls
+- [ ] Parse error `reasons` array for user-friendly messages
+- [ ] Disable debug mode in production (`set_debug(False)`)
+- [ ] Use `Zuora-Track-Id` headers for request tracing
+- [ ] Set `Idempotency-Key` for mutating operations
+- [ ] Test full order-to-cash flow in Sandbox first
+- [ ] Monitor token refresh and API error rates


### PR DESCRIPTION
  ## What

  Adds LLM-ready documentation for the Zuora subscription billing platform across six new content files:

  - `docs/api/DOC.md` — REST API reference covering authentication, environments, accounts, subscriptions, invoices, and payments
  - `docs/order-to-cash/DOC.md` — end-to-end lifecycle guide from product catalog setup through billing runs, invoicing, and revenue recognition
  - `docs/package/javascript/DOC.md`, `python/DOC.md`, `java/DOC.md`, `csharp/DOC.md` — SDK usage docs per language

  Also includes two follow-up fixes: JavaScript code examples corrected in the API and order-to-cash docs, and the `subscriptions` directory renamed to `order-to-cash` to more accurately reflect the full billing
  lifecycle covered.

  ## Why

  Zuora is a widely-used subscription billing platform with no prior coverage in context-hub. These docs give LLMs accurate, grounded context for questions about Zuora integration, API usage, SDK setup, and billing
   workflows across multiple languages.

  ## Testing

  - [x] `npm test` passes — no test script exists in this repo
  - [x] `chub build content/ --validate-only` succeeds — 1556 docs, 7 skills, 2 warnings; warnings are pre-existing and unrelated to this change
  - [x] Manual testing done:
    - Verified frontmatter on all six files (name, description, languages, versions, source, tags) is valid and consistent
    - Confirmed code examples in API and order-to-cash docs use JavaScript (Node.js CJS) and are syntactically correct; async/await usage and `require()` patterns are consistent throughout
    - Spot-checked SDK package docs for Python, Java, and C# to confirm language-specific idioms (e.g., `async with` in Python, builder patterns in Java, `using` blocks in C#)
    - Verified the `order-to-cash` rename did not leave any broken references in other content files

  ## Notes

  All SDK package docs follow the same structure: installation, authentication via environment variables, and common usage patterns. The API version targeted is `2025-08-12`. Code examples use the sandbox
  environment (`ZuoraClient.SBX`) by default, which is the safe default for documentation.