### PR TITLE
docs(openai): refresh to SDK 2.38.0 / 6.39.1 / Go v3.37.0

### DIFF
--- a/content/openai/docs/chat/go/DOC.md
+++ b/content/openai/docs/chat/go/DOC.md
@@ -3,9 +3,9 @@ name: chat
 description: "OpenAI API for text generation, chat completions, streaming, function calling, vision, embeddings, and assistants"
 metadata:
   languages: "go"
-  versions: "1.3.0"
-  revision: 1
-  updated-on: "2026-03-09"
+  versions: "3.37.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: community
   tags: "openai,chat,llm,ai"
 ---
@@ -15,57 +15,76 @@ metadata:
 You are an OpenAI API coding expert. Help me with writing code using the OpenAI API calling the official Go SDK.
 
 You can find the official SDK documentation and code samples here:
-https://platform.openai.com/docs/api-reference
+https://github.com/openai/openai-go
 
 ## Golden Rule: Use the Correct and Current SDK
 
 Always use the official OpenAI Go SDK to call OpenAI models.
 
-**Module:** `github.com/openai/openai-go`
+**Module (v3.x):** `github.com/openai/openai-go/v3`
 
 **Installation:**
 ```bash
-go get github.com/openai/openai-go
+go get github.com/openai/openai-go/v3
 ```
 
 **APIs and Usage:**
-- **Primary API (Recommended):** `client.Responses.Create(...)`
+- **Primary API (Recommended):** `client.Responses.New(...)`
 - **Legacy API (Still Supported):** `client.Chat.Completions.New(...)`
+
+## Important: v2/v3 Breaking Changes
+
+The Go SDK underwent significant breaking changes in `v2.x` and `v3.x`. If you are migrating from `v1.x`:
+
+- The `openai.F(...)` wrapper for parameter fields has been **removed**. Pass values directly.
+- Optional primitive types now use `param.Opt[T]` and constructors like `openai.String(...)`, `openai.Int(...)`, `openai.Bool(...)`, `openai.Float(...)`.
+- The import path is now `github.com/openai/openai-go/v3`.
+- Union input types are constructed with named fields (e.g. `responses.ResponseNewParamsInputUnion{OfString: openai.String("...")}`).
+
+This document targets the current `v3.x` API. Do not mix old `openai.F()` patterns with new code.
 
 ## Initialization and API Key
 
 Set the `OPENAI_API_KEY` environment variable; the SDK picks it up automatically.
 
 ```go
+package main
+
 import (
-    "github.com/openai/openai-go"
-    "github.com/openai/openai-go/option"
+    "github.com/openai/openai-go/v3"
+    "github.com/openai/openai-go/v3/option"
 )
 
-// Uses OPENAI_API_KEY environment variable automatically
-client := openai.NewClient()
+func main() {
+    // Uses OPENAI_API_KEY environment variable automatically
+    client := openai.NewClient()
 
-// Or pass the API key explicitly (not recommended for production)
-// client := openai.NewClient(option.WithAPIKey("your-api-key-here"))
+    // Or pass the API key explicitly (not recommended for production)
+    // client := openai.NewClient(option.WithAPIKey("your-api-key-here"))
+    _ = client
+}
 ```
 
 Use environment secrets or a secrets manager to keep keys out of source control.
 
-## Models (as of March 2026)
+## Models (as of May 2026)
 
-Use typed model constants from the SDK — never hardcode strings directly.
+Use typed model constants from the SDK when available; otherwise pass a string.
 
 Default choices:
-- **General Text Tasks:** `openai.ChatModelGPT4_1` (non-reasoning)
-- **Fast & Cost-Efficient:** `openai.ChatModelGPT4_1Mini`
-- **Cheapest / Fastest:** `openai.ChatModelGPT4_1Nano`
+- **General Text / Coding:** `openai.ChatModelGPT5_5` (flagship, 1M context)
+- **More Affordable Frontier:** `openai.ChatModelGPT5_4`
+- **Fast & Cost-Efficient:** `openai.ChatModelGPT5_4Mini`
+- **Cheapest / Fastest:** `openai.ChatModelGPT5_4Nano`
+- **Image Generation:** `gpt-image-2`
+- **Embeddings:** `openai.EmbeddingModelTextEmbedding3Small`
 
 ```go
 // Typed constants — preferred
-model: openai.F(openai.ChatModelGPT4_1),
+Model: openai.ChatModelGPT5_5,
 
-// String literal — only when using a model not yet in constants
-model: openai.F("gpt-5.4"),
+// String literal — for models not yet in constants
+Model: "gpt-5.5",
 ```
 
 ## Basic Inference (Text Generation)
@@ -79,17 +98,19 @@ import (
     "context"
     "fmt"
 
-    "github.com/openai/openai-go"
-    "github.com/openai/openai-go/responses"
+    "github.com/openai/openai-go/v3"
+    "github.com/openai/openai-go/v3/responses"
 )
 
 func main() {
     client := openai.NewClient()
 
     resp, err := client.Responses.New(context.Background(), responses.ResponseNewParams{
-        Model:        openai.F("gpt-4.1"),
-        Instructions: openai.F("You are a helpful coding assistant."),
-        Input:        responses.ResponseNewParamsInputUnionString("How do I reverse a slice in Go?"),
+        Model:        openai.ChatModelGPT5_5,
+        Instructions: openai.String("You are a helpful coding assistant."),
+        Input: responses.ResponseNewParamsInputUnion{
+            OfString: openai.String("How do I reverse a slice in Go?"),
+        },
     })
     if err != nil {
         panic(err)
@@ -107,18 +128,18 @@ import (
     "context"
     "fmt"
 
-    "github.com/openai/openai-go"
+    "github.com/openai/openai-go/v3"
 )
 
 func main() {
     client := openai.NewClient()
 
     completion, err := client.Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{
-        Model: openai.F(openai.ChatModelGPT4_1),
-        Messages: openai.F([]openai.ChatCompletionMessageParamUnion{
+        Model: openai.ChatModelGPT5_5,
+        Messages: []openai.ChatCompletionMessageParamUnion{
             openai.SystemMessage("You are a helpful assistant."),
             openai.UserMessage("How do I reverse a slice in Go?"),
-        }),
+        },
     })
     if err != nil {
         panic(err)
@@ -127,28 +148,23 @@ func main() {
 }
 ```
 
-## The `openai.F()` Wrapper — Critical Pattern
+## Parameter Conventions
 
-**All parameter fields in the Go SDK must be wrapped with `openai.F()`.**
-This is Go-specific and does not appear in Python or JavaScript SDK docs.
+Pass required fields directly. For optional primitive fields, use the `openai.String / Int / Bool / Float` constructors which return a `param.Opt[T]`.
 
 ```go
-// CORRECT — all fields wrapped
+// CORRECT for v3.x
 openai.ChatCompletionNewParams{
-    Model:       openai.F(openai.ChatModelGPT4_1),
-    MaxTokens:   openai.F(int64(1024)),
-    Temperature: openai.F(0.7),
-    Messages:    openai.F([]openai.ChatCompletionMessageParamUnion{...}),
-}
-
-// WRONG — missing F() wrappers (will not compile)
-openai.ChatCompletionNewParams{
-    Model:    openai.ChatModelGPT4_1,   // BAD
-    Messages: []openai.ChatCompletionMessageParamUnion{...}, // BAD
+    Model:       openai.ChatModelGPT5_5,
+    MaxTokens:   openai.Int(1024),
+    Temperature: openai.Float(0.7),
+    Messages: []openai.ChatCompletionMessageParamUnion{
+        openai.UserMessage("hello"),
+    },
 }
 ```
 
-Use `openai.Bool(true)` and `openai.Int(n)` as shortcuts for pointer-wrapped booleans and ints.
+Do not use the old `openai.F(...)` wrapper — it was removed in v2.x.
 
 ## Streaming Responses
 
@@ -156,13 +172,16 @@ Use `openai.Bool(true)` and `openai.Int(n)` as shortcuts for pointer-wrapped boo
 
 ```go
 stream := client.Responses.NewStreaming(context.Background(), responses.ResponseNewParams{
-    Model: openai.F("gpt-4.1"),
-    Input: responses.ResponseNewParamsInputUnionString("Write a short story about a robot."),
+    Model: openai.ChatModelGPT5_5,
+    Input: responses.ResponseNewParamsInputUnion{
+        OfString: openai.String("Write a short story about a robot."),
+    },
 })
 
 for stream.Next() {
     event := stream.Current()
-    fmt.Print(event.OutputText())
+    // Stream emits typed events; text deltas arrive on response.output_text.delta
+    fmt.Print(event.Delta)
 }
 if err := stream.Err(); err != nil {
     panic(err)
@@ -173,10 +192,10 @@ if err := stream.Err(); err != nil {
 
 ```go
 stream := client.Chat.Completions.NewStreaming(context.Background(), openai.ChatCompletionNewParams{
-    Model: openai.F(openai.ChatModelGPT4_1),
-    Messages: openai.F([]openai.ChatCompletionMessageParamUnion{
+    Model: openai.ChatModelGPT5_5,
+    Messages: []openai.ChatCompletionMessageParamUnion{
         openai.UserMessage("Tell me a joke"),
-    }),
+    },
 })
 
 acc := openai.ChatCompletionAccumulator{}
@@ -190,7 +209,7 @@ for stream.Next() {
 if err := stream.Err(); err != nil {
     panic(err)
 }
-// acc.Choices[0].Message.Content now holds the full assembled response
+// acc.Choices[0].Message.Content holds the full assembled response
 ```
 
 ## Function Calling (Tools)
@@ -198,41 +217,55 @@ if err := stream.Err(); err != nil {
 ```go
 tools := []openai.ChatCompletionToolParam{
     {
-        Type: openai.F(openai.ChatCompletionToolTypeFunction),
-        Function: openai.F(openai.FunctionDefinitionParam{
-            Name:        openai.F("get_weather"),
-            Description: openai.F("Get current weather for a city"),
-            Parameters: openai.F(openai.FunctionParameters{
+        Function: openai.FunctionDefinitionParam{
+            Name:        "get_weather",
+            Description: openai.String("Get current weather for a city"),
+            Parameters: openai.FunctionParameters{
                 "type": "object",
-                "properties": map[string]interface{}{
+                "properties": map[string]any{
                     "city": map[string]string{
                         "type":        "string",
                         "description": "City name",
                     },
                 },
                 "required": []string{"city"},
-            }),
-        }),
+            },
+        },
     },
 }
 
 resp, err := client.Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{
-    Model: openai.F(openai.ChatModelGPT4_1),
-    Messages: openai.F([]openai.ChatCompletionMessageParamUnion{
+    Model: openai.ChatModelGPT5_5,
+    Messages: []openai.ChatCompletionMessageParamUnion{
         openai.UserMessage("What's the weather in Paris?"),
-    }),
-    Tools: openai.F(tools),
+    },
+    Tools: tools,
 })
 if err != nil {
     panic(err)
 }
-// Inspect resp.Choices[0].Message.ToolCalls for the model's invocation
+
 for _, tc := range resp.Choices[0].Message.ToolCalls {
     fmt.Printf("Function: %s, Args: %s\n", tc.Function.Name, tc.Function.Arguments)
 }
 ```
 
+For the Responses API, function calls arrive as `function_call` items in the output:
+
+```go
+for _, item := range resp.Output {
+    if item.Type == "function_call" {
+        call := item.AsFunctionCall()
+        var args map[string]any
+        _ = json.Unmarshal([]byte(call.Arguments), &args)
+        fmt.Println(call.Name, args)
+    }
+}
+```
+
 ## Structured Outputs (JSON Schema)
+
+Use a strict JSON schema to get parseable, type-safe output.
 
 ```go
 import "encoding/json"
@@ -247,27 +280,26 @@ type MathReasoning struct {
 }
 
 schemaParam := openai.ResponseFormatJSONSchemaJSONSchemaParam{
-    Name:        openai.F("math_reasoning"),
-    Description: openai.F("Step-by-step math solution"),
-    Schema:      openai.F(generateSchema[MathReasoning]()),
+    Name:        "math_reasoning",
+    Description: openai.String("Step-by-step math solution"),
+    Schema:      generateSchema[MathReasoning](), // your schema generator
     Strict:      openai.Bool(true),
 }
 
 resp, err := client.Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{
-    Model: openai.F(openai.ChatModelGPT4_1Mini),
-    Messages: openai.F([]openai.ChatCompletionMessageParamUnion{
+    Model: openai.ChatModelGPT5_5,
+    Messages: []openai.ChatCompletionMessageParamUnion{
         openai.UserMessage("Solve: 8x + 31 = 2"),
-    }),
-    ResponseFormat: openai.F[openai.ChatCompletionNewParamsResponseFormatUnion](
-        openai.ResponseFormatJSONSchemaParam{
-            Type:       openai.F(openai.ResponseFormatJSONSchemaTypeJSONSchema),
-            JSONSchema: openai.F(schemaParam),
+    },
+    ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{
+        OfJSONSchema: &openai.ResponseFormatJSONSchemaParam{
+            JSONSchema: schemaParam,
         },
-    ),
+    },
 })
 
 var result MathReasoning
-json.Unmarshal([]byte(resp.Choices[0].Message.Content), &result)
+_ = json.Unmarshal([]byte(resp.Choices[0].Message.Content), &result)
 fmt.Println(result.FinalAnswer)
 ```
 
@@ -275,13 +307,15 @@ fmt.Println(result.FinalAnswer)
 
 ```go
 resp, err := client.Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{
-    Model: openai.F(openai.ChatModelGPT4_1Mini),
-    Messages: openai.F([]openai.ChatCompletionMessageParamUnion{
-        openai.UserMessageParts(
-            openai.TextPart("What is in this image?"),
-            openai.ImagePart("https://example.com/image.jpg"),
-        ),
-    }),
+    Model: openai.ChatModelGPT5_4Mini,
+    Messages: []openai.ChatCompletionMessageParamUnion{
+        openai.UserMessage([]openai.ChatCompletionContentPartUnionParam{
+            openai.TextContentPart("What is in this image?"),
+            openai.ImageContentPart(openai.ChatCompletionContentPartImageImageURLParam{
+                URL: "https://example.com/image.jpg",
+            }),
+        }),
+    },
 })
 ```
 
@@ -289,10 +323,10 @@ resp, err := client.Chat.Completions.New(context.Background(), openai.ChatComple
 
 ```go
 resp, err := client.Embeddings.New(context.Background(), openai.EmbeddingNewParams{
-    Model: openai.F(openai.EmbeddingModelTextEmbedding3Small),
-    Input: openai.F(openai.EmbeddingNewParamsInputUnionString(
-        "The quick brown fox jumps over the lazy dog.",
-    )),
+    Model: openai.EmbeddingModelTextEmbedding3Small,
+    Input: openai.EmbeddingNewParamsInputUnion{
+        OfString: openai.String("The quick brown fox jumps over the lazy dog."),
+    },
 })
 if err != nil {
     panic(err)
@@ -303,23 +337,38 @@ fmt.Printf("Dimensions: %d\n", len(resp.Data[0].Embedding))
 ## Error Handling
 
 ```go
-import "github.com/openai/openai-go/apierror"
+import (
+    "errors"
+
+    "github.com/openai/openai-go/v3"
+)
 
 resp, err := client.Chat.Completions.New(ctx, params)
 if err != nil {
-    var apiErr *apierror.Error
+    var apiErr *openai.Error
     if errors.As(err, &apiErr) {
         fmt.Printf("API error %d: %s\n", apiErr.StatusCode, apiErr.Message)
-        // apiErr.StatusCode: 401 auth, 429 rate limit, 500 server error
+        // Useful for debugging:
+        // apiErr.DumpRequest(true)
+        // apiErr.DumpResponse(true)
     }
     return err
 }
+_ = resp
 ```
+
+Status codes: 401 auth, 429 rate limit, 5xx server error.
 
 ## Retries and Timeouts
 
 ```go
-import "time"
+import (
+    "context"
+    "time"
+
+    "github.com/openai/openai-go/v3"
+    "github.com/openai/openai-go/v3/option"
+)
 
 // Configure retries at client level
 client := openai.NewClient(
@@ -334,6 +383,8 @@ defer cancel()
 resp, err := client.Chat.Completions.New(ctx, params,
     option.WithMaxRetries(3),
 )
+_ = resp
+_ = err
 ```
 
 ## Microsoft Azure OpenAI
@@ -348,9 +399,16 @@ client := openai.NewClient(
 
 ## Notes
 
-- **`openai.F()`** is mandatory for all param fields — missing it causes a compile error.
-- **`openai.Bool()` / `openai.Int()`** are convenience wrappers for optional pointer types.
+- **No more `openai.F()`** in v2.x/v3.x — pass values directly; wrap optional primitives with `openai.String / Int / Bool / Float`.
 - **Context is always first** in every API call — use `context.WithTimeout` in production.
 - Prefer the Responses API for new work; Chat Completions remains fully supported.
 - Both sync calls and streaming iterators (`stream.Next()`) follow the same pattern throughout the SDK.
-- Use `openai.ChatModelGPT4_1` typed constants; only use string literals for unreleased models.
+- Use typed `openai.ChatModel*` constants; fall back to string literals only when the constant is missing.
+- The voice parameter on TTS endpoints accepts either a string or an object (`{id: string}`) since v3.28.0.
+
+## Official Sources Used For This Update
+
+- OpenAI Go SDK GitHub: `https://github.com/openai/openai-go`
+- OpenAI Go SDK releases: `https://github.com/openai/openai-go/releases`
+- OpenAI models guide: `https://developers.openai.com/api/docs/models`
+- OpenAI API reference: `https://developers.openai.com/api/reference`

--- a/content/openai/docs/chat/javascript/DOC.md
+++ b/content/openai/docs/chat/javascript/DOC.md
@@ -3,8 +3,9 @@ name: chat
 description: "OpenAI API for text generation, chat completions, streaming, function calling, vision, embeddings, and assistants"
 metadata:
   languages: "javascript"
-  versions: "6.27.0"
-  updated-on: "2026-03-06"
+  versions: "6.39.1"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "openai,chat,llm,ai"
 ---
@@ -63,61 +64,35 @@ const client = new OpenAI({
 });
 ```
 
-## Models (as of March 2026)
+## Models (as of May 2026)
 
 Default choices:
-- **General Text Tasks:** `gpt-5.4` (frontier) or `gpt-4.1` (non-reasoning)
-- **Complex Reasoning Tasks:** `gpt-5.4` or `gpt-5.4-pro`
-- **Fast & Cost-Efficient:** `gpt-5-mini` or `gpt-4.1-mini`
-- **Cheapest / Fastest:** `gpt-5-nano` or `gpt-4.1-nano`
-- **Audio Processing:** `gpt-audio` or `gpt-audio-mini`
-- **Vision Tasks:** `gpt-5.4` or `gpt-4.1`
-- **Agentic Coding:** `gpt-5.3-codex`
-- **Search (Chat Completions):** `gpt-5-search-api`, `gpt-4o-search-preview`, or `gpt-4o-mini-search-preview`
+- **General Text / Coding:** `gpt-5.5` (flagship, 1M context) or `gpt-5.4` (more affordable, same capabilities)
+- **Complex Reasoning Tasks:** `gpt-5.5`
+- **Fast & Cost-Efficient:** `gpt-5.4-mini`
+- **Cheapest / Fastest:** `gpt-5.4-nano`
+- **Vision / Multimodal:** `gpt-5.5` or `gpt-5.4-mini`
+- **Image Generation:** `gpt-image-2`
 
-Frontier (reasoning, configurable effort):
-- `gpt-5.4`, `gpt-5.4-2026-03-05`, `gpt-5.4-pro`, `gpt-5.4-pro-2026-03-05`
-- `gpt-5.2`, `gpt-5.2-2025-12-11`, `gpt-5.2-pro`
-- `gpt-5.1`, `gpt-5.1-2025-11-13`, `gpt-5.1-pro`
-- `gpt-5`, `gpt-5-2025-08-07`, `gpt-5-pro`
-- `gpt-5-mini`, `gpt-5-mini-2025-08-07`
-- `gpt-5-nano`, `gpt-5-nano-2025-08-07`
+Frontier (Responses API recommended):
+- `gpt-5.5` — flagship, 1M context window
+- `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`
+- Previous `gpt-5.x` snapshots remain accessible for pinning
 
-Non-reasoning:
-- `gpt-4.1`, `gpt-4.1-2025-04-14`
-- `gpt-4.1-mini`, `gpt-4.1-mini-2025-04-14`
-- `gpt-4.1-nano`, `gpt-4.1-nano-2025-04-14`
-
-Reasoning (o-series, succeeded by GPT-5):
-- `o3`, `o3-2025-04-16`, `o3-pro`, `o3-pro-2025-06-10`
-- `o4-mini`, `o4-mini-2025-04-16`
-- `o3-mini`, `o3-mini-2025-01-31`
-- `o1`, `o1-2024-12-17`
-
-Deep research: `o3-deep-research`, `o4-mini-deep-research`
-
-Codex (agentic coding, Responses API only):
-- `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`, `gpt-5-codex`
-
-Audio chat: `gpt-audio`, `gpt-audio-2025-08-28`, `gpt-audio-mini`
-Realtime: `gpt-realtime`, `gpt-realtime-2025-08-28`, `gpt-realtime-mini`
-TTS: `gpt-4o-mini-tts`, `gpt-4o-mini-tts-2025-12-15`, `tts-1`, `tts-1-hd`
-STT: `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe-diarize`, `whisper-1`
-Image generation: `gpt-image-1.5`, `gpt-image-1.5-2025-12-16`, `gpt-image-1`, `gpt-image-1-mini`, `chatgpt-image-latest`
+Realtime: `gpt-realtime-2`, `gpt-realtime-1.5`, `gpt-realtime-mini`, `gpt-realtime-whisper`
+TTS: `gpt-4o-mini-tts`, `tts-1`, `tts-1-hd`
+STT: `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-realtime-whisper`, `whisper-1`
+Image generation: `gpt-image-2`
 Embeddings: `text-embedding-3-large`, `text-embedding-3-small`, `text-embedding-ada-002`
 Moderation: `omni-moderation-latest`
-Search (Chat Completions only): `gpt-5-search-api`, `gpt-4o-search-preview`, `gpt-4o-mini-search-preview`
 
-Legacy (still available): `gpt-4o`, `gpt-4o-mini`, `gpt-4-turbo`, `gpt-3.5-turbo`
+Legacy (still available): `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `gpt-4o`, `gpt-4o-mini`
 
-Deprecated (shutdown scheduled):
-- `dall-e-3`, `dall-e-2` → May 12, 2026 (use `gpt-image-1`)
-- `o1-preview`, `o1-mini` → deprecated (use `o3` or `gpt-5`)
-- `codex-mini-latest` → shut down Feb 12, 2026
-- `chatgpt-4o-latest` → shut down Feb 17, 2026
-- `gpt-4o-realtime-preview` → Mar 24, 2026 (use `gpt-realtime`)
-- `gpt-4o-mini-audio-preview` → Mar 24, 2026 (use `gpt-audio-mini`)
-- `gpt-4.5-preview` → deprecated
+Deprecated:
+- `dall-e-3`, `dall-e-2` (use `gpt-image-2`)
+- `o1`, `o1-preview`, `o1-mini`, `o3-mini` (succeeded by GPT-5 series)
+- `gpt-4o-realtime-preview` (use `gpt-realtime-2`)
+- `gpt-4.5-preview`
 - Assistants API → sunset Aug 26, 2026 (migrate to Responses API)
 
 ## Primary APIs
@@ -134,7 +109,7 @@ const client = new OpenAI({
 });
 
 const response = await client.responses.create({
-  model: 'gpt-5.4',
+  model: 'gpt-5.5',
   instructions: 'You are a coding assistant that talks like a pirate',
   input: 'Are semicolons optional in JavaScript?',
 });
@@ -154,7 +129,7 @@ const client = new OpenAI({
 });
 
 const completion = await client.chat.completions.create({
-  model: 'gpt-5.4',
+  model: 'gpt-5.5',
   messages: [
     { role: 'developer', content: 'Talk like a pirate.' },
     { role: 'user', content: 'Are semicolons optional in JavaScript?' },
@@ -194,7 +169,7 @@ import OpenAI from 'openai';
 const client = new OpenAI();
 
 const stream = await client.responses.create({
-  model: 'gpt-5.4',
+  model: 'gpt-5.5',
   input: 'Say "Sheep sleep deep" ten times fast!',
   stream: true,
 });
@@ -208,7 +183,7 @@ for await (const event of stream) {
 
 ```typescript
 const stream = await client.chat.completions.create({
-  model: 'gpt-5.4',
+  model: 'gpt-5.5',
   messages: [{ role: 'user', content: 'Count to 10' }],
   stream: true,
 });
@@ -259,7 +234,7 @@ await client.files.create({
 
 ```typescript
 const completion = await client.chat.completions.create({
-  model: 'gpt-5.4',
+  model: 'gpt-5.5',
   messages: [{ role: 'user', content: 'What is the weather like today?' }],
   tools: [
     {
@@ -291,7 +266,7 @@ Configure model behavior using parameters in the chat completions API:
 
 ```typescript
 const completion = await client.chat.completions.create({
-  model: 'gpt-5.4',
+  model: 'gpt-5.5',
   messages: [{ role: 'user', content: 'Write a creative story' }],
   temperature: 0.8,        // Higher = more creative (0-2)
   max_tokens: 1000,        // Maximum response length
@@ -301,20 +276,49 @@ const completion = await client.chat.completions.create({
 });
 ```
 
-### Structured Outputs (JSON Mode)
+### Structured Outputs (JSON Schema with Zod)
+
+Use `client.chat.completions.parse()` with a Zod schema for type-safe parsed output.
+
+```typescript
+import OpenAI from 'openai';
+import { zodResponseFormat } from 'openai/helpers/zod';
+import { z } from 'zod';
+
+const Person = z.object({
+  name: z.string(),
+  age: z.number(),
+});
+
+const client = new OpenAI();
+
+const completion = await client.chat.completions.parse({
+  model: 'gpt-5.5',
+  messages: [
+    { role: 'user', content: 'Extract the name and age from: "John is 30 years old"' },
+  ],
+  response_format: zodResponseFormat(Person, 'person'),
+});
+
+const person = completion.choices[0].message.parsed;
+console.log(person?.name, person?.age);
+```
+
+### JSON Mode (Loose JSON)
+
+For free-form JSON output without a schema:
 
 ```typescript
 const completion = await client.chat.completions.create({
-  model: 'gpt-5.4',
+  model: 'gpt-5.5',
   messages: [
-    { role: 'user', content: 'Extract the name and age from: "John is 30 years old"' }
+    { role: 'system', content: 'Always respond with JSON.' },
+    { role: 'user', content: 'Extract the name and age from: "John is 30 years old"' },
   ],
-  response_format: {
-    type: 'json_object'
-  },
+  response_format: { type: 'json_object' },
 });
 
-const result = JSON.parse(completion.choices[0].message.content);
+const result = JSON.parse(completion.choices[0].message.content!);
 ```
 
 ## Error Handling
@@ -328,7 +332,7 @@ const client = new OpenAI();
 
 try {
   const completion = await client.chat.completions.create({
-    model: 'gpt-5.4',
+    model: 'gpt-5.5',
     messages: [{ role: 'user', content: 'Hello!' }],
   });
 } catch (error) {
@@ -355,7 +359,7 @@ async function createCompletionWithRetry(messages: any[], maxRetries = 3) {
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
       return await client.chat.completions.create({
-        model: 'gpt-5.4',
+        model: 'gpt-5.5',
         messages,
       });
     } catch (error) {
@@ -386,7 +390,7 @@ class ChatSession {
     this.messages.push({ role: 'user', content });
 
     const completion = await this.client.chat.completions.create({
-      model: 'gpt-5.4',
+      model: 'gpt-5.5',
       messages: this.messages,
     });
 
@@ -400,8 +404,11 @@ class ChatSession {
 
 ## Useful Links
 
-- **Documentation:** https://platform.openai.com/docs/api-reference
+- **NPM Package:** https://www.npmjs.com/package/openai
+- **GitHub:** https://github.com/openai/openai-node
+- **API Reference:** https://developers.openai.com/api/reference
+- **Models Guide:** https://developers.openai.com/api/docs/models
+- **Responses API Guide:** https://developers.openai.com/api/docs/guides/responses
 - **API Keys:** https://platform.openai.com/api-keys
-- **Models:** https://platform.openai.com/docs/models
 - **Pricing:** https://openai.com/pricing
 - **Rate Limits:** https://platform.openai.com/docs/guides/rate-limits

--- a/content/openai/docs/chat/python/DOC.md
+++ b/content/openai/docs/chat/python/DOC.md
@@ -3,8 +3,9 @@ name: chat
 description: "OpenAI API for text generation, chat completions, streaming, function calling, vision, embeddings, and assistants"
 metadata:
   languages: "python"
-  versions: "2.26.0"
-  updated-on: "2026-04-27"
+  versions: "2.38.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "openai,chat,llm,ai"
 ---
@@ -49,7 +50,7 @@ client = OpenAI()
 
 Use `python-dotenv` or your secret manager of choice to keep keys out of source control.
 
-## Latest Official OpenAI Docs Update (April 2026)
+## Latest Official OpenAI Docs Update (May 2026)
 
 OpenAI's current official API docs list `gpt-5.5` as the recommended starting point for complex reasoning and coding. The same docs recommend smaller `gpt-5.4` variants when latency or cost is more important.
 
@@ -58,69 +59,40 @@ Use this update as API/model guidance layered on top of the SDK version pin in t
 - **Default for new Responses API work:** `gpt-5.5`
 - **More affordable frontier option:** `gpt-5.4`
 - **Fast and cost-efficient:** `gpt-5.4-mini`
-- **Cheapest high-volume GPT-5.4-class option:** `gpt-5.4-nano`
-- **Non-reasoning compatibility option:** `gpt-4.1`
+- **Cheapest high-volume option:** `gpt-5.4-nano`
 - **Image API generation and editing:** `gpt-image-2`
 
-The official text-generation guide now shows `client.responses.create(model="gpt-5.5", ...)` for the basic Python example. Continue to use the Responses API for new work unless an existing codebase already depends on Chat Completions.
+The official text-generation guide shows `client.responses.create(model="gpt-5.5", ...)` for the basic Python example. The Responses API is the primary surface for new code; Chat Completions remains supported for existing codebases.
 
-## Models (as of April 2026)
+## Models (as of May 2026)
 
 Default choices:
-- **General Text Tasks:** `gpt-5.5` (frontier) or `gpt-4.1` (non-reasoning)
-- **Complex Reasoning Tasks:** `gpt-5.5` or `gpt-5.5-pro`
-- **Fast & Cost-Efficient:** `gpt-5.4-mini` or `gpt-4.1-mini`
-- **Cheapest / Fastest:** `gpt-5.4-nano` or `gpt-4.1-nano`
-- **Audio Processing:** `gpt-audio` or `gpt-audio-mini`
-- **Vision Tasks:** `gpt-5.5` or `gpt-4.1`
-- **Agentic Coding:** `gpt-5.3-codex`
-- **Search (Chat Completions):** `gpt-5-search-api`, `gpt-4o-search-preview`, or `gpt-4o-mini-search-preview`
+- **General Text Tasks:** `gpt-5.5` (1M context, flagship) or `gpt-5.4` (more affordable, same capabilities)
+- **Complex Reasoning / Coding:** `gpt-5.5`
+- **Fast & Cost-Efficient:** `gpt-5.4-mini`
+- **Cheapest / Fastest:** `gpt-5.4-nano`
+- **Vision / Multimodal:** `gpt-5.5` or `gpt-5.4-mini`
+- **Image Generation:** `gpt-image-2`
 
-Frontier (reasoning, configurable effort):
-- `gpt-5.5`, `gpt-5.5-pro`
-- `gpt-5.4`, `gpt-5.4-2026-03-05`, `gpt-5.4-pro`, `gpt-5.4-pro-2026-03-05`
-- `gpt-5.2`, `gpt-5.2-2025-12-11`, `gpt-5.2-pro`
-- `gpt-5.1`, `gpt-5.1-2025-11-13`, `gpt-5.1-pro`
-- `gpt-5`, `gpt-5-2025-08-07`, `gpt-5-pro`
-- `gpt-5.4-mini`, `gpt-5.4-nano`
-- `gpt-5-mini`, `gpt-5-mini-2025-08-07`
-- `gpt-5-nano`, `gpt-5-nano-2025-08-07`
+Frontier (Responses API recommended):
+- `gpt-5.5` — flagship, 1M context window
+- `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`
+- Previous `gpt-5.x` snapshots remain accessible for pinning
 
-Non-reasoning:
-- `gpt-4.1`, `gpt-4.1-2025-04-14`
-- `gpt-4.1-mini`, `gpt-4.1-mini-2025-04-14`
-- `gpt-4.1-nano`, `gpt-4.1-nano-2025-04-14`
-
-Reasoning (o-series, succeeded by GPT-5):
-- `o3`, `o3-2025-04-16`, `o3-pro`, `o3-pro-2025-06-10`
-- `o4-mini`, `o4-mini-2025-04-16`
-- `o3-mini`, `o3-mini-2025-01-31`
-- `o1`, `o1-2024-12-17`
-
-Deep research: `o3-deep-research`, `o4-mini-deep-research`
-
-Codex (agentic coding, Responses API only):
-- `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`, `gpt-5-codex`
-
-Audio chat: `gpt-audio`, `gpt-audio-2025-08-28`, `gpt-audio-mini`
-Realtime: `gpt-realtime`, `gpt-realtime-2025-08-28`, `gpt-realtime-mini`
-TTS: `gpt-4o-mini-tts`, `gpt-4o-mini-tts-2025-12-15`, `tts-1`, `tts-1-hd`
-STT: `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe-diarize`, `whisper-1`
-Image generation: `gpt-image-2`, `gpt-image-2-2026-04-21`, `gpt-image-1.5`, `gpt-image-1.5-2025-12-16`, `gpt-image-1`, `gpt-image-1-mini`, `chatgpt-image-latest`
+Realtime: `gpt-realtime-2`, `gpt-realtime-1.5`, `gpt-realtime-mini`, `gpt-realtime-whisper`
+TTS: `gpt-4o-mini-tts`, `tts-1`, `tts-1-hd`
+STT: `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-realtime-whisper`, `whisper-1`
+Image generation: `gpt-image-2`
 Embeddings: `text-embedding-3-large`, `text-embedding-3-small`, `text-embedding-ada-002`
 Moderation: `omni-moderation-latest`
-Search (Chat Completions only): `gpt-5-search-api`, `gpt-4o-search-preview`, `gpt-4o-mini-search-preview`
 
-Legacy (still available): `gpt-4o`, `gpt-4o-mini`, `gpt-4-turbo`, `gpt-3.5-turbo`
+Legacy (still available): `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `gpt-4o`, `gpt-4o-mini`
 
-Deprecated (shutdown scheduled):
-- `dall-e-3`, `dall-e-2` → May 12, 2026 (use `gpt-image-2`)
-- `o1-preview`, `o1-mini` → deprecated (use `o3` or `gpt-5`)
-- `codex-mini-latest` → shut down Feb 12, 2026
-- `chatgpt-4o-latest` → shut down Feb 17, 2026
-- `gpt-4o-realtime-preview` → Mar 24, 2026 (use `gpt-realtime`)
-- `gpt-4o-mini-audio-preview` → Mar 24, 2026 (use `gpt-audio-mini`)
-- `gpt-4.5-preview` → deprecated
+Deprecated:
+- `dall-e-3`, `dall-e-2` (use `gpt-image-2`)
+- `o1`, `o1-preview`, `o1-mini`, `o3-mini` (succeeded by GPT-5 series)
+- `gpt-4o-realtime-preview` (use `gpt-realtime-2`)
+- `gpt-4.5-preview`
 - Assistants API → sunset Aug 26, 2026 (migrate to Responses API)
 
 ## Basic Inference (Text Generation)
@@ -149,7 +121,7 @@ from openai import OpenAI
 client = OpenAI()
 
 completion = client.chat.completions.create(
-    model="gpt-4.1",
+    model="gpt-5.5",
     messages=[
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "How do I reverse a string in Python?"},
@@ -168,7 +140,7 @@ from openai import OpenAI
 client = OpenAI()
 
 response = client.responses.create(
-    model="gpt-4.1-mini",
+    model="gpt-5.4-mini",
     input=[
         {
             "role": "user",
@@ -193,7 +165,7 @@ with open("path/to/image.png", "rb") as image_file:
     b64_image = base64.b64encode(image_file.read()).decode("utf-8")
 
 response = client.responses.create(
-    model="gpt-4.1-mini",
+    model="gpt-5.4-mini",
     input=[
         {
             "role": "user",
@@ -251,7 +223,7 @@ from openai import OpenAI
 client = OpenAI()
 
 stream = client.chat.completions.create(
-    model="gpt-4.1",
+    model="gpt-5.5",
     messages=[{"role": "user", "content": "Tell me a joke"}],
     stream=True,
 )
@@ -278,7 +250,7 @@ class WeatherQuery(BaseModel):
 client = OpenAI()
 
 completion = client.chat.completions.parse(
-    model="gpt-4.1",
+    model="gpt-5.5",
     messages=[{"role": "user", "content": "What's the weather like in Paris?"}],
     tools=[openai.pydantic_function_tool(WeatherQuery)],
 )
@@ -308,7 +280,7 @@ class MathResponse(BaseModel):
 
 client = OpenAI()
 completion = client.chat.completions.parse(
-    model="gpt-4.1",
+    model="gpt-5.5",
     messages=[
         {"role": "system", "content": "You are a helpful math tutor."},
         {"role": "user", "content": "solve 8x + 31 = 2"},
@@ -498,7 +470,7 @@ from openai import AsyncOpenAI
 async def main():
     client = AsyncOpenAI()
 
-    async with client.realtime.connect(model="gpt-realtime") as connection:
+    async with client.realtime.connect(model="gpt-realtime-2") as connection:
         await connection.session.update(session={'modalities': ['text']})
 
         await connection.conversation.item.create(
@@ -589,9 +561,8 @@ if first_page.has_next_page():
 
 ## Official Sources Used For This Update
 
+- OpenAI Python SDK on PyPI: `https://pypi.org/project/openai/2.38.0/`
+- OpenAI Python SDK README: `https://github.com/openai/openai-python`
 - OpenAI models guide: `https://developers.openai.com/api/docs/models`
-- OpenAI GPT-5.5 model page: `https://developers.openai.com/api/docs/models/gpt-5.5`
 - OpenAI text generation guide: `https://developers.openai.com/api/docs/guides/text`
-- OpenAI GPT Image 2 model page: `https://developers.openai.com/api/docs/models/gpt-image-2`
-- OpenAI image generation guide: `https://developers.openai.com/api/docs/guides/image-generation`
 - OpenAI API reference: `https://developers.openai.com/api/reference`

--- a/content/openai/docs/package/python/DOC.md
+++ b/content/openai/docs/package/python/DOC.md
@@ -3,9 +3,9 @@ name: package
 description: "openai package guide for Python with OpenAI(), AsyncOpenAI(), Responses API, streaming, webhooks, pagination, and AzureOpenAI notes"
 metadata:
   languages: "python"
-  versions: "2.26.0"
-  revision: 1
-  updated-on: "2026-04-27"
+  versions: "2.38.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "openai,python,sdk,llm,responses,chat,streaming,webhooks"
 ---
@@ -20,16 +20,16 @@ metadata:
 
 ## Version-Sensitive Notes
 
-- This entry is pinned to the version used here `2.26.0`.
-- Do not treat this package entry as "latest SDK" without refreshing the package-release binding. The API/model guidance below is current as of April 27, 2026, but the SDK pin remains intentionally version-specific.
+- This entry is pinned to the version used here `2.38.0`.
+- Do not treat this package entry as "latest SDK" without refreshing the package-release binding. The API/model guidance below is current as of May 29, 2026, but the SDK pin remains intentionally version-specific.
 - `openai` requires Python `>=3.9`.
 - The maintainers describe the package as generally following SemVer, but they reserve some backwards-incompatible changes for minor releases when the impact is limited to static typing, internals, or low-impact runtime behavior. Do not assume every `2.x` minor bump is completely frictionless.
 - The SDK README describes the Responses API as the primary API for model interaction. Chat Completions remains supported, but it is no longer the default shape to copy for new code.
 - `AzureOpenAI` is a separate client class, and the README explicitly warns that Azure API shapes differ from the core OpenAI API shapes, so static response and parameter types may not always line up perfectly.
 
-## Latest Official API/Model Update (April 2026)
+## Latest Official API/Model Update (May 2026)
 
-OpenAI's current official API docs recommend starting new complex reasoning and coding work with `gpt-5.5`. The docs also recommend `gpt-5.4-mini` and `gpt-5.4-nano` when latency or cost is more important.
+OpenAI's current official API docs recommend starting new complex reasoning and coding work with `gpt-5.5` (1M-token context). The docs also recommend `gpt-5.4`, `gpt-5.4-mini`, and `gpt-5.4-nano` when latency or cost is more important.
 
 For new Python SDK examples in this entry:
 
@@ -44,13 +44,13 @@ For new Python SDK examples in this entry:
 Pin the version when you need reproducible behavior:
 
 ```bash
-python -m pip install "openai==2.26.0"
+python -m pip install "openai==2.38.0"
 ```
 
 If you want the optional `aiohttp` backend for the async client:
 
 ```bash
-python -m pip install "openai[aiohttp]==2.26.0"
+python -m pip install "openai[aiohttp]==2.38.0"
 ```
 
 ## Recommended Setup
@@ -122,7 +122,7 @@ from openai import OpenAI
 client = OpenAI()
 
 completion = client.chat.completions.create(
-    model="gpt-4.1",
+    model="gpt-5.5",
     messages=[
         {"role": "developer", "content": "Be concise."},
         {"role": "user", "content": "Give me a Python dict comprehension example."},
@@ -200,7 +200,7 @@ from openai import OpenAI
 client = OpenAI()
 
 response = client.responses.create(
-    model="gpt-4.1-mini",
+    model="gpt-5.4-mini",
     input=[
         {
             "role": "user",
@@ -230,7 +230,7 @@ class Summary(BaseModel):
 client = OpenAI()
 
 completion = client.chat.completions.parse(
-    model="gpt-4o-2024-08-06",
+    model="gpt-5.5",
     messages=[
         {"role": "system", "content": "Return a short structured summary."},
         {"role": "user", "content": "Summarize how Python context managers work."},
@@ -415,7 +415,7 @@ from openai import AsyncOpenAI
 async def main() -> None:
     client = AsyncOpenAI()
 
-    async with client.realtime.connect(model="gpt-realtime") as connection:
+    async with client.realtime.connect(model="gpt-realtime-2") as connection:
         await connection.session.update(
             session={"type": "realtime", "output_modalities": ["text"]}
         )
@@ -454,9 +454,8 @@ Realtime pitfall: upstream documents that `error` events are delivered on the op
 - OpenAI Python SDK README: `https://github.com/openai/openai-python`
 - OpenAI Python SDK helpers: `https://github.com/openai/openai-python/blob/main/helpers.md`
 - OpenAI models guide: `https://developers.openai.com/api/docs/models`
-- OpenAI GPT-5.5 model page: `https://developers.openai.com/api/docs/models/gpt-5.5`
 - OpenAI text generation guide: `https://developers.openai.com/api/docs/guides/text`
 - OpenAI GPT Image 2 model page: `https://developers.openai.com/api/docs/models/gpt-image-2`
 - OpenAI image generation guide: `https://developers.openai.com/api/docs/guides/image-generation`
 - OpenAI Responses API reference: `https://developers.openai.com/api/reference/responses`
-- PyPI package page: `https://pypi.org/project/openai/2.26.0/`
+- PyPI package page: `https://pypi.org/project/openai/2.38.0/`


### PR DESCRIPTION
docs(openai): refresh to Python SDK 2.38.0 / JS SDK 6.39.1 / Go v3.37.0

Updates the OpenAI Chat docs across Python, JavaScript, and Go, plus the
package/python overview.

- Python and package docs pinned at openai 2.38.0
- JavaScript pinned at openai 6.39.1
- Go SDK rewritten for the v3 API (import path `github.com/openai/openai-go/v3`,
  removal of `openai.F(...)` wrappers, union-input constructors)
- Examples updated to current GPT-5 series model IDs (gpt-5.5 / gpt-5.4 family)
- JS structured-output example switched to `chat.completions.parse()` +
  `zodResponseFormat`
- `revision` bumped and `updated-on: 2026-05-29`

Verified versions against PyPI, npm, and openai-go releases.
