### PR TITLE
Alias removed `chub list` to `chub search` with deprecation notice

### DIFF
--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -15,6 +15,7 @@ import { trackEvent, shutdownAnalytics, setCliVersion } from './lib/analytics.js
 import { error, output } from './lib/output.js';
 import { showWelcomeIfNeeded } from './lib/welcome.js';
 import { loadHelpContent } from './lib/help.js';
+import { rewriteRemovedCommand } from './lib/removed-commands.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8'));
@@ -125,7 +126,13 @@ if (helpAliasOperands.length > 0) {
 } else if (isRootVersionRequest(process.argv)) {
   process.stdout.write(`${pkg.version}\n`);
 } else {
-  program.parse();
+  const rewrite = rewriteRemovedCommand(process.argv);
+  if (rewrite) {
+    process.stderr.write(`${rewrite.message}\n`);
+    program.parse(rewrite.rewritten);
+  } else {
+    program.parse();
+  }
 }
 
 // Flush analytics before exit (best-effort)

--- a/cli/src/lib/removed-commands.js
+++ b/cli/src/lib/removed-commands.js
@@ -1,0 +1,46 @@
+// Commands removed in 0.1.4 and their replacement form.
+// `chub list` was folded into `chub search` (no query lists all). A
+// transparent alias keeps existing scripts and agent muscle memory working,
+// with a one-line deprecation notice so users know to update.
+export const REMOVED_COMMANDS = {
+  list: {
+    replacement: 'search',
+    message:
+      '`chub list` was removed in 0.1.4 — use `chub search` (no query lists all). Forwarding to `chub search`.',
+  },
+};
+
+// Boolean flags on the root command that don't take a value.
+const ROOT_BOOLEAN_FLAGS = new Set([
+  '--json',
+  '--help',
+  '-h',
+  '--version',
+  '-v',
+  '-V',
+  '--cli-version',
+]);
+
+// Find the first non-flag arg, skipping root-level option values. Mirrors how
+// Commander would treat the first positional as a subcommand name.
+function findFirstPositionalIndex(args) {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (!arg.startsWith('-')) return i;
+    if (arg.includes('=')) continue;
+    if (ROOT_BOOLEAN_FLAGS.has(arg)) continue;
+    i++;
+  }
+  return -1;
+}
+
+export function rewriteRemovedCommand(argv) {
+  const args = argv.slice(2);
+  const idx = findFirstPositionalIndex(args);
+  if (idx === -1) return null;
+  const removed = REMOVED_COMMANDS[args[idx]];
+  if (!removed) return null;
+  const rewritten = [...args];
+  rewritten[idx] = removed.replacement;
+  return { rewritten: [argv[0], argv[1], ...rewritten], message: removed.message };
+}

--- a/cli/tests/lib/removed-commands.test.js
+++ b/cli/tests/lib/removed-commands.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { rewriteRemovedCommand } from '../../src/lib/removed-commands.js';
+
+function argv(...args) {
+  return ['/usr/bin/node', '/path/to/chub', ...args];
+}
+
+describe('rewriteRemovedCommand', () => {
+  it('rewrites `list` to `search` and returns deprecation message', () => {
+    const result = rewriteRemovedCommand(argv('list'));
+    expect(result).not.toBeNull();
+    expect(result.rewritten.slice(2)).toEqual(['search']);
+    expect(result.message).toMatch(/`chub list` was removed/);
+    expect(result.message).toMatch(/`chub search`/);
+  });
+
+  it('preserves trailing flags after the rewritten command', () => {
+    const result = rewriteRemovedCommand(argv('list', '--limit', '5'));
+    expect(result.rewritten.slice(2)).toEqual(['search', '--limit', '5']);
+  });
+
+  it('preserves --tags and --lang flags', () => {
+    const result = rewriteRemovedCommand(argv('list', '--tags', 'ai', '--lang', 'python'));
+    expect(result.rewritten.slice(2)).toEqual(['search', '--tags', 'ai', '--lang', 'python']);
+  });
+
+  it('skips the root --json flag when locating the positional', () => {
+    const result = rewriteRemovedCommand(argv('--json', 'list'));
+    expect(result.rewritten.slice(2)).toEqual(['--json', 'search']);
+  });
+
+  it('returns null for non-removed commands', () => {
+    expect(rewriteRemovedCommand(argv('search'))).toBeNull();
+    expect(rewriteRemovedCommand(argv('get', 'openai/chat'))).toBeNull();
+  });
+
+  it('returns null when no positional argument is present', () => {
+    expect(rewriteRemovedCommand(argv())).toBeNull();
+    expect(rewriteRemovedCommand(argv('--json'))).toBeNull();
+    expect(rewriteRemovedCommand(argv('--help'))).toBeNull();
+  });
+
+  it('does not rewrite when `list` appears as a value to a different command', () => {
+    // `chub search list` is a legitimate fuzzy query, not a removed command
+    expect(rewriteRemovedCommand(argv('search', 'list'))).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- `chub list` was removed in 0.1.4 but Commander's strict-args error (`too many arguments. Expected 0 arguments but got 1.`) gave users — and agents — no signal that the command had been removed or what the replacement was. Agents tended to retry or hallucinate adjacent commands instead of recovering.
- Forward `chub list` (and any trailing flags like `--limit`, `--tags`, `--lang`, `--json`) to `chub search`, and print a one-line deprecation notice to stderr so JSON-mode stdout stays clean.
- Pre-parse rewrite lives in `cli/src/lib/removed-commands.js` so future removals can be added in one place.

Fixes #230

## Test plan
- [x] `node cli/src/index.js list` prints the deprecation notice on stderr and lists entries
- [x] `node cli/src/index.js list --limit 2` forwards the flag through to `search`
- [x] `node cli/src/index.js --json list --limit 1` keeps JSON on stdout, notice on stderr
- [x] `node cli/src/index.js search` and other commands unaffected
- [x] `npx vitest run` — 263 tests passing (7 new tests for `rewriteRemovedCommand`)