### PR TITLE
Surface frontmatter YAML errors with file path (#238)

### DIFF
--- a/cli/src/commands/build.js
+++ b/cli/src/commands/build.js
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync, readdirSync, statSync, writeFileSync, mkdirSync, cpSync } from 'node:fs';
 import { join, relative, dirname, basename } from 'node:path';
 import chalk from 'chalk';
-import { parseFrontmatter } from '../lib/frontmatter.js';
+import { parseFrontmatter, FrontmatterParseError } from '../lib/frontmatter.js';
 import { info } from '../lib/output.js';
 import { trackEvent } from '../lib/analytics.js';
 import { buildIndex } from '../lib/bm25.js';
@@ -74,7 +74,17 @@ function discoverAuthor(authorDir, authorName, contentDir) {
 
   for (const ef of entryFiles) {
     const content = readFileSync(ef.path, 'utf8');
-    const { attributes } = parseFrontmatter(content);
+    let attributes;
+    try {
+      ({ attributes } = parseFrontmatter(content));
+    } catch (err) {
+      if (err instanceof FrontmatterParseError) {
+        const loc = err.line ? `:${err.line}${err.col ? ':' + err.col : ''}` : '';
+        errors.push(`${ef.relPath}${loc}: invalid YAML frontmatter — ${err.message}`);
+        continue;
+      }
+      throw err;
+    }
 
     if (!attributes.name) {
       errors.push(`${ef.relPath}: missing 'name' in frontmatter`);

--- a/cli/src/lib/frontmatter.js
+++ b/cli/src/lib/frontmatter.js
@@ -1,14 +1,43 @@
-import { parse as parseYaml } from 'yaml';
+import { parse as parseYaml, YAMLParseError } from 'yaml';
+
+/**
+ * Thrown when YAML inside a frontmatter block fails to parse.
+ * `line` and `col` are 1-indexed relative to the full frontmatter document
+ * (including the opening `---` fence), so callers can report file-accurate
+ * locations without further adjustment.
+ */
+export class FrontmatterParseError extends Error {
+  constructor(message, line, col, cause) {
+    super(message);
+    this.name = 'FrontmatterParseError';
+    this.line = line;
+    this.col = col;
+    this.cause = cause;
+  }
+}
 
 /**
  * Parse YAML frontmatter from markdown content.
  * Returns { attributes, body } where attributes is the parsed YAML object.
+ * Throws FrontmatterParseError if the frontmatter block contains invalid YAML.
  */
 export function parseFrontmatter(content) {
   const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
   if (!match) return { attributes: {}, body: content };
-  return {
-    attributes: parseYaml(match[1]) || {},
-    body: match[2],
-  };
+
+  let attributes;
+  try {
+    attributes = parseYaml(match[1]) || {};
+  } catch (err) {
+    if (err instanceof YAMLParseError) {
+      const start = err.linePos?.[0];
+      // +1 to account for the opening `---` line above the YAML block.
+      const line = start ? start.line + 1 : null;
+      const col = start ? start.col : null;
+      throw new FrontmatterParseError(err.message, line, col, err);
+    }
+    throw err;
+  }
+
+  return { attributes, body: match[2] };
 }

--- a/cli/tests/commands/build.test.js
+++ b/cli/tests/commands/build.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -71,5 +71,51 @@ describe('chub build', () => {
       expect(err.stderr.toString()).toContain('not found');
     }
     expect(threw).toBe(true);
+  });
+
+  itBuild('reports YAML parse errors with file path and line, not a raw stack trace', () => {
+    // Regression test for issue #238: an invalid SKILL.md used to crash the
+    // build with an unhandled YAMLParseError from node_modules/yaml. The build
+    // should now collect the error with a file-relative location and exit cleanly.
+    const contentDir = mkdtempSync(join(tmpdir(), 'chub-bad-yaml-'));
+
+    try {
+      const brokenDir = join(contentDir, 'badauthor', 'skills', 'broken');
+      mkdirSync(brokenDir, { recursive: true });
+      writeFileSync(
+        join(brokenDir, 'SKILL.md'),
+        '---\nname: broken\ndescription: Unquoted colon: oops\n---\nbody\n',
+      );
+
+      // A valid sibling file proves the loop keeps going past the bad one.
+      const goodDir = join(contentDir, 'badauthor', 'skills', 'good');
+      mkdirSync(goodDir, { recursive: true });
+      writeFileSync(
+        join(goodDir, 'SKILL.md'),
+        '---\nname: good\ndescription: "Fine here"\n---\nbody\n',
+      );
+
+      let threw = false;
+      try {
+        execFileSync(
+          process.execPath,
+          [CLI_BIN, 'build', contentDir, '--validate-only'],
+          { encoding: 'utf8', stdio: 'pipe', env: TEST_ENV },
+        );
+      } catch (err) {
+        threw = true;
+        const stderr = err.stderr.toString();
+        // Path is relative to the author dir (matches existing error format).
+        expect(stderr).toContain(join('skills', 'broken', 'SKILL.md'));
+        // File-relative line number: `description:` is line 3 of the file.
+        expect(stderr).toMatch(/SKILL\.md:3:\d+: invalid YAML frontmatter/);
+        // The point of the fix: no raw stack trace leaking from node_modules.
+        expect(stderr).not.toContain('YAMLParseError');
+        expect(stderr).not.toMatch(/node_modules[\\/]yaml/);
+      }
+      expect(threw).toBe(true);
+    } finally {
+      rmSync(contentDir, { recursive: true, force: true });
+    }
   });
 });

--- a/cli/tests/lib/frontmatter.test.js
+++ b/cli/tests/lib/frontmatter.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseFrontmatter } from '../../src/lib/frontmatter.js';
+import { parseFrontmatter, FrontmatterParseError } from '../../src/lib/frontmatter.js';
 
 describe('parseFrontmatter', () => {
   it('parses valid frontmatter with attributes and body', () => {
@@ -76,5 +76,40 @@ Immediate body.`;
 
     expect(result.attributes.name).toBe('test');
     expect(result.body).toBe('Immediate body.');
+  });
+
+  it('throws FrontmatterParseError with file-relative line/col on malformed YAML', () => {
+    // Reproduces issue #238: an unquoted colon inside a value is parsed as a
+    // nested mapping and the underlying yaml package throws.
+    const content = `---
+name: bad
+description: Unquoted colon: breaks parsing
+---
+body`;
+
+    let caught;
+    try {
+      parseFrontmatter(content);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(FrontmatterParseError);
+    // `description:` is line 3 of the file (line 1 is `---`, line 2 is `name:`).
+    expect(caught.line).toBe(3);
+    expect(caught.col).toBeGreaterThan(0);
+    expect(caught.message).toMatch(/mapping/i);
+    expect(caught.cause).toBeDefined();
+  });
+
+  it('does not throw on YAML edge cases that are valid', () => {
+    // Sanity check: a quoted value containing a colon parses cleanly.
+    const content = `---
+name: good
+description: "Quoted colon: works"
+---
+body`;
+
+    expect(() => parseFrontmatter(content)).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

Fixes #238 — `chub build` was leaking an unhandled `YAMLParseError` stack trace from `node_modules/yaml` whenever a `DOC.md` or `SKILL.md` had invalid frontmatter (the reporter hit it with an unquoted colon in a `description:` value). Users couldn't tell which file caused the crash.

After this PR, the build collects the error per-file with a file-relative location, keeps going through the rest of the entries, and exits cleanly with all errors reported.

**Before**
```
YAMLParseError: Nested mappings are not allowed in compact mappings at line 2, column 14
    at Composer.onError (.../node_modules/yaml/dist/compose/composer.js:70:34)
    at Object.resolveBlockMap (.../node_modules/yaml/dist/compose/resolve-block-map.js:78:21)
    ... 8 more frames
```

**After**
```
Error: skills/at-proto/SKILL.md:3:14: invalid YAML frontmatter — Nested mappings are not allowed in compact mappings at line 2, column 14:

description: This skill should be used when the user is working with AT Protocol: ...
             ^
```

## Changes

- **`cli/src/lib/frontmatter.js`** — Export a new `FrontmatterParseError` class. Wrap the `parseYaml` call and re-throw with `line`/`col` relative to the full frontmatter document (+1 offset for the opening `---` fence) so callers can report file-accurate locations.
- **`cli/src/commands/build.js`** — Catch `FrontmatterParseError` in the entry-file loop, push to the existing `errors[]` as `{path}:{line}:{col}: invalid YAML frontmatter — {msg}`, then `continue`. Matches the existing error-collection pattern, so one bad file no longer kills the build on the first error.

## Tests

- **`cli/tests/lib/frontmatter.test.js`** — Asserts malformed YAML throws `FrontmatterParseError` with the expected file-relative line/col, plus a sanity check that a valid quoted-colon value parses cleanly.
- **`cli/tests/commands/build.test.js`** — Regression test that a bad SKILL.md alongside a good one produces a clean error containing the file path and line number, and that the stderr does not contain `YAMLParseError` or `node_modules/yaml` (no raw stack trace leak).

Full suite: **256 passed**, no regressions.

## Test plan

- [x] `cd cli && npm test` — all 256 tests pass
- [x] Manual repro of the issue against the fix:
  ```
  $ node cli/bin/chub build /tmp/repro --validate-only
  Error: skills/at-proto/SKILL.md:3:14: invalid YAML frontmatter — ...
                                              ^
  ```
- [x] `node cli/bin/chub build content/ --validate-only` still passes on the real content

## Notes for the reviewer

- No new dependencies — `yaml` package's `YAMLParseError` was already importable.
- Other warning/error messages in `discoverAuthor` use `ef.relPath` which is relative to the *author* directory (so the author name doesn't appear in any of them, including this new one). That's a pre-existing UX gap across ~5 sites in `build.js`; intentionally left out of this PR's scope to keep the diff focused.

