### PR TITLE
Extract fetch timeouts into named constants

### DIFF
--- a/cli/src/lib/cache.js
+++ b/cli/src/lib/cache.js
@@ -4,6 +4,7 @@ import { pipeline } from 'node:stream/promises';
 import { createWriteStream } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { getChubDir, loadConfig } from './config.js';
+import { REGISTRY_FETCH_TIMEOUT_MS } from './constants.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -84,7 +85,7 @@ function shouldFetchRemoteRegistry(sourceName, force = false) {
 
 async function fetchRemoteText(url) {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 30000);
+  const timeout = setTimeout(() => controller.abort(), REGISTRY_FETCH_TIMEOUT_MS);
   try {
     const res = await fetch(url, { signal: controller.signal });
     if (!res.ok) {
@@ -179,7 +180,7 @@ export async function fetchFullBundle(sourceName) {
   const tmpPath = join(getSourceDir(sourceName), 'bundle.tar.gz');
 
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 30000);
+  const timeout = setTimeout(() => controller.abort(), REGISTRY_FETCH_TIMEOUT_MS);
   let res;
   try {
     res = await fetch(url, { signal: controller.signal });
@@ -246,7 +247,7 @@ export async function fetchDoc(source, docPath) {
   // Fetch from CDN (optional — only if source has a URL)
   const url = `${source.url}/${docPath}`;
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 30000);
+  const timeout = setTimeout(() => controller.abort(), REGISTRY_FETCH_TIMEOUT_MS);
   let res;
   try {
     res = await fetch(url, { signal: controller.signal });

--- a/cli/src/lib/constants.js
+++ b/cli/src/lib/constants.js
@@ -1,0 +1,2 @@
+export const REGISTRY_FETCH_TIMEOUT_MS = 30_000;
+export const FEEDBACK_FETCH_TIMEOUT_MS = 3_000;

--- a/cli/src/lib/telemetry.js
+++ b/cli/src/lib/telemetry.js
@@ -1,4 +1,5 @@
 import { loadConfig } from './config.js';
+import { FEEDBACK_FETCH_TIMEOUT_MS } from './constants.js';
 
 const DEFAULT_TELEMETRY_URL = 'https://api.aichub.org/v1';
 
@@ -46,7 +47,7 @@ export async function sendFeedback(entryId, entryType, rating, opts = {}) {
   const telemetryUrl = getTelemetryUrl();
 
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 3000);
+  const timeout = setTimeout(() => controller.abort(), FEEDBACK_FETCH_TIMEOUT_MS);
 
   try {
     const res = await fetch(`${telemetryUrl}/feedback`, {


### PR DESCRIPTION
## Summary
- The 30s timeout for registry/bundle/file fetches was duplicated across three call sites in `cli/src/lib/cache.js`. The 3s feedback timeout was hardcoded in `cli/src/lib/telemetry.js`.
- Moves both into a new `cli/src/lib/constants.js` as `REGISTRY_FETCH_TIMEOUT_MS` and `FEEDBACK_FETCH_TIMEOUT_MS`.
- No behavior change.

## Test plan
- [x] `npm test` in `cli/` passes (263 tests)
- [x] No call site changed behavior — same values, named instead of inline