### PR TITLE
Add Vectara REST API v2 Python docs

### DIFF
--- a/content/vectara/docs/api/python/DOC.md
+++ b/content/vectara/docs/api/python/DOC.md
@@ -1,0 +1,503 @@
+---
+name: api
+description: "Vectara REST API v2 for semantic search, RAG, agents, reranking, document indexing, and hallucination detection"
+metadata:
+  languages: "python"
+  versions: "2.0.0"
+  revision: 1
+  updated-on: "2026-03-24"
+  source: official
+  tags: "vectara,search,rag,semantic-search,vector,retrieval,reranking,agents,llm,ai"
+---
+
+# Vectara REST API v2 — Python Guidelines
+
+You are a Vectara API coding expert. Help me with writing code that calls the Vectara REST API v2.
+
+Official API reference: https://docs.vectara.com/docs/rest-api
+
+## Golden Rule: Use the REST API v2
+
+Always use the Vectara REST API v2. The base URL is:
+
+```
+https://api.vectara.io/v2
+```
+
+Use the `requests` library for API calls:
+
+```bash
+pip install requests
+```
+
+## Authentication
+
+Vectara supports two auth methods: **API keys** and **OAuth 2.0 client credentials**.
+
+### API Key (recommended for most use cases)
+
+Pass your API key in the `x-api-key` header. Three key types exist:
+- **QueryService keys** — read-only (search and query)
+- **IndexService keys** — indexing and document management
+- **Personal keys** — full account access (admin operations, agent management)
+
+```python
+import requests
+
+BASE_URL = "https://api.vectara.io/v2"
+API_KEY = "your_api_key"  # Use env var in production
+
+headers = {
+    "x-api-key": API_KEY,
+    "Content-Type": "application/json",
+}
+```
+
+### OAuth 2.0 Client Credentials
+
+For server-to-server integrations, use OAuth 2.0:
+
+```python
+import requests
+
+def get_oauth_token(client_id: str, client_secret: str) -> str:
+    """Exchange client credentials for an access token."""
+    resp = requests.post(
+        "https://auth.vectara.com/oauth2/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": client_id,
+            "client_secret": client_secret,
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    resp.raise_for_status()
+    return resp.json()["access_token"]
+
+token = get_oauth_token("your_client_id", "your_client_secret")
+headers = {
+    "Authorization": f"Bearer {token}",
+    "Content-Type": "application/json",
+}
+```
+
+## Query API — Search and RAG
+
+`POST /v2/query` is the core endpoint. It supports multi-corpus semantic search with optional RAG generation.
+
+### Simple Semantic Search
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/query",
+    headers=headers,
+    json={
+        "query": "What is retrieval augmented generation?",
+        "search": {
+            "corpora": [
+                {"corpus_key": "my-corpus"}
+            ],
+            "limit": 10,
+        },
+    },
+)
+results = resp.json()
+for result in results["search_results"]:
+    print(f"Score: {result['score']:.3f} — {result['text']}")
+```
+
+### Single Corpus Query (Shorthand)
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/corpora/my-corpus/query",
+    headers=headers,
+    json={
+        "query": "How does reranking work?",
+        "search": {
+            "limit": 10,
+        },
+    },
+)
+```
+
+### RAG — Search with Generated Answer
+
+Add the `generation` object to enable RAG. Omit it for pure search.
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/query",
+    headers=headers,
+    json={
+        "query": "Explain the benefits of hybrid search",
+        "search": {
+            "corpora": [
+                {"corpus_key": "my-corpus"}
+            ],
+            "limit": 10,
+        },
+        "generation": {
+            "generation_preset_name": "mockingbird-2.0",
+            "max_used_search_results": 5,
+            "response_language": "eng",
+            "enable_factual_consistency_score": True,
+            "citations": {
+                "style": "numeric",
+            },
+        },
+    },
+)
+data = resp.json()
+print(data["summary"])          # Generated answer with citations
+print(data["factual_consistency_score"])  # 0.0–1.0
+for r in data["search_results"]:
+    print(f"[{r['score']:.3f}] {r['text']}")
+```
+
+### Generation Presets
+
+| Preset | Model | Best For |
+|--------|-------|----------|
+| `mockingbird-2.0` | Vectara Mockingbird | RAG (recommended) |
+| `vectara-summary-ext-24-05-med-omni` | GPT-4o | General summarization |
+| `vectara-summary-ext-24-05-large` | GPT-4.0-turbo | Longer summaries |
+| `vectara-summary-ext-24-05-sml` | GPT-3.5-turbo | Fast, low-cost |
+| `vectara-summary-table-query-ext-dec-2024-gpt-4o` | GPT-4o | Tabular data |
+
+### Hybrid Search (Lexical + Neural)
+
+Control the balance between neural and keyword search with `lexical_interpolation`:
+- `0.0` = pure neural (semantic) search
+- `1.0` = pure keyword (lexical) search
+- `0.025` = recommended starting point (mostly neural with slight keyword boost)
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/query",
+    headers=headers,
+    json={
+        "query": "machine learning pipelines",
+        "search": {
+            "corpora": [
+                {
+                    "corpus_key": "my-corpus",
+                    "lexical_interpolation": 0.025,
+                }
+            ],
+            "limit": 10,
+        },
+    },
+)
+```
+
+### Multi-Corpus Search
+
+Query across multiple corpora in a single request:
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/query",
+    headers=headers,
+    json={
+        "query": "deployment best practices",
+        "search": {
+            "corpora": [
+                {"corpus_key": "engineering-docs"},
+                {"corpus_key": "runbooks"},
+                {"corpus_key": "incident-reports"},
+            ],
+            "limit": 15,
+        },
+        "generation": {
+            "generation_preset_name": "mockingbird-2.0",
+        },
+    },
+)
+```
+
+### Metadata Filtering
+
+Filter results using SQL-like expressions on `doc.*` and `part.*` fields:
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/query",
+    headers=headers,
+    json={
+        "query": "security vulnerabilities",
+        "search": {
+            "corpora": [
+                {
+                    "corpus_key": "my-corpus",
+                    "metadata_filter": "doc.category = 'security' AND doc.year >= 2024",
+                }
+            ],
+            "limit": 10,
+        },
+    },
+)
+```
+
+Filter expression syntax:
+- Comparison: `=`, `!=`, `<`, `>`, `<=`, `>=`
+- Logical: `AND`, `OR`, `NOT`
+- Null checks: `IS NULL`, `IS NOT NULL`
+- Sets: `doc.status IN ('active', 'review')`
+- Default fields: `doc.id`, `part.lang`, `part.is_title`
+
+### Reranking
+
+Add a `reranker` to improve result quality:
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/query",
+    headers=headers,
+    json={
+        "query": "database optimization techniques",
+        "search": {
+            "corpora": [{"corpus_key": "my-corpus"}],
+            "limit": 50,
+            "reranker": {
+                "type": "customer_reranker",
+                "reranker_name": "Rerank_Multilingual_v1",
+                "limit": 10,
+                "cutoff": 0.3,
+            },
+        },
+    },
+)
+```
+
+Reranker types:
+- `customer_reranker` — Vectara's neural reranker (use `Rerank_Multilingual_v1`)
+- `mmr` — Maximal Marginal Relevance (diversifies results)
+- `none` — skip reranking
+
+### Streaming Responses
+
+For RAG with streaming, use `stream_response=True`:
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/query",
+    headers=headers,
+    json={
+        "query": "Explain vector databases",
+        "search": {
+            "corpora": [{"corpus_key": "my-corpus"}],
+            "limit": 10,
+        },
+        "generation": {
+            "generation_preset_name": "mockingbird-2.0",
+        },
+        "stream_response": True,
+    },
+    stream=True,
+)
+for line in resp.iter_lines():
+    if line:
+        print(line.decode())
+```
+
+## Corpus Management
+
+### Create a Corpus
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/corpora",
+    headers=headers,
+    json={
+        "key": "my-new-corpus",
+        "name": "My New Corpus",
+        "description": "Product documentation for search",
+        "filter_attributes": [
+            {
+                "name": "category",
+                "level": "doc",
+                "type": "text",
+                "indexed": True,
+            },
+            {
+                "name": "year",
+                "level": "doc",
+                "type": "integer",
+                "indexed": True,
+            },
+        ],
+    },
+)
+corpus = resp.json()  # Returns corpus with system-generated id
+```
+
+### List Corpora
+
+```python
+resp = requests.get(f"{BASE_URL}/corpora", headers=headers)
+for corpus in resp.json()["corpora"]:
+    print(f"{corpus['key']}: {corpus['name']}")
+```
+
+### Get Corpus Details
+
+```python
+resp = requests.get(f"{BASE_URL}/corpora/my-corpus", headers=headers)
+corpus = resp.json()
+print(f"Documents: {corpus['limits']['used_docs']}")
+print(f"Characters: {corpus['limits']['used_characters']}")
+```
+
+### Delete a Corpus
+
+```python
+resp = requests.delete(f"{BASE_URL}/corpora/my-corpus", headers=headers)
+# 204 = success, corpus and all data permanently removed
+```
+
+## Document Indexing
+
+### Upload a File
+
+Upload PDF, Word, PowerPoint, HTML, Markdown, or plain text files (max 10 MB):
+
+```python
+with open("document.pdf", "rb") as f:
+    resp = requests.post(
+        f"{BASE_URL}/corpora/my-corpus/upload_file",
+        headers={"x-api-key": API_KEY},
+        files={"file": ("document.pdf", f, "application/pdf")},
+        data={
+            "metadata": '{"category": "engineering", "year": 2024}',
+        },
+    )
+# 201 = document parsed, chunked, and indexed
+```
+
+Supported file types: Markdown, PDF, Word (.docx), PowerPoint (.pptx), HTML, RTF, EPUB, plain text, email (RFC 822).
+
+### Structured Document Indexing
+
+For precise control over document structure, use the structured index API with recursive `sections`:
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/corpora/my-corpus/documents",
+    headers=headers,
+    json={
+        "id": "doc-001",
+        "type": "structured",
+        "title": "Getting Started Guide",
+        "metadata": {"category": "tutorial", "author": "team"},
+        "sections": [
+            {
+                "title": "Introduction",
+                "text": "This guide covers the basics of setting up your environment.",
+                "metadata": {"section": "introduction"},
+            },
+            {
+                "title": "Setup",
+                "text": "First, install the required dependencies using pip.",
+                "metadata": {"section": "setup"},
+                "sections": [  # Sections can be nested recursively
+                    {
+                        "text": "Run: pip install requests",
+                        "metadata": {"section": "setup-python"},
+                    },
+                ],
+            },
+        ],
+    },
+)
+```
+
+### Core Document (Pre-chunked)
+
+When you've already split text into chunks, use `"type": "core"` with `document_parts`:
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/corpora/my-corpus/documents",
+    headers=headers,
+    json={
+        "id": "doc-002",
+        "type": "core",
+        "metadata": {"source": "wiki"},
+        "document_parts": [
+            {
+                "text": "Vectara provides semantic search capabilities.",
+                "context": "From the product overview page",
+                "metadata": {"section": "overview"},
+            },
+            {
+                "text": "RAG combines retrieval with generation.",
+                "metadata": {"section": "rag"},
+            },
+        ],
+    },
+)
+```
+
+## OpenAI-Compatible Chat Completions
+
+Drop-in replacement for OpenAI's Chat Completions API:
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/llms/chat/completions",
+    headers=headers,
+    json={
+        "model": "mockingbird-2.0",
+        "messages": [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "What is semantic search?"},
+        ],
+        "temperature": 0.7,
+    },
+)
+data = resp.json()
+print(data["choices"][0]["message"]["content"])
+# Response includes: id, object, created, model, choices, usage
+```
+
+Works with any OpenAI-compatible client library by changing the base URL.
+
+## Error Handling
+
+```python
+resp = requests.post(f"{BASE_URL}/query", headers=headers, json=payload)
+
+if resp.status_code == 200:
+    data = resp.json()
+elif resp.status_code == 400:
+    print(f"Bad request: {resp.json()}")
+elif resp.status_code == 403:
+    print("Permission denied — check API key type and scope")
+elif resp.status_code == 404:
+    print("Corpus not found — verify corpus_key")
+elif resp.status_code == 429:
+    print("Rate limited — back off and retry")
+    retry_after = resp.headers.get("Retry-After", 1)
+else:
+    resp.raise_for_status()
+```
+
+Common status codes:
+| Code | Meaning |
+|------|---------|
+| 200 | Success |
+| 201 | Created (corpus, document) |
+| 204 | Deleted |
+| 400 | Malformed request |
+| 403 | Insufficient permissions |
+| 404 | Resource not found |
+| 415 | Unsupported file type (upload) |
+| 429 | Rate limited |
+
+## Useful Links
+
+- API Reference: https://docs.vectara.com/docs/rest-api
+- Developer Quickstart: https://docs.vectara.com/docs/developer-quickstart
+- Vectara Console: https://console.vectara.com
+- Filter Expressions: https://docs.vectara.com/docs/learn/metadata-search-filtering/filter-overview

--- a/content/vectara/docs/api/python/DOC.md
+++ b/content/vectara/docs/api/python/DOC.md
@@ -395,15 +395,18 @@ with open("document.pdf", "rb") as f:
         headers={"x-api-key": API_KEY, "Accept": "application/json"},
         files={
             "file": ("document.pdf", f, "application/pdf"),
+            "filename": (None, "doc-001"),  # Required — sets the document ID
             "metadata": (None, json.dumps({"category": "engineering", "year": 2024}), "application/json"),
         },
     )
 # 201 = document parsed, chunked, and indexed
 ```
 
+The `filename` multipart field is **required** and becomes the document ID inside the corpus — set it explicitly rather than relying on the uploaded file's name.
+
 Do **not** set `Content-Type` header manually for multipart uploads — let `requests` set the boundary.
 
-Supported file types: Markdown, PDF, Word (.docx), PowerPoint (.pptx), HTML, RTF, EPUB, plain text, email (RFC 822).
+Supported file types: Markdown, PDF/A, OpenOffice (.odt), Word (.doc, .docx), PowerPoint (.ppt, .pptx), HTML, LXML, RTF, EPUB, plain text, email (RFC 822).
 
 ### Structured Document Indexing
 

--- a/content/vectara/docs/api/python/DOC.md
+++ b/content/vectara/docs/api/python/DOC.md
@@ -106,7 +106,21 @@ for result in results["search_results"]:
     print(f"Score: {result['score']:.3f} — {result['text']}")
 ```
 
-### Single Corpus Query (Shorthand)
+### Simple Single Corpus Query (GET)
+
+For quick searches without generation or reranking:
+
+```python
+resp = requests.get(
+    f"{BASE_URL}/corpora/my-corpus/query",
+    headers=headers,
+    params={"query": "How does reranking work?", "limit": 10},
+)
+```
+
+### Advanced Single Corpus Query (POST)
+
+For full control over search, reranking, and generation on a single corpus:
 
 ```python
 resp = requests.post(
@@ -170,7 +184,7 @@ for r in data["search_results"]:
 Control the balance between neural and keyword search with `lexical_interpolation`:
 - `0.0` = pure neural (semantic) search
 - `1.0` = pure keyword (lexical) search
-- `0.025` = recommended starting point (mostly neural with slight keyword boost)
+- `0.005` = recommended starting point (mostly neural with slight keyword boost)
 
 ```python
 resp = requests.post(
@@ -271,18 +285,20 @@ resp = requests.post(
 ```
 
 Reranker types:
-- `customer_reranker` — Vectara's neural reranker (use `Rerank_Multilingual_v1`)
+- `customer_reranker` — Vectara's neural reranker (`Rerank_Multilingual_v1` or `qwen3-reranker`)
 - `mmr` — Maximal Marginal Relevance (diversifies results)
+- `chain` — combine multiple rerankers in sequence
 - `none` — skip reranking
 
 ### Streaming Responses
 
-For RAG with streaming, use `stream_response=True`:
+Add `stream_response: true` and set `Accept: text/event-stream` to receive SSE chunks:
 
 ```python
+import json
 resp = requests.post(
     f"{BASE_URL}/query",
-    headers=headers,
+    headers={**headers, "Accept": "text/event-stream"},
     json={
         "query": "Explain vector databases",
         "search": {
@@ -297,9 +313,17 @@ resp = requests.post(
     stream=True,
 )
 for line in resp.iter_lines():
-    if line:
-        print(line.decode())
+    if line and line.startswith(b"data:"):
+        event = json.loads(line[5:])
+        if event["type"] == "generation_chunk":
+            print(event["generation_chunk"], end="")
+        elif event["type"] == "search_results":
+            pass  # Search results arrive first
+        elif event["type"] == "factual_consistency_score":
+            print(f"\nScore: {event['factual_consistency_score']}")
 ```
+
+SSE event types: `search_results`, `generation_chunk`, `factual_consistency_score`, `generation_end`, `end`.
 
 ## Corpus Management
 
@@ -316,13 +340,13 @@ resp = requests.post(
         "filter_attributes": [
             {
                 "name": "category",
-                "level": "doc",
+                "level": "document",
                 "type": "text",
                 "indexed": True,
             },
             {
                 "name": "year",
-                "level": "doc",
+                "level": "document",
                 "type": "integer",
                 "indexed": True,
             },
@@ -363,17 +387,21 @@ resp = requests.delete(f"{BASE_URL}/corpora/my-corpus", headers=headers)
 Upload PDF, Word, PowerPoint, HTML, Markdown, or plain text files (max 10 MB):
 
 ```python
+import json
+
 with open("document.pdf", "rb") as f:
     resp = requests.post(
         f"{BASE_URL}/corpora/my-corpus/upload_file",
-        headers={"x-api-key": API_KEY},
-        files={"file": ("document.pdf", f, "application/pdf")},
-        data={
-            "metadata": '{"category": "engineering", "year": 2024}',
+        headers={"x-api-key": API_KEY, "Accept": "application/json"},
+        files={
+            "file": ("document.pdf", f, "application/pdf"),
+            "metadata": (None, json.dumps({"category": "engineering", "year": 2024}), "application/json"),
         },
     )
 # 201 = document parsed, chunked, and indexed
 ```
+
+Do **not** set `Content-Type` header manually for multipart uploads — let `requests` set the boundary.
 
 Supported file types: Markdown, PDF, Word (.docx), PowerPoint (.pptx), HTML, RTF, EPUB, plain text, email (RFC 822).
 

--- a/content/vectara/docs/api/python/references/advanced-query.md
+++ b/content/vectara/docs/api/python/references/advanced-query.md
@@ -115,6 +115,29 @@ Maximal Marginal Relevance reduces redundancy in results:
 }
 ```
 
+### User-Defined Function Reranker (`userfn`)
+
+Score results with a custom expression or a built-in utility function. The most common use is the **knee-point** function, which automatically detects where relevance scores drop off and cuts the result list there:
+
+```python
+"reranker": {
+    "type": "userfn",
+    "user_function": "knee()",
+}
+```
+
+`userfn` also accepts arbitrary expressions over result fields (e.g., `"0.7 * get('$.score') + 0.3 * get('$.document_metadata.recency')"`) for per-tenant scoring logic. Pair with chain reranking to run knee-based truncation after a neural pass:
+
+```python
+"reranker": {
+    "type": "chain",
+    "rerankers": [
+        {"type": "customer_reranker", "reranker_name": "Rerank_Multilingual_v1", "limit": 100},
+        {"type": "userfn", "user_function": "knee()"},
+    ],
+}
+```
+
 ### Disable Reranking
 
 ```python

--- a/content/vectara/docs/api/python/references/advanced-query.md
+++ b/content/vectara/docs/api/python/references/advanced-query.md
@@ -1,0 +1,206 @@
+# Vectara Advanced Query Features
+
+## Rerankers
+
+Rerankers re-score initial search results using a more powerful model for better relevance.
+
+### Neural Reranker (Recommended)
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/query",
+    headers=headers,
+    json={
+        "query": "database optimization",
+        "search": {
+            "corpora": [{"corpus_key": "my-corpus"}],
+            "limit": 100,  # Fetch more candidates for reranking
+            "reranker": {
+                "type": "customer_reranker",
+                "reranker_name": "Rerank_Multilingual_v1",
+                "limit": 10,     # Return top 10 after reranking
+                "cutoff": 0.3,   # Minimum relevance score (0.0–1.0)
+            },
+        },
+    },
+)
+```
+
+### MMR Reranker (Diversity)
+
+Maximal Marginal Relevance reduces redundancy in results:
+
+```python
+"reranker": {
+    "type": "mmr",
+    "diversity_bias": 0.3,  # 0.0 = pure relevance, 1.0 = max diversity
+    "limit": 10,
+}
+```
+
+### No Reranker
+
+```python
+"reranker": {
+    "type": "none",
+}
+```
+
+**Best practice:** Set `search.limit` higher (50–100) when using a reranker, so it has more candidates to work with. The reranker's own `limit` controls the final result count.
+
+## Filter Expressions
+
+SQL-like expressions that filter results by document and part metadata.
+
+### Operators
+
+| Operator | Example |
+|----------|---------|
+| `=`, `!=` | `doc.category = 'security'` |
+| `<`, `>`, `<=`, `>=` | `doc.year >= 2024` |
+| `AND`, `OR`, `NOT` | `doc.status = 'active' AND doc.priority > 3` |
+| `IS NULL`, `IS NOT NULL` | `doc.author IS NOT NULL` |
+| `IN` | `doc.category IN ('security', 'compliance')` |
+
+### Data Types
+
+- **Text:** `doc.category = 'Science'` (single quotes)
+- **Integer:** `doc.publication_year = 2024`
+- **Real:** `part.sentiment_score > 0.7`
+- **Boolean:** `doc.is_featured = true`
+
+### Default Metadata Fields
+
+- `doc.id` — unique document identifier
+- `part.lang` — ISO 639-2 language code (3 chars)
+- `part.is_title` — boolean, indicates title sections
+
+### Combining Filters
+
+```python
+"metadata_filter": (
+    "doc.category = 'engineering' "
+    "AND doc.year >= 2024 "
+    "AND part.lang = 'eng'"
+)
+```
+
+### List Membership
+
+For list-type attributes, use the reverse `IN` syntax:
+
+```python
+"metadata_filter": "'python' IN doc.tags"
+```
+
+## Generation Presets
+
+Generation presets bundle an LLM, a prompt template, and model parameters.
+
+### Using a Preset
+
+```python
+"generation": {
+    "generation_preset_name": "mockingbird-2.0",
+}
+```
+
+### Custom Prompt Template
+
+Override the default prompt with a Velocity template:
+
+```python
+"generation": {
+    "generation_preset_name": "mockingbird-2.0",
+    "prompt_template": (
+        "Given the search results: $results\n\n"
+        "Answer the question: $query\n\n"
+        "Be concise and cite sources."
+    ),
+    "max_used_search_results": 5,
+    "model_parameters": {
+        "temperature": 0.3,
+        "max_tokens": 1024,
+        "frequency_penalty": 0.1,
+    },
+}
+```
+
+### Citation Styles
+
+```python
+# Numeric: [1], [2], [3]
+"citations": {"style": "numeric"}
+
+# HTML: <cite data-ref="1">text</cite>
+"citations": {"style": "html"}
+
+# Markdown: [text](url)
+"citations": {"style": "markdown", "url_pattern": "https://example.com/doc/{doc.id}"}
+```
+
+### Factual Consistency Score
+
+Enable to get a 0.0–1.0 score measuring how well the generated answer is grounded in the search results:
+
+```python
+"generation": {
+    "generation_preset_name": "mockingbird-2.0",
+    "enable_factual_consistency_score": True,
+}
+
+# In response:
+# data["factual_consistency_score"] → 0.95
+```
+
+## Context Configuration
+
+Control how much surrounding text is included with each search result:
+
+```python
+"search": {
+    "corpora": [{"corpus_key": "my-corpus"}],
+    "limit": 10,
+    "context_configuration": {
+        "sentences_before": 2,
+        "sentences_after": 2,
+        "start_tag": "<b>",
+        "end_tag": "</b>",
+    },
+}
+```
+
+Alternative: use `characters_before` / `characters_after` for character-level control.
+
+## Metadata Query
+
+Fuzzy match on metadata fields across a corpus (not full-text search):
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/corpora/my-corpus/query_metadata",
+    headers=headers,
+    json={
+        "query": "machine learning",
+        "metadata_fields": ["doc.title", "doc.category"],
+        "limit": 20,
+    },
+)
+```
+
+## Query History (Observability)
+
+Retrieve past queries with latency and pipeline details:
+
+```python
+resp = requests.get(
+    f"{BASE_URL}/query_history",
+    headers=headers,
+    params={
+        "corpus_key": "my-corpus",
+        "limit": 50,
+    },
+)
+for entry in resp.json()["queries"]:
+    print(f"{entry['query']} — {entry['latency_ms']}ms")
+```

--- a/content/vectara/docs/api/python/references/advanced-query.md
+++ b/content/vectara/docs/api/python/references/advanced-query.md
@@ -4,7 +4,7 @@
 
 Rerankers re-score initial search results using a more powerful model for better relevance.
 
-### Neural Reranker (Recommended)
+### Neural Reranker
 
 ```python
 resp = requests.post(
@@ -26,11 +26,88 @@ resp = requests.post(
 )
 ```
 
+Rerankers can be identified by name or ID:
+- `"reranker_name": "Rerank_Multilingual_v1"` — by name
+- `"reranker_id": "rnk_272725719"` — by ID
+
+### Qwen3 Reranker with Instructions
+
+The `qwen3-reranker` supports natural language `instructions` to steer reranking behavior — useful for domain-specific queries:
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/query",
+    headers=headers,
+    json={
+        "query": "How does HHEM work?",
+        "search": {
+            "corpora": [
+                {
+                    "corpus_key": "my-corpus",
+                    "lexical_interpolation": 0.005,
+                }
+            ],
+            "limit": 100,
+            "context_configuration": {
+                "sentences_before": 2,
+                "sentences_after": 2,
+            },
+            "reranker": {
+                "type": "customer_reranker",
+                "reranker_name": "qwen3-reranker",
+                "instructions": (
+                    "HHEM stands for Hughes Hallucination Evaluation Model. "
+                    "Prioritize results that explain the model architecture "
+                    "and evaluation methodology."
+                ),
+                "limit": 30,
+                "cutoff": 0.2,
+            },
+        },
+        "generation": {
+            "generation_preset_name": "vectara-summary-ext-24-05-med-omni",
+            "max_used_search_results": 10,
+            "response_language": "eng",
+            "enable_factual_consistency_score": True,
+        },
+    },
+)
+```
+
+Use `instructions` to:
+- **Resolve abbreviations** — expand domain jargon so the reranker understands context
+- **Steer intent** — e.g., "prioritize practical how-to guides over academic papers"
+- **Add domain context** — e.g., "this query is about network security, not physical security"
+
+### Chain Reranker
+
+Combine multiple rerankers in sequence — e.g., neural reranking followed by diversity:
+
+```python
+"reranker": {
+    "type": "chain",
+    "rerankers": [
+        {
+            "type": "customer_reranker",
+            "reranker_name": "qwen3-reranker",
+            "instructions": "Focus on practical implementation details",
+            "limit": 100,
+            "cutoff": 0.2,
+        },
+        {
+            "type": "mmr",
+            "diversity_bias": 0.05,
+        },
+    ],
+}
+```
+
 ### MMR Reranker (Diversity)
 
 Maximal Marginal Relevance reduces redundancy in results:
 
 ```python
+# Use within a query request's search object:
 "reranker": {
     "type": "mmr",
     "diversity_bias": 0.3,  # 0.0 = pure relevance, 1.0 = max diversity
@@ -38,7 +115,7 @@ Maximal Marginal Relevance reduces redundancy in results:
 }
 ```
 
-### No Reranker
+### Disable Reranking
 
 ```python
 "reranker": {
@@ -107,16 +184,31 @@ Generation presets bundle an LLM, a prompt template, and model parameters.
 
 ### Custom Prompt Template
 
-Override the default prompt with a Velocity template:
+Override the default prompt with a Velocity template. The `prompt_template` is a JSON-stringified array of message objects using Velocity variables:
+
+- `$vectaraQuery` — the user's query text
+- `$vectaraQueryResults` — iterable of search results
+- `$qResult.text()` — result text
+- `$qResult.docMetadata().get('title')` — access document metadata
 
 ```python
+import json
+
+prompt = json.dumps([
+    {"role": "system", "content": "You are a research assistant. Cite sources."},
+    {"role": "user", "content": (
+        "Question: $vectaraQuery\n\n"
+        "Sources:\n"
+        "#foreach ($qResult in $vectaraQueryResults)\n"
+        "Title: $qResult.docMetadata().get('title')\n"
+        "Content: $qResult.text()\n"
+        "#end"
+    )},
+])
+
 "generation": {
     "generation_preset_name": "mockingbird-2.0",
-    "prompt_template": (
-        "Given the search results: $results\n\n"
-        "Answer the question: $query\n\n"
-        "Be concise and cite sources."
-    ),
+    "prompt_template": prompt,
     "max_used_search_results": 5,
     "model_parameters": {
         "temperature": 0.3,

--- a/content/vectara/docs/api/python/references/agents.md
+++ b/content/vectara/docs/api/python/references/agents.md
@@ -148,6 +148,176 @@ resp = requests.delete(f"{BASE_URL}/agents/{agent_key}", headers=headers)
 # 204 = success
 ```
 
+## Multi-Step Workflows
+
+An agent can define multiple named steps in the `steps` map and route between them with conditional transitions. Use this for classify-then-route patterns, multi-phase workflows, or handing off to specialized sub-prompts.
+
+Each step is executed serially — for parallel work, give the agent other agents as tools (`sub_agent`) instead.
+
+### Define Multiple Steps
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/agents",
+    headers=headers,
+    json={
+        "name": "Support Router",
+        "model": {"name": "gpt-4o", "parameters": {"temperature": 0.2}},
+        "first_step_name": "classifier",
+        "steps": {
+            "classifier": {
+                "instructions": [
+                    {
+                        "type": "inline",
+                        "template": (
+                            "Classify the user's intent into one of: "
+                            "`billing`, `technical`, `general`. Respond with JSON "
+                            "matching the output schema."
+                        ),
+                    }
+                ],
+                "output_parser": {
+                    "type": "structured",
+                    "json_schema": {
+                        "type": "object",
+                        "properties": {"intent": {"type": "string"}},
+                        "required": ["intent"],
+                    },
+                },
+                "next_steps": [
+                    {"condition": "get('$.output.intent') == 'billing'", "step_name": "billing_handler"},
+                    {"condition": "get('$.output.intent') == 'technical'", "step_name": "tech_handler"},
+                    {"step_name": "general_handler"},  # Catch-all (no condition)
+                ],
+                "allowed_tools": [],  # Classifier does no tool calls
+            },
+            "billing_handler": {
+                "instructions": [
+                    {"type": "inline", "template": "You are a billing specialist. Search billing docs before answering."}
+                ],
+                "output_parser": {"type": "default"},
+                "allowed_tools": ["billing_search"],
+                "reentry_step": "classifier",  # Re-classify on the next user message
+            },
+            "tech_handler": {
+                "instructions": [
+                    {"type": "inline", "template": "You are a technical specialist. Search engineering docs."}
+                ],
+                "output_parser": {"type": "default"},
+                "allowed_tools": ["tech_search"],
+                "reentry_step": "classifier",
+            },
+            "general_handler": {
+                "instructions": [
+                    {"type": "inline", "template": "You handle general questions. Be brief."}
+                ],
+                "output_parser": {"type": "default"},
+                "allowed_tools": [],
+                "reentry_step": "classifier",
+            },
+        },
+        "tool_configurations": {
+            "billing_search": {"type": "corpora_search", "query_configuration": {"search": {"corpora": [{"corpus_key": "billing-docs"}]}}},
+            "tech_search":    {"type": "corpora_search", "query_configuration": {"search": {"corpora": [{"corpus_key": "engineering-docs"}]}}},
+        },
+    },
+)
+```
+
+### Transition Conditions
+
+`next_steps` entries are evaluated in order — the **first matching condition** wins. An entry with no `condition` is a catch-all; place it last.
+
+Conditions are [UserFn](https://docs.vectara.com/docs/search-and-retrieval/rerankers/user-defined-function-reranker) boolean expressions using `get()` with JSONPath over this context:
+
+| Path | Contents |
+|------|----------|
+| `$.output.text` | LLM text output (when `output_parser.type == "default"`) |
+| `$.output.<field>` | Structured output fields (when `output_parser.type == "structured"`) |
+| `$.session.metadata.<key>` | Session metadata |
+| `$.agent.metadata.<key>` | Agent metadata |
+| `$.tools.<tool_name>.outputs.latest.<field>` | Latest tool output |
+| `$.currentDate` | ISO timestamp |
+
+Examples:
+```python
+{"condition": "get('$.output.intent') == 'sales'", "step_name": "sales_handler"}
+{"condition": "get('$.tools.corpus_search.outputs.latest.score') < 0.3", "step_name": "fallback"}
+```
+
+If no condition matches, the agent stops on the current step and emits output.
+
+### Per-Step Controls
+
+- `allowed_tools` — list of tool-configuration names this step may call. `null` (omitted) = all; `[]` = text-only.
+- `allowed_skills` — same pattern for skills (see below).
+- `reentry_step` — which step to resume at when the user sends the next message. Omit to stay on the current step; set to `first_step_name` to always restart the flow.
+- `reminders` — messages injected into conversation context when specific events occur, to keep long conversations on-task.
+
+## Skills
+
+Skills are progressively-disclosed instructions. The agent sees only the **skill name + description** in its system message; the full `content` is loaded on demand when the LLM decides to invoke the skill via the built-in `invoke_skill` tool. This keeps the base prompt small while giving the agent access to large, specialized instruction sets.
+
+Skills are defined at the agent level and can be filtered per step via `allowed_skills`.
+
+### Define Skills on an Agent
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/agents",
+    headers=headers,
+    json={
+        "name": "Engineering Assistant",
+        "model": {"name": "gpt-4o", "parameters": {"temperature": 0.2}},
+        "first_step_name": "main",
+        "steps": {
+            "main": {
+                "instructions": [
+                    {"type": "inline", "template": "You help engineers. Invoke skills when they match the task."}
+                ],
+                "output_parser": {"type": "default"},
+                "allowed_skills": ["code_review", "incident_response"],  # This step may invoke these
+            },
+        },
+        "skills": {
+            "code_review": {
+                "description": "Reviews code for best practices, bugs, and security issues.",
+                "content": (
+                    "When reviewing code, check for security vulnerabilities (injection, "
+                    "auth bypass, unsafe deserialization), performance issues (N+1 queries, "
+                    "unnecessary allocations), and adherence to our style guide. Cite line "
+                    "numbers. End with a prioritized list of suggested changes."
+                ),
+            },
+            "incident_response": {
+                "description": "Guides on-call engineers through an incident triage workflow.",
+                "content": (
+                    "1. Establish severity (SEV1/2/3). 2. Open a war-room channel. "
+                    "3. Identify the blast radius. 4. Mitigate before diagnosing root cause. "
+                    "5. Page the service owner if user-facing. ..."
+                ),
+            },
+        },
+        "tool_configurations": {},
+    },
+)
+```
+
+Each skill entry requires `description` (≤500 chars) and `content` (≤50 000 chars).
+
+### Per-Step Skill Filtering
+
+`allowed_skills` on a step restricts which skills the LLM can invoke at that point:
+- Omit (null) → all agent skills available
+- `[]` → no skills; `invoke_skill` tool is not shown to the LLM
+- `["code_review"]` → only `code_review` is invocable in this step
+
+### Skills vs Instructions vs Tools
+
+- **Instructions** (`steps[x].instructions`) — always included in the system prompt. Use for core behavior that must always apply.
+- **Skills** — name + description always shown; full content loaded only when invoked. Use for large, specialized instruction sets that only apply to specific tasks.
+- **Tools** (`tool_configurations`) — executed actions that return data (search, web, lambda). Use when the agent needs to **do** something, not just **know** something.
+
 ## Tool Configurations
 
 Tools are defined in the `tool_configurations` dict when creating or updating an agent. Each key is a tool name, and the value specifies the tool type and config.
@@ -520,6 +690,122 @@ resp = requests.post(
         "query": "Summarize new documents added in the last 24 hours",
     },
 )
+```
+
+## Pipelines
+
+Pipelines continuously ingest data from a source system (e.g., S3) and send each record to an agent for processing. Each record creates a new agent session — this is how pipelines differ from **schedules** (recurring single execution of one agent) and **connectors** (bidirectional chat like Slack).
+
+### Create a Pipeline
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/pipelines",
+    headers=headers,
+    json={
+        "key": "s3-legal-ingest",  # Optional; auto-generated if omitted
+        "name": "Legal Docs S3 Ingest",
+        "description": "Ingests contracts from S3 and routes them to the legal review agent",
+        "source": {
+            "type": "s3",
+            "bucket": "my-legal-docs",
+            "region": "us-east-1",
+            "prefix": "contracts/2026/",          # Optional — scope to a subfolder
+            "access_key_id": "AKIA...",           # Encrypted at rest, not returned in responses
+            "secret_access_key": "...",
+            # "endpoint_url": "https://minio.example.com:9000",  # Optional — for S3-compatible stores
+        },
+        "trigger": {
+            "type": "cron",
+            "expression": "0 */6 * * *",         # Every 6 hours, UTC
+        },
+        "transform": {
+            "type": "agent",
+            "agent_key": agent_key,
+            # Optional output verification:
+            # "verification": {"type": "condition", "expression": "get('$.output.status') == 'success'"},
+            # or a judge agent:
+            # "verification": {"type": "agent", "agent_key": "agt_judge_..."},
+        },
+        "sync_mode": "incremental",              # or "full_refresh" — default: "incremental"
+        "enabled": True,
+    },
+)
+pipeline = resp.json()
+pipeline_key = pipeline["key"]
+```
+
+Trigger types:
+- `cron` — 5-field UTC cron expression
+- `interval` — ISO-8601 duration (e.g., `"duration": "PT1H"` for hourly)
+- `manual` — only runs via the trigger endpoint
+
+Source types currently include `s3` (S3-compatible storage). Additional source types (e.g., `sharepoint`) are available; check `GET /v2/pipelines?source_type=...` for what's live in your account.
+
+### List Pipelines
+
+```python
+resp = requests.get(
+    f"{BASE_URL}/pipelines",
+    headers=headers,
+    params={"enabled": True, "limit": 50},
+)
+for p in resp.json()["pipelines"]:
+    print(f"{p['key']}: {p['name']} — {p.get('status')}")
+```
+
+### Get / Update / Delete
+
+```python
+# Get
+resp = requests.get(f"{BASE_URL}/pipelines/{pipeline_key}", headers=headers)
+
+# Partial update
+resp = requests.patch(
+    f"{BASE_URL}/pipelines/{pipeline_key}",
+    headers=headers,
+    json={"enabled": False, "description": "Paused for Q2 audit"},
+)
+
+# Replace (full schema required — same as create)
+resp = requests.put(f"{BASE_URL}/pipelines/{pipeline_key}", headers=headers, json={...})
+
+# Delete (cancels in-progress runs; does not delete sessions the pipeline created)
+resp = requests.delete(f"{BASE_URL}/pipelines/{pipeline_key}", headers=headers)
+```
+
+### Trigger a Run Manually
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/pipelines/{pipeline_key}/trigger",
+    headers=headers,
+)
+run = resp.json()
+print(f"Run {run['id']}: {run['status']} (fetched {run['records_fetched']} records)")
+# 409 = a run is already in progress for this pipeline
+```
+
+### Pipeline Runs
+
+Inspect past executions:
+
+```python
+resp = requests.get(f"{BASE_URL}/pipelines/{pipeline_key}/runs", headers=headers)
+for run in resp.json()["runs"]:
+    print(f"{run['id']}: {run['status']} — fetched {run['records_fetched']}, processed {run['records_processed']}")
+```
+
+### Dead Letters
+
+Records that failed processing are captured in a dead-letter queue for reprocessing:
+
+```python
+# List dead letters
+resp = requests.get(f"{BASE_URL}/pipelines/{pipeline_key}/dead_letters", headers=headers)
+
+# Retry all dead letters
+resp = requests.post(f"{BASE_URL}/pipelines/{pipeline_key}/dead_letters/process", headers=headers)
 ```
 
 ## Instructions

--- a/content/vectara/docs/api/python/references/agents.md
+++ b/content/vectara/docs/api/python/references/agents.md
@@ -1,0 +1,227 @@
+# Vectara Agents API
+
+Agents are AI entities that use tools and corpora to handle multi-step queries autonomously.
+
+## Create an Agent
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/agents",
+    headers=headers,
+    json={
+        "name": "Research Assistant",
+        "description": "Answers research questions using internal docs",
+        "instructions": [
+            "Search the knowledge base before answering.",
+            "Always cite your sources.",
+            "If unsure, say so rather than guessing.",
+        ],
+        "first_step": {
+            "tools": ["web_search", "corpus_search"],
+        },
+        "model_parameters": {
+            "llm_name": "gpt-4o",
+            "temperature": 0.3,
+            "max_tokens": 2048,
+        },
+        "retry_settings": {
+            "max_retries": 3,
+            "initial_backoff_ms": 1000,
+            "backoff_factor": 2,
+            "max_backoff_ms": 10000,
+        },
+        "metadata": {"category": "Research", "version": "1.0"},
+    },
+)
+agent = resp.json()
+agent_key = agent["agent_key"]
+```
+
+## List Agents
+
+```python
+resp = requests.get(f"{BASE_URL}/agents", headers=headers)
+for agent in resp.json()["agents"]:
+    print(f"{agent['agent_key']}: {agent['name']}")
+```
+
+## Get Agent Details
+
+```python
+resp = requests.get(f"{BASE_URL}/agents/{agent_key}", headers=headers)
+agent = resp.json()
+```
+
+## Update Agent
+
+Partial update — only specified fields change:
+
+```python
+resp = requests.patch(
+    f"{BASE_URL}/agents/{agent_key}",
+    headers=headers,
+    json={
+        "description": "Updated description",
+        "model_parameters": {"temperature": 0.5},
+    },
+)
+```
+
+## Replace Agent
+
+Full replacement — all fields must be provided:
+
+```python
+resp = requests.put(
+    f"{BASE_URL}/agents/{agent_key}",
+    headers=headers,
+    json={
+        "name": "Research Assistant v2",
+        "description": "Improved research agent",
+        "instructions": ["Search thoroughly.", "Cite all sources."],
+        "first_step": {"tools": ["web_search", "corpus_search"]},
+        "model_parameters": {"llm_name": "gpt-4o", "temperature": 0.2},
+    },
+)
+```
+
+## Delete Agent
+
+```python
+resp = requests.delete(f"{BASE_URL}/agents/{agent_key}", headers=headers)
+# 204 = success
+```
+
+## Tools
+
+Tools extend agent capabilities. Three types exist:
+- **Built-in tools** — provided by Vectara (e.g., web search, corpus search)
+- **Lambda tools** — custom code executed by the platform
+- **Tool servers** — external services the agent can call
+
+### Create a Tool
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/agents/{agent_key}/tools",
+    headers=headers,
+    json={
+        "name": "web_search",
+        "type": "built_in",
+        "description": "Search the web for current information",
+        "configuration": {
+            "max_results": 10,
+        },
+    },
+)
+```
+
+### List Tools
+
+```python
+resp = requests.get(f"{BASE_URL}/agents/{agent_key}/tools", headers=headers)
+```
+
+## Sessions (Multi-turn Conversations)
+
+Sessions maintain conversation state across multiple interactions.
+
+### Create a Session
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/agents/{agent_key}/sessions",
+    headers=headers,
+    json={},
+)
+session = resp.json()
+session_key = session["session_key"]
+```
+
+### Interact with an Agent
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/agents/{agent_key}/sessions/{session_key}/interact",
+    headers=headers,
+    json={
+        "query": "What were our Q4 revenue numbers?",
+    },
+)
+answer = resp.json()
+print(answer["answer"])
+# The agent searches corpora, uses tools, and returns a grounded answer
+```
+
+### Streaming Interaction
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/agents/{agent_key}/sessions/{session_key}/interact",
+    headers=headers,
+    json={
+        "query": "Summarize the latest incident report",
+        "stream_response": True,
+    },
+    stream=True,
+)
+for line in resp.iter_lines():
+    if line:
+        print(line.decode())
+```
+
+### List Sessions
+
+```python
+resp = requests.get(
+    f"{BASE_URL}/agents/{agent_key}/sessions",
+    headers=headers,
+)
+```
+
+## Schedules
+
+Automate agent execution on a recurring basis:
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/agents/{agent_key}/schedules",
+    headers=headers,
+    json={
+        "name": "daily-summary",
+        "cron_expression": "0 9 * * *",  # 9 AM daily
+        "query": "Summarize new documents added in the last 24 hours",
+    },
+)
+```
+
+## Instructions and Examples
+
+### Set Agent Instructions
+
+```python
+resp = requests.put(
+    f"{BASE_URL}/agents/{agent_key}/instructions",
+    headers=headers,
+    json={
+        "instructions": [
+            "Always search before answering.",
+            "Respond in the user's language.",
+            "Cite sources with [1], [2] notation.",
+        ],
+    },
+)
+```
+
+### Add Few-shot Examples
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/agents/{agent_key}/examples",
+    headers=headers,
+    json={
+        "user_message": "What is our refund policy?",
+        "agent_response": "Based on our documentation [1], refunds are available within 30 days of purchase...",
+    },
+)
+```

--- a/content/vectara/docs/api/python/references/agents.md
+++ b/content/vectara/docs/api/python/references/agents.md
@@ -11,30 +11,54 @@ resp = requests.post(
     json={
         "name": "Research Assistant",
         "description": "Answers research questions using internal docs",
-        "instructions": [
-            "Search the knowledge base before answering.",
-            "Always cite your sources.",
-            "If unsure, say so rather than guessing.",
-        ],
-        "first_step": {
-            "tools": ["web_search", "corpus_search"],
+        "model": {
+            "name": "gpt-4o",
+            "parameters": {"temperature": 0.3, "max_tokens": 2048},
         },
-        "model_parameters": {
-            "llm_name": "gpt-4o",
-            "temperature": 0.3,
-            "max_tokens": 2048,
+        "first_step_name": "main",
+        "steps": {
+            "main": {
+                "instructions": [
+                    {
+                        "type": "inline",
+                        "name": "system_prompt",
+                        "template": (
+                            "You are a research assistant. Search the knowledge base "
+                            "before answering. Always cite your sources. If unsure, say so."
+                        ),
+                    }
+                ],
+                "output_parser": {"type": "default"},
+            },
         },
-        "retry_settings": {
-            "max_retries": 3,
-            "initial_backoff_ms": 1000,
-            "backoff_factor": 2,
-            "max_backoff_ms": 10000,
+        "tool_configurations": {
+            "corpus_search": {
+                "type": "corpora_search",
+                "query_configuration": {
+                    "search": {
+                        "corpora": [{"corpus_key": "my-corpus"}],
+                        "limit": 100,
+                        "context_configuration": {
+                            "sentences_before": 2,
+                            "sentences_after": 2,
+                        },
+                        "reranker": {
+                            "type": "customer_reranker",
+                            "reranker_name": "Rerank_Multilingual_v1",
+                            "limit": 30,
+                        },
+                    },
+                    "generation": {
+                        "generation_preset_name": "vectara-summary-ext-24-05-med-omni",
+                    },
+                    "save_history": True,
+                },
+            },
         },
-        "metadata": {"category": "Research", "version": "1.0"},
     },
 )
 agent = resp.json()
-agent_key = agent["agent_key"]
+agent_key = agent["key"]
 ```
 
 ## List Agents
@@ -42,7 +66,7 @@ agent_key = agent["agent_key"]
 ```python
 resp = requests.get(f"{BASE_URL}/agents", headers=headers)
 for agent in resp.json()["agents"]:
-    print(f"{agent['agent_key']}: {agent['name']}")
+    print(f"{agent['key']}: {agent['name']}")
 ```
 
 ## Get Agent Details
@@ -62,14 +86,17 @@ resp = requests.patch(
     headers=headers,
     json={
         "description": "Updated description",
-        "model_parameters": {"temperature": 0.5},
+        "model": {
+            "name": "gpt-4o",
+            "parameters": {"temperature": 0.5},
+        },
     },
 )
 ```
 
 ## Replace Agent
 
-Full replacement — all fields must be provided:
+Full replacement — uses the same schema as create. All fields must be provided:
 
 ```python
 resp = requests.put(
@@ -78,9 +105,38 @@ resp = requests.put(
     json={
         "name": "Research Assistant v2",
         "description": "Improved research agent",
-        "instructions": ["Search thoroughly.", "Cite all sources."],
-        "first_step": {"tools": ["web_search", "corpus_search"]},
-        "model_parameters": {"llm_name": "gpt-4o", "temperature": 0.2},
+        "model": {
+            "name": "gpt-4o",
+            "parameters": {"temperature": 0.2},
+        },
+        "first_step_name": "main",
+        "steps": {
+            "main": {
+                "instructions": [
+                    {
+                        "type": "inline",
+                        "name": "system_prompt",
+                        "template": "You are a thorough research assistant. Always cite sources.",
+                    }
+                ],
+                "output_parser": {"type": "default"},
+            },
+        },
+        "tool_configurations": {
+            "corpus_search": {
+                "type": "corpora_search",
+                "query_configuration": {
+                    "search": {
+                        "corpora": [{"corpus_key": "my-corpus"}],
+                        "limit": 100,
+                    },
+                    "generation": {
+                        "generation_preset_name": "vectara-summary-ext-24-05-med-omni",
+                    },
+                    "save_history": True,
+                },
+            },
+        },
     },
 )
 ```
@@ -92,34 +148,156 @@ resp = requests.delete(f"{BASE_URL}/agents/{agent_key}", headers=headers)
 # 204 = success
 ```
 
-## Tools
+## Tool Configurations
 
-Tools extend agent capabilities. Three types exist:
-- **Built-in tools** — provided by Vectara (e.g., web search, corpus search)
-- **Lambda tools** — custom code executed by the platform
-- **Tool servers** — external services the agent can call
+Tools are defined in the `tool_configurations` dict when creating or updating an agent. Each key is a tool name, and the value specifies the tool type and config.
 
-### Create a Tool
+### Tool Types
+
+**Corpus search** — search one or more corpora:
+
+```python
+"corpus_search": {
+    "type": "corpora_search",
+    "query_configuration": {
+        "search": {
+            "corpora": [{"corpus_key": "my-corpus"}],
+            "limit": 100,
+            "reranker": {"type": "customer_reranker", "reranker_name": "Rerank_Multilingual_v1", "limit": 30},
+        },
+        "generation": {"generation_preset_name": "vectara-summary-ext-24-05-med-omni"},
+        "save_history": True,
+    },
+}
+```
+
+**Web search** — internet search:
+
+```python
+"web": {"type": "web_search"}
+```
+
+**Sub-agent** — delegate to another agent:
+
+```python
+"research_agent": {
+    "type": "sub_agent",
+    "description_template": "Handles deep research questions",
+    "sub_agent_configuration": {
+        "agent_key": "agt_...",
+        "session_mode": "ephemeral",  # No memory between calls
+    },
+}
+```
+
+**Lambda tool** — custom Python code:
+
+```python
+"analyzer": {"type": "lambda", "tool_id": "tol_1234"}
+```
+
+**Artifact tools** — for file handling in sessions:
+
+```python
+"read_file": {"type": "artifact_read"}
+"read_image": {"type": "image_read"}
+"convert_doc": {"type": "document_conversion"}
+"search_file": {"type": "artifact_grep"}
+```
+
+## Lambda Tools
+
+Create reusable custom tools with Python code. The code must define a `process()` function.
+
+### Create a Lambda Tool
 
 ```python
 resp = requests.post(
-    f"{BASE_URL}/agents/{agent_key}/tools",
+    f"{BASE_URL}/tools",
     headers=headers,
     json={
-        "name": "web_search",
-        "type": "built_in",
-        "description": "Search the web for current information",
-        "configuration": {
-            "max_results": 10,
-        },
+        "type": "lambda",
+        "language": "python",
+        "name": "calculate_stats",
+        "title": "Statistics Calculator",
+        "description": "Calculates summary statistics for a list of numbers",
+        "code": """
+def process(numbers: list[float]) -> dict:
+    import numpy as np
+    arr = np.array(numbers)
+    return {"mean": float(arr.mean()), "std": float(arr.std()), "median": float(np.median(arr))}
+""",
     },
 )
+tool_id = resp.json()["id"]  # e.g., "tol_..."
 ```
+
+Available libraries in Lambda: `json`, `pandas` (as `pd`), `numpy` (as `np`).
 
 ### List Tools
 
 ```python
-resp = requests.get(f"{BASE_URL}/agents/{agent_key}/tools", headers=headers)
+resp = requests.get(f"{BASE_URL}/tools", headers=headers)
+```
+
+### Delete a Tool
+
+```python
+resp = requests.delete(f"{BASE_URL}/tools/{tool_id}", headers=headers)
+# 204 = success
+```
+
+## Tool Servers
+
+Tool servers are external services that agents can call as tools.
+
+### Create a Tool Server
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/tool_servers",
+    headers=headers,
+    json={
+        "name": "my-tool-server",
+        "description": "Custom tool server for data lookups",
+        "url": "https://my-tools.example.com/api",
+        "authentication": {
+            "type": "api_key",
+            "api_key": "server-api-key",
+        },
+    },
+)
+tool_server = resp.json()
+tool_server_key = tool_server["tool_server_key"]
+```
+
+### List Tool Servers
+
+```python
+resp = requests.get(f"{BASE_URL}/tool_servers", headers=headers)
+```
+
+### Get a Tool Server
+
+```python
+resp = requests.get(f"{BASE_URL}/tool_servers/{tool_server_key}", headers=headers)
+```
+
+### Update a Tool Server
+
+```python
+resp = requests.patch(
+    f"{BASE_URL}/tool_servers/{tool_server_key}",
+    headers=headers,
+    json={"description": "Updated description"},
+)
+```
+
+### Delete a Tool Server
+
+```python
+resp = requests.delete(f"{BASE_URL}/tool_servers/{tool_server_key}", headers=headers)
+# 204 = success
 ```
 
 ## Sessions (Multi-turn Conversations)
@@ -132,35 +310,54 @@ Sessions maintain conversation state across multiple interactions.
 resp = requests.post(
     f"{BASE_URL}/agents/{agent_key}/sessions",
     headers=headers,
-    json={},
-)
-session = resp.json()
-session_key = session["session_key"]
-```
-
-### Interact with an Agent
-
-```python
-resp = requests.post(
-    f"{BASE_URL}/agents/{agent_key}/sessions/{session_key}/interact",
-    headers=headers,
     json={
-        "query": "What were our Q4 revenue numbers?",
+        "name": "Research session",
+        "metadata": {"user_type": "developer", "purpose": "Q4 analysis"},
     },
 )
-answer = resp.json()
-print(answer["answer"])
-# The agent searches corpora, uses tools, and returns a grounded answer
+session = resp.json()
+session_key = session["key"]
 ```
 
-### Streaming Interaction
+### Send a Message to an Agent
 
 ```python
 resp = requests.post(
-    f"{BASE_URL}/agents/{agent_key}/sessions/{session_key}/interact",
+    f"{BASE_URL}/agents/{agent_key}/sessions/{session_key}/events",
     headers=headers,
     json={
-        "query": "Summarize the latest incident report",
+        "type": "input_message",
+        "messages": [
+            {"type": "text", "content": "What were our Q4 revenue numbers?"}
+        ],
+        "stream_response": False,
+    },
+)
+data = resp.json()
+for event in data["events"]:
+    if event["type"] == "agent_output":
+        print(event["content"])
+    elif event["type"] == "tool_input":
+        print(f"Tool used: {event['tool_configuration_name']}")
+```
+
+Response event types:
+- `input_message` — echoes the user's message
+- `agent_output` — the agent's answer (field: `content`)
+- `tool_input` — tool invocation details
+- `tool_output` — tool results
+
+### Streaming Messages
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/agents/{agent_key}/sessions/{session_key}/events",
+    headers={**headers, "Accept": "text/event-stream"},
+    json={
+        "type": "input_message",
+        "messages": [
+            {"type": "text", "content": "Summarize the latest incident report"}
+        ],
         "stream_response": True,
     },
     stream=True,
@@ -179,6 +376,136 @@ resp = requests.get(
 )
 ```
 
+### Get a Specific Session
+
+```python
+resp = requests.get(
+    f"{BASE_URL}/agents/{agent_key}/sessions/{session_key}",
+    headers=headers,
+)
+session = resp.json()
+```
+
+### Update a Session
+
+```python
+resp = requests.patch(
+    f"{BASE_URL}/agents/{agent_key}/sessions/{session_key}",
+    headers=headers,
+    json={
+        "name": "Renamed session",
+        "metadata": {"topic": "Q4 analysis"},
+    },
+)
+```
+
+### Delete a Session
+
+```python
+resp = requests.delete(
+    f"{BASE_URL}/agents/{agent_key}/sessions/{session_key}",
+    headers=headers,
+)
+# 204 = success
+```
+
+## Session Events
+
+Events are the individual messages and actions within a session (user messages, agent outputs, tool calls).
+
+### List Events
+
+```python
+resp = requests.get(
+    f"{BASE_URL}/agents/{agent_key}/sessions/{session_key}/events",
+    headers=headers,
+)
+for event in resp.json()["events"]:
+    if event["type"] == "agent_output":
+        print(f"Agent: {event['content']}")
+    elif event["type"] == "input_message":
+        print(f"User: {event['content']}")
+    elif event["type"] == "tool_input":
+        print(f"Tool call: {event['tool_configuration_name']}")
+```
+
+### Get a Specific Event
+
+```python
+resp = requests.get(
+    f"{BASE_URL}/agents/{agent_key}/sessions/{session_key}/events/{event_id}",
+    headers=headers,
+)
+```
+
+### Delete an Event
+
+```python
+resp = requests.delete(
+    f"{BASE_URL}/agents/{agent_key}/sessions/{session_key}/events/{event_id}",
+    headers=headers,
+)
+# 204 = success
+```
+
+### Hide / Unhide Events
+
+Hide events from the conversation context without deleting them:
+
+```python
+# Hide an event
+resp = requests.post(
+    f"{BASE_URL}/agents/{agent_key}/sessions/{session_key}/events/{event_id}/hide",
+    headers=headers,
+)
+
+# Unhide an event
+resp = requests.post(
+    f"{BASE_URL}/agents/{agent_key}/sessions/{session_key}/events/{event_id}/unhide",
+    headers=headers,
+)
+```
+
+## Session Artifacts
+
+Artifacts are files uploaded to or produced by an agent during a session. Default TTL: 30 days.
+
+### Upload an Artifact
+
+Upload files via the events endpoint using multipart form data:
+
+```python
+with open("data.csv", "rb") as f:
+    resp = requests.post(
+        f"{BASE_URL}/agents/{agent_key}/sessions/{session_key}/events",
+        headers={"x-api-key": API_KEY, "Accept": "application/json"},
+        files={"files": ("data.csv", f, "text/csv")},
+        data={"stream_response": "false"},
+    )
+# Response includes artifact_upload events with artifact_id, filename, mime_type, size_bytes
+```
+
+### List Artifacts
+
+```python
+resp = requests.get(
+    f"{BASE_URL}/agents/{agent_key}/sessions/{session_key}/artifacts",
+    headers=headers,
+)
+for artifact in resp.json()["artifacts"]:
+    print(f"{artifact['artifact_id']}: {artifact['filename']} ({artifact['mime_type']})")
+```
+
+### Get a Specific Artifact
+
+```python
+resp = requests.get(
+    f"{BASE_URL}/agents/{agent_key}/sessions/{session_key}/artifacts/{artifact_id}",
+    headers=headers,
+)
+artifact = resp.json()
+```
+
 ## Schedules
 
 Automate agent execution on a recurring basis:
@@ -195,33 +522,60 @@ resp = requests.post(
 )
 ```
 
-## Instructions and Examples
+## Instructions
 
-### Set Agent Instructions
+Instructions are a top-level resource that can be shared across agents. They define how an agent should behave, reason, and respond. Instructions support Velocity templating.
 
-```python
-resp = requests.put(
-    f"{BASE_URL}/agents/{agent_key}/instructions",
-    headers=headers,
-    json={
-        "instructions": [
-            "Always search before answering.",
-            "Respond in the user's language.",
-            "Cite sources with [1], [2] notation.",
-        ],
-    },
-)
-```
-
-### Add Few-shot Examples
+### Create an Instruction
 
 ```python
 resp = requests.post(
-    f"{BASE_URL}/agents/{agent_key}/examples",
+    f"{BASE_URL}/instructions",
     headers=headers,
     json={
-        "user_message": "What is our refund policy?",
-        "agent_response": "Based on our documentation [1], refunds are available within 30 days of purchase...",
+        "name": "Customer Support Guide",
+        "description": "Defines tone and behavior for support interactions",
+        "template": (
+            "You are a customer support agent for the "
+            "${session.metadata.department} department. "
+            "Always search before answering. Cite sources with [1], [2] notation."
+        ),
+        "enabled": True,
+        "metadata": {"owner": "support-team", "version": "1.0.0"},
     },
 )
+instruction = resp.json()
+instruction_id = instruction["id"]
+```
+
+### Use an Instruction by Reference in an Agent
+
+Instead of inlining instructions, reference a shared instruction by ID:
+
+```python
+"steps": {
+    "main": {
+        "instructions": [
+            {
+                "type": "reference",
+                "id": instruction_id,
+                "version": 1,  # Optional; omit for latest
+            }
+        ],
+        "output_parser": {"type": "default"},
+    },
+}
+```
+
+### List Instructions
+
+```python
+resp = requests.get(f"{BASE_URL}/instructions", headers=headers)
+```
+
+### Delete an Instruction
+
+```python
+resp = requests.delete(f"{BASE_URL}/instructions/{instruction_id}", headers=headers)
+# 204 = success
 ```

--- a/content/vectara/docs/api/python/references/data-management.md
+++ b/content/vectara/docs/api/python/references/data-management.md
@@ -296,7 +296,10 @@ with open("report.pdf", "rb") as f:
     resp = requests.post(
         f"{BASE_URL}/corpora/my-corpus/upload_file",
         headers={"x-api-key": API_KEY},
-        files={"file": ("report.pdf", f, "application/pdf")},
+        files={
+            "file": ("report.pdf", f, "application/pdf"),
+            "filename": (None, "report-q4-2024"),
+        },
         data={
             "table_extraction_config": '{"extract_tables": true}',
         },
@@ -305,7 +308,7 @@ with open("report.pdf", "rb") as f:
 
 ## Factual Consistency Evaluation
 
-Score how well generated text is grounded in source material. Uses the HHEM (Hughes Hallucination Evaluation Model) v2.2 by default.
+Score how well generated text is grounded in source material. Uses the HHEM (Hughes Hallucination Evaluation Model) **v2.3**, which supports 11 languages and is the only value accepted by the API.
 
 ```python
 resp = requests.post(
@@ -318,16 +321,59 @@ resp = requests.post(
             "The company currently employs 487 people.",
         ],
         "language": "eng",
-        "model_parameters": {"model": "hhem_v2.2"},
+        "model_parameters": {"model_name": "hhem_v2.3"},  # Default; only value supported
     },
 )
 result = resp.json()
-print(f"Score: {result['score']}")            # 0.0–1.0
-print(f"Consistent: {result['p_consistent']}")
-print(f"Inconsistent: {result['p_inconsistent']}")
+print(f"Score: {result['score']}")            # 0.0–1.0 — higher = more consistent
 ```
 
-This is also available inline during RAG queries via `enable_factual_consistency_score: true` in the generation config.
+Language is an ISO 639-3 code (`eng`, `fra`, etc.). The same score is also available inline during RAG queries via `enable_factual_consistency_score: true` in the generation config.
+
+## Hallucination Correction (VHC)
+
+The Vectara Hallucination Corrector rewrites generated text to remove unsupported claims, keeping edits minimal. This is distinct from the evaluation API above — `evaluate_factual_consistency` **measures**, while this endpoint **rewrites**.
+
+### List Available Correctors
+
+```python
+resp = requests.get(f"{BASE_URL}/hallucination_correctors", headers=headers)
+for corrector in resp.json()["hallucination_correctors"]:
+    print(f"{corrector['name']}: {corrector.get('description', '')}")
+```
+
+### Correct Hallucinations
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/hallucination_correctors/correct_hallucinations",
+    headers=headers,
+    json={
+        "generated_text": "The Eiffel Tower is located in Berlin and was built in 1789.",
+        "documents": [
+            {"text": "The Eiffel Tower is a famous landmark located in Paris, France."},
+            {"text": "It was built in 1889 and remains one of the most visited monuments in the world."},
+        ],
+        "model_name": "vhc-large-1.0",
+        "query": "Where is the Eiffel Tower and when was it built?",  # Optional — enables query-aware correction
+    },
+)
+data = resp.json()
+print(data["corrected_text"])  # Minimal-edit rewrite grounded in documents
+for c in data["corrections"]:
+    print(f"[{c['original_text']}] → [{c['corrected_text']}] — {c['explanation']}")
+```
+
+Request fields:
+- `generated_text` (required) — the text to correct
+- `documents` (required) — array of `{"text": "..."}` source documents
+- `model_name` (required) — e.g., `vhc-large-1.0` (call `GET /v2/hallucination_correctors` to discover current models)
+- `query` (optional) — the original user query; enables query-aware correction
+
+Response fields:
+- `corrected_text` — the revised text (empty string indicates VHC judged the entire input as unsupported)
+- `corrections` — array of `{original_text, corrected_text, explanation}` spans
+- `model` — the model that produced the correction
 
 ## Jobs (Async Operations)
 

--- a/content/vectara/docs/api/python/references/data-management.md
+++ b/content/vectara/docs/api/python/references/data-management.md
@@ -14,6 +14,31 @@ for doc in resp.json()["documents"]:
     print(f"{doc['id']}: {doc.get('metadata', {})}")
 ```
 
+### Pagination
+
+All list endpoints use cursor-based pagination with `limit` + `page_key`:
+
+```python
+page_key = None
+all_docs = []
+while True:
+    params = {"limit": 100}
+    if page_key:
+        params["page_key"] = page_key
+    resp = requests.get(
+        f"{BASE_URL}/corpora/my-corpus/documents",
+        headers=headers,
+        params=params,
+    )
+    data = resp.json()
+    all_docs.extend(data["documents"])
+    page_key = data.get("metadata", {}).get("page_key")
+    if not page_key:
+        break
+```
+
+This pattern works for all list endpoints (`/corpora`, `/documents`, `/agents`, `/sessions`, etc.).
+
 ### Get Document Details
 
 ```python
@@ -36,14 +61,17 @@ resp = requests.delete(
 
 ### Bulk Delete Documents
 
+Async operation — accepts document IDs, metadata filters, or both:
+
 ```python
-resp = requests.post(
-    f"{BASE_URL}/corpora/my-corpus/documents/bulk_delete",
+resp = requests.delete(
+    f"{BASE_URL}/corpora/my-corpus/documents",
     headers=headers,
     json={
         "document_ids": ["doc-001", "doc-002", "doc-003"],
     },
 )
+# Async — returns a job. Poll via GET /v2/jobs/{job_id}
 ```
 
 ### Summarize a Document
@@ -62,6 +90,34 @@ resp = requests.post(
 print(resp.json()["summary"])
 ```
 
+### Update Document Metadata
+
+Partial update — only specified metadata fields change:
+
+```python
+resp = requests.patch(
+    f"{BASE_URL}/corpora/my-corpus/documents/doc-001",
+    headers=headers,
+    json={
+        "metadata": {"category": "updated-category", "reviewed": True},
+    },
+)
+```
+
+### Replace Document Metadata
+
+Full replacement — all existing metadata is overwritten:
+
+```python
+resp = requests.put(
+    f"{BASE_URL}/corpora/my-corpus/documents/doc-001/metadata",
+    headers=headers,
+    json={
+        "metadata": {"category": "new-category", "author": "team-b"},
+    },
+)
+```
+
 ### Retrieve Images from Documents
 
 ```python
@@ -73,7 +129,58 @@ for image in resp.json()["images"]:
     print(f"Image: {image['id']} — {image['content_type']}")
 ```
 
+### Get a Specific Image
+
+```python
+resp = requests.get(
+    f"{BASE_URL}/corpora/my-corpus/documents/doc-001/images/{image_id}",
+    headers=headers,
+)
+```
+
 ## Corpus Management
+
+### Update a Corpus
+
+Partial update — modify name, description, or enabled status:
+
+```python
+resp = requests.patch(
+    f"{BASE_URL}/corpora/my-corpus",
+    headers=headers,
+    json={
+        "name": "Updated Corpus Name",
+        "description": "New description",
+        "enabled": True,
+    },
+)
+```
+
+### Compute Corpus Size
+
+Trigger an async size computation:
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/corpora/my-corpus/compute_size",
+    headers=headers,
+)
+# Returns a job object — poll via GET /v2/jobs/{job_id}
+job_id = resp.json()["job_id"]
+```
+
+### Get Filter Attribute Statistics
+
+Retrieve statistics about filter attribute values in a corpus:
+
+```python
+resp = requests.get(
+    f"{BASE_URL}/corpora/my-corpus/filter_attribute_stats",
+    headers=headers,
+)
+for attr in resp.json()["filter_attributes"]:
+    print(f"{attr['name']}: {attr['type']} — {attr.get('unique_values', 'N/A')}")
+```
 
 ### Filter Attributes
 
@@ -87,10 +194,10 @@ resp = requests.post(
         "key": "products",
         "name": "Product Catalog",
         "filter_attributes": [
-            {"name": "category", "level": "doc", "type": "text", "indexed": True},
-            {"name": "price", "level": "doc", "type": "real", "indexed": True},
-            {"name": "in_stock", "level": "doc", "type": "boolean", "indexed": True},
-            {"name": "tags", "level": "doc", "type": "text_list", "indexed": True},
+            {"name": "category", "level": "document", "type": "text", "indexed": True},
+            {"name": "price", "level": "document", "type": "real", "indexed": True},
+            {"name": "in_stock", "level": "document", "type": "boolean", "indexed": True},
+            {"name": "tags", "level": "document", "type": "text_list", "indexed": True},
             {"name": "section", "level": "part", "type": "text", "indexed": True},
         ],
     },
@@ -100,22 +207,25 @@ resp = requests.post(
 Filter attribute types: `integer`, `real`, `text`, `boolean`, `integer_list`, `real_list`, `text_list`.
 
 Levels:
-- `doc` — document-level metadata (consistent across all parts)
+- `document` — document-level metadata (consistent across all parts)
 - `part` — part-level metadata (varies per chunk/section)
 
 ### Replace Filter Attributes
 
+Replaces all filter attributes on a corpus (async operation — returns a job):
+
 ```python
-resp = requests.put(
-    f"{BASE_URL}/corpora/my-corpus/filter_attributes",
+resp = requests.post(
+    f"{BASE_URL}/corpora/my-corpus/replace_filter_attributes",
     headers=headers,
     json={
         "filter_attributes": [
-            {"name": "category", "level": "doc", "type": "text", "indexed": True},
-            {"name": "status", "level": "doc", "type": "text", "indexed": True},
+            {"name": "category", "level": "document", "type": "text", "indexed": True},
+            {"name": "status", "level": "document", "type": "text", "indexed": True},
         ],
     },
 )
+# Returns a job — poll via GET /v2/jobs/{job_id}
 ```
 
 ### Corpus Statistics

--- a/content/vectara/docs/api/python/references/data-management.md
+++ b/content/vectara/docs/api/python/references/data-management.md
@@ -1,0 +1,265 @@
+# Vectara Data Management API
+
+## Document Operations
+
+### List Documents
+
+```python
+resp = requests.get(
+    f"{BASE_URL}/corpora/my-corpus/documents",
+    headers=headers,
+    params={"limit": 20},
+)
+for doc in resp.json()["documents"]:
+    print(f"{doc['id']}: {doc.get('metadata', {})}")
+```
+
+### Get Document Details
+
+```python
+resp = requests.get(
+    f"{BASE_URL}/corpora/my-corpus/documents/doc-001",
+    headers=headers,
+)
+doc = resp.json()
+```
+
+### Delete a Document
+
+```python
+resp = requests.delete(
+    f"{BASE_URL}/corpora/my-corpus/documents/doc-001",
+    headers=headers,
+)
+# 204 = success
+```
+
+### Bulk Delete Documents
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/corpora/my-corpus/documents/bulk_delete",
+    headers=headers,
+    json={
+        "document_ids": ["doc-001", "doc-002", "doc-003"],
+    },
+)
+```
+
+### Summarize a Document
+
+Generate a summary of a specific document:
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/corpora/my-corpus/documents/doc-001/summarize",
+    headers=headers,
+    json={
+        "generation_preset_name": "mockingbird-2.0",
+        "max_tokens": 512,
+    },
+)
+print(resp.json()["summary"])
+```
+
+### Retrieve Images from Documents
+
+```python
+resp = requests.get(
+    f"{BASE_URL}/corpora/my-corpus/documents/doc-001/images",
+    headers=headers,
+)
+for image in resp.json()["images"]:
+    print(f"Image: {image['id']} — {image['content_type']}")
+```
+
+## Corpus Management
+
+### Filter Attributes
+
+Define metadata fields at corpus creation for efficient filtering:
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/corpora",
+    headers=headers,
+    json={
+        "key": "products",
+        "name": "Product Catalog",
+        "filter_attributes": [
+            {"name": "category", "level": "doc", "type": "text", "indexed": True},
+            {"name": "price", "level": "doc", "type": "real", "indexed": True},
+            {"name": "in_stock", "level": "doc", "type": "boolean", "indexed": True},
+            {"name": "tags", "level": "doc", "type": "text_list", "indexed": True},
+            {"name": "section", "level": "part", "type": "text", "indexed": True},
+        ],
+    },
+)
+```
+
+Filter attribute types: `integer`, `real`, `text`, `boolean`, `integer_list`, `real_list`, `text_list`.
+
+Levels:
+- `doc` — document-level metadata (consistent across all parts)
+- `part` — part-level metadata (varies per chunk/section)
+
+### Replace Filter Attributes
+
+```python
+resp = requests.put(
+    f"{BASE_URL}/corpora/my-corpus/filter_attributes",
+    headers=headers,
+    json={
+        "filter_attributes": [
+            {"name": "category", "level": "doc", "type": "text", "indexed": True},
+            {"name": "status", "level": "doc", "type": "text", "indexed": True},
+        ],
+    },
+)
+```
+
+### Corpus Statistics
+
+```python
+resp = requests.get(
+    f"{BASE_URL}/corpora/my-corpus/statistics",
+    headers=headers,
+)
+stats = resp.json()
+print(f"Documents: {stats['document_count']}")
+print(f"Parts: {stats['part_count']}")
+print(f"Characters: {stats['character_count']}")
+```
+
+### Reset Corpus
+
+Remove all documents but keep the corpus configuration:
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/corpora/my-corpus/reset",
+    headers=headers,
+)
+# 204 = all documents removed, corpus config preserved
+```
+
+## Encoders
+
+Encoders convert text into vector embeddings. Vectara manages these automatically, but you can list and configure them.
+
+```python
+resp = requests.get(f"{BASE_URL}/encoders", headers=headers)
+for encoder in resp.json()["encoders"]:
+    print(f"{encoder['name']}: {encoder['description']}")
+```
+
+The default encoder is **Boomerang**, Vectara's multilingual embedding model.
+
+## LLM Management
+
+Bring your own OpenAI-compatible LLM:
+
+```python
+# List available LLMs
+resp = requests.get(f"{BASE_URL}/llms", headers=headers)
+
+# Register a custom LLM
+resp = requests.post(
+    f"{BASE_URL}/llms",
+    headers=headers,
+    json={
+        "name": "my-llm",
+        "description": "Custom GPT-4 endpoint",
+        "api_base_url": "https://my-llm-endpoint.example.com/v1",
+        "api_key": "my-llm-api-key",
+        "model_name": "gpt-4",
+    },
+)
+```
+
+## Table Extraction
+
+Extract structured tables from uploaded PDFs:
+
+```python
+with open("report.pdf", "rb") as f:
+    resp = requests.post(
+        f"{BASE_URL}/corpora/my-corpus/upload_file",
+        headers={"x-api-key": API_KEY},
+        files={"file": ("report.pdf", f, "application/pdf")},
+        data={
+            "table_extraction_config": '{"extract_tables": true}',
+        },
+    )
+```
+
+## Factual Consistency Evaluation
+
+Score how well generated text is grounded in source material. Uses the HHEM (Hughes Hallucination Evaluation Model) v2.2 by default.
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/evaluate_factual_consistency",
+    headers=headers,
+    json={
+        "generated_text": "The company was founded in 2020 and has 500 employees.",
+        "source_texts": [
+            "The company was founded in 2019.",
+            "The company currently employs 487 people.",
+        ],
+        "language": "eng",
+        "model_parameters": {"model": "hhem_v2.2"},
+    },
+)
+result = resp.json()
+print(f"Score: {result['score']}")            # 0.0–1.0
+print(f"Consistent: {result['p_consistent']}")
+print(f"Inconsistent: {result['p_inconsistent']}")
+```
+
+This is also available inline during RAG queries via `enable_factual_consistency_score: true` in the generation config.
+
+## Jobs (Async Operations)
+
+Some operations run asynchronously. Track their status:
+
+```python
+resp = requests.get(f"{BASE_URL}/jobs", headers=headers)
+for job in resp.json()["jobs"]:
+    print(f"{job['id']}: {job['state']} — {job['type']}")
+
+# Get specific job status
+resp = requests.get(f"{BASE_URL}/jobs/{job_id}", headers=headers)
+```
+
+## API Keys Management
+
+### List API Keys
+
+```python
+resp = requests.get(f"{BASE_URL}/api_keys", headers=headers)
+for key in resp.json()["api_keys"]:
+    print(f"{key['name']}: {key['api_key_type']} — enabled: {key['enabled']}")
+```
+
+### Create an API Key
+
+```python
+resp = requests.post(
+    f"{BASE_URL}/api_keys",
+    headers=headers,
+    json={
+        "name": "search-service-key",
+        "api_key_type": "query_service",  # or "personal"
+        "corpus_keys": ["my-corpus"],     # scope to specific corpora
+    },
+)
+new_key = resp.json()["api_key"]
+```
+
+### Delete an API Key
+
+```python
+resp = requests.delete(f"{BASE_URL}/api_keys/{key_id}", headers=headers)
+# 204 = success
+```


### PR DESCRIPTION
## Summary

Adds a Python-focused reference for the Vectara REST API v2 under `content/vectara/docs/api/python/`:

- **`DOC.md`** — main guide: auth (API keys + OAuth), query / RAG, hybrid search, multi-corpus, metadata filters, rerankers, streaming SSE, corpus management, file upload, structured + core document indexing, OpenAI-compatible chat completions.
- **`references/advanced-query.md`** — rerankers (customer, MMR, chain, `userfn` with `knee()`, Qwen3), filter expressions, generation presets, custom Velocity prompts, citation styles, factual consistency, context configuration, metadata query, query history.
- **`references/agents.md`** — agents CRUD, multi-step workflows with `next_steps` and UserFn conditions, skills (progressively-disclosed instructions), tool configurations, Lambda tools, tool servers, sessions, events, artifacts, schedules, pipelines (S3 source + agent transform), instructions.
- **`references/data-management.md`** — document ops, corpus management, filter attributes, encoders, LLMs, table extraction, HHEM v2.3 factual consistency evaluation, VHC hallucination correction, jobs, API keys.

All code and schemas were cross-checked against [`docs.vectara.com/vectara-oas-v2.yaml`](https://docs.vectara.com/vectara-oas-v2.yaml) (OpenAPI spec).

## Test plan

- [ ] Sanity-check the `POST /v2/query` examples against a live corpus
- [ ] Run the `upload_file` example and confirm `filename` sets the document ID
- [ ] Verify the HHEM v2.3 factual consistency call returns a score
- [ ] Confirm a multi-step agent with `next_steps` transitions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)