### PR TITLE
Fix `chub --version` rejected at top level (#231)

### DIFF
--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -31,6 +31,15 @@ function isRootHelpRequest(argv) {
   return args.every((arg) => arg.startsWith('-'));
 }
 
+function isRootVersionRequest(argv) {
+  const args = argv.slice(2);
+  const idx = args.findIndex((arg) => arg === '--version' || arg === '-v');
+  if (idx === -1) return false;
+
+  // Preserve subcommand --version, e.g. `chub get foo --version 1.0.0`.
+  return args.slice(0, idx).every((arg) => arg.startsWith('-'));
+}
+
 function isRootHelpAlias(argv) {
   const args = argv.slice(2);
   return args[0] === 'help' && args.slice(1).every((arg) => arg.startsWith('-'));
@@ -113,6 +122,8 @@ if (helpAliasOperands.length > 0) {
   );
 } else if (isRootHelpAlias(process.argv) || isRootHelpRequest(process.argv)) {
   await printRootHelp();
+} else if (isRootVersionRequest(process.argv)) {
+  process.stdout.write(`${pkg.version}\n`);
 } else {
   program.parse();
 }


### PR DESCRIPTION
## Summary

- `chub --version` returned `error: unknown option '--version'` because the flag was bound to `-V, --cli-version`. Closes #231.
- The bug-report template (`.github/ISSUE_TEMPLATE/bug_report.md`) already instructs reporters to run `chub --version`, so anyone filing an issue hit this immediately.
- Both human users and agents reach for `--version` first; `--cli-version` is non-standard for Node CLIs.

## Why not just rename `--cli-version` to `--version`?

`chub get` has a real subcommand option `--version <version>` for content versioning. Commander parses global options before dispatching to subcommands, so making `--version` a global flag swallows `chub get --version 1.0.0` (verified — 2 e2e tests broke under that approach).

`enablePositionalOptions()` would scope flags correctly, but it also breaks the existing pattern of passing `--json` after a subcommand name — 20 tests broke under that approach.

## Approach

Intercept `--version` / `-v` in `process.argv` **before** Commander parses, but only when no subcommand precedes the flag. This mirrors the existing `isRootHelpRequest` pattern in the same file. The original `-V` / `--cli-version` binding is preserved for backwards compatibility.

After the fix:
- `chub --version` → `0.1.4`
- `chub -v` → `0.1.4`
- `chub -V` → `0.1.4` (unchanged)
- `chub --cli-version` → `0.1.4` (unchanged)
- `chub get acme/versioned-api --lang js --version 1.0.0` → still resolves to the subcommand option

## Test plan

- [x] `npm test -w @aisuite/chub` — all 253 tests pass, including the two `chub get --version <ver>` tests that broke under the rename approach
- [x] Manually verified all four root-level version flag forms print `0.1.4`
- [x] Manually verified `chub get --help` still shows the subcommand `--version <version>` option