### PR TITLE
docs: fix broken CLI Reference link in cli/README (Issue #229)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -52,4 +52,4 @@ chub annotate stripe/api "note"      # local annotation
 chub feedback stripe/api up          # rate a doc
 ```
 
-For the full command reference, see [CLI Reference](../docs/cli-reference.md).
+For the full command reference, see [CLI Reference](https://github.com/andrewyng/context-hub/blob/main/docs/cli-reference.md).


### PR DESCRIPTION
## What
Updated the relative link to the CLI Reference in `cli/README.md` to an absolute GitHub URL:

[CLI Reference](https://github.com/andrewyng/context-hub/blob/main/docs/cli-reference.md)

## Why
The previous relative link (`../docs/cli-reference.md`) was broken in the published npm package because the `docs/` directory is not included in the package distribution (as defined in `package.json`).

By switching to an absolute GitHub URL, the link will correctly resolve for users viewing the README on npmjs.com or after a local installation, ensuring they can always access the full command documentation.

## Testing
- [x] `npm test` passes (verified locally after adjusting `BUILD_TEST_TIMEOUT`)
- [x] `chub build sample-content/ --validate-only` succeeds
- [x] Manual testing: confirmed that the target URL correctly points to the existing `docs/cli-reference.md` on the main branch.

## Notes
- This fix specifically targets the README that is rendered on npm.
- The root `README.md` was kept as-is with its relative link to maintain portability within the GitHub repository view, where it already resolves correctly.
- Local test timeout issues in `go-lang.test.js` were observed but handled locally; those changes are **not** included in this commit to keep the PR focused on Issue #229.

Closes #229 