### PR TITLE
docs(langchain, langgraph): refresh to v1.3.x / v1.2.x

### DIFF
--- a/content/langchain/docs/agents/python/DOC.md
+++ b/content/langchain/docs/agents/python/DOC.md
@@ -1,22 +1,25 @@
 ---
 name: agents
-description: "LangChain Python SDK v1.x guidance for building agents on top of LangGraph, with correct sub-package imports for langchain_openai, langchain_anthropic, and other providers"
+description: "LangChain Python SDK v1.x guidance for building agents with create_agent on top of LangGraph, with correct sub-package imports for langchain_openai, langchain_anthropic, and other providers"
 metadata:
   languages: "python"
-  versions: "1.0.0"
-  revision: 1
-  updated-on: "2026-03-19"
+  versions: "1.3.2"
+  revision: 2
+  updated-on: "2026-05-29"
   source: community
   tags: "langchain,langgraph,python,agents,llm,ai,openai,anthropic"
 ---
 
-# LangChain Python SDK (v1.x)
+# LangChain Python SDK Agents (v1.x)
 
 ## Golden Rule
 
 Always import from the correct sub-packages. The monolithic `langchain` package
 no longer exports model classes directly — use `langchain_openai`, `langchain_anthropic`,
-`langchain_google_genai`, etc. Agents built on `langchain.agents` run on top of LangGraph.
+`langchain_google_genai`, etc. In v1.x the recommended agent API is
+`langchain.agents.create_agent`, which runs on top of LangGraph. The legacy
+`AgentExecutor` / `create_tool_calling_agent` / `initialize_agent` flow has
+moved to `langchain-classic`.
 
 ## Install
 
@@ -24,17 +27,18 @@ no longer exports model classes directly — use `langchain_openai`, `langchain_
 pip install langchain langchain-openai langchain-anthropic  # add whichever provider you need
 ```
 
-##  Wrong imports that agents hallucinate
+## Wrong imports that agents hallucinate
 
 ```python
-# WRONG — these no longer exist in v1.x
+# WRONG — these no longer exist in v1.x langchain
 from langchain.chat_models import ChatOpenAI
 from langchain.llms import OpenAI
 from langchain.agents import initialize_agent, AgentType
+from langchain.agents import AgentExecutor, create_tool_calling_agent
 from langchain.schema import HumanMessage
 ```
 
-##  Correct imports (v1.x)
+## Correct imports (v1.x)
 
 ```python
 # Models — always from provider-specific packages
@@ -42,26 +46,29 @@ from langchain_openai import ChatOpenAI
 from langchain_anthropic import ChatAnthropic
 from langchain_google_genai import ChatGoogleGenerativeAI
 
+# Or use the universal initializer
+from langchain.chat_models import init_chat_model
+
 # Core message types
 from langchain_core.messages import HumanMessage, AIMessage, SystemMessage, ToolMessage
 
-# Agents
-from langchain.agents import create_tool_calling_agent, AgentExecutor
+# Agents (v1 API)
+from langchain.agents import create_agent
 
 # Prompts
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 
 # Tools
 from langchain_core.tools import tool
-from langchain_community.tools.tavily_search import TavilySearchResults
 ```
 
 ## Chat Models
 
 ```python
 from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
-llm = ChatOpenAI(model="gpt-4o", temperature=0)
+llm = ChatOpenAI(model="gpt-4.1-mini", temperature=0)
 
 # Invoke
 response = llm.invoke([HumanMessage(content="Hello")])
@@ -83,7 +90,7 @@ from langchain_core.tools import tool
 @tool
 def get_weather(city: str) -> str:
     """Get current weather for a city."""
-    return f"Weather in {city}: 72°F, sunny"
+    return f"Weather in {city}: 72F, sunny"
 
 @tool
 def calculate(expression: str) -> float:
@@ -95,76 +102,143 @@ print(get_weather.name)         # "get_weather"
 print(get_weather.description)  # used by the LLM to decide when to call it
 ```
 
-## Tool Calling Agent (recommended pattern)
+## Create An Agent (v1 recommended pattern)
+
+`create_agent` builds a tool-using agent compiled as a LangGraph runnable. It
+handles the model -> tool call -> tool result -> model loop for you.
 
 ```python
-from langchain_openai import ChatOpenAI
-from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain.agents import create_agent
 from langchain_core.tools import tool
-from langchain.agents import create_tool_calling_agent, AgentExecutor
-
-llm = ChatOpenAI(model="gpt-4o", temperature=0)
 
 @tool
 def search(query: str) -> str:
     """Search the web for information."""
     return f"Results for: {query}"
 
-tools = [search]
+agent = create_agent(
+    model="openai:gpt-4.1-mini",
+    tools=[search],
+    system_prompt="You are a helpful assistant. Be concise.",
+)
 
-prompt = ChatPromptTemplate.from_messages([
-    ("system", "You are a helpful assistant."),
-    MessagesPlaceholder("chat_history", optional=True),
-    ("human", "{input}"),
-    MessagesPlaceholder("agent_scratchpad"),  # required — holds tool call/result turns
-])
+result = agent.invoke(
+    {"messages": [{"role": "user", "content": "What is the capital of France?"}]}
+)
 
-agent = create_tool_calling_agent(llm, tools, prompt)
-agent_executor = AgentExecutor(agent=agent, tools=tools, verbose=True)
-
-result = agent_executor.invoke({"input": "What is the capital of France?"})
-print(result["output"])
+# The final answer is the last message in the returned state.
+print(result["messages"][-1].content)
 ```
 
-## Multi-turn Conversation with Memory
+Key things to know:
+
+- `model` accepts either a provider-qualified string such as `"openai:gpt-4.1-mini"`
+  or a pre-built chat model instance from `init_chat_model(...)` or
+  `ChatOpenAI(...)`.
+- Agent input is a dict shaped like `{"messages": [...]}` where each entry is
+  either a LangChain message object or an OpenAI-style `{"role", "content"}`
+  dict.
+- Agent output is the full message-list state. The model's final reply is
+  `result["messages"][-1]`.
+
+## Streaming Agent Steps
 
 ```python
-from langchain_core.chat_history import InMemoryChatMessageHistory
-from langchain_core.runnables.history import RunnableWithMessageHistory
-
-store = {}
-
-def get_session_history(session_id: str):
-    if session_id not in store:
-        store[session_id] = InMemoryChatMessageHistory()
-    return store[session_id]
-
-agent_with_history = RunnableWithMessageHistory(
-    agent_executor,
-    get_session_history,
-    input_messages_key="input",
-    history_messages_key="chat_history",
-)
-
-# First turn
-agent_with_history.invoke(
-    {"input": "My name is Naren"},
-    config={"configurable": {"session_id": "session-1"}},
-)
-
-# Second turn — agent remembers previous context
-agent_with_history.invoke(
-    {"input": "What's my name?"},
-    config={"configurable": {"session_id": "session-1"}},
-)
+for chunk in agent.stream(
+    {"messages": [{"role": "user", "content": "Search for python 3.13 features"}]},
+    stream_mode="updates",
+):
+    print(chunk)
 ```
 
-## LCEL Chains (LangChain Expression Language)
+Stream modes inherited from LangGraph include `"updates"` (per-node updates),
+`"values"` (full state after each step), and `"messages"` (token-level chat
+streaming).
+
+## Multi-turn Conversation With Checkpointing
+
+Because `create_agent` returns a compiled LangGraph, conversation memory is
+handled by a checkpointer + `thread_id`, not `RunnableWithMessageHistory`.
+
+```python
+from langchain.agents import create_agent
+from langgraph.checkpoint.memory import InMemorySaver
+
+checkpointer = InMemorySaver()
+
+agent = create_agent(
+    model="openai:gpt-4.1-mini",
+    tools=[],
+    checkpointer=checkpointer,
+)
+
+config = {"configurable": {"thread_id": "session-1"}}
+
+agent.invoke({"messages": [{"role": "user", "content": "My name is Naren."}]}, config)
+result = agent.invoke({"messages": [{"role": "user", "content": "What is my name?"}]}, config)
+print(result["messages"][-1].content)
+```
+
+Use a persistent checkpointer (`langgraph-checkpoint-postgres`,
+`langgraph-checkpoint-sqlite`) in production. `InMemorySaver` is debug-only.
+
+## Structured Output From An Agent
+
+`create_agent` accepts a Pydantic `response_format` that constrains the final
+answer to a validated schema:
+
+```python
+from pydantic import BaseModel
+from langchain.agents import create_agent
+
+class WeatherReport(BaseModel):
+    city: str
+    temperature_f: int
+    summary: str
+
+agent = create_agent(
+    model="openai:gpt-4.1-mini",
+    tools=[],
+    response_format=WeatherReport,
+)
+
+result = agent.invoke(
+    {"messages": [{"role": "user", "content": "Make up a weather report for Paris."}]}
+)
+print(result["structured_response"])  # WeatherReport(...)
+```
+
+## Structured Output From A Bare Model
+
+For non-agent extraction, `with_structured_output` on a chat model is the
+canonical helper:
+
+```python
+from pydantic import BaseModel
+from langchain_openai import ChatOpenAI
+
+class ExtractedData(BaseModel):
+    name: str
+    age: int
+    occupation: str
+
+llm = ChatOpenAI(model="gpt-4.1-mini")
+structured_llm = llm.with_structured_output(ExtractedData)
+
+result = structured_llm.invoke("John is a 30-year-old software engineer.")
+print(result.name, result.age, result.occupation)
+```
+
+## LCEL Chains (Composition)
+
+Plain runnable composition still works for non-agent pipelines:
 
 ```python
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
+from langchain_openai import ChatOpenAI
 
+llm = ChatOpenAI(model="gpt-4.1-mini")
 prompt = ChatPromptTemplate.from_template("Summarize this text: {text}")
 chain = prompt | llm | StrOutputParser()
 
@@ -178,59 +252,19 @@ for chunk in chain.stream({"text": "Long article..."}):
     print(chunk, end="")
 ```
 
-## Structured Output
-
-```python
-from pydantic import BaseModel
-from langchain_openai import ChatOpenAI
-
-class ExtractedData(BaseModel):
-    name: str
-    age: int
-    occupation: str
-
-llm = ChatOpenAI(model="gpt-4o")
-structured_llm = llm.with_structured_output(ExtractedData)
-
-result = structured_llm.invoke("John is a 30-year-old software engineer.")
-print(result.name)        # "John"
-print(result.age)         # 30
-print(result.occupation)  # "software engineer"
-```
-
-## Retrieval-Augmented Generation (RAG)
-
-```python
-from langchain_openai import OpenAIEmbeddings, ChatOpenAI
-from langchain_community.vectorstores import FAISS
-from langchain_core.output_parsers import StrOutputParser
-from langchain_core.runnables import RunnablePassthrough
-
-embeddings = OpenAIEmbeddings()
-vectorstore = FAISS.from_texts(
-    ["LangGraph is a graph-based agent framework", "LangChain builds on LangGraph"],
-    embedding=embeddings,
-)
-retriever = vectorstore.as_retriever(search_kwargs={"k": 3})
-
-prompt = ChatPromptTemplate.from_template(
-    "Answer using only this context:\n{context}\n\nQuestion: {question}"
-)
-
-rag_chain = (
-    {"context": retriever, "question": RunnablePassthrough()}
-    | prompt
-    | ChatOpenAI(model="gpt-4o")
-    | StrOutputParser()
-)
-
-answer = rag_chain.invoke("What is LangGraph?")
-```
-
 ## Common Gotchas
 
-- `MessagesPlaceholder("agent_scratchpad")` is **required** in the prompt for tool-calling agents — omitting it causes silent failures
-- `AgentExecutor` wraps the agent and handles the tool call → tool result → LLM loop automatically
-- Use `verbose=True` on `AgentExecutor` during development to see each step
-- `with_structured_output()` uses function calling under the hood — model must support tool use
-- `RunnableWithMessageHistory` needs `input_messages_key` and `history_messages_key` to match prompt variable names exactly
+- The v1 agent API is `create_agent`, not `create_tool_calling_agent` +
+  `AgentExecutor`. The latter pair was removed from `langchain` and now lives
+  in `langchain-classic` for migration only.
+- Agent input must be a dict with a `messages` list. Passing a bare string or
+  the wrong key produces schema errors before the model is ever called.
+- Conversation memory in v1 uses a LangGraph checkpointer plus
+  `configurable.thread_id`, not `RunnableWithMessageHistory`.
+- `response_format=` returns the typed object on `result["structured_response"]`,
+  separately from the message list.
+- `with_structured_output()` uses tool/function calling under the hood — the
+  model must support tool use.
+- Provider model classes live in their own packages
+  (`langchain_openai`, `langchain_anthropic`, ...). They are not re-exported
+  from `langchain`.

--- a/content/langchain/docs/community/python/DOC.md
+++ b/content/langchain/docs/community/python/DOC.md
@@ -1,11 +1,11 @@
 ---
 name: community
-description: "langchain-community package guide for Python covering third-party integrations, loaders, vector stores, tools, and 0.4.1 version notes"
+description: "langchain-community package guide for Python covering third-party integrations, loaders, vector stores, tools, and 0.4.2 version notes"
 metadata:
   languages: "python"
-  versions: "0.4.1"
-  revision: 1
-  updated-on: "2026-03-12"
+  versions: "0.4.2"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "langchain-community,langchain,python,integrations,document-loaders,vectorstores,tools"
 ---
@@ -20,11 +20,11 @@ Prefer dedicated integration packages when they exist. LangChain's provider docs
 
 ## Version-Sensitive Notes
 
-- This entry is pinned to the version used here `0.4.1`.
-- PyPI lists `0.4.1` as the current package version covered here and shows it was uploaded on October 27, 2025.
+- This entry is pinned to the version used here `0.4.2`.
+- PyPI lists `0.4.2` as the current package version covered here on 2026-05-29.
 - LangChain's Python release policy explicitly says `langchain-community` does not follow the same strict semantic versioning guarantees as `langchain` and `langchain-core`. Pin exact versions when you need reproducible behavior.
-- PyPI metadata for `0.4.1` requires Python `>=3.10,<4.0`.
-- PyPI metadata for `0.4.1` also shows the package depends on the `1.x` lines of `langchain-core` and `langchain-classic`. Do not mix this package with pre-`1.0` LangChain dependencies.
+- PyPI metadata for `0.4.2` requires Python `>=3.10,<4.0`.
+- PyPI metadata for `0.4.2` also shows the package depends on the `1.x` lines of `langchain-core` and `langchain-classic`. Do not mix this package with pre-`1.0` LangChain dependencies.
 - The current LangChain integration publishing guidance says new integrations should usually be standalone `langchain-*` packages instead of new additions to the monorepo. Treat `langchain-community` as the compatibility bucket for community or older shared integrations, not the first package to assume for every provider.
 - The PyPI project description still contains stale wording that says `langchain-community` is on version `0.0.x`; use the actual PyPI release metadata and current reference docs instead of that older description text.
 
@@ -33,14 +33,14 @@ Prefer dedicated integration packages when they exist. LangChain's provider docs
 Pin the package if your project depends on a known set of community integrations:
 
 ```bash
-python -m pip install "langchain-community==0.4.1"
+python -m pip install "langchain-community==0.4.2"
 ```
 
 Common alternatives:
 
 ```bash
-uv add "langchain-community==0.4.1"
-poetry add "langchain-community==0.4.1"
+uv add "langchain-community==0.4.2"
+poetry add "langchain-community==0.4.2"
 ```
 
 In practice you often install this package together with:
@@ -53,9 +53,9 @@ In practice you often install this package together with:
 Example installs:
 
 ```bash
-python -m pip install "langchain-community==0.4.1" "langchain-openai"
-python -m pip install "langchain-community==0.4.1" "faiss-cpu"
-python -m pip install "langchain-community==0.4.1" "duckduckgo-search"
+python -m pip install "langchain-community==0.4.2" "langchain-openai"
+python -m pip install "langchain-community==0.4.2" "faiss-cpu"
+python -m pip install "langchain-community==0.4.2" "duckduckgo-search"
 ```
 
 ## Setup And Configuration

--- a/content/langchain/docs/core/python/DOC.md
+++ b/content/langchain/docs/core/python/DOC.md
@@ -3,9 +3,9 @@ name: core
 description: "langchain-core package guide for Python covering runnables, prompt templates, messages, tools, config, and tracing handoff points"
 metadata:
   languages: "python"
-  versions: "1.2.18"
-  revision: 1
-  updated-on: "2026-03-11"
+  versions: "1.4.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "langchain-core,langchain,python,llm,runnables,prompts,tools,langsmith"
 ---
@@ -37,8 +37,8 @@ Common imports:
 
 - Package: `langchain-core`
 - Ecosystem: `pypi`
-- Target version version: `1.2.18`
-- PyPI latest on 2026-03-11: `1.2.18`
+- Target version: `1.4.0`
+- PyPI latest on 2026-05-29: `1.4.0`
 - Requires Python: `>=3.10,<4.0`
 - Registry URL: `https://pypi.org/project/langchain-core/`
 - Canonical API reference root used for this entry: `https://reference.langchain.com/python/langchain_core/`
@@ -53,13 +53,13 @@ Version note:
 Pin the version used here when you need reproducible behavior:
 
 ```bash
-python -m pip install "langchain-core==1.2.18"
+python -m pip install "langchain-core==1.4.0"
 ```
 
 If you are building an actual application, you will usually install at least one provider integration too:
 
 ```bash
-python -m pip install "langchain-core==1.2.18" "langchain-openai"
+python -m pip install "langchain-core==1.4.0" "langchain-openai"
 ```
 
 ## Recommended Setup
@@ -244,11 +244,11 @@ This is optional. Pure `langchain-core` composition does not require LangSmith.
 - `ChatPromptTemplate.invoke(...)` returns a prompt value with message objects, not a plain string. Downstream code must accept prompt values or messages.
 - `RunnableLambda` is convenient for normal Python logic, but the official reference notes it is best for code that does not need token-by-token streaming support.
 - Tool schemas are only as good as the underlying function signature and docstring. Untyped or poorly described callables produce weaker tool metadata.
-- Older LangChain examples on the web may still target pre-`1.0` imports or the older docs hostname. Prefer the current `reference.langchain.com` pages for `1.2.18`.
+- Older LangChain examples on the web may still target pre-`1.0` imports or the older docs hostname. Prefer the current `reference.langchain.com` pages for `1.4.0`.
 
 ## Version-Sensitive Notes
 
-- This entry is pinned to `1.2.18`, and that version matches the current PyPI latest on 2026-03-11.
+- This entry is pinned to `1.4.0`, and that version matches the current PyPI latest on 2026-05-29.
 - LangChain's install docs emphasize a package split: keep `langchain-core` for abstractions and add integrations separately.
 - When copying examples, check whether the snippet depends only on `langchain-core` or also on `langchain`, `langgraph`, LangSmith, or a provider package. Many official examples span more than one package.
 

--- a/content/langchain/docs/openai/python/DOC.md
+++ b/content/langchain/docs/openai/python/DOC.md
@@ -1,11 +1,11 @@
 ---
 name: openai
-description: "langchain-openai package guide for Python covering ChatOpenAI, OpenAIEmbeddings, Responses API, Azure setup, and 1.1.11 notes"
+description: "langchain-openai package guide for Python covering ChatOpenAI, OpenAIEmbeddings, Responses API, Azure setup, and 1.2.2 notes"
 metadata:
   languages: "python"
-  versions: "1.1.11"
-  revision: 1
-  updated-on: "2026-03-12"
+  versions: "1.2.2"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "langchain-openai,langchain,openai,python,llm,embeddings,azure-openai"
 ---
@@ -27,32 +27,32 @@ Important boundary: `langchain-openai` is an integration package, not the full f
 
 ## Version-Sensitive Notes
 
-- This entry is pinned to the version used here `1.1.11`.
-- PyPI still shows `1.1.11` as the current release on 2026-03-12, so the version used here matches upstream for review.
+- This entry is pinned to the version used here `1.2.2`.
+- PyPI shows `1.2.2` as the current release on 2026-05-29, so the version used here matches upstream for review.
 - The docs URL `https://python.langchain.com/api_reference/openai/` is a legacy LangChain API-reference landing page. Current conceptual guides live under `docs.langchain.com`, and the current Python API reference is under `reference.langchain.com`.
 - LangChain's release policy treats integration packages such as `langchain-openai` as separately versioned packages. Do not assume they should match `langchain` or `langchain-core` patch versions.
 - Official docs note that `ChatOpenAI` can automatically use the OpenAI Responses API in some cases and can be forced with `use_responses_api=True`. If behavior matters, test against the exact model and request shape you use.
 - Official docs also note that, as of `langchain-openai >= 1.0.1`, `ChatOpenAI` and `OpenAIEmbeddings` can target Azure OpenAI's v1 API directly. Older Azure-specific examples may still use `AzureChatOpenAI` and `AzureOpenAIEmbeddings`.
-- The current chat integration guide marks OpenAI tool search as requiring `langchain-openai >= 1.1.11`, so this pinned version is new enough for that feature.
+- The current chat integration guide marks OpenAI tool search and related newer features as requiring recent `langchain-openai >= 1.1.x` versions, so this pinned version is new enough for those features.
 
 ## Install
 
 Pin the integration package and whichever LangChain package your app actually uses:
 
 ```bash
-python -m pip install "langchain-openai==1.1.11" "langchain-core"
+python -m pip install "langchain-openai==1.2.2" "langchain-core"
 ```
 
 Typical application install:
 
 ```bash
-python -m pip install "langchain==1.2.11" "langchain-openai==1.1.11"
+python -m pip install "langchain==1.3.2" "langchain-openai==1.2.2"
 ```
 
 If you are using Azure and want to stay close to LangChain's Azure-specific examples, the same package provides those classes:
 
 ```bash
-python -m pip install "langchain-openai==1.1.11"
+python -m pip install "langchain-openai==1.2.2"
 ```
 
 ## Auth And Setup
@@ -282,7 +282,7 @@ Keep these in constructor arguments or environment variables, not hard-coded ins
 - Installing `langchain-openai` alone is not enough if your code also imports `langchain` or `langchain_core` abstractions.
 - Do not assume every `langchain-*` package should share the same version number. `langchain-openai` is separately versioned.
 - Older blog posts often show legacy `OpenAI` completion classes or pre-Responses OpenAI behavior. For new code, prefer `ChatOpenAI` unless you specifically need older completion behavior.
-- The hosted docs are live product docs, not an archive pinned to `1.1.11`. If you are debugging a version-specific mismatch, check PyPI release history and the LangChain release policy before copying a newer example verbatim.
+- The hosted docs are live product docs, not an archive pinned to `1.2.2`. If you are debugging a version-specific mismatch, check PyPI release history and the LangChain release policy before copying a newer example verbatim.
 - When streaming, usage metadata is not automatic in all paths. If your code depends on token counts, enable the documented usage option and test it.
 - If you are targeting Azure, do not mix OpenAI and Azure environment variables casually. Pick either the Azure-specific class pattern or the Azure v1 `base_url` pattern and keep the configuration consistent.
 - `OpenAIEmbeddings.dimensions` applies to the newer embedding models; do not assume every model supports custom dimensions.

--- a/content/langchain/docs/package/python/DOC.md
+++ b/content/langchain/docs/package/python/DOC.md
@@ -1,11 +1,11 @@
 ---
 name: package
-description: "LangChain package guide for Python with v1 agent patterns, model initialization, provider setup, and 1.2.11 notes"
+description: "LangChain package guide for Python with v1 agent patterns, model initialization, provider setup, and 1.3.2 notes"
 metadata:
   languages: "python"
-  versions: "1.2.11"
-  revision: 1
-  updated-on: "2026-03-12"
+  versions: "1.3.2"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "langchain,python,agents,llm,rag,langgraph,langsmith"
 ---
@@ -25,26 +25,26 @@ Use `langchain` when Python code needs:
 
 ## Version-Sensitive Notes
 
-- This entry is pinned to the version used here `1.2.11`.
-- PyPI release history shows `1.2.11` was released on 2026-03-11 and `1.2.12` on 2026-03-12. The earlier pinned version is already one patch behind current upstream.
-- The docs site is a live v1 documentation site, not a patch-versioned archive. If an example behaves differently in `1.2.11`, check the LangChain release notes before assuming the docs exactly match that patch.
-- PyPI metadata for `1.2.11` requires Python `>=3.10,<4.0`.
+- This entry is pinned to the version used here `1.3.2`.
+- PyPI lists `1.3.2` as the current `langchain` release on 2026-05-29.
+- The docs site is a live v1 documentation site, not a patch-versioned archive. If an example behaves differently in `1.3.2`, check the LangChain release notes before assuming the docs exactly match that patch.
+- PyPI metadata for `1.3.2` requires Python `>=3.10,<4.0`.
 - In v1, many older pre-1.0 chains, agents, and memory helpers were moved into `langchain-classic`. Use `langchain-classic` only when maintaining legacy code. For new code, prefer the v1 `create_agent(...)` and LangGraph-based patterns.
-- LangChain's versioning policy says `langchain` and `langchain-core` share major and minor versions. Integration packages such as `langchain-openai`, `langchain-anthropic`, and `langchain-community` are separately versioned. Do not assume all companion packages should match `1.2.11`.
+- LangChain's versioning policy says `langchain` and `langchain-core` share major and minor versions. Integration packages such as `langchain-openai`, `langchain-anthropic`, and `langchain-community` are separately versioned. Do not assume all companion packages should match `1.3.2`.
 
 ## Install
 
 For reproducible behavior, pin `langchain` and install the provider integration you actually use:
 
 ```bash
-python -m pip install "langchain==1.2.11" "langchain-openai"
+python -m pip install "langchain==1.3.2" "langchain-openai"
 ```
 
 Other common integrations follow the same pattern:
 
 ```bash
-python -m pip install "langchain==1.2.11" "langchain-anthropic"
-python -m pip install "langchain==1.2.11" "langchain-community"
+python -m pip install "langchain==1.3.2" "langchain-anthropic"
+python -m pip install "langchain==1.3.2" "langchain-community"
 ```
 
 If you need production memory or checkpoint persistence, install the relevant LangGraph checkpoint package separately. The official install docs use packages such as `langgraph-checkpoint-postgres`.
@@ -159,8 +159,8 @@ Tracing is optional. Do not hard-code LangSmith credentials into application cod
 
 - Installing only `langchain` is not enough for real provider calls. Also install the provider package such as `langchain-openai`.
 - Many search results still show pre-v1 imports and abstractions such as `LLMChain`, older agent executors, or legacy memory classes. Treat those as migration material, not the default pattern for new code.
-- The docs site is current-state documentation. When you are pinned to `1.2.11`, verify behavior against PyPI release history and LangChain release notes if you hit a mismatch.
-- Companion packages are versioned independently. Avoid blanket pinning every `langchain-*` package to `1.2.11` unless that package actually uses that version line.
+- The docs site is current-state documentation. When you are pinned to `1.3.2`, verify behavior against PyPI release history and LangChain release notes if you hit a mismatch.
+- Companion packages are versioned independently. Avoid blanket pinning every `langchain-*` package to `1.3.2` unless that package actually uses that version line.
 - Agent code expects message-oriented state. If you pass the wrong input shape to `agent.invoke(...)`, failures are often schema or state errors rather than model errors.
 - LangSmith tracing is useful in development, but it can leak sensitive inputs if you enable it indiscriminately in production environments.
 

--- a/content/langgraph/docs/package/python/DOC.md
+++ b/content/langgraph/docs/package/python/DOC.md
@@ -3,9 +3,9 @@ name: package
 description: "langgraph package guide for Python graphs, persistence, streaming, and local agent development"
 metadata:
   languages: "python"
-  versions: "1.1.0"
-  revision: 1
-  updated-on: "2026-03-11"
+  versions: "1.2.2"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "langgraph,langchain,agents,graphs,workflow,streaming,persistence"
 ---
@@ -103,14 +103,14 @@ import operator
 from typing import Annotated
 from typing_extensions import TypedDict
 from langchain.chat_models import init_chat_model
-from langchain.messages import AnyMessage, SystemMessage
+from langchain_core.messages import AnyMessage, SystemMessage
 from langgraph.graph import StateGraph, START, END
 
 class AgentState(TypedDict):
     messages: Annotated[list[AnyMessage], operator.add]
     llm_calls: int
 
-model = init_chat_model("gpt-4.1", temperature=0)
+model = init_chat_model("openai:gpt-4.1", temperature=0)
 
 def llm_call(state: AgentState) -> dict:
     response = model.invoke(
@@ -279,9 +279,10 @@ Use `langgraph dev` for fast local development. Official platform docs describe 
 
 ## Version-Sensitive Notes
 
-- The target version for this session is `1.1.0`.
+- The target version for this session is `1.2.2`.
+- PyPI lists `1.2.2` as the current `langgraph` release on 2026-05-29.
 - The official docs site is now rooted at `docs.langchain.com`, and the API reference is at `reference.langchain.com`; the previous `langchain-ai.github.io` URL is an older docs location.
-- Official reference pages still display package labels such as `v1.0.9` and `v1.0.10` on some modules. Treat the docs as a floating v1.x reference and verify your installed package version when debugging behavior differences.
+- Official reference pages still display per-module package labels on some modules. Treat the docs as a floating v1.x reference and verify your installed package version when debugging behavior differences.
 - The official v1 release notes state that LangGraph's `create_react_agent` prebuilt is deprecated in favor of LangChain's `create_agent`.
 - If you copy pre-v1 examples from blogs or archived docs, re-check imports and prebuilt APIs against the current reference before using them unchanged.
 


### PR DESCRIPTION
docs(langchain, langgraph): refresh to v1.3.x / v1.2.x

Updates LangChain (core, agents, community, openai, package) and LangGraph
Python docs to the current PyPI versions.

- langchain → 1.3.2, langchain-core → 1.4.0, langchain-community → 0.4.2,
  langchain-openai → 1.2.2, langgraph → 1.2.2
- Agents doc rewritten around the v1 `create_agent` API; removes obsolete
  `create_tool_calling_agent` / `AgentExecutor` / `RunnableWithMessageHistory`
  patterns (now in `langchain-classic`)
- Memory section replaced with LangGraph checkpointer + `thread_id`
- Adds `response_format` structured output example
- LangGraph: fixes `from langchain.messages` → `langchain_core.messages`, and
  uses provider-qualified `init_chat_model("openai:gpt-4.1", ...)`
- `revision` bumped and `updated-on: 2026-05-29`

Verified versions against PyPI for each package.
