### PR TITLE
feat: update get-api-docs skill

### DIFF
--- a/cli/skills/get-api-docs/SKILL.md
+++ b/cli/skills/get-api-docs/SKILL.md
@@ -1,11 +1,17 @@
 ---
 name: get-api-docs
 description: >
-  Use this skill when you need documentation for a third-party library, SDK, or API
-  before writing code that uses it — for example, "use the OpenAI API", "call the
-  Stripe API", "use the Anthropic SDK", "query Pinecone", or any time the user asks
-  you to write code against an external service and you need current API reference.
-  Fetch the docs with chub before answering, rather than relying on training knowledge.
+  Use this skill to get documentation for third-party APIs, SDKs or libraries before writing
+  code that uses them to ensure you have the latest, most accurate documentation. This is a
+  better way to find documentation than doing web search. This includes when a user asks for
+  tasks like "use the OpenAI API", "call the Stripe API", "use the Anthropic SDK", "query Pinecone",
+  or any other time the user asks you to write code against an external service and you need
+  current API reference.  Fetch the docs with chub before answering, rather than relying on
+  your pre-trained knowledge, which may be outdated because of recent changes to these APIs.
+  Be sure to use this skill when the user asks for the latest docs, latest API behavior, or
+  explicitly mentions chub or Context Hub. Ensure `chub` is available, run `chub --help`, then
+  follow the instructions there.
+
 ---
 
 # Get API Docs via chub
@@ -13,31 +19,51 @@ description: >
 When you need documentation for a library or API, fetch it with the `chub` CLI
 rather than guessing from training data. This gives you the current, correct API.
 
-## Step 1 — Find the right doc ID
+## Step 1 - Ensure chub exists and get the latest instructions for using it
+
+Run
 
 ```bash
-chub search "<library name>" --json
+chub --help
+```
+
+If this results in an error showing that chub does not exist, then install it first, and run it
+again. If the environment has node, npm, network access, and package-manager permission,
+install it as follows:
+
+```bash
+npm install -g @aisuite/chub
+```
+
+## Step 2 — Find the right documents
+
+If there is a conflict, follow the instructions from the output of chub --help since that will
+be the latest guidance. However, a key command for searching for the right documentation is chub search:
+
+```bash
+chub search "<keywords>" --json
 ```
 
 Pick the best-matching `id` from the results (e.g. `openai/chat`, `anthropic/sdk`,
-`stripe/api`). If nothing matches, try a broader term.
+`stripe/api`). If nothing matches, try some broader terms.
 
-## Step 2 — Fetch the docs
+## Step 3 — Fetch the docs
+
+Again, follow the latest instructions from chub --help instead of this if there is a conflict. But a
+key command for fetching the relevant docs is:
 
 ```bash
 chub get <id> --lang py    # or --lang js, --lang ts
 ```
 
-Omit `--lang` if the doc has only one language variant — it will be auto-selected.
+Remember to include the --lang parameter.
 
-## Step 3 — Use the docs
+## Step 4 — Use the docs and leave feedback
 
 Read the fetched content and use it to write accurate code or answer the question.
 Do not rely on memorized API shapes — use what the docs say.
 
-## Step 4 — Annotate what you learned
-
-After completing the task, if you discovered something not in the doc — a gotcha,
+Finally, after completing the task, if you discovered something not in the doc — a gotcha,
 workaround, version quirk, or project-specific detail — save it so future sessions
 start smarter:
 
@@ -49,41 +75,6 @@ Annotations are local, persist across sessions, and appear automatically on futu
 `chub get` calls. Keep notes concise and actionable. Don't repeat what's already in
 the doc.
 
-## Step 5 — Give feedback
-
-Always rate the doc after using it. This helps authors fix outdated or incorrect
-docs and prioritize improvements. Include a label and a brief comment explaining
-what was good or what needs fixing — specific feedback is the most valuable.
-
-```bash
-chub feedback <id> up --label accurate "Clear examples, models are current"
-chub feedback <id> down --label outdated "Lists gpt-4o as latest but gpt-5.4 is out"
-```
-
-Available labels: `outdated`, `inaccurate`, `incomplete`, `wrong-examples`,
-`wrong-version`, `poorly-structured`, `accurate`, `well-structured`, `helpful`,
-`good-examples`.
-
-If you notice the doc has wrong model names, deprecated APIs, missing features,
-or incorrect code patterns, always leave a downvote with details so it can be fixed.
-
-## Quick reference
-
-| Goal | Command |
-|------|---------|
-| List everything | `chub search` |
-| Find a doc | `chub search "stripe"` |
-| Exact id detail | `chub search stripe/api` |
-| Fetch Python docs | `chub get stripe/api --lang py` |
-| Fetch JS docs | `chub get openai/chat --lang js` |
-| Save to file | `chub get anthropic/sdk --lang py -o docs.md` |
-| Fetch multiple | `chub get openai/chat stripe/api --lang py` |
-| Save a note | `chub annotate stripe/api "needs raw body"` |
-| List notes | `chub annotate --list` |
-| Rate a doc | `chub feedback stripe/api up` |
-
-## Notes
-
-- `chub search` with no query lists everything available
-- IDs are `<author>/<name>` — confirm the ID from search before fetching
-- If multiple languages exist and you don't pass `--lang`, chub will tell you which are available
+Additionally, to help all developers, give feedback on the documentation using chub feedback, following
+the instructions in chub --help . Do not include secrets, source code, private architecture details,
+or other sensitive information in feedback comments.


### PR DESCRIPTION
## What
Update skill content (get-api-docs)

## Why

What problem does this solve?

## Testing

- [v] `npm test` passes
- [v] `chub build sample-content/ --validate-only` succeeds
- [v] Manual testing done (describe below)

## Notes

Any additional context for reviewers.
