### PR TITLE
Lead registry-unavailable error with actionable advice

### DIFF
--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -103,7 +103,7 @@ program.hook('preAction', async (thisCommand) => {
     await ensureRegistry();
   } catch (err) {
     await trackEvent('command_error', { command: cmdName, error_type: 'registry_unavailable' });
-    error(`Registry not available: ${err.message}. Run \`chub update\` to refresh remote registries, or check that local source paths in ~/.chub/config.yaml are correct.`, globalOpts);
+    error(`Registry not available. Run \`chub update\` to refresh remote registries, or check that local source paths in ~/.chub/config.yaml are correct. (cause: ${err.message})`, globalOpts);
   }
 });
 


### PR DESCRIPTION
## Summary
- The registry-unavailable error in `cli/src/index.js` led with the low-level fetch error and buried the "Run \`chub update\`" recommendation.
- Re-orders the message so the actionable advice is first and the underlying cause is in parens at the end.

## Test plan
- [x] `npm test` in `cli/` passes
- [x] No tests assert the exact wording, so no test churn