### PR TITLE
Drop dead --force flag from `chub cache clear`

### DIFF
--- a/cli/src/commands/cache.js
+++ b/cli/src/commands/cache.js
@@ -39,7 +39,6 @@ export function registerCacheCommand(program) {
   cache
     .command('clear')
     .description('Clear cached data')
-    .option('--force', 'Skip confirmation')
     .action((opts) => {
       const globalOpts = program.optsWithGlobals();
       clearCache();

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -151,7 +151,7 @@ Download or refresh the cached registry from remote sources.
 Manage the local cache.
 
 - `cache status` — shows cache info (sources, registries, sizes, last updated)
-- `cache clear` — removes cached content (`--force` to skip confirmation)
+- `cache clear` — removes cached content
 
 ## chub build \<content-dir\>
 


### PR DESCRIPTION
## Summary
- `chub cache clear --force` parsed the flag but never read it — there was no confirmation prompt to skip. The flag was effectively dead.
- Removes the unused option from `cli/src/commands/cache.js` and the matching docs reference in `docs/cli-reference.md`.

## Test plan
- [x] `npm test` in `cli/` passes
- [x] `chub cache clear` still clears the cache
- [x] `chub cache clear --force` now errors with an unknown-flag message (expected — flag is gone)