### PR TITLE
Add docs for Aircall, Fireflies, Bright Data, Livestorm, CloudTalk, Demodesk, and Dreamdata APIs

### DIFF
--- a/content/aircall/docs/telephony/python/DOC.md
+++ b/content/aircall/docs/telephony/python/DOC.md
@@ -24,20 +24,19 @@ Aircall supports two auth methods:
 Get `api_id` and `api_token` from Dashboard → Company Settings → API Keys.
 
 ```python
-import base64
 import httpx
 
 api_id = "YOUR_API_ID"
 api_token = "YOUR_API_TOKEN"
-credentials = base64.b64encode(f"{api_id}:{api_token}".encode()).decode()
-
-headers = {"Authorization": f"Basic {credentials}"}
+auth = httpx.BasicAuth(api_id, api_token)
 BASE_URL = "https://api.aircall.io/v1"
 ```
 
 ### OAuth Bearer Token (Technology Partners — multi-tenant)
 
 ```python
+import httpx
+
 headers = {"Authorization": f"Bearer {access_token}"}
 BASE_URL = "https://api.aircall.io/v1"
 ```
@@ -45,8 +44,8 @@ BASE_URL = "https://api.aircall.io/v1"
 Use the `/v1/ping` endpoint to validate a token:
 
 ```python
-async with httpx.AsyncClient() as client:
-    r = await client.get(f"{BASE_URL}/ping", headers=headers)
+async with httpx.AsyncClient(auth=auth) as client:
+    r = await client.get(f"{BASE_URL}/ping")
     # 200 OK → {"ping": "pong"}
 ```
 
@@ -66,19 +65,17 @@ async with httpx.AsyncClient() as client:
 ### Calls
 
 ```python
-async with httpx.AsyncClient() as client:
+async with httpx.AsyncClient(auth=auth) as client:
     # List calls
-    r = await client.get(f"{BASE_URL}/calls", headers=headers)
+    r = await client.get(f"{BASE_URL}/calls")
     calls = r.json()["calls"]
 
     # Get a specific call
-    r = await client.get(f"{BASE_URL}/calls/{call_id}", headers=headers)
+    r = await client.get(f"{BASE_URL}/calls/{call_id}")
     call = r.json()["call"]
 
     # Get call transcription (requires AI Assist Pro)
-    r = await client.get(
-        f"{BASE_URL}/calls/{call_id}/transcription", headers=headers
-    )
+    r = await client.get(f"{BASE_URL}/calls/{call_id}/transcription")
 ```
 
 ### Contacts
@@ -88,15 +85,14 @@ Contact attributes: `id`, `first_name`, `last_name`, `company_name`, `informatio
 All contacts returned via the Public API are shared contacts. Contacts synced from third-party CRM integrations are not accessible via the API.
 
 ```python
-async with httpx.AsyncClient() as client:
+async with httpx.AsyncClient(auth=auth) as client:
     # List contacts
-    r = await client.get(f"{BASE_URL}/contacts", headers=headers)
+    r = await client.get(f"{BASE_URL}/contacts")
     contacts = r.json()["contacts"]
 
     # Update a contact — NOTE: uses POST, not PUT
     r = await client.post(
         f"{BASE_URL}/contacts/{contact_id}",
-        headers=headers,
         json={"first_name": "Jane", "company_name": "Acme Corp"},
     )
     updated = r.json()["contact"]
@@ -107,9 +103,9 @@ Phone numbers and emails must be updated via dedicated sub-endpoints, not the ma
 ### Users
 
 ```python
-async with httpx.AsyncClient() as client:
+async with httpx.AsyncClient(auth=auth) as client:
     # List users (v2 recommended)
-    r = await client.get(f"https://api.aircall.io/v2/users", headers=headers)
+    r = await client.get("https://api.aircall.io/v2/users")
     users = r.json()["users"]
 ```
 
@@ -121,14 +117,13 @@ async with httpx.AsyncClient() as client:
 import httpx
 import asyncio
 
-async def fetch_all_calls(headers: dict) -> list:
+async def fetch_all_calls(auth: httpx.BasicAuth) -> list:
     results = []
     page = 1
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(auth=auth) as client:
         while True:
             r = await client.get(
                 f"{BASE_URL}/calls",
-                headers=headers,
                 params={"page": page, "per_page": 50},
             )
             data = r.json()
@@ -146,14 +141,15 @@ async def fetch_all_calls(headers: dict) -> list:
 import asyncio
 import httpx
 
-async def get_with_retry(client: httpx.AsyncClient, url: str, headers: dict):
-    r = await client.get(url, headers=headers)
-    if r.status_code == 429:
-        reset = int(r.headers.get("X-AircallApi-Reset", 60))
-        await asyncio.sleep(reset)
-        r = await client.get(url, headers=headers)
-    r.raise_for_status()
-    return r.json()
+async def get_with_retry(client: httpx.AsyncClient, url: str, max_retries: int = 5):
+    for attempt in range(max_retries):
+        r = await client.get(url)
+        if r.status_code == 429:
+            await asyncio.sleep(2 ** attempt)
+            continue
+        r.raise_for_status()
+        return r.json()
+    raise RuntimeError("Max retries exceeded after rate limiting")
 ```
 
 ## Installation

--- a/content/aircall/docs/telephony/python/DOC.md
+++ b/content/aircall/docs/telephony/python/DOC.md
@@ -44,7 +44,7 @@ BASE_URL = "https://api.aircall.io/v1"
 Use the `/v1/ping` endpoint to validate a token:
 
 ```python
-async with httpx.AsyncClient(auth=auth) as client:
+async with httpx.AsyncClient(headers=headers) as client:
     r = await client.get(f"{BASE_URL}/ping")
     # 200 OK → {"ping": "pong"}
 ```
@@ -57,7 +57,7 @@ async with httpx.AsyncClient(auth=auth) as client:
 ## API Versioning
 
 - Most endpoints: `/v1/` (stable)
-- Users: `/v2/users` available (v2 adds fields)
+- Users: `/v2/users` available (v2 adds `substatus` field, per-user number listing via `GET /v2/users/:id/numbers`, and v2-specific webhook events)
 - Webhooks: v2 event names are suffixed `.v2` (e.g. `user.connected.v2`)
 
 ## Core Resources
@@ -74,7 +74,7 @@ async with httpx.AsyncClient(auth=auth) as client:
     r = await client.get(f"{BASE_URL}/calls/{call_id}")
     call = r.json()["call"]
 
-    # Get call transcription (requires AI Assist Pro)
+    # Get call transcription (requires AI Assist or AI Assist Pro)
     r = await client.get(f"{BASE_URL}/calls/{call_id}/transcription")
 ```
 
@@ -145,11 +145,43 @@ async def get_with_retry(client: httpx.AsyncClient, url: str, max_retries: int =
     for attempt in range(max_retries):
         r = await client.get(url)
         if r.status_code == 429:
+            # X-AircallApi-Reset header gives exact reset timestamp — use it for precise retry timing
             await asyncio.sleep(2 ** attempt)
             continue
         r.raise_for_status()
         return r.json()
     raise RuntimeError("Max retries exceeded after rate limiting")
+```
+
+## Webhooks
+
+Common events: `call.created`, `call.answered`, `call.ended`, `call.transferred`, `call.external_transferred`, `call.evaluation.created`, `contact.created`, `contact.updated`, `user.created.v2`, `user.connected.v2`, `number.deleted`
+
+Configure webhooks in Dashboard → Integrations → Webhooks or via API (`POST /v1/webhooks`).
+
+## Numbers
+
+```python
+async with httpx.AsyncClient(auth=auth) as client:
+    # List all numbers
+    r = await client.get(f"{BASE_URL}/numbers")
+    numbers = r.json()["numbers"]
+
+    # Get numbers for a specific user (v2)
+    r = await client.get(f"https://api.aircall.io/v2/users/{user_id}/numbers")
+    user_numbers = r.json()["numbers"]
+```
+
+## Outbound Calls
+
+```python
+async with httpx.AsyncClient(auth=auth) as client:
+    # Initiate an outbound call from a user
+    r = await client.post(
+        f"{BASE_URL}/users/{user_id}/calls",
+        json={"to": "+15551234567"},
+    )
+    call = r.json()["call"]
 ```
 
 ## Installation

--- a/content/aircall/docs/telephony/python/DOC.md
+++ b/content/aircall/docs/telephony/python/DOC.md
@@ -1,0 +1,163 @@
+---
+name: telephony
+description: "Aircall REST API for accessing call data, contacts, users, and phone numbers via Basic Auth or OAuth."
+metadata:
+  languages: "python"
+  versions: "v1"
+  updated-on: "2026-05-08"
+  source: community
+  tags: "aircall,telephony,calls,contacts,voip,call-center"
+---
+
+# Aircall REST API — Python Guide
+
+You are an Aircall API coding expert. Help me write Python code using the Aircall Public REST API.
+
+Official API documentation: https://developer.aircall.io/api-references/
+
+## Authentication
+
+Aircall supports two auth methods:
+
+### Basic Auth (Aircall customers — own account only)
+
+Get `api_id` and `api_token` from Dashboard → Company Settings → API Keys.
+
+```python
+import base64
+import httpx
+
+api_id = "YOUR_API_ID"
+api_token = "YOUR_API_TOKEN"
+credentials = base64.b64encode(f"{api_id}:{api_token}".encode()).decode()
+
+headers = {"Authorization": f"Basic {credentials}"}
+BASE_URL = "https://api.aircall.io/v1"
+```
+
+### OAuth Bearer Token (Technology Partners — multi-tenant)
+
+```python
+headers = {"Authorization": f"Bearer {access_token}"}
+BASE_URL = "https://api.aircall.io/v1"
+```
+
+Use the `/v1/ping` endpoint to validate a token:
+
+```python
+async with httpx.AsyncClient() as client:
+    r = await client.get(f"{BASE_URL}/ping", headers=headers)
+    # 200 OK → {"ping": "pong"}
+```
+
+## Rate Limiting
+
+- **60 requests per minute** per company
+- Response headers on limit: `X-AircallApi-Limit`, `X-AircallApi-Remaining`, `X-AircallApi-Reset`
+
+## API Versioning
+
+- Most endpoints: `/v1/` (stable)
+- Users: `/v2/users` available (v2 adds fields)
+- Webhooks: v2 event names are suffixed `.v2` (e.g. `user.connected.v2`)
+
+## Core Resources
+
+### Calls
+
+```python
+async with httpx.AsyncClient() as client:
+    # List calls
+    r = await client.get(f"{BASE_URL}/calls", headers=headers)
+    calls = r.json()["calls"]
+
+    # Get a specific call
+    r = await client.get(f"{BASE_URL}/calls/{call_id}", headers=headers)
+    call = r.json()["call"]
+
+    # Get call transcription (requires AI Assist Pro)
+    r = await client.get(
+        f"{BASE_URL}/calls/{call_id}/transcription", headers=headers
+    )
+```
+
+### Contacts
+
+Contact attributes: `id`, `first_name`, `last_name`, `company_name`, `information`, `is_shared`, `phone_numbers`, `emails`, `created_at`, `updated_at`.
+
+All contacts returned via the Public API are shared contacts. Contacts synced from third-party CRM integrations are not accessible via the API.
+
+```python
+async with httpx.AsyncClient() as client:
+    # List contacts
+    r = await client.get(f"{BASE_URL}/contacts", headers=headers)
+    contacts = r.json()["contacts"]
+
+    # Update a contact — NOTE: uses POST, not PUT
+    r = await client.post(
+        f"{BASE_URL}/contacts/{contact_id}",
+        headers=headers,
+        json={"first_name": "Jane", "company_name": "Acme Corp"},
+    )
+    updated = r.json()["contact"]
+```
+
+Phone numbers and emails must be updated via dedicated sub-endpoints, not the main update call.
+
+### Users
+
+```python
+async with httpx.AsyncClient() as client:
+    # List users (v2 recommended)
+    r = await client.get(f"https://api.aircall.io/v2/users", headers=headers)
+    users = r.json()["users"]
+```
+
+## Common Patterns
+
+### Paginated fetch with async
+
+```python
+import httpx
+import asyncio
+
+async def fetch_all_calls(headers: dict) -> list:
+    results = []
+    page = 1
+    async with httpx.AsyncClient() as client:
+        while True:
+            r = await client.get(
+                f"{BASE_URL}/calls",
+                headers=headers,
+                params={"page": page, "per_page": 50},
+            )
+            data = r.json()
+            results.extend(data["calls"])
+            meta = data.get("meta", {})
+            if page >= meta.get("total_pages", 1):
+                break
+            page += 1
+    return results
+```
+
+### Handle rate limit
+
+```python
+import asyncio
+import httpx
+
+async def get_with_retry(client: httpx.AsyncClient, url: str, headers: dict):
+    r = await client.get(url, headers=headers)
+    if r.status_code == 429:
+        reset = int(r.headers.get("X-AircallApi-Reset", 60))
+        await asyncio.sleep(reset)
+        r = await client.get(url, headers=headers)
+    r.raise_for_status()
+    return r.json()
+```
+
+## Installation
+
+```bash
+pip install httpx
+```

--- a/content/brightdata/docs/web-scraping/python/DOC.md
+++ b/content/brightdata/docs/web-scraping/python/DOC.md
@@ -1,6 +1,6 @@
 ---
 name: web-scraping
-description: "Bright Data Python SDK for web scraping, SERP results, and browser automation using the Unlocker, SERP, and Browser APIs."
+description: "Bright Data Python SDK for web scraping, SERP results, and browser automation using the Web Unlocker, SERP, and Browser APIs."
 metadata:
   languages: "python"
   versions: "v1"
@@ -17,15 +17,15 @@ Official documentation: https://docs.brightdata.com/api-reference/SDK
 
 ## Authentication
 
-All API access requires an API key. Generate one from your Bright Data dashboard.
+All API access requires an API token. Generate one from your Bright Data dashboard.
 
-Set the API key via environment variable (recommended):
+Set the token via environment variable (recommended):
 
 ```bash
-export BRIGHTDATA_API_KEY="YOUR_API_KEY"
+export BRIGHTDATA_API_TOKEN="YOUR_API_TOKEN"
 ```
 
-Or pass it directly to the client.
+Or pass it directly: `BrightDataClient(api_token="YOUR_API_TOKEN")`.
 
 ## Installation
 
@@ -39,37 +39,40 @@ Bright Data exposes several products via the SDK:
 
 | Product | Use case |
 |---|---|
-| **Unlocker API** | Fetch any URL bypassing bot detection — returns HTML or JSON |
+| **Web Unlocker** | Fetch any URL bypassing bot detection — returns HTML or JSON |
 | **SERP API** | Structured search engine results (Google, Bing, etc.) |
 | **Browser API** | Full browser automation via Playwright — handles JS-heavy pages |
 | **Scrapers** | Managed scrapers for specific sites (LinkedIn, Amazon, etc.) |
 | **Marketplace Datasets** | Pre-built datasets ready for download |
 
-## Sync Usage
-
-```python
-from brightdata import BrightDataClient
-
-client = BrightDataClient()  # reads BRIGHTDATA_API_KEY from env
-
-# Generic URL scrape
-result = client.scrape.generic.url("https://example.com")
-if result.success:
-    print(result.content)
-```
-
 ## Async Usage (recommended for pipelines)
+
+`BrightDataClient` is async-native and must be used as an async context manager:
 
 ```python
 import asyncio
 from brightdata import BrightDataClient
 
 async def scrape_urls(urls: list[str]) -> list:
-    async with BrightDataClient() as client:
-        results = await client.scrape.generic.url_async(urls)
-        return [r.content for r in results if r.success]
+    async with BrightDataClient() as client:  # reads BRIGHTDATA_API_TOKEN from env
+        results = await asyncio.gather(*[client.scrape_url(url) for url in urls])
+        return [r.data for r in results if r.success]
 
 data = asyncio.run(scrape_urls(["https://example1.com", "https://example2.com"]))
+```
+
+## Sync Usage
+
+For sync contexts, use `SyncBrightDataClient` (separate class):
+
+```python
+from brightdata import SyncBrightDataClient
+
+client = SyncBrightDataClient()  # reads BRIGHTDATA_API_TOKEN from env
+
+result = client.scrape_url("https://example.com")
+if result.success:
+    print(result.data)
 ```
 
 ## SERP API
@@ -77,24 +80,28 @@ data = asyncio.run(scrape_urls(["https://example1.com", "https://example2.com"])
 ```python
 from brightdata import BrightDataClient
 
-async def search_google(query: str, location: str = "United States"):
+async def search_google(query: str, num_results: int = 10) -> list:
     async with BrightDataClient() as client:
-        results = await client.search.google(query, location=location)
+        results = await client.search.google(query=query, num_results=num_results)
         return results
 ```
 
 ## Browser API (Playwright)
 
-For JavaScript-heavy pages. Bright Data's browser integration uses the Chrome DevTools Protocol (CDP) — connect Playwright to Bright Data's managed browser via `client.connect_browser()`:
+For JavaScript-heavy pages. Requires `browser_username` and `browser_password` from your Bright Data dashboard. Connects Playwright to Bright Data's managed browser via CDP:
 
 ```python
 from brightdata import BrightDataClient
 from playwright.sync_api import sync_playwright
 
 def scrape_with_browser(url: str) -> str:
-    client = BrightDataClient()
+    client = BrightDataClient(
+        browser_username="YOUR_BROWSER_USERNAME",
+        browser_password="YOUR_BROWSER_PASSWORD",
+    )
+    connect_url = client.browser.get_connect_url(country="us")
     with sync_playwright() as playwright:
-        browser = playwright.chromium.connect_over_cdp(client.connect_browser())
+        browser = playwright.chromium.connect_over_cdp(connect_url)
         try:
             page = browser.new_page()
             page.goto(url)
@@ -103,24 +110,11 @@ def scrape_with_browser(url: str) -> str:
             browser.close()
 ```
 
-## CLI Usage
-
-```bash
-# SERP
-brightdata search google "python tutorial" --location "United States"
-
-# Scrape a URL
-brightdata scrape generic "https://example.com" --output-format pretty
-
-# Save output
-brightdata search google "AI news" --output-file results.json
-```
-
 ## Authentication Methods
 
 | Method | Products |
 |---|---|
-| API key (SDK) | Unlocker API, SERP API, Browsers, Scrapers, Marketplace |
+| API token (SDK) | Web Unlocker, SERP API, Browsers, Scrapers, Marketplace |
 | username:password proxy | Proxy networks only |
 
 See https://docs.brightdata.com/api-reference/authentication for full details.

--- a/content/brightdata/docs/web-scraping/python/DOC.md
+++ b/content/brightdata/docs/web-scraping/python/DOC.md
@@ -3,7 +3,7 @@ name: web-scraping
 description: "Bright Data Python SDK for web scraping, SERP results, and browser automation using the Unlocker, SERP, and Browser APIs."
 metadata:
   languages: "python"
-  versions: "latest"
+  versions: "v1"
   updated-on: "2026-05-08"
   source: community
   tags: "brightdata,web-scraping,serp,proxy,browser-automation,data-collection"
@@ -30,7 +30,7 @@ Or pass it directly to the client.
 ## Installation
 
 ```bash
-pip install brightdata
+pip install brightdata-sdk
 ```
 
 ## Core Products
@@ -85,7 +85,7 @@ async def search_google(query: str, location: str = "United States"):
 
 ## Browser API (Playwright)
 
-For JavaScript-heavy pages:
+For JavaScript-heavy pages. Bright Data's browser integration uses the Chrome DevTools Protocol (CDP) — connect Playwright to Bright Data's managed browser via `client.connect_browser()`:
 
 ```python
 from brightdata import BrightDataClient
@@ -94,7 +94,7 @@ from playwright.sync_api import sync_playwright
 def scrape_with_browser(url: str) -> str:
     client = BrightDataClient()
     with sync_playwright() as playwright:
-        browser = client.browser.launch(playwright)
+        browser = playwright.chromium.connect_over_cdp(client.connect_browser())
         try:
             page = browser.new_page()
             page.goto(url)

--- a/content/brightdata/docs/web-scraping/python/DOC.md
+++ b/content/brightdata/docs/web-scraping/python/DOC.md
@@ -1,0 +1,126 @@
+---
+name: web-scraping
+description: "Bright Data Python SDK for web scraping, SERP results, and browser automation using the Unlocker, SERP, and Browser APIs."
+metadata:
+  languages: "python"
+  versions: "latest"
+  updated-on: "2026-05-08"
+  source: community
+  tags: "brightdata,web-scraping,serp,proxy,browser-automation,data-collection"
+---
+
+# Bright Data Python SDK — Python Guide
+
+You are a Bright Data API coding expert. Help me write Python code using the Bright Data Python SDK.
+
+Official documentation: https://docs.brightdata.com/api-reference/SDK
+
+## Authentication
+
+All API access requires an API key. Generate one from your Bright Data dashboard.
+
+Set the API key via environment variable (recommended):
+
+```bash
+export BRIGHTDATA_API_KEY="YOUR_API_KEY"
+```
+
+Or pass it directly to the client.
+
+## Installation
+
+```bash
+pip install brightdata
+```
+
+## Core Products
+
+Bright Data exposes several products via the SDK:
+
+| Product | Use case |
+|---|---|
+| **Unlocker API** | Fetch any URL bypassing bot detection — returns HTML or JSON |
+| **SERP API** | Structured search engine results (Google, Bing, etc.) |
+| **Browser API** | Full browser automation via Playwright — handles JS-heavy pages |
+| **Scrapers** | Managed scrapers for specific sites (LinkedIn, Amazon, etc.) |
+| **Marketplace Datasets** | Pre-built datasets ready for download |
+
+## Sync Usage
+
+```python
+from brightdata import BrightDataClient
+
+client = BrightDataClient()  # reads BRIGHTDATA_API_KEY from env
+
+# Generic URL scrape
+result = client.scrape.generic.url("https://example.com")
+if result.success:
+    print(result.content)
+```
+
+## Async Usage (recommended for pipelines)
+
+```python
+import asyncio
+from brightdata import BrightDataClient
+
+async def scrape_urls(urls: list[str]) -> list:
+    async with BrightDataClient() as client:
+        results = await client.scrape.generic.url_async(urls)
+        return [r.content for r in results if r.success]
+
+data = asyncio.run(scrape_urls(["https://example1.com", "https://example2.com"]))
+```
+
+## SERP API
+
+```python
+from brightdata import BrightDataClient
+
+async def search_google(query: str, location: str = "United States"):
+    async with BrightDataClient() as client:
+        results = await client.search.google(query, location=location)
+        return results
+```
+
+## Browser API (Playwright)
+
+For JavaScript-heavy pages:
+
+```python
+from brightdata import BrightDataClient
+from playwright.sync_api import sync_playwright
+
+def scrape_with_browser(url: str) -> str:
+    client = BrightDataClient()
+    with sync_playwright() as playwright:
+        browser = client.browser.launch(playwright)
+        try:
+            page = browser.new_page()
+            page.goto(url)
+            return page.content()
+        finally:
+            browser.close()
+```
+
+## CLI Usage
+
+```bash
+# SERP
+brightdata search google "python tutorial" --location "United States"
+
+# Scrape a URL
+brightdata scrape generic "https://example.com" --output-format pretty
+
+# Save output
+brightdata search google "AI news" --output-file results.json
+```
+
+## Authentication Methods
+
+| Method | Products |
+|---|---|
+| API key (SDK) | Unlocker API, SERP API, Browsers, Scrapers, Marketplace |
+| username:password proxy | Proxy networks only |
+
+See https://docs.brightdata.com/api-reference/authentication for full details.

--- a/content/cloudtalk/docs/telephony/python/DOC.md
+++ b/content/cloudtalk/docs/telephony/python/DOC.md
@@ -20,14 +20,11 @@ Official API documentation: https://developers.cloudtalk.io/
 Auth method: HTTP Basic Auth. Generate an API key in the CloudTalk dashboard under Account Settings → Integrations → API. Note both the Key ID and Key Secret.
 
 ```python
-import base64
 import httpx
 
 key_id = "YOUR_KEY_ID"
 key_secret = "YOUR_KEY_SECRET"
-credentials = base64.b64encode(f"{key_id}:{key_secret}".encode()).decode()
-
-headers = {"Authorization": f"Basic {credentials}"}
+auth = httpx.BasicAuth(key_id, key_secret)
 BASE_URL = "https://my.cloudtalk.io/api"
 ```
 
@@ -64,11 +61,10 @@ params = {"page": 1, "limit": 100}
 ### Agents
 
 ```python
-async with httpx.AsyncClient() as client:
+async with httpx.AsyncClient(auth=auth) as client:
     # List all agents (paginated)
     r = await client.get(
         f"{BASE_URL}/agents.json",
-        headers=headers,
         params={"page": 1, "limit": 100},
     )
     data = r.json()
@@ -76,7 +72,7 @@ async with httpx.AsyncClient() as client:
     total = data["data"]["total"]
 
     # Get a single agent
-    r = await client.get(f"{BASE_URL}/agents/{agent_id}.json", headers=headers)
+    r = await client.get(f"{BASE_URL}/agents/{agent_id}.json")
     agent = r.json()["data"]
 ```
 
@@ -85,10 +81,9 @@ Agent fields: `id`, `name`, `email`, `role`, `status`, `extension`, `phone_numbe
 ### Calls
 
 ```python
-async with httpx.AsyncClient() as client:
+async with httpx.AsyncClient(auth=auth) as client:
     r = await client.get(
         f"{BASE_URL}/calls.json",
-        headers=headers,
         params={"page": 1, "limit": 100},
     )
     calls = r.json()["data"]["items"]
@@ -99,8 +94,8 @@ Call fields include: `id`, `agent_id`, `direction` (`inbound`/`outbound`).
 ### Groups (Queues)
 
 ```python
-async with httpx.AsyncClient() as client:
-    r = await client.get(f"{BASE_URL}/groups.json", headers=headers)
+async with httpx.AsyncClient(auth=auth) as client:
+    r = await client.get(f"{BASE_URL}/groups.json")
     groups = r.json()["data"]["items"]
 ```
 
@@ -109,20 +104,21 @@ async with httpx.AsyncClient() as client:
 ```python
 import httpx
 
-async def fetch_all(resource: str, headers: dict) -> list:
+async def fetch_all(resource: str, auth: httpx.BasicAuth) -> list:
     results = []
     page = 1
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(auth=auth) as client:
         while True:
             r = await client.get(
                 f"https://my.cloudtalk.io/api/{resource}.json",
-                headers=headers,
                 params={"page": page, "limit": 100},
             )
             r.raise_for_status()
             body = r.json()
             items = body["data"]["items"]
             results.extend(items)
+            if not items:
+                break
             total = body["data"]["total"]
             if len(results) >= total:
                 break
@@ -138,9 +134,9 @@ CloudTalk does not publicly document rate limit thresholds. Implement exponentia
 import asyncio
 import httpx
 
-async def get_with_backoff(client: httpx.AsyncClient, url: str, headers: dict, params: dict = None):
+async def get_with_backoff(client: httpx.AsyncClient, url: str, params: dict = None):
     for attempt in range(5):
-        r = await client.get(url, headers=headers, params=params)
+        r = await client.get(url, params=params)
         if r.status_code == 429:
             await asyncio.sleep(2 ** attempt)
             continue

--- a/content/cloudtalk/docs/telephony/python/DOC.md
+++ b/content/cloudtalk/docs/telephony/python/DOC.md
@@ -1,0 +1,168 @@
+---
+name: telephony
+description: "CloudTalk REST API for accessing call data, agents, and groups via HTTP Basic Auth."
+metadata:
+  languages: "python"
+  versions: "v1"
+  updated-on: "2026-05-08"
+  source: community
+  tags: "cloudtalk,telephony,calls,agents,voip,call-center"
+---
+
+# CloudTalk REST API — Python Guide
+
+You are a CloudTalk API coding expert. Help me write Python code using the CloudTalk REST API.
+
+Official API documentation: https://developers.cloudtalk.io/
+
+## Authentication
+
+Auth method: HTTP Basic Auth. Generate an API key in the CloudTalk dashboard under Account Settings → Integrations → API. Note both the Key ID and Key Secret.
+
+```python
+import base64
+import httpx
+
+key_id = "YOUR_KEY_ID"
+key_secret = "YOUR_KEY_SECRET"
+credentials = base64.b64encode(f"{key_id}:{key_secret}".encode()).decode()
+
+headers = {"Authorization": f"Basic {credentials}"}
+BASE_URL = "https://my.cloudtalk.io/api"
+```
+
+**Important:** All endpoints use a `.json` suffix (e.g. `/api/agents.json`). This is non-standard but required.
+
+## Response Format
+
+All responses are wrapped:
+
+```json
+{
+  "responseCode": 200,
+  "data": {
+    "items": [...],
+    "total": 42
+  }
+}
+```
+
+Check `responseCode` — HTTP 200 does not guarantee success; the body `responseCode` field is authoritative.
+
+## Pagination
+
+All list endpoints use offset pagination:
+- `page` — page number starting at 1
+- `limit` — items per page (default: 20, max: 100)
+
+```python
+params = {"page": 1, "limit": 100}
+```
+
+## Core Resources
+
+### Agents
+
+```python
+async with httpx.AsyncClient() as client:
+    # List all agents (paginated)
+    r = await client.get(
+        f"{BASE_URL}/agents.json",
+        headers=headers,
+        params={"page": 1, "limit": 100},
+    )
+    data = r.json()
+    agents = data["data"]["items"]
+    total = data["data"]["total"]
+
+    # Get a single agent
+    r = await client.get(f"{BASE_URL}/agents/{agent_id}.json", headers=headers)
+    agent = r.json()["data"]
+```
+
+Agent fields: `id`, `name`, `email`, `role`, `status`, `extension`, `phone_number`, `groups`, `created_at`, `updated_at`.
+
+### Calls
+
+```python
+async with httpx.AsyncClient() as client:
+    r = await client.get(
+        f"{BASE_URL}/calls.json",
+        headers=headers,
+        params={"page": 1, "limit": 100},
+    )
+    calls = r.json()["data"]["items"]
+```
+
+Call fields include: `id`, `agent_id`, `direction` (`inbound`/`outbound`).
+
+### Groups (Queues)
+
+```python
+async with httpx.AsyncClient() as client:
+    r = await client.get(f"{BASE_URL}/groups.json", headers=headers)
+    groups = r.json()["data"]["items"]
+```
+
+## Common Pattern: Fetch All Pages
+
+```python
+import httpx
+
+async def fetch_all(resource: str, headers: dict) -> list:
+    results = []
+    page = 1
+    async with httpx.AsyncClient() as client:
+        while True:
+            r = await client.get(
+                f"https://my.cloudtalk.io/api/{resource}.json",
+                headers=headers,
+                params={"page": page, "limit": 100},
+            )
+            r.raise_for_status()
+            body = r.json()
+            items = body["data"]["items"]
+            results.extend(items)
+            total = body["data"]["total"]
+            if len(results) >= total:
+                break
+            page += 1
+    return results
+```
+
+## Rate Limits
+
+CloudTalk does not publicly document rate limit thresholds. Implement exponential backoff on HTTP 429.
+
+```python
+import asyncio
+import httpx
+
+async def get_with_backoff(client: httpx.AsyncClient, url: str, headers: dict, params: dict = None):
+    for attempt in range(5):
+        r = await client.get(url, headers=headers, params=params)
+        if r.status_code == 429:
+            await asyncio.sleep(2 ** attempt)
+            continue
+        r.raise_for_status()
+        return r.json()
+    raise RuntimeError("Max retries exceeded")
+```
+
+## Webhooks
+
+CloudTalk supports outbound webhooks configured in the dashboard under Integrations → Webhooks.
+
+Documented webhook events:
+- `call.started`
+- `call.answered`
+- `call.ended`
+- `call.missed`
+- `voicemail.received`
+- `sms.received`
+
+## Installation
+
+```bash
+pip install httpx
+```

--- a/content/cloudtalk/docs/telephony/python/DOC.md
+++ b/content/cloudtalk/docs/telephony/python/DOC.md
@@ -89,7 +89,7 @@ async with httpx.AsyncClient(auth=auth) as client:
     calls = r.json()["data"]["items"]
 ```
 
-Call fields include: `id`, `agent_id`, `direction` (`inbound`/`outbound`).
+Call fields include: `id`, `agent_id`, `direction` (`inbound`/`outgoing`).
 
 ### Groups (Queues)
 
@@ -126,6 +126,12 @@ async def fetch_all(resource: str, auth: httpx.BasicAuth) -> list:
     return results
 ```
 
+## Known Limitations
+
+> **CDR ID mismatch**: CloudTalk does not expose agent IDs or call IDs via the API in a way that cross-references with their CDR (Call Detail Records) export page. IDs from the API and CDR report are separate — they cannot be reliably joined without manual mapping.
+
+> **PUT is full-replace**: `PUT` endpoints are full-replace operations. Omitting any field silently resets it to its default value. Always fetch the current resource first, then send the complete updated object.
+
 ## Rate Limits
 
 CloudTalk does not publicly document rate limit thresholds. Implement exponential backoff on HTTP 429.
@@ -156,6 +162,24 @@ Documented webhook events:
 - `call.missed`
 - `voicemail.received`
 - `sms.received`
+
+## Contacts
+
+```python
+async with httpx.AsyncClient(auth=auth) as client:
+    # List contacts
+    r = await client.get(
+        f"{BASE_URL}/contacts.json",
+        params={"page": 1, "limit": 100},
+    )
+    contacts = r.json()["data"]["items"]
+
+    # Add tags to a contact
+    r = await client.post(
+        f"{BASE_URL}/contacts/addTags/{contact_id}.json",
+        json={"tags": ["vip", "enterprise"]},
+    )
+```
 
 ## Installation
 

--- a/content/demodesk/docs/meeting-intelligence/python/DOC.md
+++ b/content/demodesk/docs/meeting-intelligence/python/DOC.md
@@ -136,6 +136,8 @@ async with httpx.AsyncClient() as client:
 
 ### Users
 
+Your `company_id` is available in Demodesk dashboard → Settings → Company Info, or from the `company_id` field in any user object returned by the API.
+
 ```python
 async with httpx.AsyncClient() as client:
     # List users in a company

--- a/content/demodesk/docs/meeting-intelligence/python/DOC.md
+++ b/content/demodesk/docs/meeting-intelligence/python/DOC.md
@@ -15,6 +15,15 @@ You are a Demodesk API coding expert. Help me write Python code using the Demode
 
 Official API documentation: https://help.demodesk.com/en/articles/8518816-api-reference
 
+## API Versions
+
+Demodesk has two API versions:
+
+- **v1** (covered in this guide) — REST API for scheduling, meetings, users, and webhooks. **Will be discontinued in the future.** Avoid v1 for new integrations where v2 is available.
+- **v2** (recommended) — Covers recordings, transcripts, AI summaries, and additional features. Use v2 for any meeting intelligence / transcript / AI use cases.
+
+v2 API reference: https://demodesk.com/api/docs/index.html
+
 ## Authentication
 
 Auth is via the `api-key` header. Three key types exist:
@@ -84,9 +93,20 @@ Available filters:
 - `filter[account_i_cont]` — meeting name substring
 - `filter[template_name_i_cont]` — meeting type name substring
 - `filter[recordings_present]` — `true` / `false`
+
+When `filter[recordings_present]=true`, recordings are in the `included` key of the response:
+
+```python
+payload = r.json()
+for item in payload.get("included", []):
+    if item.get("type") == "recording":
+        media_url = item["attributes"].get("customerUrl")
+```
+
+> **Note**: Transcripts and AI summaries are only available via the **v2 API** — see https://demodesk.com/api/docs/index.html
 - `filter[group_id_eq]` — group id
 
-Meeting object fields: `id`, `token`, `status` (scheduled/started/ended/canceled), `duration`, `account`, `link`, `startDate`, `userFirstName`, `userLastName`.
+Meeting object fields: `id`, `token`, `status` (`scheduled`/`starting`/`started`/`ending`/`ended`/`canceled`), `duration`, `account`, `link`, `startDate`, `userFirstName`, `userLastName`.
 
 ### Get a Single Meeting
 
@@ -214,6 +234,32 @@ Supported events:
 - `recording.uploaded`, `recording.transcription_postprocessed`
 
 Full webhook payload schema: https://demodesk.com/api/docs/index.html
+
+## Customer Booking (No Auth Required)
+
+These endpoints require no API key — designed for embedding in chatbots, voice agents, and booking widgets.
+
+```python
+import httpx
+
+async def get_available_slots(owner: str, slug: str) -> dict:
+    async with httpx.AsyncClient() as client:
+        r = await client.get(
+            "https://demodesk.com/api/v1/customer-booking-calendar",
+            params={"owner": owner, "slug": slug},
+        )
+        r.raise_for_status()
+        return r.json()
+
+async def book_meeting(owner: str, slug: str, booking_data: dict) -> dict:
+    async with httpx.AsyncClient() as client:
+        r = await client.post(
+            f"https://demodesk.com/api/v1/book/{owner}/{slug}",
+            json=booking_data,
+        )
+        r.raise_for_status()
+        return r.json()
+```
 
 ## Installation
 

--- a/content/demodesk/docs/meeting-intelligence/python/DOC.md
+++ b/content/demodesk/docs/meeting-intelligence/python/DOC.md
@@ -1,0 +1,220 @@
+---
+name: meeting-intelligence
+description: "Demodesk REST API for managing meetings, users, recordings, and scheduling via api-key header auth."
+metadata:
+  languages: "python"
+  versions: "v1"
+  updated-on: "2026-05-08"
+  source: community
+  tags: "demodesk,meetings,scheduling,recordings,sales,demo"
+---
+
+# Demodesk REST API — Python Guide
+
+You are a Demodesk API coding expert. Help me write Python code using the Demodesk REST API.
+
+Official API documentation: https://help.demodesk.com/en/articles/8518816-api-reference
+
+## Authentication
+
+Auth is via the `api-key` header. Three key types exist:
+
+| Key type | Use |
+|---|---|
+| `COMPANY_ADMIN_USER_API_KEY` | Full company access — meetings, users, groups |
+| `USER_API_KEY` | Single user scope — own meetings only |
+| `MASTER_3RD_PARTY_API_KEY` | Whitelabel only — create new accounts |
+
+Generate keys in Demodesk dashboard: Settings → Integrations → scroll to "Demodesk API".
+
+```python
+import httpx
+
+API_KEY = "YOUR_COMPANY_ADMIN_API_KEY"
+BASE_URL = "https://demodesk.com/api/v1"
+
+headers = {
+    "api-key": API_KEY,
+    "Content-Type": "application/json",
+}
+```
+
+## Error Response Format
+
+```json
+{
+  "errors": [{"detail": "The provided API key is invalid."}],
+  "status": "unauthorized"
+}
+```
+
+| HTTP | Status string | Meaning |
+|---|---|---|
+| 401 | `unauthorized` | Invalid API key |
+| 403 | `forbidden` | Not authorized for this action |
+| 404 | `not_found` | Resource not found |
+| 422 | `unprocessable_entity` | Invalid request body |
+
+## Core Resources
+
+### List Meetings
+
+```python
+async with httpx.AsyncClient() as client:
+    r = await client.get(
+        f"{BASE_URL}/demos",
+        headers=headers,
+        params={
+            "page": 1,
+            "filter[schedule_eq]": "past",          # "past" or "upcoming"
+            "filter[all_team_members_dashboard]": "true",
+        },
+    )
+    r.raise_for_status()
+    payload = r.json()
+    meetings = payload["data"]
+    meta = payload["meta"]  # currentPage, hasNextPage, pageSize (25)
+```
+
+Available filters:
+- `filter[schedule_eq]` — `past` or `upcoming`
+- `filter[all_team_members_dashboard]` — `true` / `false`
+- `filter[start_date_gteq]` — e.g. `2024-01-01`
+- `filter[start_date_lteq]` — e.g. `2024-12-31`
+- `filter[account_i_cont]` — meeting name substring
+- `filter[template_name_i_cont]` — meeting type name substring
+- `filter[recordings_present]` — `true` / `false`
+- `filter[group_id_eq]` — group id
+
+Meeting object fields: `id`, `token`, `status` (scheduled/started/ended/canceled), `duration`, `account`, `link`, `startDate`, `userFirstName`, `userLastName`.
+
+### Get a Single Meeting
+
+```python
+async with httpx.AsyncClient() as client:
+    # Use the meeting token (not ID)
+    r = await client.get(
+        f"{BASE_URL}/scheduled_demos/{demo_token}",
+        headers=headers,
+    )
+    meeting = r.json()["data"]
+```
+
+### Create a Meeting
+
+```python
+async with httpx.AsyncClient() as client:
+    r = await client.post(
+        f"{BASE_URL}/scheduled_demos",
+        headers=headers,
+        json={
+            "data": {
+                "type": "demos",
+                "attributes": {
+                    "account": "Acme Corp",
+                    "startDate": "2026-06-01T10:00:00.000+01:00",
+                    "duration": 1800,
+                    "timeZone": "Europe/London",
+                    "user_id": USER_ID,
+                },
+            }
+        },
+    )
+    meeting_id = r.json()["data"]["id"]
+```
+
+### Cancel / Delete a Meeting
+
+```python
+async with httpx.AsyncClient() as client:
+    # Cancel (keeps record)
+    await client.post(f"{BASE_URL}/scheduled_demos/{demo_id}/cancel", headers=headers)
+
+    # Delete (removes record)
+    await client.delete(f"{BASE_URL}/scheduled_demos/{demo_id}", headers=headers)
+```
+
+### Users
+
+```python
+async with httpx.AsyncClient() as client:
+    # List users in a company
+    r = await client.get(
+        f"{BASE_URL}/companies/{company_id}/users", headers=headers
+    )
+
+    # Create user
+    r = await client.post(
+        f"{BASE_URL}/users",
+        headers=headers,
+        json={
+            "data": {
+                "type": "users",
+                "attributes": {
+                    "firstName": "Jane",
+                    "lastName": "Smith",
+                    "email": "jane@example.com",
+                    "locale": "en",
+                },
+            }
+        },
+    )
+    user_id = r.json()["data"]["id"]
+    user_api_key = r.json()["data"]["apiKey"]
+```
+
+### Meeting Types
+
+```python
+async with httpx.AsyncClient() as client:
+    r = await client.get(f"{BASE_URL}/demo_templates", headers=headers)
+    templates = r.json()["data"]
+```
+
+## Common Pattern: Fetch All Past Meetings
+
+```python
+import httpx
+
+async def fetch_all_past_meetings(api_key: str) -> list:
+    headers = {"api-key": api_key, "Content-Type": "application/json"}
+    results = []
+    page = 1
+
+    async with httpx.AsyncClient() as client:
+        while True:
+            r = await client.get(
+                "https://demodesk.com/api/v1/demos",
+                headers=headers,
+                params={
+                    "page": page,
+                    "filter[schedule_eq]": "past",
+                    "filter[all_team_members_dashboard]": "true",
+                },
+            )
+            r.raise_for_status()
+            payload = r.json()
+            results.extend(payload["data"])
+            if not payload["meta"]["hasNextPage"]:
+                break
+            page += 1
+
+    return results
+```
+
+## Webhooks
+
+Enable by emailing support@demodesk.com with your endpoint URL.
+
+Supported events:
+- `demo.scheduled`, `demo.rescheduled`, `demo.canceled`
+- `demo.started`, `demo.ended`, `demo.handovered`
+- `recording.uploaded`, `recording.transcription_postprocessed`
+
+Full webhook payload schema: https://demodesk.com/api/docs/index.html
+
+## Installation
+
+```bash
+pip install httpx
+```

--- a/content/dreamdata/docs/event-tracking/python/DOC.md
+++ b/content/dreamdata/docs/event-tracking/python/DOC.md
@@ -1,0 +1,168 @@
+---
+name: event-tracking
+description: "Dreamdata server-side Tracking API for sending identify, track, and page events to the Dreamdata attribution platform."
+metadata:
+  languages: "python"
+  versions: "v1"
+  updated-on: "2026-05-08"
+  source: community
+  tags: "dreamdata,tracking,attribution,events,b2b,revenue"
+---
+
+# Dreamdata Server-Side Tracking API — Python Guide
+
+You are a Dreamdata API coding expert. Help me write Python code using the Dreamdata Server-Side Tracking API.
+
+Official documentation: https://developer.dreamdata.io/server-side/server-side-tracking/
+
+> **Direction:** This API is for sending events TO Dreamdata (inbound tracking). It is not a data extraction API. To pull attribution data OUT of Dreamdata, use their BigQuery V2 or Snowflake V3 warehouse export.
+
+## Authentication
+
+HTTP Basic Auth. API key is the username; password is empty.
+
+Get your Source API Key in the Dreamdata platform under: Data Platform → Sources → Server Side Analytics APIs.
+
+```python
+import base64
+import httpx
+
+API_KEY = "YOUR_DREAMDATA_API_KEY"
+credentials = base64.b64encode(f"{API_KEY}:".encode()).decode()
+
+headers = {
+    "Authorization": f"Basic {credentials}",
+    "Content-Type": "application/json",
+}
+
+BATCH_URL = "https://api.dreamdata.cloud/v1/batch"
+```
+
+## Sending Events
+
+All events are sent as a batch to `POST https://api.dreamdata.cloud/v1/batch`. Max 500KB per request. Each event needs a unique `messageId` (UUID) and an ISO 8601 `timestamp`.
+
+### Identify + Track (known user)
+
+Use both `identify` and `track` when you know the user (e.g. form submission, login).
+
+```python
+import asyncio
+import uuid
+from datetime import datetime, timezone
+import httpx
+
+async def send_events(api_key: str, events: list[dict]) -> None:
+    credentials = base64.b64encode(f"{api_key}:".encode()).decode()
+    headers = {
+        "Authorization": f"Basic {credentials}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "messageId": str(uuid.uuid4()),
+        "sentAt": datetime.now(timezone.utc).isoformat(),
+        "batch": events,
+    }
+    async with httpx.AsyncClient() as client:
+        r = await client.post(
+            "https://api.dreamdata.cloud/v1/batch",
+            headers=headers,
+            json=payload,
+        )
+        r.raise_for_status()
+
+events = [
+    {
+        "type": "identify",
+        "messageId": str(uuid.uuid4()),
+        "userId": "user-123",
+        "traits": {
+            "email": "jane@example.com",
+            "name": "Jane Smith",
+        },
+        "context": {"ip": "1.2.3.4"},
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    },
+    {
+        "type": "track",
+        "messageId": str(uuid.uuid4()),
+        "userId": "user-123",
+        "event": "form_submitted",
+        "context": {
+            "ip": "1.2.3.4",
+            "page": {"url": "https://example.com/contact"},
+        },
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    },
+]
+
+asyncio.run(send_events(API_KEY, events))
+```
+
+### Page View (anonymous visitor)
+
+Use `anonymousId` when the user is not yet identified.
+
+```python
+page_event = {
+    "type": "page",
+    "messageId": str(uuid.uuid4()),
+    "anonymousId": "anon-uuid-here",
+    "context": {
+        "ip": "1.2.3.4",
+        "page": {
+            "url": "https://example.com/pricing",
+            "referrer": "https://google.com",
+        },
+        "campaign": {
+            "source": "google",
+            "medium": "cpc",
+            "name": "brand",
+        },
+    },
+    "timestamp": datetime.now(timezone.utc).isoformat(),
+}
+```
+
+### Link Anonymous to Known User
+
+When a visitor identifies (e.g. signs up), send an `alias` event:
+
+```python
+alias_event = {
+    "type": "alias",
+    "userId": "user-123",
+    "previousId": "anon-uuid-here",
+}
+```
+
+## User Identification Rules
+
+- Use `userId` when user is logged in or you have a CRM/DB ID
+- Use `anonymousId` for pre-login or unauthenticated visitors
+- Every event requires either `userId` or `anonymousId`
+
+## Cookieless Tracking (company-level only)
+
+When you only need company-level attribution via IP lookup:
+
+```python
+cookieless_event = {
+    "type": "track",
+    "anonymousId": "cookieless",
+    "event": "Page Viewed",
+    "context": {"ip": "203.0.113.42"},
+}
+```
+
+## Batch Size Limits
+
+- Max payload: **500KB per request**
+- Mix `identify`, `track`, `page`, and `alias` events freely in one batch
+- Timestamps must be ISO 8601 format
+
+## Installation
+
+```bash
+pip install httpx
+```

--- a/content/dreamdata/docs/event-tracking/python/DOC.md
+++ b/content/dreamdata/docs/event-tracking/python/DOC.md
@@ -49,12 +49,12 @@ async def send_events(api_key: str, events: list[dict]) -> None:
     auth = httpx.BasicAuth(api_key, "")
     payload = {
         "messageId": str(uuid.uuid4()),
-        "sentAt": datetime.now(timezone.utc).isoformat(),
+        "sentAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "batch": events,
     }
     async with httpx.AsyncClient(auth=auth) as client:
         r = await client.post(
-            "https://api.dreamdata.cloud/v1/batch",
+            BATCH_URL,
             json=payload,
         )
         r.raise_for_status()
@@ -68,19 +68,38 @@ events = [
             "email": "jane@example.com",
             "name": "Jane Smith",
         },
-        "context": {"ip": "1.2.3.4"},
-        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "context": {
+            "ip": "1.2.3.4",
+            "campaign": {
+                "source": "google",
+                "medium": "cpc",
+                "name": "q4-trial-signup",
+            },
+            "library": {"name": "custom-backend", "version": "1.0"},
+        },
+        "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
     },
     {
         "type": "track",
         "messageId": str(uuid.uuid4()),
         "userId": "user-123",
         "event": "form_submitted",
+        "properties": {
+            "form_name": "contact",
+            "plan": "pro",
+        },
         "context": {
             "ip": "1.2.3.4",
             "page": {"url": "https://example.com/contact"},
+            "campaign": {
+                "source": "google",
+                "medium": "cpc",
+                "name": "q4-trial-signup",
+            },
+            "library": {"name": "custom-backend", "version": "1.0"},
+            "userAgent": "python-httpx/0.27",
         },
-        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
     },
 ]
 
@@ -107,8 +126,33 @@ page_event = {
             "medium": "cpc",
             "name": "brand",
         },
+        "library": {"name": "custom-backend", "version": "1.0"},
+        "userAgent": "Mozilla/5.0 ...",
     },
-    "timestamp": datetime.now(timezone.utc).isoformat(),
+    "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+}
+```
+
+### Group Event (Account Association)
+
+Use `group` to associate a user with a company/account — critical for B2B revenue attribution.
+
+```python
+group_event = {
+    "type": "group",
+    "messageId": str(uuid.uuid4()),
+    "userId": "user-123",
+    "groupId": "company-456",
+    "traits": {
+        "name": "Acme Corp",
+        "industry": "SaaS",
+        "plan": "enterprise",
+        "employee_count": 500,
+    },
+    "context": {
+        "library": {"name": "custom-backend", "version": "1.0"},
+    },
+    "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
 }
 ```
 

--- a/content/dreamdata/docs/event-tracking/python/DOC.md
+++ b/content/dreamdata/docs/event-tracking/python/DOC.md
@@ -24,17 +24,10 @@ HTTP Basic Auth. API key is the username; password is empty.
 Get your Source API Key in the Dreamdata platform under: Data Platform → Sources → Server Side Analytics APIs.
 
 ```python
-import base64
 import httpx
 
 API_KEY = "YOUR_DREAMDATA_API_KEY"
-credentials = base64.b64encode(f"{API_KEY}:".encode()).decode()
-
-headers = {
-    "Authorization": f"Basic {credentials}",
-    "Content-Type": "application/json",
-}
-
+auth = httpx.BasicAuth(API_KEY, "")  # API key as username, empty password
 BATCH_URL = "https://api.dreamdata.cloud/v1/batch"
 ```
 
@@ -53,20 +46,15 @@ from datetime import datetime, timezone
 import httpx
 
 async def send_events(api_key: str, events: list[dict]) -> None:
-    credentials = base64.b64encode(f"{api_key}:".encode()).decode()
-    headers = {
-        "Authorization": f"Basic {credentials}",
-        "Content-Type": "application/json",
-    }
+    auth = httpx.BasicAuth(api_key, "")
     payload = {
         "messageId": str(uuid.uuid4()),
         "sentAt": datetime.now(timezone.utc).isoformat(),
         "batch": events,
     }
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(auth=auth) as client:
         r = await client.post(
             "https://api.dreamdata.cloud/v1/batch",
-            headers=headers,
             json=payload,
         )
         r.raise_for_status()
@@ -126,7 +114,7 @@ page_event = {
 
 ### Link Anonymous to Known User
 
-When a visitor identifies (e.g. signs up), send an `alias` event:
+When a visitor identifies (e.g. signs up), send an `alias` event to merge the anonymous and known identities:
 
 ```python
 alias_event = {

--- a/content/fireflies/docs/meeting-intelligence/python/DOC.md
+++ b/content/fireflies/docs/meeting-intelligence/python/DOC.md
@@ -124,6 +124,38 @@ transcript = data["transcript"]
 - **MeetingAttendee** — attendee details including email and name
 - **MeetingInfo** — metadata about the recorded meeting
 
+## Common Pattern: Fetch All Transcripts (Paginated)
+
+For workspaces with many meetings, use `limit` and `skip` to page through results:
+
+```python
+async def fetch_all_transcripts() -> list:
+    results = []
+    skip = 0
+    limit = 50
+    while True:
+        data = await query({
+            "query": """
+            query GetTranscripts($limit: Int, $skip: Int) {
+              transcripts(limit: $limit, skip: $skip) {
+                id
+                title
+                date
+                duration
+                participants
+              }
+            }
+            """,
+            "variables": {"limit": limit, "skip": skip},
+        })
+        batch = data["transcripts"]
+        results.extend(batch)
+        if len(batch) < limit:
+            break
+        skip += limit
+    return results
+```
+
 ## Webhooks
 
 Fireflies supports webhooks (v1 and v2) to push transcript-ready events. See: https://docs.fireflies.ai/graphql-api/webhooks

--- a/content/fireflies/docs/meeting-intelligence/python/DOC.md
+++ b/content/fireflies/docs/meeting-intelligence/python/DOC.md
@@ -42,7 +42,10 @@ async def query(payload: dict) -> dict:
     async with httpx.AsyncClient() as client:
         r = await client.post(GRAPHQL_URL, headers=headers, json=payload)
         r.raise_for_status()
-        return r.json()["data"]
+        result = r.json()
+        if "errors" in result:
+            raise ValueError(f"GraphQL errors: {result['errors']}")
+        return result["data"]
 ```
 
 ## Core Queries
@@ -73,6 +76,8 @@ data = await query({
           action_items
           overview
           shorthand_bullet
+          gist
+          bullet_gist
         }
       }
     }
@@ -106,6 +111,8 @@ data = await query({
           action_items
           overview
           shorthand_bullet
+          gist
+          bullet_gist
         }
       }
     }
@@ -119,7 +126,7 @@ transcript = data["transcript"]
 
 - **Transcript** — a recorded meeting: `id`, `title`, `date`, `duration`, `participants`, `sentences`, `summary`
 - **Sentence** — a single utterance: `index`, `text`, `start_time`, `end_time`, `speaker_name`, `speaker_id`
-- **Summary** — AI-generated meeting summary: `keywords`, `action_items`, `overview`, `shorthand_bullet`
+- **Summary** — AI-generated meeting summary: `keywords`, `action_items`, `overview`, `shorthand_bullet`, `gist` (1-sentence), `bullet_gist`
 - **User** — a Fireflies workspace user: `name`, `user_id`
 - **MeetingAttendee** — attendee details including email and name
 - **MeetingInfo** — metadata about the recorded meeting
@@ -156,9 +163,72 @@ async def fetch_all_transcripts() -> list:
     return results
 ```
 
+## Date Filtering
+
+```python
+data = await query({
+    "query": """
+    query GetTranscripts($fromDate: DateTime, $toDate: DateTime) {
+      transcripts(fromDate: $fromDate, toDate: $toDate) {
+        id
+        title
+        date
+        duration
+        participants
+      }
+    }
+    """,
+    "variables": {
+        "fromDate": "2025-01-01T00:00:00Z",
+        "toDate": "2025-12-31T23:59:59Z",
+    },
+})
+```
+
+## Upload Audio
+
+Upload an external recording URL for Fireflies to transcribe:
+
+```python
+data = await query({
+    "query": """
+    mutation UploadAudio($input: AudioUploadInput) {
+      uploadAudio(input: $input) {
+        success
+        title
+        message
+      }
+    }
+    """,
+    "variables": {
+        "input": {
+            "url": "https://your-storage.com/recording.mp3",
+            "title": "Sales call - 2025-01-15",
+            "meeting_attendees": [
+                {"displayName": "Alice", "email": "alice@example.com"},
+                {"displayName": "Bob", "email": "bob@example.com"},
+            ],
+        }
+    },
+})
+```
+
 ## Webhooks
 
 Fireflies supports webhooks (v1 and v2) to push transcript-ready events. See: https://docs.fireflies.ai/graphql-api/webhooks
+
+Minimal webhook payload when a transcript is ready:
+
+```json
+{
+  "meetingId": "abc123",
+  "clientReferenceId": null,
+  "title": "Team standup",
+  "fireflies_user": "user@example.com"
+}
+```
+
+Fetch the full transcript using `transcript(id: "abc123")` after receiving the webhook.
 
 ## Installation
 

--- a/content/fireflies/docs/meeting-intelligence/python/DOC.md
+++ b/content/fireflies/docs/meeting-intelligence/python/DOC.md
@@ -1,0 +1,135 @@
+---
+name: meeting-intelligence
+description: "Fireflies.ai GraphQL API for fetching meeting transcripts, summaries, and speaker analytics."
+metadata:
+  languages: "python"
+  versions: "v1"
+  updated-on: "2026-05-08"
+  source: community
+  tags: "fireflies,transcription,meetings,graphql,summaries,ai"
+---
+
+# Fireflies.ai GraphQL API — Python Guide
+
+You are a Fireflies.ai API coding expert. Help me write Python code using the Fireflies.ai GraphQL API.
+
+Official API documentation: https://docs.fireflies.ai/getting-started/introduction
+
+## Authentication
+
+All requests use Bearer token auth. Get your API key from the Fireflies dashboard → Integrations → API.
+
+```python
+import httpx
+
+API_KEY = "YOUR_API_KEY"
+GRAPHQL_URL = "https://api.fireflies.ai/graphql"
+
+headers = {
+    "Content-Type": "application/json",
+    "Authorization": f"Bearer {API_KEY}",
+}
+```
+
+## Making GraphQL Requests
+
+All requests are HTTP POST to `https://api.fireflies.ai/graphql`.
+
+```python
+import httpx
+
+async def query(payload: dict) -> dict:
+    async with httpx.AsyncClient() as client:
+        r = await client.post(GRAPHQL_URL, headers=headers, json=payload)
+        r.raise_for_status()
+        return r.json()["data"]
+```
+
+## Core Queries
+
+### List Users
+
+```python
+data = await query({
+    "query": "{ users { name user_id } }"
+})
+users = data["users"]
+```
+
+### List Transcripts (Meetings)
+
+```python
+data = await query({
+    "query": """
+    {
+      transcripts {
+        id
+        title
+        date
+        duration
+        participants
+        summary {
+          keywords
+          action_items
+          overview
+          shorthand_bullet
+        }
+      }
+    }
+    """
+})
+transcripts = data["transcripts"]
+```
+
+### Get a Specific Transcript
+
+```python
+data = await query({
+    "query": """
+    query GetTranscript($id: String!) {
+      transcript(id: $id) {
+        id
+        title
+        date
+        duration
+        participants
+        sentences {
+          index
+          text
+          start_time
+          end_time
+          speaker_name
+          speaker_id
+        }
+        summary {
+          keywords
+          action_items
+          overview
+          shorthand_bullet
+        }
+      }
+    }
+    """,
+    "variables": {"id": "TRANSCRIPT_ID"},
+})
+transcript = data["transcript"]
+```
+
+## Key Schema Types
+
+- **Transcript** — a recorded meeting: `id`, `title`, `date`, `duration`, `participants`, `sentences`, `summary`
+- **Sentence** — a single utterance: `index`, `text`, `start_time`, `end_time`, `speaker_name`, `speaker_id`
+- **Summary** — AI-generated meeting summary: `keywords`, `action_items`, `overview`, `shorthand_bullet`
+- **User** — a Fireflies workspace user: `name`, `user_id`
+- **MeetingAttendee** — attendee details including email and name
+- **MeetingInfo** — metadata about the recorded meeting
+
+## Webhooks
+
+Fireflies supports webhooks (v1 and v2) to push transcript-ready events. See: https://docs.fireflies.ai/graphql-api/webhooks
+
+## Installation
+
+```bash
+pip install httpx
+```

--- a/content/livestorm/docs/webinars/python/DOC.md
+++ b/content/livestorm/docs/webinars/python/DOC.md
@@ -1,0 +1,159 @@
+---
+name: webinars
+description: "Livestorm REST API for managing events, registrants, and engagement data from webinars and virtual meetings."
+metadata:
+  languages: "python"
+  versions: "v1"
+  updated-on: "2026-05-08"
+  source: community
+  tags: "livestorm,webinars,events,registrants,engagement"
+---
+
+# Livestorm REST API — Python Guide
+
+You are a Livestorm API coding expert. Help me write Python code using the Livestorm REST API.
+
+Official documentation: https://developers.livestorm.co/docs/getting-started-api
+
+## Authentication
+
+Livestorm supports two auth methods:
+
+### API Token (private apps — own workspace)
+
+Generate a token in Account Settings → Integrations → Public API. Tokens require scope permissions chosen at creation time.
+
+```python
+import httpx
+
+API_TOKEN = "YOUR_API_TOKEN"
+BASE_URL = "https://api.livestorm.co/v1"
+
+headers = {"authorization": API_TOKEN}
+```
+
+Note: the header name is lowercase `authorization` and the value is the token directly (no `Bearer` prefix).
+
+### OAuth2 (Technology Partners — public integrations only)
+
+OAuth2 is only available for official Technology Partners building publicly-listed apps.
+
+## Rate Limits
+
+- **Monthly**: 10,000 requests per 30-day rolling window (from first request)
+- **Burst**: 5 requests per second
+
+Response headers on every request:
+- `RateLimit-Monthly-Limit` — max calls per 30-day period
+- `RateLimit-Monthly-Remaining` — calls left this period
+- `RateLimit-Interval-Limit` — burst limit per second
+- `RateLimit-Interval-Remaining` — remaining in current second window
+- `RateLimit-Reset` — timestamp when monthly period resets
+- `Retry-After` — seconds until next available window (on 429)
+
+## Pagination
+
+List endpoints use cursor-style pagination with JSON:API conventions:
+
+- `page[number]` — zero-indexed page number (default: `0`)
+- `page[size]` — items per page (default: `20`, max: `50`)
+
+Response shape:
+
+```json
+{
+  "data": [...],
+  "meta": {
+    "current_page": 0,
+    "previous_page": null,
+    "next_page": 1,
+    "record_count": 25,
+    "page_count": 2,
+    "items_per_page": 20
+  }
+}
+```
+
+## Core Resources
+
+### Events
+
+```python
+async with httpx.AsyncClient() as client:
+    # List events (paginated)
+    r = await client.get(
+        f"{BASE_URL}/events",
+        headers=headers,
+        params={"page[number]": 0, "page[size]": 50},
+    )
+    r.raise_for_status()
+    payload = r.json()
+    events = payload["data"]
+    meta = payload["meta"]
+```
+
+Filter events by title:
+
+```python
+params = {
+    "page[number]": 0,
+    "page[size]": 50,
+    "filter[title]": "Product Demo",
+}
+```
+
+## Common Pattern: Fetch All Pages
+
+```python
+import httpx
+
+async def fetch_all_events(api_token: str) -> list:
+    headers = {"authorization": api_token}
+    base_url = "https://api.livestorm.co/v1"
+    results = []
+    page = 0
+
+    async with httpx.AsyncClient() as client:
+        while True:
+            r = await client.get(
+                f"{base_url}/events",
+                headers=headers,
+                params={"page[number]": page, "page[size]": 50},
+            )
+            r.raise_for_status()
+            payload = r.json()
+            results.extend(payload["data"])
+            meta = payload["meta"]
+            if meta["next_page"] is None:
+                break
+            page = meta["next_page"]
+
+    return results
+```
+
+## Rate Limit Handling
+
+```python
+import asyncio
+import httpx
+
+async def get_with_retry(client: httpx.AsyncClient, url: str, headers: dict, params: dict = None):
+    r = await client.get(url, headers=headers, params=params)
+    if r.status_code == 429:
+        wait = int(r.headers.get("Retry-After", 1))
+        await asyncio.sleep(wait)
+        r = await client.get(url, headers=headers, params=params)
+    r.raise_for_status()
+    return r.json()
+```
+
+## Notes
+
+- API access requires a **validated Livestorm workspace**. Contact support@livestorm.co to enable API access.
+- Token scopes are set at creation time and cannot be changed — create a new token to change scopes.
+
+## Installation
+
+```bash
+pip install httpx
+```

--- a/content/livestorm/docs/webinars/python/DOC.md
+++ b/content/livestorm/docs/webinars/python/DOC.md
@@ -29,7 +29,10 @@ import httpx
 API_TOKEN = "YOUR_API_TOKEN"
 BASE_URL = "https://api.livestorm.co/v1"
 
-headers = {"Authorization": API_TOKEN}
+headers = {
+    "Authorization": API_TOKEN,
+    "Content-Type": "application/vnd.api+json",
+}
 ```
 
 Note: the header value is the token directly (no `Bearer` prefix).
@@ -53,7 +56,7 @@ Response headers on every request:
 
 ## Pagination
 
-List endpoints use cursor-style pagination with JSON:API conventions:
+List endpoints use page-number pagination with JSON:API conventions:
 
 - `page[number]` — zero-indexed page number (default: `0`)
 - `page[size]` — items per page (default: `20`, max: `50`)
@@ -140,11 +143,84 @@ import httpx
 async def get_with_retry(client: httpx.AsyncClient, url: str, headers: dict, params: dict = None):
     r = await client.get(url, headers=headers, params=params)
     if r.status_code == 429:
-        wait = int(r.headers.get("Retry-After", 1))
+        if r.headers.get("RateLimit-Monthly-Remaining") == "0":
+            raise RuntimeError("Monthly API quota exhausted — resets per RateLimit-Reset header")
+        wait = int(r.headers.get("Retry-After", 60))
         await asyncio.sleep(wait)
         r = await client.get(url, headers=headers, params=params)
     r.raise_for_status()
     return r.json()
+```
+
+## Data Model: Events and Sessions
+
+Livestorm uses a two-level hierarchy:
+
+- **Event** — the recurring template (e.g., "Monthly Product Demo"). Created once, holds settings and branding.
+- **Session** — a specific scheduled occurrence of an Event with its own date/time and attendee list.
+
+Most attendee data (registrants, attendance, engagement) lives at the Session level.
+
+## Single vs List Response Access
+
+Livestorm's API follows JSON:API spec. List and single-resource responses have different shapes:
+
+```python
+# List response: payload["data"] is an array
+events = payload["data"]
+for event in events:
+    title = event["attributes"]["title"]
+
+# Single-resource response (create, get by ID): payload["data"] is an object
+payload = r.json()
+event_id = payload["data"]["id"]
+title = payload["data"]["attributes"]["title"]
+```
+
+## Create and Fetch Events
+
+```python
+async with httpx.AsyncClient(headers=headers) as client:
+    # Create an event
+    r = await client.post(
+        f"{BASE_URL}/events",
+        json={
+            "data": {
+                "type": "events",
+                "attributes": {
+                    "title": "Product Demo",
+                    "estimated_duration": 60,
+                    "slug": "product-demo",
+                },
+            }
+        },
+    )
+    r.raise_for_status()
+    event_id = r.json()["data"]["id"]
+
+    # Get a single event by ID
+    r = await client.get(f"{BASE_URL}/events/{event_id}")
+    r.raise_for_status()
+    event = r.json()["data"]
+    title = event["attributes"]["title"]
+```
+
+## Sessions and People
+
+```python
+async with httpx.AsyncClient(headers=headers) as client:
+    # List sessions for an event
+    r = await client.get(f"{BASE_URL}/events/{event_id}/sessions")
+    r.raise_for_status()
+    sessions = r.json()["data"]
+
+    # List people (registrants + attendees) for a session
+    r = await client.get(f"{BASE_URL}/sessions/{session_id}/people")
+    r.raise_for_status()
+    people = r.json()["data"]
+    for person in people:
+        email = person["attributes"]["email"]
+        attended = person["attributes"]["attended"]
 ```
 
 ## Notes

--- a/content/livestorm/docs/webinars/python/DOC.md
+++ b/content/livestorm/docs/webinars/python/DOC.md
@@ -29,10 +29,10 @@ import httpx
 API_TOKEN = "YOUR_API_TOKEN"
 BASE_URL = "https://api.livestorm.co/v1"
 
-headers = {"authorization": API_TOKEN}
+headers = {"Authorization": API_TOKEN}
 ```
 
-Note: the header name is lowercase `authorization` and the value is the token directly (no `Bearer` prefix).
+Note: the header value is the token directly (no `Bearer` prefix).
 
 ### OAuth2 (Technology Partners — public integrations only)
 
@@ -108,7 +108,7 @@ params = {
 import httpx
 
 async def fetch_all_events(api_token: str) -> list:
-    headers = {"authorization": api_token}
+    headers = {"Authorization": api_token}
     base_url = "https://api.livestorm.co/v1"
     results = []
     page = 0


### PR DESCRIPTION
## What

Adds Python DOC.md entries for 7 APIs commonly used in B2B SaaS data pipelines:

| Service | Path | Category |
|---|---|---|
| **Aircall** | `content/aircall/docs/telephony/python/` | REST, Basic Auth, calls/contacts/users |
| **Fireflies** | `content/fireflies/docs/meeting-intelligence/python/` | GraphQL, Bearer token, transcripts/summaries |
| **Bright Data** | `content/brightdata/docs/web-scraping/python/` | Python SDK, Unlocker/SERP/Browser APIs |
| **Livestorm** | `content/livestorm/docs/webinars/python/` | REST, API token, events/pagination |
| **CloudTalk** | `content/cloudtalk/docs/telephony/python/` | REST, Basic Auth, `.json` suffix convention, agents/calls/groups |
| **Demodesk** | `content/demodesk/docs/meeting-intelligence/python/` | REST, `api-key` header, meetings/users/recordings |
| **Dreamdata** | `content/dreamdata/docs/event-tracking/python/` | Server-side tracking API, batch events (identify/track/page/alias) |

## Why

These APIs are missing from the registry and are in active use for B2B SaaS revenue and sales data pipelines (call recordings, meeting intelligence, web data, webinar engagement, attribution tracking).

## Source verification

All content sourced directly from official API documentation — no invented endpoints or parameters:
- https://developer.aircall.io/api-references/
- https://docs.fireflies.ai/getting-started/introduction
- https://docs.brightdata.com/api-reference/SDK
- https://developers.livestorm.co/docs/getting-started-api
- https://developers.cloudtalk.io/
- https://help.demodesk.com/en/articles/8518816-api-reference
- https://developer.dreamdata.io/server-side/server-side-tracking/

## Notes

- Dreamdata doc covers the **inbound tracking API** (sending events to Dreamdata). For extracting data from Dreamdata, use their BigQuery V2 / Snowflake V3 warehouse export.
- CloudTalk endpoints use a non-standard `.json` suffix (e.g. `/api/agents.json`) — documented in the guide.
- Demodesk has both v1 (covered here) and v2 API; v2 docs at https://demodesk.com/api/docs/index.html

## Testing

- [x] `cd cli && npm test` — 252/253 passed; 1 pre-existing timeout in `tests/commands/go-lang.test.js` (Go build integration test, unrelated to this PR)
- [x] `node cli/bin/chub build content/ --validate-only` — `Valid: 1560 docs, 7 skills, 2 warnings` (2 warnings are pre-existing, unrelated to this PR)