### PR TITLE
Update OpenAI docs for latest model guidance

### DIFF
--- a/content/openai/docs/chat/python/DOC.md
+++ b/content/openai/docs/chat/python/DOC.md
@@ -4,7 +4,7 @@ description: "OpenAI API for text generation, chat completions, streaming, funct
 metadata:
   languages: "python"
   versions: "2.26.0"
-  updated-on: "2026-03-06"
+  updated-on: "2026-04-27"
   source: maintainer
   tags: "openai,chat,llm,ai"
 ---
@@ -49,23 +49,40 @@ client = OpenAI()
 
 Use `python-dotenv` or your secret manager of choice to keep keys out of source control.
 
-## Models (as of March 2026)
+## Latest Official OpenAI Docs Update (April 2026)
+
+OpenAI's current official API docs list `gpt-5.5` as the recommended starting point for complex reasoning and coding. The same docs recommend smaller `gpt-5.4` variants when latency or cost is more important.
+
+Use this update as API/model guidance layered on top of the SDK version pin in this document:
+
+- **Default for new Responses API work:** `gpt-5.5`
+- **More affordable frontier option:** `gpt-5.4`
+- **Fast and cost-efficient:** `gpt-5.4-mini`
+- **Cheapest high-volume GPT-5.4-class option:** `gpt-5.4-nano`
+- **Non-reasoning compatibility option:** `gpt-4.1`
+- **Image API generation and editing:** `gpt-image-2`
+
+The official text-generation guide now shows `client.responses.create(model="gpt-5.5", ...)` for the basic Python example. Continue to use the Responses API for new work unless an existing codebase already depends on Chat Completions.
+
+## Models (as of April 2026)
 
 Default choices:
-- **General Text Tasks:** `gpt-5.4` (frontier) or `gpt-4.1` (non-reasoning)
-- **Complex Reasoning Tasks:** `gpt-5.4` or `gpt-5.4-pro`
-- **Fast & Cost-Efficient:** `gpt-5-mini` or `gpt-4.1-mini`
-- **Cheapest / Fastest:** `gpt-5-nano` or `gpt-4.1-nano`
+- **General Text Tasks:** `gpt-5.5` (frontier) or `gpt-4.1` (non-reasoning)
+- **Complex Reasoning Tasks:** `gpt-5.5` or `gpt-5.5-pro`
+- **Fast & Cost-Efficient:** `gpt-5.4-mini` or `gpt-4.1-mini`
+- **Cheapest / Fastest:** `gpt-5.4-nano` or `gpt-4.1-nano`
 - **Audio Processing:** `gpt-audio` or `gpt-audio-mini`
-- **Vision Tasks:** `gpt-5.4` or `gpt-4.1`
+- **Vision Tasks:** `gpt-5.5` or `gpt-4.1`
 - **Agentic Coding:** `gpt-5.3-codex`
 - **Search (Chat Completions):** `gpt-5-search-api`, `gpt-4o-search-preview`, or `gpt-4o-mini-search-preview`
 
 Frontier (reasoning, configurable effort):
+- `gpt-5.5`, `gpt-5.5-pro`
 - `gpt-5.4`, `gpt-5.4-2026-03-05`, `gpt-5.4-pro`, `gpt-5.4-pro-2026-03-05`
 - `gpt-5.2`, `gpt-5.2-2025-12-11`, `gpt-5.2-pro`
 - `gpt-5.1`, `gpt-5.1-2025-11-13`, `gpt-5.1-pro`
 - `gpt-5`, `gpt-5-2025-08-07`, `gpt-5-pro`
+- `gpt-5.4-mini`, `gpt-5.4-nano`
 - `gpt-5-mini`, `gpt-5-mini-2025-08-07`
 - `gpt-5-nano`, `gpt-5-nano-2025-08-07`
 
@@ -89,7 +106,7 @@ Audio chat: `gpt-audio`, `gpt-audio-2025-08-28`, `gpt-audio-mini`
 Realtime: `gpt-realtime`, `gpt-realtime-2025-08-28`, `gpt-realtime-mini`
 TTS: `gpt-4o-mini-tts`, `gpt-4o-mini-tts-2025-12-15`, `tts-1`, `tts-1-hd`
 STT: `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe-diarize`, `whisper-1`
-Image generation: `gpt-image-1.5`, `gpt-image-1.5-2025-12-16`, `gpt-image-1`, `gpt-image-1-mini`, `chatgpt-image-latest`
+Image generation: `gpt-image-2`, `gpt-image-2-2026-04-21`, `gpt-image-1.5`, `gpt-image-1.5-2025-12-16`, `gpt-image-1`, `gpt-image-1-mini`, `chatgpt-image-latest`
 Embeddings: `text-embedding-3-large`, `text-embedding-3-small`, `text-embedding-ada-002`
 Moderation: `omni-moderation-latest`
 Search (Chat Completions only): `gpt-5-search-api`, `gpt-4o-search-preview`, `gpt-4o-mini-search-preview`
@@ -97,7 +114,7 @@ Search (Chat Completions only): `gpt-5-search-api`, `gpt-4o-search-preview`, `gp
 Legacy (still available): `gpt-4o`, `gpt-4o-mini`, `gpt-4-turbo`, `gpt-3.5-turbo`
 
 Deprecated (shutdown scheduled):
-- `dall-e-3`, `dall-e-2` → May 12, 2026 (use `gpt-image-1`)
+- `dall-e-3`, `dall-e-2` → May 12, 2026 (use `gpt-image-2`)
 - `o1-preview`, `o1-mini` → deprecated (use `o3` or `gpt-5`)
 - `codex-mini-latest` → shut down Feb 12, 2026
 - `chatgpt-4o-latest` → shut down Feb 17, 2026
@@ -116,7 +133,7 @@ from openai import OpenAI
 client = OpenAI()
 
 response = client.responses.create(
-    model="gpt-5.4",
+    model="gpt-5.5",
     instructions="You are a helpful coding assistant.",
     input="How do I reverse a string in Python?",
 )
@@ -199,7 +216,7 @@ client = AsyncOpenAI()
 
 async def main():
     response = await client.responses.create(
-        model="gpt-5.4",
+        model="gpt-5.5",
         input="Explain quantum computing to a beginner."
     )
     print(response.output_text)
@@ -218,7 +235,7 @@ from openai import OpenAI
 client = OpenAI()
 
 stream = client.responses.create(
-    model="gpt-5.4",
+    model="gpt-5.5",
     input="Write a short story about a robot.",
     stream=True,
 )
@@ -403,12 +420,14 @@ print(f"Embedding dimensions: {len(embeddings)}")
 
 ## Image Generation
 
+Use the Image API with `gpt-image-2` for direct image generation or editing from one prompt. For conversational image generation with the Responses API, keep the request model on a mainline model such as `gpt-5.5` and add the hosted `image_generation` tool.
+
 ```python
 from openai import OpenAI
 client = OpenAI()
 
 response = client.images.generate(
-    model="gpt-image-1.5",
+    model="gpt-image-2",
     prompt="A futuristic city skyline at sunset",
     size="1024x1024",
     quality="standard",
@@ -427,7 +446,7 @@ from openai import OpenAI
 client = OpenAI()
 
 try:
-    response = client.responses.create(model="gpt-5.4", input="Hello, world!")
+    response = client.responses.create(model="gpt-5.5", input="Hello, world!")
 except openai.RateLimitError:
     print("Rate limit exceeded. Please wait before retrying.")
 except openai.APIConnectionError:
@@ -445,7 +464,7 @@ except openai.APIStatusError as e:
 from openai import OpenAI
 client = OpenAI()
 
-response = client.responses.create(model="gpt-5.4", input="Test message")
+response = client.responses.create(model="gpt-5.5", input="Test message")
 print(f"Request ID: {response._request_id}")
 ```
 
@@ -465,7 +484,7 @@ response = client.with_options(
     max_retries=3,
     timeout=60.0
 ).responses.create(
-    model="gpt-5.4",
+    model="gpt-5.5",
     input="Hello"
 )
 ```
@@ -562,7 +581,17 @@ if first_page.has_next_page():
 ## Notes
 
 - Prefer the Responses API for new work; Chat Completions remains supported.
+- Start new complex reasoning and coding work on `gpt-5.5`; choose `gpt-5.4-mini` or `gpt-5.4-nano` when latency or cost dominates.
 - Keep API keys in env vars or a secret manager.
 - Both sync and async clients are available; interfaces mirror each other.
 - Use streaming for lower latency UX.
 - Pydantic-based structured outputs and function calling provide type safety.
+
+## Official Sources Used For This Update
+
+- OpenAI models guide: `https://developers.openai.com/api/docs/models`
+- OpenAI GPT-5.5 model page: `https://developers.openai.com/api/docs/models/gpt-5.5`
+- OpenAI text generation guide: `https://developers.openai.com/api/docs/guides/text`
+- OpenAI GPT Image 2 model page: `https://developers.openai.com/api/docs/models/gpt-image-2`
+- OpenAI image generation guide: `https://developers.openai.com/api/docs/guides/image-generation`
+- OpenAI API reference: `https://developers.openai.com/api/reference`

--- a/content/openai/docs/package/python/DOC.md
+++ b/content/openai/docs/package/python/DOC.md
@@ -5,7 +5,7 @@ metadata:
   languages: "python"
   versions: "2.26.0"
   revision: 1
-  updated-on: "2026-03-12"
+  updated-on: "2026-04-27"
   source: maintainer
   tags: "openai,python,sdk,llm,responses,chat,streaming,webhooks"
 ---
@@ -21,11 +21,23 @@ metadata:
 ## Version-Sensitive Notes
 
 - This entry is pinned to the version used here `2.26.0`.
-- Upstream currently publishes `v2.26.0` as the latest GitHub release and PyPI package version, so the version used here matches current upstream.
+- Do not treat this package entry as "latest SDK" without refreshing the package-release binding. The API/model guidance below is current as of April 27, 2026, but the SDK pin remains intentionally version-specific.
 - `openai` requires Python `>=3.9`.
 - The maintainers describe the package as generally following SemVer, but they reserve some backwards-incompatible changes for minor releases when the impact is limited to static typing, internals, or low-impact runtime behavior. Do not assume every `2.x` minor bump is completely frictionless.
 - The SDK README describes the Responses API as the primary API for model interaction. Chat Completions remains supported, but it is no longer the default shape to copy for new code.
 - `AzureOpenAI` is a separate client class, and the README explicitly warns that Azure API shapes differ from the core OpenAI API shapes, so static response and parameter types may not always line up perfectly.
+
+## Latest Official API/Model Update (April 2026)
+
+OpenAI's current official API docs recommend starting new complex reasoning and coding work with `gpt-5.5`. The docs also recommend `gpt-5.4-mini` and `gpt-5.4-nano` when latency or cost is more important.
+
+For new Python SDK examples in this entry:
+
+- Prefer `client.responses.create(...)`.
+- Use `model="gpt-5.5"` as the default current model for high-quality text, coding, multimodal, and reasoning work.
+- Use `model="gpt-5.4-mini"` or `model="gpt-5.4-nano"` for lower-latency or lower-cost workloads.
+- Use `model="gpt-image-2"` for direct Image API generation or editing. For conversational image generation through the Responses API, use a mainline model such as `gpt-5.5` with the `image_generation` tool instead of putting `gpt-image-2` in the Responses `model` field.
+- Keep Chat Completions examples only for existing codebases or SDK helpers that are explicitly documented there.
 
 ## Install
 
@@ -62,7 +74,7 @@ from openai import OpenAI
 
 with OpenAI() as client:
     response = client.responses.create(
-        model="gpt-4.1",
+        model="gpt-5.5",
         input="Ping",
     )
     print(response.output_text)
@@ -80,7 +92,7 @@ from openai import OpenAI
 client = OpenAI()
 
 response = client.responses.create(
-    model="gpt-4.1",
+    model="gpt-5.5",
     instructions="You are a concise coding assistant.",
     input="How do I reverse a list in Python?",
 )
@@ -132,7 +144,7 @@ client = AsyncOpenAI()
 
 async def main() -> None:
     response = await client.responses.create(
-        model="gpt-4.1",
+        model="gpt-5.5",
         input="Explain what an event loop does in Python.",
     )
     print(response.output_text)
@@ -149,7 +161,7 @@ from openai import AsyncOpenAI, DefaultAioHttpClient
 async def main() -> None:
     async with AsyncOpenAI(http_client=DefaultAioHttpClient()) as client:
         response = await client.responses.create(
-            model="gpt-4.1",
+            model="gpt-5.5",
             input="Say hello.",
         )
         print(response.output_text)
@@ -167,7 +179,7 @@ from openai import OpenAI
 client = OpenAI()
 
 stream = client.responses.create(
-    model="gpt-4.1",
+    model="gpt-5.5",
     input="Write a one-sentence bedtime story about a unicorn.",
     stream=True,
 )
@@ -269,7 +281,7 @@ Per-request overrides use `with_options(...)`:
 
 ```python
 response = client.with_options(timeout=5.0, max_retries=0).responses.create(
-    model="gpt-4.1",
+    model="gpt-5.5",
     input="Quick health check.",
 )
 ```
@@ -382,7 +394,7 @@ from openai import OpenAI
 client = OpenAI()
 
 try:
-    client.responses.create(model="gpt-4.1", input="Hello")
+    client.responses.create(model="gpt-5.5", input="Hello")
 except openai.RateLimitError:
     # Back off and retry later.
     raise
@@ -441,5 +453,10 @@ Realtime pitfall: upstream documents that `error` events are delivered on the op
 
 - OpenAI Python SDK README: `https://github.com/openai/openai-python`
 - OpenAI Python SDK helpers: `https://github.com/openai/openai-python/blob/main/helpers.md`
-- OpenAI Responses API reference: `https://platform.openai.com/docs/api-reference/responses`
+- OpenAI models guide: `https://developers.openai.com/api/docs/models`
+- OpenAI GPT-5.5 model page: `https://developers.openai.com/api/docs/models/gpt-5.5`
+- OpenAI text generation guide: `https://developers.openai.com/api/docs/guides/text`
+- OpenAI GPT Image 2 model page: `https://developers.openai.com/api/docs/models/gpt-image-2`
+- OpenAI image generation guide: `https://developers.openai.com/api/docs/guides/image-generation`
+- OpenAI Responses API reference: `https://developers.openai.com/api/reference/responses`
 - PyPI package page: `https://pypi.org/project/openai/2.26.0/`


### PR DESCRIPTION
## Summary
- update OpenAI Python chat/package docs for current Responses API model guidance
- add GPT Image 2 guidance for direct Image API generation/editing
- clarify that Responses API image generation should use a mainline model with the image_generation tool

## Verification
- git diff --check origin/main..HEAD
- CHUB_TELEMETRY=0 CHUB_FEEDBACK=0 node cli/bin/chub build content -o /tmp/context-hub-openai-quick-update-build --base-url https://cdn.aichub.org/v1