### PR TITLE
add pybamm documentation & skill

### DIFF
--- a/content/pybamm/docs/pybamm/python/DOC.md
+++ b/content/pybamm/docs/pybamm/python/DOC.md
@@ -1,0 +1,294 @@
+---
+name: pybamm
+description: "PyBaMM battery simulation framework: models (DFN/SPM/SPMe), ParameterValues, Simulation, Solution, and solver selection"
+metadata:
+  languages: "python"
+  versions: "26.4.2"
+  revision: 1
+  updated-on: "2026-05-09"
+  source: community
+  tags: "pybamm,battery,simulation,electrochemistry,python,scientific-computing"
+---
+
+# PyBaMM Python Package Guide
+
+## Golden Rule
+
+**Use `pybamm.Simulation()` as your entry point: choose a model (DFN for accuracy, SPM for speed), apply a built-in `ParameterValues` set, call `.solve()`, then extract results from the returned `Solution`.**
+
+PyBaMM (Python Battery Mathematical Modelling) is the leading open-source framework for physics-based battery simulation. It provides pre-built electrochemical models (DFN, SPMe, SPM), curated parameter sets for real cells, flexible experiment protocols, and fast solvers built on Sundials.
+
+## Installation
+
+```bash
+pip install pybamm==26.4.2
+```
+
+Verify:
+
+```python
+import pybamm
+print(pybamm.__version__)  # 26.4.2
+```
+
+## Core Workflow (Quick Start)
+
+The full pattern from model to results in one block:
+
+```python
+import pybamm
+
+# 1. Choose a model
+model = pybamm.lithium_ion.DFN()
+
+# 2. Load a built-in parameter set
+param = pybamm.ParameterValues("Chen2020")
+
+# 3. Create and solve the simulation
+sim = pybamm.Simulation(model, parameter_values=param)
+sim.solve([0, 3600])  # time span in seconds
+
+# 4. Extract results from the Solution
+solution = sim.solution
+t = solution["Time [s]"].entries
+V = solution["Voltage [V]"].entries
+I = solution["Current [A]"].entries
+
+print(f"Final voltage: {V[-1]:.3f} V")
+
+# 5. Quick interactive plot
+sim.plot()
+```
+
+## Choosing a Model
+
+All three models are in `pybamm.lithium_ion`:
+
+| Model | Class | Accuracy | Speed | Use when |
+|-------|-------|----------|-------|----------|
+| DFN (Doyle-Fuller-Newman) | `DFN()` | Highest | ~270 ms | Full physics, degradation studies |
+| SPMe (Single Particle + Electrolyte) | `SPMe()` | Medium | ~39 ms | Balanced accuracy/speed |
+| SPM (Single Particle) | `SPM()` | Lowest | ~21 ms | Rapid prototyping, parameter sweeps |
+
+```python
+model_dfn  = pybamm.lithium_ion.DFN()
+model_spme = pybamm.lithium_ion.SPMe()
+model_spm  = pybamm.lithium_ion.SPM()
+```
+
+All three share the same `Simulation` interface, so you can swap models by changing one line.
+
+## ParameterValues
+
+### Using built-in sets
+
+PyBaMM ships with curated parameter sets for real cells. Pass the set name as a string:
+
+```python
+param = pybamm.ParameterValues("Chen2020")      # graphite/LFP 21700, most commonly used
+param = pybamm.ParameterValues("Marquis2019")   # graphite/LiCoO2 (default in many examples)
+param = pybamm.ParameterValues("OKane2022")     # includes degradation parameters
+```
+
+See the [parameter-sets reference](references/parameter-sets.md) for a full list.
+
+### Searching parameters
+
+```python
+param.search("diffusion")          # print all params whose name contains "diffusion"
+param.search("negative electrode") # narrow by electrode
+```
+
+### Updating individual values
+
+```python
+param.update({
+    "Negative electrode thickness [m]": 75e-6,
+    "Positive electrode thickness [m]": 90e-6,
+    "Current function [A]": 1.5,
+})
+```
+
+Units must match exactly. PyBaMM uses SI units internally and parameter names encode the unit in square brackets — always check the unit in the parameter name before assigning a value.
+
+### Printing all parameters
+
+```python
+param.print_parameter_info()  # shows every parameter with its value and units
+```
+
+## Running Simulations
+
+### Simple time-span solve
+
+Pass a two-element list `[t_start, t_end]` in seconds. PyBaMM chooses internal time steps automatically:
+
+```python
+sim = pybamm.Simulation(model, parameter_values=param)
+sim.solve([0, 3600])  # 1-hour discharge
+```
+
+### Experiment protocols
+
+Use `pybamm.Experiment` for multi-step protocols (CC discharge, CV charge, rests):
+
+```python
+experiment = pybamm.Experiment([
+    "Discharge at 1C for 1 hour or until 2.5 V",
+    "Rest for 10 minutes",
+    "Charge at 0.5C until 4.2 V",
+    "Hold at 4.2 V until C/20",
+])
+
+sim = pybamm.Simulation(model, parameter_values=param, experiment=experiment)
+sim.solve()
+```
+
+Experiment strings follow the pattern `"<action> at <rate> [for <time>] [or until <condition>]"`.
+
+### Controlling output times
+
+Use `t_eval` to specify exactly which time points to record:
+
+```python
+import numpy as np
+
+t_eval = np.linspace(0, 3600, 500)
+sim.solve(t_eval=t_eval)
+```
+
+### Accessing the C-rate
+
+"1C" means full discharge in 1 hour. PyBaMM interprets C-rate strings from the parameter set's nominal capacity. To set the current directly:
+
+```python
+param.update({"Current function [A]": 5.0})  # 5 A discharge
+sim.solve([0, 3600])
+```
+
+## Working with Results (Solution)
+
+### Variable access
+
+Variables are accessed by their full name with units:
+
+```python
+solution = sim.solution
+
+t  = solution["Time [s]"].entries          # numpy array
+V  = solution["Voltage [V]"].entries
+I  = solution["Current [A]"].entries
+Q  = solution["Discharge capacity [A.h]"].entries
+T  = solution["Cell temperature [K]"].entries
+```
+
+### Listing available variables
+
+```python
+print(solution.all_models[0].variables.keys())  # full variable list for the model
+```
+
+### Interpolating at specific times
+
+```python
+V_at_1800s = solution["Voltage [V]"](t=1800)  # interpolate at t=1800 s
+```
+
+### Comparing across runs
+
+```python
+solutions = []
+for c_rate in [0.5, 1.0, 2.0]:
+    param.update({"Current function [A]": c_rate * 5.0})
+    sim = pybamm.Simulation(model, parameter_values=param)
+    sim.solve([0, 3600 / c_rate])
+    solutions.append(sim.solution)
+
+pybamm.QuickPlot(solutions, ["Voltage [V]"]).dynamic_plot()
+```
+
+### Plotting
+
+```python
+sim.plot()                                      # default variable set
+sim.plot(["Voltage [V]", "Current [A]"])        # specific variables
+sim.plot(["Voltage [V]", ["Current [A]", "Discharge capacity [A.h]"]])  # shared axis
+```
+
+Pass a list of solution objects to `QuickPlot` to compare runs:
+
+```python
+pybamm.QuickPlot([sol1, sol2], ["Voltage [V]"]).dynamic_plot()
+```
+
+## Solver Selection
+
+PyBaMM's default solver is `IDAKLUSolver`. Explicitly setting it is optional but recommended when tuning performance:
+
+```python
+# Recommended: IDAKLU (fastest, supports sensitivities, parallelizable)
+solver = pybamm.IDAKLUSolver(rtol=1e-6, atol=1e-6)
+
+# Alternative: CasADi (sometimes faster for certain physics, legacy default)
+solver = pybamm.CasadiSolver(mode="safe")
+
+# Avoid in production: ScipySolver (pure Python, slow — testing only)
+solver = pybamm.ScipySolver()
+
+sim = pybamm.Simulation(model, parameter_values=param, solver=solver)
+```
+
+The default tolerances (`rtol=1e-3`, `atol=1e-6`) are adequate for most simulations. Tighten them when comparing to experimental data or running degradation models.
+
+## Common Pitfalls
+
+### Unit mismatch
+
+Parameter names encode units: `"Negative electrode thickness [m]"` expects metres, not micrometres. Passing `75` when you mean `75e-6` is the most common silent error — the simulation runs but produces nonsense results.
+
+### Wrong parameter set for the chemistry
+
+`"Chen2020"` is an LFP cell. Using it with a model tuned for NMC or NCA will give physically wrong results. Match the parameter set to your target chemistry.
+
+### Accessing Solution before calling solve
+
+```python
+sim = pybamm.Simulation(model, parameter_values=param)
+sol = sim.solution  # None — solve() has not been called yet
+sim.solve([0, 3600])
+sol = sim.solution  # correct
+```
+
+### Forgetting units in variable names
+
+```python
+solution["Voltage"]      # KeyError — must include units
+solution["Voltage [V]"]  # correct
+```
+
+### Experiment strings vs time-span solve
+
+If you pass an `experiment=` argument to `Simulation`, do not also pass a time span to `.solve()`. Pass `sim.solve()` with no arguments and let the experiment define the protocol.
+
+```python
+sim = pybamm.Simulation(model, parameter_values=param, experiment=experiment)
+sim.solve()  # no time span — the experiment defines it
+```
+
+## Practical Workflow For Agents
+
+1. `pip install pybamm` and confirm `pybamm.__version__`.
+2. Start with `pybamm.lithium_ion.SPM()` for fast iteration; switch to `DFN()` when accuracy matters.
+3. Pick the closest built-in parameter set for your cell chemistry (see [parameter-sets reference](references/parameter-sets.md)).
+4. Override individual parameters with `param.update({...})` — always include the `[unit]` suffix in the key.
+5. Use `pybamm.Experiment` for multi-step protocols; use a plain time span for simple discharges.
+6. After `.solve()`, access results via `solution["Variable [unit]"].entries`.
+7. Use `sim.plot()` to sanity-check results visually before processing data.
+
+## Official Sources
+
+- PyBaMM documentation: https://docs.pybamm.org/en/stable/
+- GitHub repository: https://github.com/pybamm-team/PyBaMM
+- Getting-started notebooks: https://docs.pybamm.org/en/stable/source/examples/index.html
+- Parameter sets list: https://docs.pybamm.org/en/stable/source/api/parameters/parameter_sets.html
+- PyPI package page: https://pypi.org/project/pybamm/

--- a/content/pybamm/docs/pybamm/python/references/models-advanced.md
+++ b/content/pybamm/docs/pybamm/python/references/models-advanced.md
@@ -1,0 +1,228 @@
+# PyBaMM Advanced Models Reference
+
+## Lead-Acid Models
+
+PyBaMM includes full lead-acid battery models:
+
+```python
+import pybamm
+
+# Full order lead-acid model
+model = pybamm.lead_acid.Full()
+
+# Simplified lead-acid model (like SPM for li-ion)
+model = pybamm.lead_acid.LOQS()
+
+param = pybamm.ParameterValues("Sulzer2019")
+sim = pybamm.Simulation(model, parameter_values=param)
+sim.solve([0, 3600])
+```
+
+---
+
+## Equivalent Circuit Models (ECM)
+
+ECMs represent the battery as a resistor-capacitor network — much faster than physics-based models, useful for state estimation and real-time applications:
+
+```python
+model = pybamm.equivalent_circuit.Thevenin()
+
+# ECMs use different parameter sets
+param = pybamm.ParameterValues({
+    "Cell capacity [A.h]": 3.0,
+    "Nominal cell capacity [A.h]": 3.0,
+    "Current function [A]": 1.0,
+    "Initial SoC": 1.0,
+    "R0 [Ohm]": 0.01,
+    "R1 [Ohm]": 0.005,
+    "C1 [F]": 1000,
+    "Open-circuit voltage [V]": pybamm.linear(2.5, 4.2),  # or a lookup table
+    "Cell thermal mass [J/K]": 1000,
+    "Cell cooling coefficient [W/K]": 10,
+    "Ambient temperature [K]": 298.15,
+    "Initial temperature [K]": 298.15,
+})
+
+sim = pybamm.Simulation(model, parameter_values=param)
+sim.solve([0, 3600])
+```
+
+---
+
+## Electrochemical Impedance Spectroscopy (EIS)
+
+`pybamm.EISSimulation` solves for the complex impedance spectrum at a given state of charge:
+
+```python
+import pybamm
+import numpy as np
+
+model = pybamm.lithium_ion.DFN()
+param = pybamm.ParameterValues("Chen2020")
+
+eis_sim = pybamm.EISSimulation(model, parameter_values=param)
+
+# Frequency range in Hz
+frequencies = np.logspace(-4, 4, 100)
+impedance = eis_sim.solve(frequencies)
+
+# impedance is a complex numpy array: Z = Z_real + j*Z_imag
+Z_real = impedance.real
+Z_imag = impedance.imag
+
+# Nyquist plot
+import matplotlib.pyplot as plt
+plt.plot(Z_real, -Z_imag)
+plt.xlabel("Z' [Ohm]")
+plt.ylabel("-Z'' [Ohm]")
+plt.show()
+```
+
+`EISSimulation` linearizes the model around the operating point. The state of charge at which impedance is evaluated is set via the initial conditions in `ParameterValues`.
+
+---
+
+## Submodel Options
+
+PyBaMM models are composed of swappable submodels. Pass an `options` dictionary to customize physics:
+
+```python
+# Enable thermal effects
+model = pybamm.lithium_ion.DFN(options={"thermal": "lumped"})
+
+# Include SEI growth (degradation)
+model = pybamm.lithium_ion.DFN(options={
+    "SEI": "ec reaction limited",
+    "SEI porosity change": "true",
+})
+
+# Include lithium plating
+model = pybamm.lithium_ion.DFN(options={
+    "lithium plating": "irreversible",
+    "lithium plating porosity change": "true",
+})
+
+# Particle size distribution (many-particle model)
+model = pybamm.lithium_ion.DFN(options={"particle size": "distribution"})
+```
+
+Check available options with:
+
+```python
+model = pybamm.lithium_ion.DFN()
+print(model.default_options)
+```
+
+Common option keys: `"thermal"`, `"SEI"`, `"lithium plating"`, `"particle"`, `"loss of active material"`.
+
+---
+
+## Manual Geometry and Discretisation
+
+`pybamm.Simulation` handles geometry and discretisation automatically. When you need full control (custom meshes, non-standard spatial methods), set it up manually:
+
+```python
+import pybamm
+
+model = pybamm.lithium_ion.SPM()
+param = pybamm.ParameterValues("Chen2020")
+
+# Geometry
+geometry = model.default_geometry
+param.process_geometry(geometry)
+
+# Mesh
+submesh_types = model.default_submesh_types
+var_pts = {
+    pybamm.standard_spatial_vars.x_n: 5,   # negative electrode points
+    pybamm.standard_spatial_vars.x_s: 5,   # separator points
+    pybamm.standard_spatial_vars.x_p: 5,   # positive electrode points
+    pybamm.standard_spatial_vars.r_n: 5,   # negative particle radial points
+    pybamm.standard_spatial_vars.r_p: 5,   # positive particle radial points
+}
+mesh = pybamm.Mesh(geometry, submesh_types, var_pts)
+
+# Discretisation
+spatial_methods = model.default_spatial_methods
+disc = pybamm.Discretisation(mesh, spatial_methods)
+disc.process_model(model)
+
+# Solve
+solver = pybamm.IDAKLUSolver()
+t_eval = [0, 3600]
+solution = solver.solve(model, t_eval)
+```
+
+More mesh points increase accuracy but raise computation time. `var_pts` defaults are set per model (usually 10–20 points per domain).
+
+---
+
+## Building Custom Models from Submodels
+
+PyBaMM's architecture lets you compose models from individual submodels:
+
+```python
+import pybamm
+
+# Start with an empty lithium-ion model
+model = pybamm.lithium_ion.BaseModel()
+
+# Attach specific submodel classes
+model.submodels["external circuit"] = pybamm.external_circuit.ExplicitCurrentControl(model.param, model.options)
+model.submodels["negative electrode sei"] = pybamm.sei.NoSEI(model.param, "negative", model.options)
+# ... add all required submodels
+
+model.build_model()
+```
+
+This is an advanced workflow — consult the [PyBaMM submodels API reference](https://docs.pybamm.org/en/stable/source/api/models/submodels/index.html) and look at the source of `DFN()` to see which submodels it wires together.
+
+---
+
+## Saving and Loading Solutions
+
+```python
+import pickle
+
+# Save
+with open("solution.pkl", "wb") as f:
+    pickle.dump(sim.solution, f)
+
+# Load
+with open("solution.pkl", "rb") as f:
+    solution = pickle.load(f)
+
+V = solution["Voltage [V]"].entries
+```
+
+PyBaMM solutions are plain Python objects and are pickle-compatible.
+
+---
+
+## Parallelising Parameter Sweeps with IDAKLUSolver
+
+`IDAKLUSolver` supports multi-threaded batch solving via OpenMP:
+
+```python
+import pybamm
+import numpy as np
+
+model = pybamm.lithium_ion.SPM()
+param = pybamm.ParameterValues("Chen2020")
+
+c_rates = [0.5, 1.0, 2.0, 5.0]
+solutions = []
+
+solver = pybamm.IDAKLUSolver()
+
+for c_rate in c_rates:
+    param.update({"Current function [A]": c_rate * param["Nominal cell capacity [A.h]"]})
+    sim = pybamm.Simulation(model, parameter_values=param, solver=solver)
+    sim.solve([0, 3600 / c_rate])
+    solutions.append(sim.solution)
+
+pybamm.QuickPlot(solutions, ["Voltage [V]"],
+                 labels=[f"{c}C" for c in c_rates]).dynamic_plot()
+```
+
+For large sweeps, consider `multiprocessing` to parallelize at the Python level, or use PyBaMM's `BaseBatteryModel.rhs_algebraic` interface directly with `IDAKLUSolver.solve()` to batch calls.

--- a/content/pybamm/docs/pybamm/python/references/parameter-sets.md
+++ b/content/pybamm/docs/pybamm/python/references/parameter-sets.md
@@ -1,0 +1,169 @@
+# PyBaMM Parameter Sets Reference
+
+## Built-in Parameter Sets
+
+PyBaMM ships with curated parameter sets for real lithium-ion cells. Load any by passing its name to `pybamm.ParameterValues`:
+
+```python
+param = pybamm.ParameterValues("Chen2020")
+```
+
+### Commonly Used Sets
+
+| Name | Chemistry | Cell type | Notes |
+|------|-----------|-----------|-------|
+| `"Chen2020"` | Graphite/LFP | 21700 cylindrical | Most widely used default; validated against discharge curves |
+| `"Marquis2019"` | Graphite/LiCoO2 | Pouch | Original SPMe paper parameters |
+| `"OKane2022"` | Graphite/LFP | 21700 cylindrical | Extends Chen2020 with degradation (SEI, lithium plating) |
+| `"Mohtat2020"` | Graphite/NMC | — | SPM-focused parameter set |
+| `"Ai2020"` | Graphite/LiCoO2 | — | Thermal model parameters |
+| `"Ecker2015"` | Graphite/NMC | Pouch | Frequently cited in literature |
+| `"NCA_Kim2011"` | Graphite/NCA | 18650 cylindrical | NCA chemistry |
+| `"Prada2013"` | Graphite/LFP | 26650 cylindrical | LFP, lower voltage plateau |
+| `"Ramadass2004"` | Graphite/LiCoO2 | — | Early foundational set |
+
+### Sodium-ion
+
+| Name | Chemistry |
+|------|-----------|
+| `"Borges_2024"` | Hard carbon/Prussian blue analogue |
+
+### Lead-acid
+
+| Name | Chemistry |
+|------|-----------|
+| `"Sulzer2019"` | Lead-acid |
+
+List all available sets programmatically:
+
+```python
+import pybamm
+print(pybamm.parameter_sets)
+```
+
+---
+
+## Inspecting Parameters
+
+### Search by keyword
+
+```python
+param = pybamm.ParameterValues("Chen2020")
+param.search("diffusion")          # all diffusion-related parameters
+param.search("negative electrode") # only negative electrode params
+```
+
+### Print everything
+
+```python
+param.print_parameter_info()
+```
+
+### Access a single value
+
+```python
+thickness = param["Negative electrode thickness [m]"]
+print(thickness)  # e.g., 8.52e-05
+```
+
+---
+
+## Updating Parameters
+
+### Scalar values
+
+```python
+param.update({
+    "Negative electrode thickness [m]": 75e-6,    # must be in metres
+    "Positive electrode thickness [m]": 90e-6,
+    "Separator thickness [m]": 25e-6,
+    "Nominal cell capacity [A.h]": 5.0,
+})
+```
+
+### Function parameters
+
+Some parameters are functions of temperature or concentration. Replace them with a Python callable:
+
+```python
+def my_diffusivity(c_e, T):
+    return 5.34e-10 * np.exp(-0.65 * c_e / 1000)
+
+param.update({
+    "Electrolyte diffusivity [m2.s-1]": my_diffusivity
+})
+```
+
+The function signature must match what PyBaMM expects — check `param.print_parameter_info()` to see whether a parameter is a constant or a function.
+
+---
+
+## Creating a Custom Parameter Set
+
+Build a parameter set from a dictionary. The simplest approach is to start from a built-in set and override what you need:
+
+```python
+param = pybamm.ParameterValues("Chen2020")
+
+# Override specific parameters for your cell
+param.update({
+    "Nominal cell capacity [A.h]": 3.0,
+    "Negative electrode thickness [m]": 80e-6,
+    "Positive electrode thickness [m]": 100e-6,
+    "Electrolyte conductivity [S.m-1]": 1.0,
+})
+```
+
+To build from scratch, pass a dictionary of all required parameters to `pybamm.ParameterValues(...)`. The required keys depend on the model — run the simulation once and inspect the `KeyError` to find missing parameters.
+
+---
+
+## Common Parameter Names (with units)
+
+### Geometry
+
+- `"Negative electrode thickness [m]"`
+- `"Separator thickness [m]"`
+- `"Positive electrode thickness [m]"`
+- `"Electrode height [m]"`
+- `"Electrode width [m]"`
+
+### Transport
+
+- `"Electrolyte diffusivity [m2.s-1]"` (may be a function of `c_e`, `T`)
+- `"Electrolyte conductivity [S.m-1]"` (may be a function)
+- `"Negative electrode diffusivity [m2.s-1]"` (may be a function of `c_s`, `T`)
+- `"Positive electrode diffusivity [m2.s-1]"` (may be a function of `c_s`, `T`)
+
+### Kinetics
+
+- `"Negative electrode exchange-current density [A.m-2]"` (function of `c_e`, `c_s`, `c_s_max`, `T`)
+- `"Positive electrode exchange-current density [A.m-2]"` (function of `c_e`, `c_s`, `c_s_max`, `T`)
+
+### Thermal
+
+- `"Cell cooling surface area [m2]"`
+- `"Cell volume [m3]"`
+- `"Negative electrode specific heat capacity [J.kg-1.K-1]"`
+- `"Ambient temperature [K]"` — default 298.15 K (25°C)
+
+### Operating conditions
+
+- `"Current function [A]"` — constant current value; or pass a function `f(t)` for time-varying current
+- `"Nominal cell capacity [A.h]"` — used to interpret C-rate strings in Experiment
+
+---
+
+## Unit Conventions
+
+PyBaMM uses SI units throughout. Parameter names always encode the unit in square brackets. Mistakes:
+
+```python
+# Wrong — micrometres instead of metres
+param.update({"Negative electrode thickness [m]": 75})
+
+# Correct
+param.update({"Negative electrode thickness [m]": 75e-6})
+```
+
+Temperature parameters expect Kelvin, not Celsius. `298.15 K` = `25°C`.

--- a/content/pybamm/docs/pybamm/python/references/parameter-sets.md
+++ b/content/pybamm/docs/pybamm/python/references/parameter-sets.md
@@ -12,13 +12,13 @@ param = pybamm.ParameterValues("Chen2020")
 
 | Name | Chemistry | Cell type | Notes |
 |------|-----------|-----------|-------|
-| `"Chen2020"` | Graphite/LFP | 21700 cylindrical | Most widely used default; validated against discharge curves |
-| `"Marquis2019"` | Graphite/LiCoO2 | Pouch | Original SPMe paper parameters |
-| `"OKane2022"` | Graphite/LFP | 21700 cylindrical | Extends Chen2020 with degradation (SEI, lithium plating) |
-| `"Mohtat2020"` | Graphite/NMC | — | SPM-focused parameter set |
-| `"Ai2020"` | Graphite/LiCoO2 | — | Thermal model parameters |
-| `"Ecker2015"` | Graphite/NMC | Pouch | Frequently cited in literature |
-| `"NCA_Kim2011"` | Graphite/NCA | 18650 cylindrical | NCA chemistry |
+| `"Chen2020"` | Graphite/NMC811 | 21700 cylindrical | LG M50 cell; most widely used default; validated against discharge curves |
+| `"Marquis2019"` | Graphite/NMC | Pouch | Kokam SLPB78205130H; original SPMe paper parameters |
+| `"OKane2022"` | Graphite/NMC811 | 21700 cylindrical | LG M50; extends Chen2020 with degradation (SEI, lithium plating) |
+| `"Mohtat2020"` | Graphite/NMC532 | Pouch | SPM-focused parameter set |
+| `"Ai2020"` | Graphite/LiCoO2 | Pouch | Enertech cell; thermal model parameters |
+| `"Ecker2015"` | Graphite/NMC | Pouch | Kokam SLPB 75106100; frequently cited in literature |
+| `"NCA_Kim2011"` | Graphite/NCA | Pouch | NCA chemistry |
 | `"Prada2013"` | Graphite/LFP | 26650 cylindrical | LFP, lower voltage plateau |
 | `"Ramadass2004"` | Graphite/LiCoO2 | — | Early foundational set |
 

--- a/content/pybamm/skills/analyze/SKILL.md
+++ b/content/pybamm/skills/analyze/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: analyze
+description: "Workflow for extracting, plotting, and interpreting PyBaMM simulation results from a Solution object"
+metadata:
+  revision: 1
+  updated-on: "2026-05-09"
+  source: community
+  tags: "pybamm,battery,simulation,analysis,plotting,python"
+---
+
+# PyBaMM: Analysing Simulation Results
+
+After `sim.solve()`, all results live in the `Solution` object. This skill covers how to extract variables, plot them, compare runs, and interpret common outputs.
+
+## Accessing Variables
+
+Variables are accessed by their full name including unit suffix:
+
+```python
+solution = sim.solution
+
+t  = solution["Time [s]"].entries           # time array (numpy)
+V  = solution["Voltage [V]"].entries        # terminal voltage
+I  = solution["Current [A]"].entries        # current (positive = discharge)
+Q  = solution["Discharge capacity [A.h]"].entries
+T  = solution["Cell temperature [K]"].entries
+```
+
+`.entries` returns a 1-D numpy array aligned with the time vector.
+
+## Common Variable Names
+
+### Cell-level
+
+| Variable | Unit |
+|----------|------|
+| `"Time [s]"` | s |
+| `"Time [h]"` | h |
+| `"Voltage [V]"` | V |
+| `"Current [A]"` | A |
+| `"Discharge capacity [A.h]"` | A·h |
+| `"Throughput capacity [A.h]"` | A·h (cumulative, multi-cycle) |
+| `"Cell temperature [K]"` | K |
+| `"Power [W]"` | W |
+
+### Electrode and electrolyte (DFN / SPMe)
+
+| Variable | Unit |
+|----------|------|
+| `"Electrolyte concentration [mol.m-3]"` | mol m⁻³ |
+| `"Negative electrode potential [V]"` | V |
+| `"Positive electrode potential [V]"` | V |
+| `"Negative particle surface concentration [mol.m-3]"` | mol m⁻³ |
+| `"Positive particle surface concentration [mol.m-3]"` | mol m⁻³ |
+
+### State of charge
+
+| Variable | Unit |
+|----------|------|
+| `"State of charge"` | dimensionless (0–1) |
+| `"Depth of discharge"` | dimensionless (0–1) |
+
+## Listing Available Variables
+
+```python
+# Variables available for the solved model
+print(list(solution.all_models[0].variables.keys()))
+```
+
+This is the authoritative list — it depends on which model and submodel options were used.
+
+## Interpolating at a Specific Time
+
+```python
+# Voltage at exactly t = 1800 s
+V_at_half = solution["Voltage [V]"](t=1800)
+
+# Multiple times
+import numpy as np
+t_query = np.array([600, 1200, 1800, 2400, 3000])
+V_values = solution["Voltage [V]"](t=t_query)
+```
+
+## Plotting
+
+### Quick plot (interactive)
+
+```python
+sim.plot()                                   # default variables
+sim.plot(["Voltage [V]", "Current [A]"])     # selected variables
+```
+
+Pass a nested list to share a y-axis:
+
+```python
+sim.plot([
+    "Voltage [V]",
+    ["Current [A]", "Discharge capacity [A.h]"],  # these two share an axis
+])
+```
+
+### Comparing multiple runs
+
+```python
+import pybamm
+
+solutions = []
+labels = []
+
+for c_rate in [0.5, 1.0, 2.0]:
+    param.update({"Current function [A]": c_rate * 5.0})
+    sim = pybamm.Simulation(model, parameter_values=param)
+    sim.solve([0, 3600 / c_rate])
+    solutions.append(sim.solution)
+    labels.append(f"{c_rate}C")
+
+pybamm.QuickPlot(solutions, ["Voltage [V]"], labels=labels).dynamic_plot()
+```
+
+### Matplotlib plot (for publication)
+
+```python
+import matplotlib.pyplot as plt
+
+t = solution["Time [h]"].entries
+V = solution["Voltage [V]"].entries
+Q = solution["Discharge capacity [A.h]"].entries
+
+fig, axes = plt.subplots(1, 2, figsize=(10, 4))
+
+axes[0].plot(t, V)
+axes[0].set(xlabel="Time [h]", ylabel="Voltage [V]", title="Voltage vs Time")
+
+axes[1].plot(Q, V)
+axes[1].set(xlabel="Discharge capacity [A.h]", ylabel="Voltage [V]", title="V vs Q")
+
+plt.tight_layout()
+plt.savefig("discharge.png", dpi=150)
+plt.show()
+```
+
+## Multi-Cycle Analysis
+
+When using `pybamm.Experiment` with repeated cycles, the Solution contains data for all cycles concatenated. Use `solution.cycles` to access individual cycles:
+
+```python
+experiment = pybamm.Experiment([
+    ("Discharge at 1C until 2.5 V",
+     "Charge at 1C until 4.2 V",
+     "Hold at 4.2 V until C/50"),
+] * 10)  # 10 cycles
+
+sim = pybamm.Simulation(model, parameter_values=param, experiment=experiment)
+sim.solve()
+
+solution = sim.solution
+
+# Per-cycle capacity
+for i, cycle in enumerate(solution.cycles):
+    Q_end = cycle["Discharge capacity [A.h]"].entries[-1]
+    print(f"Cycle {i+1}: {Q_end:.3f} A.h")
+
+# Capacity fade plot
+capacities = [
+    cycle["Discharge capacity [A.h]"].entries[-1]
+    for cycle in solution.cycles
+]
+plt.plot(range(1, len(capacities) + 1), capacities)
+plt.xlabel("Cycle number")
+plt.ylabel("Discharge capacity [A.h]")
+plt.show()
+```
+
+## Saving and Loading Results
+
+```python
+import pickle
+
+# Save
+with open("result.pkl", "wb") as f:
+    pickle.dump(solution, f)
+
+# Load and use without re-solving
+with open("result.pkl", "rb") as f:
+    solution = pickle.load(f)
+
+V = solution["Voltage [V]"].entries
+```
+
+## Summary Statistics
+
+```python
+solution = sim.solution
+V = solution["Voltage [V]"].entries
+Q = solution["Discharge capacity [A.h]"].entries
+
+print(f"Capacity:           {Q[-1]:.3f} A.h")
+print(f"Minimum voltage:    {V.min():.3f} V")
+print(f"Energy delivered:   {solution['Energy [W.h]'].entries[-1]:.3f} W.h")
+print(f"Solver wall time:   {solution.solve_time:.3f} s")
+```
+
+## Interpreting Results
+
+- **Voltage drop at start of discharge**: ohmic resistance (`R0`)
+- **Curved voltage profile**: intercalation thermodynamics (OCV curve shape)
+- **Sharp voltage drop near end**: lithium depletion in one electrode
+- **Temperature rise**: Joule heating — significant at high C-rates
+- **NaN or unrealistic values**: usually a unit error in a parameter or a solver divergence — check parameter values and tighten tolerances

--- a/content/pybamm/skills/fit-parameters/SKILL.md
+++ b/content/pybamm/skills/fit-parameters/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: fit-parameters
+description: "Workflow for fitting PyBaMM model parameters to experimental battery data using optimisation"
+metadata:
+  revision: 1
+  updated-on: "2026-05-09"
+  source: community
+  tags: "pybamm,battery,parameter-fitting,optimisation,inverse-problem,python"
+---
+
+# PyBaMM: Fitting Model Parameters to Experimental Data
+
+Parameter fitting (also called parameter identification or inverse modelling) finds parameter values that minimise the difference between simulated and measured data. This skill covers the standard approach using `scipy.optimize` with PyBaMM simulations.
+
+## Overview
+
+The core loop:
+
+1. Load experimental data (time, voltage, current)
+2. Choose which parameters to fit and set initial guesses
+3. Define a cost function: run a simulation, compute RMSE vs data
+4. Call an optimiser (`scipy.optimize.minimize` or `differential_evolution`)
+5. Verify the fit and check for physical plausibility
+
+## Step 1 — Prepare Experimental Data
+
+Load your measured discharge data:
+
+```python
+import numpy as np
+
+# Measured data: time in seconds, voltage in volts
+# Replace with your actual data source
+t_exp = np.array([0, 360, 720, 1080, 1440, 1800, 2160, 2520, 2880, 3240, 3600])
+V_exp = np.array([4.18, 4.05, 3.95, 3.87, 3.80, 3.74, 3.68, 3.60, 3.48, 3.30, 2.80])
+I_exp = 1.5  # constant discharge current in A
+```
+
+## Step 2 — Set Up the Baseline Simulation
+
+Start from a built-in parameter set and decide which parameters to fit:
+
+```python
+import pybamm
+
+model = pybamm.lithium_ion.SPM()  # SPM is faster — good for optimisation loops
+param = pybamm.ParameterValues("Chen2020")
+
+# Parameters to fit and their initial guesses
+initial_guess = {
+    "Negative electrode diffusivity [m2.s-1]": 3.3e-14,
+    "Positive electrode diffusivity [m2.s-1]": 4.0e-15,
+}
+```
+
+Use `SPM()` or `SPMe()` during fitting — `DFN()` is slower and the optimiser will call the simulation hundreds of times. Switch to `DFN()` only for a final validation run.
+
+## Step 3 — Define the Cost Function
+
+```python
+def simulate_voltage(params_dict, t_eval):
+    """Run a simulation and return interpolated voltage at t_eval."""
+    local_param = param.copy()
+    local_param.update(params_dict)
+    local_param.update({"Current function [A]": I_exp})
+
+    sim = pybamm.Simulation(
+        model,
+        parameter_values=local_param,
+        solver=pybamm.IDAKLUSolver(rtol=1e-4, atol=1e-6),
+    )
+    try:
+        sim.solve([t_eval[0], t_eval[-1]])
+        V_sim = sim.solution["Voltage [V]"](t=t_eval)
+        return V_sim
+    except pybamm.SolverError:
+        return np.full_like(t_eval, np.nan, dtype=float)
+
+
+def cost(x):
+    """RMSE cost function for scipy.optimize."""
+    params_dict = {
+        "Negative electrode diffusivity [m2.s-1]": x[0],
+        "Positive electrode diffusivity [m2.s-1]": x[1],
+    }
+    V_sim = simulate_voltage(params_dict, t_exp)
+
+    if np.any(np.isnan(V_sim)):
+        return 1e6  # penalise failed solves heavily
+
+    rmse = np.sqrt(np.mean((V_sim - V_exp) ** 2))
+    return rmse
+```
+
+## Step 4 — Run the Optimiser
+
+### Gradient-free local optimiser (Nelder-Mead)
+
+Good starting point when the cost landscape is smooth:
+
+```python
+from scipy.optimize import minimize
+
+x0 = [initial_guess["Negative electrode diffusivity [m2.s-1]"],
+      initial_guess["Positive electrode diffusivity [m2.s-1]"]]
+
+result = minimize(cost, x0, method="Nelder-Mead",
+                  options={"xatol": 1e-12, "fatol": 1e-6, "maxiter": 500})
+
+print(f"RMSE: {result.fun:.4f} V")
+print(f"D_n = {result.x[0]:.3e}")
+print(f"D_p = {result.x[1]:.3e}")
+```
+
+### Global optimiser (differential evolution)
+
+Use when the cost surface has multiple local minima — more robust but slower:
+
+```python
+from scipy.optimize import differential_evolution
+
+bounds = [
+    (1e-15, 1e-12),   # D_n range
+    (1e-16, 1e-13),   # D_p range
+]
+
+result = differential_evolution(cost, bounds, seed=42, maxiter=200,
+                                tol=1e-6, workers=1, disp=True)
+
+print(f"RMSE: {result.fun:.4f} V")
+print(f"D_n = {result.x[0]:.3e}, D_p = {result.x[1]:.3e}")
+```
+
+## Step 5 — Validate the Fit
+
+Plot the best-fit simulation against experimental data:
+
+```python
+import matplotlib.pyplot as plt
+
+best_params = {
+    "Negative electrode diffusivity [m2.s-1]": result.x[0],
+    "Positive electrode diffusivity [m2.s-1]": result.x[1],
+}
+
+# Validate with DFN for higher accuracy
+model_val = pybamm.lithium_ion.DFN()
+param_val = param.copy()
+param_val.update(best_params)
+param_val.update({"Current function [A]": I_exp})
+
+sim_val = pybamm.Simulation(model_val, parameter_values=param_val)
+sim_val.solve([t_exp[0], t_exp[-1]])
+sol = sim_val.solution
+
+t_sim = sol["Time [s]"].entries
+V_sim = sol["Voltage [V]"].entries
+
+plt.figure(figsize=(8, 4))
+plt.plot(t_exp, V_exp, "ko", label="Experiment", markersize=5)
+plt.plot(t_sim, V_sim, "r-", label="Fit (DFN)")
+plt.xlabel("Time [s]")
+plt.ylabel("Voltage [V]")
+plt.legend()
+plt.title(f"Parameter fit — RMSE = {result.fun*1000:.1f} mV")
+plt.tight_layout()
+plt.show()
+```
+
+## Fit Quality Guidelines
+
+| RMSE | Interpretation |
+|------|---------------|
+| < 5 mV | Excellent fit |
+| 5–20 mV | Good — acceptable for most use cases |
+| 20–50 mV | Marginal — consider fitting more parameters or using a higher-fidelity model |
+| > 50 mV | Poor — check data quality, parameter bounds, and model choice |
+
+## Common Pitfalls
+
+### Parameters at bounds
+
+If the optimiser converges to a value at the edge of a bound, the true optimum is likely outside your bound. Widen the bound and re-run.
+
+### Local minima
+
+Nelder-Mead is sensitive to the initial guess. If RMSE is high, try `differential_evolution` or run Nelder-Mead from multiple starting points:
+
+```python
+from itertools import product
+
+candidates = list(product([1e-14, 5e-14], [1e-15, 5e-15]))
+best = min((minimize(cost, list(x0), method="Nelder-Mead") for x0 in candidates),
+           key=lambda r: r.fun)
+```
+
+### Physically implausible values
+
+Always check that fitted values are physically reasonable:
+
+- Solid diffusivities: `1e-16` to `1e-12` m² s⁻¹
+- Electrolyte diffusivity: `1e-11` to `1e-9` m² s⁻¹
+- Exchange current density: `0.1` to `10` A m⁻²
+
+### Unit errors in parameters
+
+The optimiser works in whatever units you specify. If the cost function passes a value in µm² s⁻¹ when PyBaMM expects m² s⁻¹, the simulation will fail silently. Keep all values in SI units throughout.
+
+### Overfitting
+
+Fitting many parameters to a single discharge curve leads to non-unique solutions. Prefer fitting to multiple datasets (different C-rates, temperatures) simultaneously by summing their costs.
+
+## Multi-Dataset Fitting
+
+```python
+datasets = [
+    {"I": 1.0, "t": t_1C, "V": V_1C},
+    {"I": 2.0, "t": t_2C, "V": V_2C},
+    {"I": 0.5, "t": t_half_C, "V": V_half_C},
+]
+
+def cost_multi(x):
+    total = 0.0
+    for ds in datasets:
+        p = {
+            "Negative electrode diffusivity [m2.s-1]": x[0],
+            "Positive electrode diffusivity [m2.s-1]": x[1],
+            "Current function [A]": ds["I"],
+        }
+        V_sim = simulate_voltage(p, ds["t"])
+        if np.any(np.isnan(V_sim)):
+            return 1e6
+        total += np.mean((V_sim - ds["V"]) ** 2)
+    return np.sqrt(total / len(datasets))
+```

--- a/content/pybamm/skills/simulate/SKILL.md
+++ b/content/pybamm/skills/simulate/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: simulate
+description: "Step-by-step workflow for setting up and running a PyBaMM battery simulation from scratch"
+metadata:
+  revision: 1
+  updated-on: "2026-05-09"
+  source: community
+  tags: "pybamm,battery,simulation,electrochemistry,python"
+---
+
+# PyBaMM: Running a Battery Simulation
+
+Use this workflow to go from zero to a solved simulation. Each step is a decision point — read the notes to pick the right option.
+
+## Step 1 — Choose a Model
+
+Pick based on your accuracy vs speed requirement:
+
+```python
+import pybamm
+
+model = pybamm.lithium_ion.DFN()   # highest accuracy, ~270 ms solve
+model = pybamm.lithium_ion.SPMe()  # balanced, ~39 ms solve
+model = pybamm.lithium_ion.SPM()   # fastest, ~21 ms solve — use for sweeps
+```
+
+**Rule of thumb:** start with `SPM()` while building the simulation, switch to `DFN()` when you need physics-accurate results.
+
+## Step 2 — Load Parameter Values
+
+Always use a built-in set that matches your cell chemistry:
+
+```python
+param = pybamm.ParameterValues("Chen2020")    # graphite/LFP 21700 — most common default
+param = pybamm.ParameterValues("Marquis2019") # graphite/LiCoO2
+param = pybamm.ParameterValues("OKane2022")   # Chen2020 + degradation parameters
+```
+
+Override specific parameters after loading:
+
+```python
+param.update({
+    "Negative electrode thickness [m]": 75e-6,  # always SI units
+    "Current function [A]": 2.5,
+})
+```
+
+If unsure what parameters exist: `param.search("keyword")`.
+
+## Step 3 — Define the Protocol
+
+### Simple constant-current discharge
+
+Pass a `[t_start, t_end]` time span in seconds directly to `.solve()`:
+
+```python
+sim = pybamm.Simulation(model, parameter_values=param)
+sim.solve([0, 3600])  # 1-hour discharge
+```
+
+### Multi-step experiment (CC/CV cycling)
+
+Use `pybamm.Experiment` for discharge/charge/rest sequences:
+
+```python
+experiment = pybamm.Experiment([
+    "Discharge at 1C for 1 hour or until 2.5 V",
+    "Rest for 10 minutes",
+    "Charge at 0.5C until 4.2 V",
+    "Hold at 4.2 V until C/20",
+    "Rest for 30 minutes",
+])
+
+sim = pybamm.Simulation(model, parameter_values=param, experiment=experiment)
+sim.solve()  # no time span — experiment defines it
+```
+
+Experiment string grammar: `"<action> at <rate> [for <time>] [or until <condition>]"`
+
+Valid actions: `Discharge`, `Charge`, `Hold`, `Rest`
+Valid rates: `1C`, `0.5A`, `4.2V` (context-dependent)
+Valid conditions: `2.5 V`, `4.2 V`, `C/20`, `1 hour`
+
+## Step 4 — Select a Solver (Optional)
+
+The default solver is `IDAKLUSolver`. Set it explicitly only when tuning:
+
+```python
+solver = pybamm.IDAKLUSolver(rtol=1e-6, atol=1e-6)  # tighter tolerances
+sim = pybamm.Simulation(model, parameter_values=param, solver=solver)
+```
+
+Use `CasadiSolver` only if you have a specific reason (e.g., legacy code or certain physics configurations that perform better with it).
+
+## Step 5 — Solve
+
+```python
+sim.solve([0, 3600])        # time-span solve
+# or
+sim.solve()                 # experiment-driven solve (requires experiment=)
+```
+
+To control output resolution:
+
+```python
+import numpy as np
+t_eval = np.linspace(0, 3600, 200)
+sim.solve(t_eval=t_eval)
+```
+
+## Step 6 — Verify the Result
+
+Always sanity-check before processing data:
+
+```python
+solution = sim.solution
+
+t = solution["Time [s]"].entries
+V = solution["Voltage [V]"].entries
+
+print(f"Solve time: {solution.solve_time:.3f} s")
+print(f"Voltage range: {V.min():.3f} – {V.max():.3f} V")
+
+sim.plot()  # visual check
+```
+
+Expected voltage range for a lithium-ion cell: roughly 2.5–4.2 V. Values outside this range or NaN usually indicate a unit error in a parameter.
+
+## Complete Example
+
+```python
+import pybamm
+import numpy as np
+
+# Model and parameters
+model = pybamm.lithium_ion.DFN()
+param = pybamm.ParameterValues("Chen2020")
+
+# Multi-step experiment: 1C discharge then CC-CV charge
+experiment = pybamm.Experiment([
+    "Discharge at 1C until 2.5 V",
+    "Rest for 5 minutes",
+    "Charge at 1C until 4.2 V",
+    "Hold at 4.2 V until C/50",
+])
+
+# Simulation
+sim = pybamm.Simulation(
+    model,
+    parameter_values=param,
+    experiment=experiment,
+    solver=pybamm.IDAKLUSolver(),
+)
+sim.solve()
+
+# Results
+solution = sim.solution
+print(f"Discharge capacity: {solution['Discharge capacity [A.h]'].entries[-1]:.3f} A.h")
+sim.plot(["Voltage [V]", "Current [A]"])
+```
+
+## Common Errors
+
+| Error | Likely cause |
+|-------|-------------|
+| `KeyError: 'Voltage [V]'` | Typo in variable name — units are mandatory |
+| `NaN` in voltage | Parameter unit mismatch (e.g., µm instead of m) |
+| `solution` is `None` | `.solve()` not called yet |
+| Experiment solve + time span | Passed time span to `.solve()` when `experiment=` is set — remove the time span |
+| `SolverError` / divergence | Tolerances too loose or parameter set incompatible with model |

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
     },
     "cli": {
       "name": "@aisuite/chub",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",


### PR DESCRIPTION
Added support for the package pybamm, a battery modeling & simulation package in python. https://github.com/pybamm-team/PyBaMM

## What

Added support for the package pybamm, a battery modeling & simulation package in python.
Under content, now pybamm/docs and pybamm/skills with 3 skills

## Why

Giving agents context to use the PyBAMM package

## Testing

- [ x] `npm test` passes
- [ x] `chub build sample-content/ --validate-only` succeeds
- [x ] Manual testing done (describe below)
- 
After building local version on new skills, ran the following tests:
```
node cli/bin/chub search pybamm
node cli/bin/chub get pybamm/pybamm --lang py
node cli/bin/chub get pybamm/simulate
```
Gave good results

## Notes

Only added support for one library, no change to core code
