### PR TITLE
Validate `chub build --output` path upfront

### DIFF
--- a/cli/src/commands/build.js
+++ b/cli/src/commands/build.js
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync, readdirSync, statSync, writeFileSync, mkdirSync, cpSync } from 'node:fs';
-import { join, relative, dirname, basename } from 'node:path';
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync, mkdirSync, cpSync, accessSync, constants as fsConstants } from 'node:fs';
+import { join, relative, dirname, basename, resolve } from 'node:path';
 import chalk from 'chalk';
 import { parseFrontmatter, FrontmatterParseError } from '../lib/frontmatter.js';
 import { info } from '../lib/output.js';
@@ -60,6 +60,45 @@ function dirSize(dir) {
   };
   walk(dir);
   return total;
+}
+
+// Verify the build output directory is usable before doing any work.
+// Returns null on success, or a user-facing error string on failure.
+// Catches: parent path is a file (ENOTDIR), parent missing, target exists but
+// is a file, or no write permission. These otherwise surface as opaque Node
+// stack traces after the build has already done its parsing work.
+function validateOutputDir(outputDir) {
+  const absolute = resolve(outputDir);
+  if (existsSync(absolute)) {
+    const st = statSync(absolute);
+    if (!st.isDirectory()) {
+      return `Output path is not a directory: ${outputDir}. Remove the file or pass a different --output path.`;
+    }
+    try {
+      accessSync(absolute, fsConstants.W_OK);
+    } catch {
+      return `Output directory is not writable: ${outputDir}. Check permissions or pass a different --output path.`;
+    }
+    return null;
+  }
+  // Path doesn't exist — mkdirSync({ recursive: true }) will try to create it.
+  // Walk up to the nearest existing ancestor and check that it's a writable directory.
+  let ancestor = dirname(absolute);
+  while (ancestor !== dirname(ancestor) && !existsSync(ancestor)) {
+    ancestor = dirname(ancestor);
+  }
+  if (!existsSync(ancestor)) {
+    return `Cannot create output directory: ${outputDir}. No existing ancestor directory found.`;
+  }
+  if (!statSync(ancestor).isDirectory()) {
+    return `Cannot create output directory: ${outputDir}. Parent path "${ancestor}" is not a directory.`;
+  }
+  try {
+    accessSync(ancestor, fsConstants.W_OK);
+  } catch {
+    return `Cannot create output directory: ${outputDir}. No write permission on "${ancestor}".`;
+  }
+  return null;
 }
 
 /**
@@ -214,6 +253,18 @@ export function registerBuildCommand(program) {
       }
 
       const outputDir = opts.output || join(contentDir, 'dist');
+
+      // Fail fast on a bad output path so users get an actionable message
+      // instead of an ENOENT/EACCES stack trace after parsing all content.
+      // Skip when --validate-only since nothing is written.
+      if (!opts.validateOnly) {
+        const outputErr = validateOutputDir(outputDir);
+        if (outputErr) {
+          process.stderr.write(`Error: ${outputErr}\n`);
+          process.exit(1);
+        }
+      }
+
       const allDocs = [];
       const allSkills = [];
       const allWarnings = [];

--- a/cli/tests/commands/build.test.js
+++ b/cli/tests/commands/build.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, closeSync, openSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -71,6 +71,69 @@ describe('chub build', () => {
       expect(err.stderr.toString()).toContain('not found');
     }
     expect(threw).toBe(true);
+  });
+
+  itBuild('rejects --output when the target path is an existing file, not a directory', () => {
+    const tmpFile = join(mkdtempSync(join(tmpdir(), 'chub-out-')), 'a-file-not-a-dir');
+    closeSync(openSync(tmpFile, 'w'));
+    let threw = false;
+    try {
+      execFileSync(
+        process.execPath,
+        [CLI_BIN, 'build', FIXTURES, '-o', tmpFile, '--json'],
+        { encoding: 'utf8', stdio: 'pipe', env: TEST_ENV },
+      );
+    } catch (err) {
+      threw = true;
+      expect(err.status).not.toBe(0);
+      const stderr = err.stderr.toString();
+      expect(stderr).toContain('Output path is not a directory');
+      expect(stderr).toContain(tmpFile);
+    } finally {
+      rmSync(tmpFile, { force: true });
+    }
+    expect(threw).toBe(true);
+  });
+
+  itBuild('rejects --output when the parent path is a file, not a directory', () => {
+    const tmpFile = join(mkdtempSync(join(tmpdir(), 'chub-out-')), 'parent-is-a-file');
+    closeSync(openSync(tmpFile, 'w'));
+    const badTarget = join(tmpFile, 'sub');
+    let threw = false;
+    try {
+      execFileSync(
+        process.execPath,
+        [CLI_BIN, 'build', FIXTURES, '-o', badTarget, '--json'],
+        { encoding: 'utf8', stdio: 'pipe', env: TEST_ENV },
+      );
+    } catch (err) {
+      threw = true;
+      expect(err.status).not.toBe(0);
+      const stderr = err.stderr.toString();
+      expect(stderr).toContain('Cannot create output directory');
+      expect(stderr).toContain('is not a directory');
+    } finally {
+      rmSync(tmpFile, { force: true });
+    }
+    expect(threw).toBe(true);
+  });
+
+  itBuild('skips output-path validation under --validate-only', () => {
+    const tmpFile = join(mkdtempSync(join(tmpdir(), 'chub-out-')), 'a-file-not-a-dir');
+    closeSync(openSync(tmpFile, 'w'));
+    try {
+      // Bad -o that would otherwise be rejected. With --validate-only, no
+      // output is written, so the check should be skipped and exit 0.
+      const result = execFileSync(
+        process.execPath,
+        [CLI_BIN, 'build', FIXTURES, '--validate-only', '-o', tmpFile, '--json'],
+        { encoding: 'utf8', env: TEST_ENV },
+      );
+      const parsed = JSON.parse(result.trim());
+      expect(parsed).toHaveProperty('docs');
+    } finally {
+      rmSync(tmpFile, { force: true });
+    }
   });
 
   itBuild('reports YAML parse errors with file path and line, not a raw stack trace', () => {


### PR DESCRIPTION
## Summary
- `chub build -o <path>` failed late with an opaque `ENOTDIR`/`EACCES` stack trace from `mkdirSync`/`writeFileSync` if the target was a file, the parent was a file, or the location wasn't writable — and only after parsing all content.
- Adds a fast preflight check (`validateOutputDir`) that rejects with an actionable message when the output path is an existing non-directory, the parent isn't a directory, or there's no write permission on the nearest existing ancestor.
- Skipped under `--validate-only` since nothing is written in that mode.

## Test plan
- [x] `chub build -o <file>` → `Error: Output path is not a directory: …`
- [x] `chub build -o <file>/sub` → `Error: Cannot create output directory: … Parent path "…" is not a directory.`
- [x] `chub build -o /tmp/new/deep/path` → still works (recursive mkdir on writable ancestor)
- [x] `chub build … --validate-only -o <file>` → succeeds, validation skipped
- [x] `npm test` in `cli/` passes (3 new tests added in `cli/tests/commands/build.test.js`)