### PR TITLE
Make MCP `chub_list` a thin alias of `chub_search`

### DIFF
--- a/cli/src/mcp/server.js
+++ b/cli/src/mcp/server.js
@@ -63,9 +63,12 @@ server.tool(
   async (args) => handleGet(args),
 );
 
+// `chub_list` is kept as an alias over `chub_search` (no query) so existing
+// MCP clients keep working. New integrations should call `chub_search` with
+// no query for the same result.
 server.tool(
   'chub_list',
-  'List all available docs and skills in Context Hub',
+  'List all available docs and skills in Context Hub. Alias of `chub_search` with no query — prefer `chub_search` for new integrations.',
   {
     tags: z.string().optional().describe('Comma-separated tag filter'),
     lang: z.string().optional().describe('Filter by language'),

--- a/cli/src/mcp/tools.js
+++ b/cli/src/mcp/tools.js
@@ -198,18 +198,18 @@ export async function handleGet({ id, lang, version, full = false, file, withAnn
   }
 }
 
+// `chub_list` is a thin alias over `chub_search` (no query) so the two MCP
+// tools share one code path. The response uses `entries` instead of `results`
+// for backwards compatibility with agents that already call chub_list.
 export async function handleList({ tags, lang, limit = 50 }) {
-  try {
-    const entries = listEntries({ tags, lang });
-    const sliced = entries.slice(0, limit);
-    return textResult({
-      entries: sliced.map(simplifyEntry),
-      total: entries.length,
-      showing: sliced.length,
-    });
-  } catch (err) {
-    return errorResult(`List failed: ${err.message}`);
-  }
+  const result = await handleSearch({ tags, lang, limit });
+  if (result.isError) return result;
+  const data = JSON.parse(result.content[0].text);
+  return textResult({
+    entries: data.results,
+    total: data.total,
+    showing: data.showing,
+  });
 }
 
 export async function handleAnnotate({ id, note, clear = false, list = false }) {

--- a/cli/tests/mcp/tools.test.js
+++ b/cli/tests/mcp/tools.test.js
@@ -162,6 +162,14 @@ describe('chub_list (handleList)', () => {
       }
     }
   });
+
+  it('returns the same entries as handleSearch with no query (alias contract)', async () => {
+    const listResult = parseResult(await handleList({ limit: 10 }));
+    const searchResult = parseResult(await handleSearch({ limit: 10 }));
+    expect(listResult.entries).toEqual(searchResult.results);
+    expect(listResult.total).toBe(searchResult.total);
+    expect(listResult.showing).toBe(searchResult.showing);
+  });
 });
 
 describe('chub_annotate (handleAnnotate)', () => {


### PR DESCRIPTION
## Summary
- `chub_list` and `chub_search` (no query) were two MCP handlers running the same conceptual op against the same underlying lib functions. The CLI dropped its `list` subcommand in 0.1.4, so the MCP surface was the only place still maintaining both names.
- Routes `handleList` through `handleSearch` so there's a single code path going forward.
- Preserves the `entries` field name in the response (vs `handleSearch`'s `results`) so existing MCP clients calling `chub_list` keep working unchanged.
- Updates the `chub_list` tool description to point new integrations at `chub_search`.
- Adds a contract test asserting `handleList` and `handleSearch` (no query) return the same entries.

## Test plan
- [x] `npm test` in `cli/` — 291/291 (was 290 + 1 new contract test)
- [x] MCP tests pass (27 existing + 1 new = 28)