### PR TITLE
Use npm trusted publishing for releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: npm-publish
     permissions:
       contents: read
       id-token: write
@@ -16,6 +17,7 @@ jobs:
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
+      - run: npm install -g npm@latest
       - run: npm install
       - run: cd cli && npm test
       - name: Verify versioned help is already live on the CDN
@@ -38,6 +40,4 @@ jobs:
 
             sleep 10
           done
-      - run: cd cli && npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: cd cli && npm publish --access public --provenance


### PR DESCRIPTION
Switches the publish workflow from a long-lived NPM_TOKEN secret to npm trusted publishing (OIDC).

## Changes
- Add `environment: npm-publish` to the publish job for required-reviewer gating
- Upgrade npm CLI in CI (needs ≥ 11.5.1 for trusted publishing)
- Remove `NODE_AUTH_TOKEN` (no token needed)
- Add `--provenance` to sign the publish via GitHub OIDC

## Do not merge until the `npm-publish` environment exists in repo Settings → Environments
Otherwise the next release will fail at a missing environment gate. Trusted publisher on npmjs.com is already configured.