### PR TITLE
docs(anthropic): refresh to SDK 0.105.2 / 0.100.1

### DIFF
--- a/content/anthropic/docs/claude-api/javascript/DOC.md
+++ b/content/anthropic/docs/claude-api/javascript/DOC.md
@@ -3,8 +3,9 @@ name: claude-api
 description: "Claude AI assistant API for text generation, analysis, conversation, streaming, tool use, vision, and batch processing"
 metadata:
   languages: "javascript"
-  versions: "0.78.0"
-  updated-on: "2026-03-05"
+  versions: "0.100.1"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "anthropic,sdk,llm,ai,claude"
 ---
@@ -14,7 +15,7 @@ metadata:
 You are an Anthropic API coding expert. Help me with writing code using the Anthropic API calling the official libraries and SDKs.
 
 You can find the official SDK documentation and code samples here:
-https://docs.anthropic.com/claude/reference/
+https://platform.claude.com/docs/en/api/client-sdks
 
 ## Golden Rule: Use the Correct and Current SDK
 
@@ -22,77 +23,124 @@ Always use the Anthropic TypeScript SDK to call the Claude models, which is the 
 
 - **Library Name:** Anthropic TypeScript SDK
 - **NPM Package:** `@anthropic-ai/sdk`
-- **Legacy Libraries**: Other unofficial packages are not recommended
+- **Runtime:** Node.js 18+, Deno, Bun, Cloudflare Workers, browsers (with explicit `dangerouslyAllowBrowser: true`).
 
 **Installation:**
 
-- **Correct:** `npm install @anthropic-ai/sdk`
+```bash
+npm install @anthropic-ai/sdk
+```
 
 **APIs and Usage:**
 
 - **Correct:** `import Anthropic from '@anthropic-ai/sdk'`
-- **Correct:** `const client = new Anthropic({})`
+- **Correct:** `const client = new Anthropic()`
 - **Correct:** `await client.messages.create(...)`
 - **Correct:** `await client.messages.stream(...)`
 - **Incorrect:** `AnthropicClient` or `AnthropicAPI`
-- **Incorrect:** `client.generate` or `client.completions`
-- **Incorrect:** Legacy completion endpoints
+- **Incorrect:** `client.generate` or `client.completions` (legacy text-completion endpoint, do not use)
 
-## Initialization and API key
+## Initialization and API Key
 
 The `@anthropic-ai/sdk` library requires creating an `Anthropic` instance for all API calls.
 
-- Always use `const client = new Anthropic({})` to create an instance.
+- Always use `const client = new Anthropic()` to create an instance.
 - Set the `ANTHROPIC_API_KEY` environment variable, which will be picked up automatically.
 
 ```javascript
 import Anthropic from '@anthropic-ai/sdk';
 
-// Uses the ANTHROPIC_API_KEY environment variable if apiKey not specified
-const client = new Anthropic({});
+// Uses ANTHROPIC_API_KEY environment variable if apiKey not specified
+const client = new Anthropic();
 
 // Or pass the API key directly
-// const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+// const client = new Anthropic({ apiKey: process.env.MY_API_KEY });
 ```
 
 ## Models
 
-- By default, use the following models as of March 2026:
-  - **General Tasks:** `claude-sonnet-4-6-20250827`
-  - **High-performance:** `claude-opus-4-6-20250826`
-  - **Fast and Efficient:** `claude-haiku-4-5-20251001`
+Use the following models as of May 2026:
 
-- Previous generation models (still supported):
-  - `claude-sonnet-4-20250514`, `claude-opus-4-20250514`
-  - `claude-3-5-haiku-20241022`
+- **Most capable (reasoning, agentic coding):** `claude-opus-4-7`
+- **Balanced (speed + intelligence):** `claude-sonnet-4-6`
+- **Fast and efficient:** `claude-haiku-4-5`
 
-- Do not use deprecated models: `claude-3-7-sonnet`, `claude-3-5-sonnet`, `claude-3-opus`
+Claude 4.6+ model IDs are dateless and pin to a specific snapshot. Older models still resolve via aliases (e.g. `claude-opus-4-1`, `claude-sonnet-4-5`).
+
+Deprecated and scheduled for retirement on 2026-06-15: `claude-sonnet-4-20250514`, `claude-opus-4-20250514`. Migrate off these now.
+
+Query the live model list programmatically when unsure:
+
+```javascript
+const models = await client.models.list();
+for (const m of models.data) console.log(m.id);
+```
 
 ## Basic Inference (Text Generation)
-
-Here's how to generate a response from a text prompt.
 
 ```javascript
 import Anthropic from '@anthropic-ai/sdk';
 
-const client = new Anthropic({}); // Assumes ANTHROPIC_API_KEY is set
+const client = new Anthropic();
 
-async function run() {
-  const message = await client.messages.create({
-    max_tokens: 1024,
-    messages: [{ role: 'user', content: 'Hello, Claude' }],
-    model: 'claude-sonnet-4-20250514',
-  });
+const message = await client.messages.create({
+  model: 'claude-sonnet-4-6',
+  max_tokens: 1024,
+  messages: [{ role: 'user', content: 'Hello, Claude' }],
+});
 
-  console.log(message.content);
+// content is an array of typed blocks, not a string
+for (const block of message.content) {
+  if (block.type === 'text') console.log(block.text);
 }
-
-run();
 ```
 
-Multimodal inputs are supported by passing image data in the messages array. You can include images, documents, and other file types using base64 encoding or file uploads.
+`max_tokens` is required. The response `content` is always an array of typed blocks (`text`, `tool_use`, `thinking`, etc.).
 
-For file uploads, use the `client.beta.files.upload` method:
+## Multi-Turn Conversations
+
+Append the assistant's full content blocks back into `messages` to continue a conversation.
+
+```javascript
+const conversation = [{ role: 'user', content: "What's the capital of France?" }];
+
+const reply = await client.messages.create({
+  model: 'claude-sonnet-4-6',
+  max_tokens: 512,
+  messages: conversation,
+});
+
+conversation.push({ role: 'assistant', content: reply.content });
+conversation.push({ role: 'user', content: 'And its population?' });
+
+const followup = await client.messages.create({
+  model: 'claude-sonnet-4-6',
+  max_tokens: 512,
+  messages: conversation,
+});
+```
+
+## Multimodal Inputs
+
+Multimodal inputs are supported by passing image data in the messages array. You can include images by URL or base64.
+
+```javascript
+const message = await client.messages.create({
+  model: 'claude-sonnet-4-6',
+  max_tokens: 1024,
+  messages: [
+    {
+      role: 'user',
+      content: [
+        { type: 'image', source: { type: 'url', url: 'https://example.com/image.jpg' } },
+        { type: 'text', text: "What's in this image?" },
+      ],
+    },
+  ],
+});
+```
+
+For file uploads (beta), use `client.beta.files.upload`:
 
 ```javascript
 import fs from 'fs';
@@ -100,205 +148,213 @@ import Anthropic, { toFile } from '@anthropic-ai/sdk';
 
 const client = new Anthropic();
 
-// File upload example
-await client.beta.files.upload({
-  file: await toFile(fs.createReadStream('/path/to/file'), undefined, { type: 'application/json' }),
-  betas: ['files-api-2025-04-14'],
-});
+const uploaded = await client.beta.files.upload(
+  { file: await toFile(fs.createReadStream('/path/to/document.pdf')) },
+  { headers: { 'anthropic-beta': 'files-api-2025-04-14' } },
+);
 ```
 
 ## Streaming Responses
 
-We provide comprehensive support for streaming responses using Server Sent Events (SSE).
+The SDK supports streaming via Server-Sent Events (SSE).
 
 ### Basic Streaming
 
 ```javascript
-import Anthropic from '@anthropic-ai/sdk';
-
-const client = new Anthropic();
-
 const stream = await client.messages.create({
+  model: 'claude-sonnet-4-6',
   max_tokens: 1024,
   messages: [{ role: 'user', content: 'Hello, Claude' }],
-  model: 'claude-sonnet-4-20250514',
   stream: true,
 });
 
-for await (const messageStreamEvent of stream) {
-  console.log(messageStreamEvent.type);
+for await (const event of stream) {
+  if (event.type === 'content_block_delta' && event.delta.type === 'text_delta') {
+    process.stdout.write(event.delta.text);
+  }
 }
 ```
 
-### Advanced Streaming with Helpers
+### Streaming Helper
 
-The SDK provides powerful streaming helpers for convenience:
+The `client.messages.stream()` helper exposes typed events and the final assembled message.
 
 ```javascript
-import Anthropic from '@anthropic-ai/sdk';
+const stream = client.messages
+  .stream({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 1024,
+    messages: [{ role: 'user', content: 'Say hello there!' }],
+  })
+  .on('text', (text) => process.stdout.write(text));
 
-const client = new Anthropic();
-
-async function main() {
-  const stream = client.messages
-    .stream({
-      model: 'claude-sonnet-4-20250514',
-      max_tokens: 1024,
-      messages: [
-        {
-          role: 'user',
-          content: 'Say hello there!',
-        },
-      ],
-    })
-    .on('text', (text) => {
-      console.log(text);
-    });
-
-  const message = await stream.finalMessage();
-  console.log(message);
-}
-
-main();
+const message = await stream.finalMessage();
+console.log('\n\nDone. Stop reason:', message.stop_reason);
 ```
 
-You can cancel streams by calling `stream.controller.abort()` or breaking from loops.
+Cancel a stream with `stream.controller.abort()` or by breaking from the loop.
 
 ## Tool Use (Function Calling)
 
-The SDK supports tool use (function calling) for extending Claude's capabilities.
-
-### Custom Tools
-
-Define custom functions that Claude can call:
+Define tools Claude can request to invoke. Run the tool yourself and feed the result back as a `tool_result` block.
 
 ```javascript
-import Anthropic from '@anthropic-ai/sdk';
+const tools = [
+  {
+    name: 'get_weather',
+    description: 'Get the current weather in a given location',
+    input_schema: {
+      type: 'object',
+      properties: {
+        location: { type: 'string', description: 'City and state, e.g. San Francisco, CA' },
+        unit: { type: 'string', enum: ['celsius', 'fahrenheit'] },
+      },
+      required: ['location'],
+    },
+  },
+];
 
-const client = new Anthropic();
+const userMessage = { role: 'user', content: "What's the weather in San Francisco?" };
 
-async function run() {
-  const response = await client.messages.create({
-    model: 'claude-sonnet-4-20250514',
+const response = await client.messages.create({
+  model: 'claude-sonnet-4-6',
+  max_tokens: 1024,
+  tools,
+  messages: [userMessage],
+});
+
+if (response.stop_reason === 'tool_use') {
+  const toolUse = response.content.find((b) => b.type === 'tool_use');
+  const toolResult = `72F and sunny in ${toolUse.input.location}`;
+
+  const followup = await client.messages.create({
+    model: 'claude-sonnet-4-6',
     max_tokens: 1024,
-    messages: [{ role: 'user', content: "What's the weather like in San Francisco?" }],
-    tools: [
+    tools,
+    messages: [
+      userMessage,
+      { role: 'assistant', content: response.content },
       {
-        name: 'get_weather',
-        description: 'Get the current weather in a given location',
-        input_schema: {
-          type: 'object',
-          properties: {
-            location: { description: 'The city and state, e.g. San Francisco, CA', type: 'string' },
-            unit: { description: 'Unit for the output - one of (celsius, fahrenheit)', type: 'string' },
-          },
-          required: ['location'],
-        },
-        type: 'custom',
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: toolUse.id, content: toolResult }],
       },
     ],
-    tool_choice: { type: 'auto' },
   });
-
-  // Handle tool use in the response
-  if (response.content.some((block) => block.type === 'tool_use')) {
-    // Process tool calls and provide results back to Claude
-    console.log('Claude wants to use a tool!');
-  }
 }
-
-run();
 ```
+
+### Tool Choice
+
+- `{ type: 'auto' }` (default) — Claude decides when to use tools
+- `{ type: 'any' }` — Claude must use a tool
+- `{ type: 'tool', name: 'specific_tool' }` — Force a specific tool
+- `{ type: 'auto', disable_parallel_tool_use: true }` — Disable parallel tool execution
 
 ### Built-in Beta Tools
 
-The beta API provides specialized built-in tools.
-
-#### Bash Tool
+These tools require beta headers and the `client.beta.messages.create` namespace.
 
 ```javascript
-const response = await client.beta.messages.create({
-  model: 'claude-sonnet-4-20250514',
-  max_tokens: 1024,
-  messages: [{ role: 'user', content: 'List the files in the current directory' }],
-  tools: [{ type: 'bash_20250124', name: 'bash' }],
-});
-```
-
-#### Computer Use Tool
-
-```javascript
-const response = await client.beta.messages.create({
-  model: 'claude-sonnet-4-20250514',
+// Computer use
+await client.beta.messages.create({
+  model: 'claude-sonnet-4-6',
   max_tokens: 1024,
   messages: [{ role: 'user', content: 'Take a screenshot' }],
   tools: [
-    {
-      type: 'computer_20250124',
-      name: 'computer',
-      display_width_px: 1920,
-      display_height_px: 1080,
-    },
+    { type: 'computer_20250124', name: 'computer', display_width_px: 1920, display_height_px: 1080 },
   ],
+  betas: ['computer-use-2025-01-24'],
 });
-```
 
-#### Text Editor Tool
+// Bash
+await client.beta.messages.create({
+  model: 'claude-sonnet-4-6',
+  max_tokens: 1024,
+  messages: [{ role: 'user', content: 'List the files' }],
+  tools: [{ type: 'bash_20250124', name: 'bash' }],
+  betas: ['computer-use-2025-01-24'],
+});
 
-```javascript
-const response = await client.beta.messages.create({
-  model: 'claude-sonnet-4-20250514',
+// Text editor
+await client.beta.messages.create({
+  model: 'claude-sonnet-4-6',
   max_tokens: 1024,
   messages: [{ role: 'user', content: 'Create a Python script' }],
   tools: [{ type: 'text_editor_20250124', name: 'str_replace_editor' }],
 });
 ```
 
-### Tool Choice Configuration
+## Prompt Caching
 
-Control how Claude uses tools:
+Mark a prefix as cacheable to reuse it across requests at a discount.
 
-- `{ type: 'auto' }` - Claude decides when to use tools
-- `{ type: 'any' }` - Claude must use a tool
-- `{ type: 'tool', name: 'specific_tool' }` - Force a specific tool
-- `{ disable_parallel_tool_use: true }` - Disable parallel tool execution
+```javascript
+const message = await client.messages.create({
+  model: 'claude-sonnet-4-6',
+  max_tokens: 1024,
+  system: [
+    {
+      type: 'text',
+      text: '<long system prompt or reference document>',
+      cache_control: { type: 'ephemeral' },
+    },
+  ],
+  messages: [{ role: 'user', content: 'Question about the document?' }],
+});
+
+console.log(message.usage.cache_creation_input_tokens);
+console.log(message.usage.cache_read_input_tokens);
+```
+
+## Extended Thinking
+
+Available on Sonnet 4.6 and Haiku 4.5. Opus 4.7 uses adaptive thinking and does not take an explicit `thinking` block.
+
+```javascript
+const response = await client.messages.create({
+  model: 'claude-sonnet-4-6',
+  max_tokens: 16000,
+  thinking: { type: 'enabled', budget_tokens: 10000 },
+  messages: [{ role: 'user', content: 'Solve this complex problem...' }],
+});
+
+for (const block of response.content) {
+  if (block.type === 'thinking') console.log('REASONING:', block.thinking);
+  if (block.type === 'text') console.log('ANSWER:', block.text);
+}
+```
 
 ## Message Batches
 
-The SDK supports the Message Batches API for processing multiple requests efficiently.
-
-### Creating a Batch
+Batches run asynchronously at a 50% discount and support up to 256 MB of requests.
 
 ```javascript
-await client.messages.batches.create({
+const batch = await client.messages.batches.create({
   requests: [
     {
-      custom_id: 'my-first-request',
+      custom_id: 'request-1',
       params: {
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         max_tokens: 1024,
         messages: [{ role: 'user', content: 'Hello, world' }],
       },
     },
     {
-      custom_id: 'my-second-request',
+      custom_id: 'request-2',
       params: {
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         max_tokens: 1024,
         messages: [{ role: 'user', content: 'Hi again, friend' }],
       },
     },
   ],
 });
-```
 
-### Getting Batch Results
-
-```javascript
-const results = await client.messages.batches.results(batch_id);
+// Poll batch.processing_status until 'ended', then stream results
+const results = await client.messages.batches.results(batch.id);
 for await (const entry of results) {
   if (entry.result.type === 'succeeded') {
-    console.log(entry.result.message.content);
+    console.log(entry.custom_id, entry.result.message.content);
   }
 }
 ```
@@ -307,75 +363,48 @@ for await (const entry of results) {
 
 ### System Instructions
 
-Guide Claude's behavior with system instructions:
-
 ```javascript
 const response = await client.messages.create({
-  model: 'claude-sonnet-4-20250514',
+  model: 'claude-sonnet-4-6',
   max_tokens: 1024,
+  system: 'You are a helpful assistant that responds in a pirate voice.',
   messages: [{ role: 'user', content: 'Hello' }],
-  system: [{ text: 'You are a helpful assistant that responds in a pirate voice.', type: 'text' }],
 });
 ```
 
-### Thinking
-
-Configure Claude's extended thinking (reasoning process):
+### Generation Parameters
 
 ```javascript
-const response = await client.messages.create({
-  model: 'claude-sonnet-4-6-20250827',
-  max_tokens: 16000,
-  messages: [{ role: 'user', content: 'Solve this complex problem...' }],
-  thinking: { type: 'enabled', budget_tokens: 10000 },
-});
-```
-
-### Temperature and Generation Parameters
-
-Control randomness and output:
-
-```javascript
-const response = await client.messages.create({
-  model: 'claude-sonnet-4-20250514',
+await client.messages.create({
+  model: 'claude-sonnet-4-6',
   max_tokens: 1024,
   messages: [{ role: 'user', content: 'Write a creative story' }],
   temperature: 0.7,
-  top_k: 5,
   top_p: 0.9,
 });
 ```
 
+Do not set both `temperature` and `top_p` simultaneously.
+
 ### Token Counting
 
-Count tokens before making requests:
-
 ```javascript
-const tokenCount = await client.messages.countTokens({
+const count = await client.messages.countTokens({
+  model: 'claude-sonnet-4-6',
   messages: [{ role: 'user', content: 'Hello, Claude' }],
-  model: 'claude-sonnet-4-20250514',
 });
-console.log(tokenCount); // { input_tokens: 25, output_tokens: 13 }
+console.log(count.input_tokens);
 ```
 
 ### Auto-pagination
 
-Handle paginated responses automatically:
-
 ```javascript
-async function fetchAllMessageBatches(params) {
-  const allMessageBatches = [];
-  // Automatically fetches more pages as needed.
-  for await (const messageBatch of client.messages.batches.list({ limit: 20 })) {
-    allMessageBatches.push(messageBatch);
-  }
-  return allMessageBatches;
+for await (const batch of client.messages.batches.list({ limit: 20 })) {
+  console.log(batch.id, batch.processing_status);
 }
 ```
 
 ## Error Handling
-
-The SDK provides comprehensive error handling with specific error types:
 
 ```javascript
 import Anthropic from '@anthropic-ai/sdk';
@@ -383,17 +412,17 @@ import Anthropic from '@anthropic-ai/sdk';
 const client = new Anthropic();
 
 try {
-  const message = await client.messages.create({
+  await client.messages.create({
+    model: 'claude-sonnet-4-6',
     max_tokens: 1024,
     messages: [{ role: 'user', content: 'Hello, Claude' }],
-    model: 'claude-sonnet-4-20250514',
   });
 } catch (err) {
   if (err instanceof Anthropic.APIError) {
     console.log(err.status); // 400
     console.log(err.name); // BadRequestError
-    console.log(err.headers); // {server: 'nginx', ...}
-    console.log(err.requestID); // request id string
+    console.log(err.headers); // { server: 'nginx', ... }
+    console.log(err.requestID); // request id string for support
   } else {
     throw err;
   }
@@ -413,18 +442,14 @@ try {
 | >=500       | `InternalServerError`      |
 | N/A         | `APIConnectionError`       |
 
-All errors extend from `AnthropicError` which extends the standard `Error` class.
+All errors extend `AnthropicError`, which extends the standard `Error` class.
 
 ### Request IDs
 
-All responses include a `_request_id` property for debugging:
+Every response includes a `_request_id` property mirroring the `request-id` HTTP response header.
 
 ```javascript
-const message = await client.messages.create({
-  max_tokens: 1024,
-  messages: [{ role: 'user', content: 'Hello, Claude' }],
-  model: 'claude-sonnet-4-20250514',
-});
+const message = await client.messages.create({ /* ... */ });
 console.log(message._request_id);
 ```
 
@@ -432,72 +457,106 @@ console.log(message._request_id);
 
 ### Retries
 
-Configure automatic retry behavior:
+Connection errors, `408`, `409`, `429`, and `>=500` are retried by default (2 retries).
 
 ```javascript
 // Configure default retries for all requests
-const client = new Anthropic({
-  maxRetries: 3, // default is 2
-});
+const client = new Anthropic({ maxRetries: 3 });
 
-// Or configure per-request
+// Per-request override
 await client.messages.create(
-  { max_tokens: 1024, messages: [{ role: 'user', content: 'Hello, Claude' }], model: 'claude-sonnet-4-20250514' },
+  {
+    model: 'claude-sonnet-4-6',
+    max_tokens: 1024,
+    messages: [{ role: 'user', content: 'Hello, Claude' }],
+  },
   { maxRetries: 5 },
 );
 ```
 
 ### Timeouts
 
-Set custom timeout values:
+Default timeout is 10 minutes.
 
 ```javascript
-// Configure default timeout for all requests
-const client = new Anthropic({
-  timeout: 20 * 1000, // 20 seconds (default is 10 minutes)
-});
+const client = new Anthropic({ timeout: 20 * 1000 });
 
-// Override per-request
 await client.messages.create(
-  { max_tokens: 1024, messages: [{ role: 'user', content: 'Hello, Claude' }], model: 'claude-sonnet-4-20250514' },
+  {
+    model: 'claude-sonnet-4-6',
+    max_tokens: 1024,
+    messages: [{ role: 'user', content: 'Hello, Claude' }],
+  },
   { timeout: 5 * 1000 },
 );
 ```
 
 ### Logging
 
-Enable debug logging:
-
 ```javascript
-import Anthropic from '@anthropic-ai/sdk';
-
 const client = new Anthropic({
-  logLevel: 'debug', // Show all log messages
+  logLevel: 'debug', // 'debug' | 'info' | 'warn' | 'error' | 'off'
 });
 
-// Or use environment variable
+// Or via env var
 // ANTHROPIC_LOG=debug
 ```
 
-### Custom Fetch Options
-
-Customize the underlying fetch behavior:
+### Custom Fetch
 
 ```javascript
-import Anthropic from '@anthropic-ai/sdk';
-
 const client = new Anthropic({
   fetchOptions: {
-    // Custom RequestInit options
+    // Standard RequestInit options
   },
+});
+```
+
+## Cloud Deployments
+
+### Claude Platform on AWS
+
+Uses the same model IDs as the direct Claude API.
+
+```javascript
+import { AnthropicAWS } from '@anthropic-ai/sdk';
+
+const client = new AnthropicAWS({ awsRegion: 'us-east-1' });
+```
+
+### AWS Bedrock
+
+```javascript
+import { AnthropicBedrock } from '@anthropic-ai/sdk';
+
+const client = new AnthropicBedrock({ awsRegion: 'us-east-1' });
+
+await client.messages.create({
+  model: 'anthropic.claude-sonnet-4-6',
+  max_tokens: 1024,
+  messages: [{ role: 'user', content: 'Hello!' }],
+});
+```
+
+### Google Vertex AI
+
+```javascript
+import { AnthropicVertex } from '@anthropic-ai/sdk';
+
+const client = new AnthropicVertex({ projectId: 'my-gcp-project', region: 'us-east5' });
+
+await client.messages.create({
+  model: 'claude-sonnet-4-6',
+  max_tokens: 1024,
+  messages: [{ role: 'user', content: 'Hello!' }],
 });
 ```
 
 ## Useful Links
 
-- Documentation: https://docs.anthropic.com/
-- API Reference: https://docs.anthropic.com/claude/reference/
-- Models: https://docs.anthropic.com/claude/docs/models-overview
-- API Pricing: https://www.anthropic.com/pricing
-- Rate Limits: https://docs.anthropic.com/claude/reference/rate-limits
-
+- Documentation: https://platform.claude.com/docs/en/api/overview
+- Models: https://platform.claude.com/docs/en/about-claude/models/overview
+- SDK Repository: https://github.com/anthropics/anthropic-sdk-typescript
+- API Keys: https://platform.claude.com/settings/keys
+- Rate Limits: https://platform.claude.com/docs/en/api/rate-limits
+- Beta Headers: https://platform.claude.com/docs/en/api/beta-headers

--- a/content/anthropic/docs/claude-api/python/DOC.md
+++ b/content/anthropic/docs/claude-api/python/DOC.md
@@ -3,8 +3,9 @@ name: claude-api
 description: "Claude AI assistant API for text generation, analysis, conversation, streaming, tool use, vision, and batch processing"
 metadata:
   languages: "python"
-  versions: "0.84.0"
-  updated-on: "2026-03-05"
+  versions: "0.105.2"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "anthropic,sdk,llm,ai,claude"
 ---
@@ -15,7 +16,7 @@ metadata:
 You are an Anthropic API coding expert. Help me with writing code using the Anthropic API calling the official libraries and SDKs.
 
 You can find the official SDK documentation and code samples here:
-https://docs.anthropic.com/claude/reference/
+https://platform.claude.com/docs/en/api/client-sdks
 
 ## Golden Rule: Use the Correct and Current SDK
 
@@ -24,6 +25,7 @@ Always use the Anthropic Python SDK to call Claude models, which is the standard
 - **Library Name:** Anthropic Python SDK
 - **Python Package:** `anthropic`
 - **Installation:** `pip install anthropic`
+- **Python Requirement:** `>=3.9`
 
 **APIs and Usage:**
 
@@ -42,31 +44,31 @@ The `anthropic` library requires creating a client object for all API calls.
 
 ## Models
 
-By default, use the following models as of March 2026:
+By default, use the following models as of May 2026:
 
-- **General Tasks:** `claude-sonnet-4-6-20250827`
-- **High-performance:** `claude-opus-4-6-20250826`
-- **Fast and Efficient:** `claude-haiku-4-5-20251001`
+- **Most capable (reasoning, agentic coding):** `claude-opus-4-7`
+- **Balanced (speed + intelligence):** `claude-sonnet-4-6`
+- **Fast and efficient:** `claude-haiku-4-5`
 
-Previous generation models (still supported):
-- `claude-sonnet-4-20250514`, `claude-opus-4-20250514`
-- `claude-3-5-haiku-20241022`
+Claude 4.6+ model IDs are dateless and pin to a specific snapshot. Older models still resolve via aliases (e.g. `claude-opus-4-1`, `claude-sonnet-4-5`).
 
-Do not use deprecated models: `claude-3-7-sonnet`, `claude-3-5-sonnet`, `claude-3-opus`
+Deprecated and scheduled for retirement on 2026-06-15: `claude-sonnet-4-20250514`, `claude-opus-4-20250514`. Migrate off these now.
+
+Do not invent model names. If unsure, query the registry:
 
 ```python
 # List all available models
 models = client.models.list()
+for m in models.data:
+    print(m.id)
 ```
+
 ```python
-# List all deprecated models
+# Inspect deprecated models bundled with the SDK
 from anthropic.resources.messages.messages import DEPRECATED_MODELS
 for model, deprecation_date in DEPRECATED_MODELS.items():
     print(f"{model}: deprecated {deprecation_date}")
 ```
-
-- It is acceptable to use specific dated versions if consistency is required.
-- Avoid using deprecated models - check the SDK documentation for deprecation notices.
 
 ## Basic Inference (Text Generation)
 
@@ -76,25 +78,54 @@ from anthropic import Anthropic
 client = Anthropic()
 
 message = client.messages.create(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-4-6",
     max_tokens=1024,
     messages=[
-        {
-            "role": "user",
-            "content": "Hello, Claude"
-        }
-    ]
+        {"role": "user", "content": "Hello, Claude"}
+    ],
 )
-print(message.content)
+
+# message.content is a list of content blocks, not a string
+for block in message.content:
+    if block.type == "text":
+        print(block.text)
+```
+
+`max_tokens` is required. The response `content` is always a list of typed blocks (`text`, `tool_use`, `thinking`, etc.).
+
+## Multi-Turn Conversations
+
+Append assistant responses back into `messages` to continue a conversation.
+
+```python
+conversation = [
+    {"role": "user", "content": "What's the capital of France?"}
+]
+
+reply = client.messages.create(
+    model="claude-sonnet-4-6",
+    max_tokens=512,
+    messages=conversation,
+)
+
+# Append the full assistant message (the SDK content blocks roundtrip cleanly)
+conversation.append({"role": "assistant", "content": reply.content})
+conversation.append({"role": "user", "content": "And its population?"})
+
+followup = client.messages.create(
+    model="claude-sonnet-4-6",
+    max_tokens=512,
+    messages=conversation,
+)
 ```
 
 ## Multimodal Inputs
 
-### Image Inputs
+### Image Inputs (base64)
 
 ```python
 message = client.messages.create(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-4-6",
     max_tokens=1024,
     messages=[
         {
@@ -105,26 +136,57 @@ message = client.messages.create(
                     "source": {
                         "type": "base64",
                         "media_type": "image/jpeg",
-                        "data": "/9j/4AAQSkZJRgABAQ..."
-                    }
+                        "data": "/9j/4AAQSkZJRgABAQ...",
+                    },
                 },
-                {
-                    "type": "text",
-                    "text": "What's in this image?"
-                }
-            ]
+                {"type": "text", "text": "What's in this image?"},
+            ],
         }
-    ]
+    ],
 )
 ```
 
-### File Uploads
+### Image Inputs (URL)
+
+```python
+message = client.messages.create(
+    model="claude-sonnet-4-6",
+    max_tokens=1024,
+    messages=[
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {"type": "url", "url": "https://example.com/image.jpg"},
+                },
+                {"type": "text", "text": "Describe this."},
+            ],
+        }
+    ],
+)
+```
+
+### File Uploads (beta)
 
 ```python
 from pathlib import Path
 
-client.beta.files.upload(
-    file=Path("/path/to/file"),
+uploaded = client.beta.files.upload(file=Path("/path/to/document.pdf"))
+
+message = client.beta.messages.create(
+    model="claude-sonnet-4-6",
+    max_tokens=1024,
+    messages=[
+        {
+            "role": "user",
+            "content": [
+                {"type": "document", "source": {"type": "file", "file_id": uploaded.id}},
+                {"type": "text", "text": "Summarize this document."},
+            ],
+        }
+    ],
+    betas=["files-api-2025-04-14"],
 )
 ```
 
@@ -138,77 +200,88 @@ client = AsyncAnthropic()
 
 async def main():
     message = await client.messages.create(
-        model="claude-sonnet-4-20250514",
+        model="claude-sonnet-4-6",
         max_tokens=1024,
-        messages=[
-            {
-                "role": "user",
-                "content": "Hello, Claude"
-            }
-        ]
+        messages=[{"role": "user", "content": "Hello, Claude"}],
     )
     print(message.content)
 
 asyncio.run(main())
 ```
 
-## Advanced Capabilities and Configurations
+To use `aiohttp` instead of the default `httpx` transport for the async client:
+
+```python
+from anthropic import AsyncAnthropic, DefaultAioHttpClient
+
+client = AsyncAnthropic(http_client=DefaultAioHttpClient())
+```
+
+Install with `pip install "anthropic[aiohttp]"`.
+
+## Advanced Capabilities
 
 ### System Instructions
 
 ```python
 message = client.messages.create(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-4-6",
     max_tokens=1024,
     system="You are a helpful assistant that speaks like a pirate.",
-    messages=[
-        {
-            "role": "user",
-            "content": "Hello!"
-        }
-    ]
+    messages=[{"role": "user", "content": "Hello!"}],
 )
 ```
 
-### Thinking
+### Extended Thinking
 
-Configure Claude's extended thinking (reasoning process):
+Available on Sonnet 4.6 and Haiku 4.5. Opus 4.7 uses adaptive thinking (no explicit `thinking` parameter required).
 
 ```python
 message = client.messages.create(
-    model="claude-sonnet-4-6-20250827",
+    model="claude-sonnet-4-6",
     max_tokens=16000,
-    messages=[
+    thinking={"type": "enabled", "budget_tokens": 10000},
+    messages=[{"role": "user", "content": "Solve this complex problem step by step."}],
+)
+
+for block in message.content:
+    if block.type == "thinking":
+        print("REASONING:", block.thinking)
+    elif block.type == "text":
+        print("ANSWER:", block.text)
+```
+
+### Prompt Caching
+
+Mark prefix content as cacheable to reuse it across requests. Cached input tokens are billed at a discount.
+
+```python
+message = client.messages.create(
+    model="claude-sonnet-4-6",
+    max_tokens=1024,
+    system=[
         {
-            "role": "user",
-            "content": "Solve this complex problem step by step."
+            "type": "text",
+            "text": "<long system prompt or document>",
+            "cache_control": {"type": "ephemeral"},
         }
     ],
-    thinking={
-        "type": "enabled",
-        "budget_tokens": 10000
-    }
+    messages=[{"role": "user", "content": "Question about the document?"}],
 )
+
+print(message.usage.cache_creation_input_tokens)
+print(message.usage.cache_read_input_tokens)
 ```
 
 ### Tool Use (Function Calling)
 
 ```python
-def get_weather(location: str) -> str:
-    return f"Weather in {location}: 72°F and sunny"
-
 message = client.messages.create(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-4-6",
     max_tokens=1024,
-    messages=[
-        {
-            "role": "user",
-            "content": "What's the weather in San Francisco?"
-        }
-    ],
+    messages=[{"role": "user", "content": "What's the weather in San Francisco?"}],
     tools=[
         {
-            "type": "custom",
             "name": "get_weather",
             "description": "Get current weather for a location",
             "input_schema": {
@@ -216,127 +289,167 @@ message = client.messages.create(
                 "properties": {
                     "location": {
                         "type": "string",
-                        "description": "The city and state, e.g. San Francisco, CA"
+                        "description": "The city and state, e.g. San Francisco, CA",
                     }
                 },
-                "required": ["location"]
-            }
+                "required": ["location"],
+            },
         }
-    ]
+    ],
 )
+
+# Inspect tool_use blocks and feed results back as tool_result blocks
+for block in message.content:
+    if block.type == "tool_use":
+        result = f"Weather in {block.input['location']}: 72F"
+        followup = client.messages.create(
+            model="claude-sonnet-4-6",
+            max_tokens=1024,
+            messages=[
+                {"role": "user", "content": "What's the weather in San Francisco?"},
+                {"role": "assistant", "content": message.content},
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": block.id,
+                            "content": result,
+                        }
+                    ],
+                },
+            ],
+            tools=[...],
+        )
 ```
 
 ### Streaming Responses
 
-```python
-stream = client.messages.create(
-    model="claude-sonnet-4-20250514",
-    max_tokens=1024,
-    messages=[
-        {
-            "role": "user",
-            "content": "Tell me a story"
-        }
-    ],
-    stream=True
-)
+Low-level event stream:
 
-for event in stream:
-    if event.type == "content_block_delta":
-        print(event.delta.text, end="", flush=True)
+```python
+with client.messages.stream(
+    model="claude-sonnet-4-6",
+    max_tokens=1024,
+    messages=[{"role": "user", "content": "Tell me a story"}],
+) as stream:
+    for text in stream.text_stream:
+        print(text, end="", flush=True)
+    final_message = stream.get_final_message()
 ```
 
-### Streaming Helpers
+Async streaming helper:
 
 ```python
 async with client.messages.stream(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-4-6",
     max_tokens=1024,
-    messages=[
-        {
-            "role": "user",
-            "content": "Say hello there!"
-        }
-    ]
+    messages=[{"role": "user", "content": "Say hello there!"}],
 ) as stream:
     async for text in stream.text_stream:
         print(text, end="", flush=True)
-    print()
+    final = await stream.get_final_message()
+```
 
-message = await stream.get_final_message()
+Raw event iteration (`stream=True`):
+
+```python
+stream = client.messages.create(
+    model="claude-sonnet-4-6",
+    max_tokens=1024,
+    messages=[{"role": "user", "content": "Tell me a story"}],
+    stream=True,
+)
+for event in stream:
+    if event.type == "content_block_delta" and event.delta.type == "text_delta":
+        print(event.delta.text, end="", flush=True)
 ```
 
 ### Token Counting
 
 ```python
 count = client.messages.count_tokens(
-    model="claude-sonnet-4-20250514",
-    messages=[
-        {"role": "user", "content": "Hello, world"}
-    ]
+    model="claude-sonnet-4-6",
+    messages=[{"role": "user", "content": "Hello, world"}],
 )
 print(f"Input tokens: {count.input_tokens}")
 ```
 
 ### Message Batches
 
+Batches run asynchronously at a 50% discount.
+
 ```python
-batch = await client.messages.batches.create(
+batch = client.messages.batches.create(
     requests=[
         {
             "custom_id": "request-1",
             "params": {
-                "model": "claude-sonnet-4-20250514",
+                "model": "claude-sonnet-4-6",
                 "max_tokens": 1024,
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
         }
     ]
 )
+
+# Poll until processing_status == "ended", then stream results
+for entry in client.messages.batches.results(batch.id):
+    if entry.result.type == "succeeded":
+        print(entry.custom_id, entry.result.message.content)
 ```
 
 ## Specialized Deployments
+
+### Claude Platform on AWS
+
+Uses the same model IDs as the direct Claude API (not Bedrock-style IDs).
+
+```python
+from anthropic import AnthropicAWS
+
+client = AnthropicAWS(aws_region="us-east-1")
+
+message = client.messages.create(
+    model="claude-sonnet-4-6",
+    max_tokens=1024,
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+```
+
+Install with `pip install "anthropic[aws]"`.
 
 ### AWS Bedrock
 
 ```python
 from anthropic import AnthropicBedrock
 
-client = AnthropicBedrock(
-    aws_region="us-east-1",
-    aws_profile="default"
-)
+client = AnthropicBedrock(aws_region="us-east-1")
 
 message = client.messages.create(
-    model="anthropic.claude-sonnet-4-20250514-v1:0",
+    model="anthropic.claude-sonnet-4-6",
     max_tokens=1024,
-    messages=[
-        {
-            "role": "user",
-            "content": "Hello!"
-        }
-    ]
+    messages=[{"role": "user", "content": "Hello!"}],
 )
 ```
+
+Install with `pip install "anthropic[bedrock]"`.
 
 ### Google Vertex AI
 
 ```python
 from anthropic import AnthropicVertex
 
-client = AnthropicVertex()
+client = AnthropicVertex(project_id="my-gcp-project", region="us-east5")
 
 message = client.messages.create(
-    model="claude-sonnet-4@20250514",
+    model="claude-sonnet-4-6",
     max_tokens=1024,
-    messages=[
-        {
-            "role": "user",
-            "content": "Hello!"
-        }
-    ]
+    messages=[{"role": "user", "content": "Hello!"}],
 )
 ```
+
+Install with `pip install "anthropic[vertex]"`.
 
 ## Error Handling
 
@@ -345,45 +458,70 @@ import anthropic
 
 try:
     message = client.messages.create(
-        model="claude-sonnet-4-20250514",
+        model="claude-sonnet-4-6",
         max_tokens=1024,
-        messages=[
-            {
-                "role": "user",
-                "content": "Hello, Claude"
-            }
-        ]
+        messages=[{"role": "user", "content": "Hello, Claude"}],
     )
 except anthropic.APIConnectionError as e:
     print("Connection error occurred")
 except anthropic.RateLimitError as e:
-    print("Rate limit exceeded")
+    print("Rate limit exceeded, retry-after:", e.response.headers.get("retry-after"))
+except anthropic.BadRequestError as e:
+    print("Bad request:", e.message)
+except anthropic.AuthenticationError as e:
+    print("Auth failed")
 except anthropic.APIStatusError as e:
-    print(f"API error: {e.status_code}")
+    print(f"API error: {e.status_code} {e.message}")
 ```
+
+Every response object exposes `_request_id` (also surfaced as `request-id` response header) for support debugging.
 
 ## Configuration Options
 
 ### Retries
 
+The SDK retries connection errors, `408`, `409`, `429`, and `>=500` responses by default (2 retries).
+
 ```python
 client = Anthropic(max_retries=3)
 
+# Per-request override
 client.with_options(max_retries=5).messages.create(...)
 ```
 
 ### Timeouts
 
-```python
-client = Anthropic(timeout=30.0)
+Default timeout is 10 minutes.
 
+```python
+import httpx
+
+client = Anthropic(timeout=30.0)
+client = Anthropic(timeout=httpx.Timeout(60.0, connect=5.0))
+
+# Per-request override
 client.with_options(timeout=60.0).messages.create(...)
+```
+
+### Custom HTTP Client
+
+```python
+import httpx
+from anthropic import Anthropic, DefaultHttpxClient
+
+client = Anthropic(
+    http_client=DefaultHttpxClient(
+        proxy="http://proxy.internal:8080",
+        transport=httpx.HTTPTransport(local_address="0.0.0.0"),
+    )
+)
 ```
 
 ## Useful Links
 
-- **Documentation:** https://docs.anthropic.com/claude/reference/
-- **API Keys:** https://console.anthropic.com/
+- **Documentation:** https://platform.claude.com/docs/en/api/overview
+- **Models:** https://platform.claude.com/docs/en/about-claude/models/overview
+- **API Keys:** https://platform.claude.com/settings/keys
 - **SDK Repository:** https://github.com/anthropics/anthropic-sdk-python
-- **Rate Limits:** https://docs.anthropic.com/claude/reference/rate-limits
-- **Error Codes:** https://docs.anthropic.com/claude/reference/errors
+- **Rate Limits:** https://platform.claude.com/docs/en/api/rate-limits
+- **Beta Headers:** https://platform.claude.com/docs/en/api/beta-headers

--- a/content/anthropic/docs/package/python/DOC.md
+++ b/content/anthropic/docs/package/python/DOC.md
@@ -3,9 +3,9 @@ name: package
 description: "Anthropic Python package guide for the Claude SDK: install, auth, messages, streaming, async, tools, and runtime configuration"
 metadata:
   languages: "python"
-  versions: "0.84.0"
-  revision: 1
-  updated-on: "2026-03-12"
+  versions: "0.105.2"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "anthropic,claude,llm,api,sdk,python"
 ---
@@ -14,7 +14,7 @@ metadata:
 
 ## What This Covers
 
-This entry is for the PyPI package [`anthropic`](https://pypi.org/project/anthropic/) version `0.84.0`, which Anthropic documents as the Claude SDK for Python.
+This entry is for the PyPI package [`anthropic`](https://pypi.org/project/anthropic/) version `0.105.2`, which Anthropic documents as the Claude SDK for Python.
 
 Use it when you need to:
 
@@ -22,28 +22,34 @@ Use it when you need to:
 - stream tokens or structured events
 - use the async client
 - configure retries, timeouts, or custom HTTP transports
-- switch to Anthropic-hosted, Bedrock, or Vertex clients without changing the overall SDK shape
+- switch to Anthropic-hosted, Claude Platform on AWS, Bedrock, or Vertex clients without changing the overall SDK shape
 
 ## Install
 
 ```bash
-pip install anthropic==0.84.0
+pip install anthropic==0.105.2
 ```
+
+Anthropic documents Python `>=3.9` as the minimum supported runtime.
 
 Optional extras documented by Anthropic:
 
 ```bash
 pip install "anthropic[aiohttp]"
+pip install "anthropic[aws]"
 pip install "anthropic[bedrock]"
 pip install "anthropic[vertex]"
 pip install "anthropic[mcp]"
+pip install "anthropic[webhooks]"
 ```
 
 Notes:
 
 - `anthropic[aiohttp]` lets the async client use `aiohttp` instead of the default `httpx`.
+- `anthropic[aws]` installs the Claude Platform on AWS client.
 - `anthropic[bedrock]` and `anthropic[vertex]` install cloud-specific integrations.
 - `anthropic[mcp]` installs Model Context Protocol helpers. Anthropic documents that this extra requires Python `3.10+`.
+- `anthropic[webhooks]` installs `standardwebhooks` for verifying webhook signatures.
 
 ## Authentication And Client Setup
 
@@ -67,14 +73,17 @@ from anthropic import Anthropic
 client = Anthropic(api_key="your-api-key")
 ```
 
-Cloud-specific clients use different classes:
+Cloud-specific clients use different classes and credentials:
 
 ```python
-from anthropic import AnthropicBedrock, AnthropicVertex
+from anthropic import AnthropicAWS, AnthropicBedrock, AnthropicVertex
 
+aws = AnthropicAWS(aws_region="us-east-1")
 bedrock = AnthropicBedrock(aws_region="us-east-1")
 vertex = AnthropicVertex(project_id="my-gcp-project", region="us-east5")
 ```
+
+Claude Platform on AWS uses the same model IDs as the direct Claude API; Bedrock and Vertex use platform-specific IDs.
 
 ## Core Usage
 
@@ -86,7 +95,7 @@ from anthropic import Anthropic
 client = Anthropic()
 
 message = client.messages.create(
-    model="claude-opus-4-6",
+    model="claude-opus-4-7",
     max_tokens=1024,
     messages=[
         {"role": "user", "content": "Write a haiku about clean APIs."}
@@ -103,7 +112,8 @@ Practical notes:
 
 - `max_tokens` is required in normal `messages.create` calls.
 - Response `content` is block-based. Do not assume the SDK returns a single plain string.
-- Model IDs change independently of SDK releases. If a copied example uses an outdated model, check Anthropic's current model docs or `client.models.list()`.
+- Recommended current model IDs: `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5`. Claude 4.6+ IDs are dateless pinned snapshots; older models still use dated IDs.
+- Model IDs change independently of SDK releases. When in doubt, query `client.models.list()`.
 
 ### Count tokens before sending
 
@@ -113,7 +123,7 @@ from anthropic import Anthropic
 client = Anthropic()
 
 count = client.messages.count_tokens(
-    model="claude-opus-4-1",
+    model="claude-sonnet-4-6",
     messages=[
         {"role": "user", "content": "Hello, Claude"}
     ],
@@ -132,7 +142,7 @@ client = AsyncAnthropic()
 
 async def main() -> None:
     message = await client.messages.create(
-        model="claude-opus-4-6",
+        model="claude-sonnet-4-6",
         max_tokens=512,
         messages=[
             {"role": "user", "content": "Summarize this repository layout."}
@@ -164,7 +174,7 @@ from anthropic import Anthropic
 client = Anthropic()
 
 with client.messages.stream(
-    model="claude-opus-4-6",
+    model="claude-sonnet-4-6",
     max_tokens=1024,
     messages=[
         {"role": "user", "content": "Stream a short explanation of retries."}
@@ -184,7 +194,7 @@ from anthropic import Anthropic
 client = Anthropic()
 
 with client.messages.with_streaming_response.create(
-    model="claude-opus-4-6",
+    model="claude-sonnet-4-6",
     max_tokens=1024,
     messages=[
         {"role": "user", "content": "List three HTTP status codes."}
@@ -197,39 +207,119 @@ with client.messages.with_streaming_response.create(
 
 ### Tool use
 
-The direct Messages API accepts tool definitions inline:
+The direct Messages API accepts tool definitions inline. Run the tool yourself and return the result as a `tool_result` block on the next turn.
 
 ```python
 from anthropic import Anthropic
 
 client = Anthropic()
 
+tools = [
+    {
+        "name": "get_weather",
+        "description": "Get the weather for a city",
+        "input_schema": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    }
+]
+
 message = client.messages.create(
-    model="claude-opus-4-6",
+    model="claude-sonnet-4-6",
     max_tokens=1024,
-    messages=[
-        {"role": "user", "content": "What is the weather in SF?"}
-    ],
-    tools=[
-        {
-            "name": "get_weather",
-            "description": "Get the weather for a city",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "city": {"type": "string"}
-                },
-                "required": ["city"],
-            },
-        }
-    ],
+    tools=tools,
+    messages=[{"role": "user", "content": "What is the weather in SF?"}],
 )
 
 for block in message.content:
-    print(block)
+    if block.type == "tool_use":
+        result = f"72F and sunny in {block.input['city']}"
+        followup = client.messages.create(
+            model="claude-sonnet-4-6",
+            max_tokens=1024,
+            tools=tools,
+            messages=[
+                {"role": "user", "content": "What is the weather in SF?"},
+                {"role": "assistant", "content": message.content},
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": block.id,
+                            "content": result,
+                        }
+                    ],
+                },
+            ],
+        )
 ```
 
 For local Python functions, Anthropic also ships beta helpers such as `@beta_tool`, `client.beta.messages.tool_runner(...)`, and MCP adapters in `anthropic[mcp]`.
+
+### Prompt caching
+
+Mark a prefix as cacheable to reuse it across requests at a discount.
+
+```python
+message = client.messages.create(
+    model="claude-sonnet-4-6",
+    max_tokens=1024,
+    system=[
+        {
+            "type": "text",
+            "text": "<long system prompt or reference document>",
+            "cache_control": {"type": "ephemeral"},
+        }
+    ],
+    messages=[{"role": "user", "content": "Question about the doc?"}],
+)
+
+print(message.usage.cache_creation_input_tokens)
+print(message.usage.cache_read_input_tokens)
+```
+
+### Extended thinking
+
+Available on Sonnet 4.6 and Haiku 4.5. Opus 4.7 uses adaptive thinking and does not take an explicit `thinking` parameter.
+
+```python
+message = client.messages.create(
+    model="claude-sonnet-4-6",
+    max_tokens=16000,
+    thinking={"type": "enabled", "budget_tokens": 10000},
+    messages=[{"role": "user", "content": "Solve this complex problem."}],
+)
+
+for block in message.content:
+    if block.type == "thinking":
+        print("REASONING:", block.thinking)
+    elif block.type == "text":
+        print("ANSWER:", block.text)
+```
+
+### Message batches
+
+```python
+batch = client.messages.batches.create(
+    requests=[
+        {
+            "custom_id": "request-1",
+            "params": {
+                "model": "claude-sonnet-4-6",
+                "max_tokens": 1024,
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
+        }
+    ]
+)
+
+for entry in client.messages.batches.results(batch.id):
+    if entry.result.type == "succeeded":
+        print(entry.custom_id, entry.result.message.content)
+```
 
 ## Configuration
 
@@ -252,7 +342,7 @@ client = Anthropic(max_retries=5)
 
 # Per-request override
 message = client.with_options(max_retries=0).messages.create(
-    model="claude-opus-4-6",
+    model="claude-sonnet-4-6",
     max_tokens=256,
     messages=[{"role": "user", "content": "No automatic retries for this call."}],
 )
@@ -294,16 +384,19 @@ Anthropic also documents per-request overrides through `client.with_options(...)
 ## Common Pitfalls
 
 - The package name and import root are both `anthropic`, but Anthropic's current docs brand the library as the Claude SDK for Python.
-- Use `client.messages.create(...)` for new code. Anthropic's modern SDK documentation is centered on the Messages API, not legacy text-completions patterns.
-- Do not treat `message.content` as a single string. It is a list of content blocks.
+- Use `client.messages.create(...)` for new code. Anthropic's modern SDK documentation is centered on the Messages API, not legacy text-completion patterns.
+- Do not treat `message.content` as a single string. It is a list of content blocks (`text`, `tool_use`, `thinking`, etc.).
 - Streaming has two different APIs: `client.messages.stream(...)` for helper-driven iteration and `client.messages.with_streaming_response.create(...)` for lower-level raw access.
 - Beta helpers live under `client.beta...` and may require explicit `betas=[...]` flags. Do not copy beta examples into stable code paths without checking the named beta header requirement.
-- Bedrock and Vertex use dedicated client classes and platform credentials. `ANTHROPIC_API_KEY` is for Anthropic-hosted API usage, not for those cloud provider flows.
+- Claude Platform on AWS, Bedrock, and Vertex use dedicated client classes and platform credentials. `ANTHROPIC_API_KEY` is for the direct Anthropic-hosted API, not those cloud provider flows.
+- Migrate off `claude-sonnet-4-20250514` and `claude-opus-4-20250514` before their 2026-06-15 retirement date.
 
-## Version-Sensitive Notes For 0.84.0
+## Version-Sensitive Notes For 0.105.2
 
-- PyPI lists `0.84.0` as the current release published on `2026-02-25`.
-- PyPI lists Python support as `>=3.8`.
+- PyPI lists `0.105.2` as the current release published on `2026-05-29`.
+- PyPI lists Python support as `>=3.9`.
+- The `0.105.x` series added support for the latest Claude models, mid-conversation system blocks, and the `usage.output_tokens_details` field.
+- Claude Platform on AWS support (`anthropic[aws]`, `AnthropicAWS`) was introduced in `0.101.0`.
 - The optional MCP helper package path (`anthropic[mcp]`) is documented separately and requires Python `3.10+`.
 - Anthropic's current SDK docs live under `platform.claude.com`. The older docs URL `https://docs.anthropic.com/en/api/client-sdks` redirects there.
 


### PR DESCRIPTION
docs(anthropic): refresh to Python SDK 0.105.2 / JS SDK 0.100.1

Updates the Anthropic Claude API docs (Python + JavaScript) and the
package/python doc to the latest published SDKs.

- Bumps pinned versions to the npm/PyPI `latest` for each
- Refreshes example model IDs (claude-opus-4-7 / sonnet-4-6 / haiku-4-5)
- Adds full tool-use roundtrips, prompt caching, multi-turn examples
- Adds Claude Platform on AWS (`AnthropicAWS`) section
- Flags 2026-06-15 retirement of the *-20250514 model IDs
- Bumps `revision` and `updated-on: 2026-05-29` in frontmatter

Verified versions against PyPI (anthropic) and npm (@anthropic-ai/sdk).
