### PR TITLE
docs(mcp, pydantic-ai): refresh to mcp 1.27.2 / pydantic-ai 1.104.0

### DIFF
--- a/content/mcp/docs/package/python/DOC.md
+++ b/content/mcp/docs/package/python/DOC.md
@@ -3,9 +3,9 @@ name: package
 description: "mcp package guide for Python MCP servers and clients with FastMCP, stdio, and Streamable HTTP"
 metadata:
   languages: "python"
-  versions: "1.26.0"
-  revision: 1
-  updated-on: "2026-03-12"
+  versions: "1.27.2"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "mcp,model-context-protocol,python,fastmcp,server,client,stdio,streamable-http,oauth"
 ---
@@ -28,14 +28,14 @@ For most server work, start with `FastMCP`. Drop down to the low-level server AP
 Install the exact version covered here:
 
 ```bash
-pip install mcp==1.26.0
+pip install mcp==1.27.2
 ```
 
 Common package-manager equivalents:
 
 ```bash
-uv add mcp==1.26.0
-poetry add mcp==1.26.0
+uv add mcp==1.27.2
+poetry add mcp==1.27.2
 ```
 
 If you are writing both server and client code in the same project, the base package is usually enough. Add web-framework or auth dependencies separately only when your server integration needs them.
@@ -231,12 +231,13 @@ This is the canonical pattern for testing a local server from Python without inv
 - Do not leak long-running work past session or transport shutdown. Keep async context managers scoped tightly.
 - Do not assume local stdio and remote HTTP share the same operational concerns. Stdio is process-launch/config oriented; HTTP adds auth, routing, proxies, and deployment timeouts.
 
-## Version-Sensitive Notes For 1.26.0
+## Version-Sensitive Notes For 1.27.2
 
-- PyPI is the authoritative source for the covered package version: `1.26.0`.
-- PyPI metadata for `1.26.0` requires Python `>=3.10`.
+- PyPI is the authoritative source for the covered package version: `1.27.2`.
+- PyPI metadata for `1.27.2` requires Python `>=3.10`.
+- The `1.27.x` line adds streamable HTTP idle timeouts, RFC 8707 resource validation in the OAuth client, and binds transport sessions to authenticated principals. `AccessToken` now carries subject and claims.
 - The docs and spec emphasize Streamable HTTP as the current HTTP transport. Older SSE-era examples are the most likely source of stale guidance when copying from blogs, gists, or older issue threads.
-- The official docs root is not version-pinned to `1.26.0`. When a docs example and the package version appear to drift, trust PyPI for the released version and prefer the Python SDK repository examples over third-party material.
+- The official docs root is not version-pinned to `1.27.2`. When a docs example and the package version appear to drift, trust PyPI for the released version and prefer the Python SDK repository examples over third-party material.
 
 ## Official Sources
 
@@ -245,4 +246,4 @@ This is the canonical pattern for testing a local server from Python without inv
 - MCP transport docs: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports
 - Python SDK repository: https://github.com/modelcontextprotocol/python-sdk
 - PyPI project page: https://pypi.org/project/mcp/
-- PyPI release metadata for `1.26.0`: https://pypi.org/pypi/mcp/1.26.0/json
+- PyPI release metadata for `1.27.2`: https://pypi.org/pypi/mcp/1.27.2/json

--- a/content/pydantic-ai/docs/package/python/DOC.md
+++ b/content/pydantic-ai/docs/package/python/DOC.md
@@ -3,11 +3,11 @@ name: package
 description: "PydanticAI framework for building typed Python agents with tools, structured output, message history, and multi-provider model support"
 metadata:
   languages: "python"
-  versions: "1.67.0"
-  revision: 1
-  updated-on: "2026-03-12"
+  versions: "1.104.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
-  tags: "pydantic-ai,python,agents,llm,pydantic,tools,structured-output"
+  tags: "pydantic-ai,python,agents,llm,pydantic,tools,structured-output,streaming"
 ---
 
 # pydantic-ai Python Package Guide
@@ -19,22 +19,22 @@ Use `pydantic-ai` as an orchestration layer for typed agent workflows in Python.
 Install the main package when you want the default provider integrations:
 
 ```bash
-python -m pip install "pydantic-ai==1.67.0"
+python -m pip install "pydantic-ai==1.104.0"
 ```
 
 Common alternatives:
 
 ```bash
-uv add "pydantic-ai==1.67.0"
-poetry add "pydantic-ai==1.67.0"
+uv add "pydantic-ai==1.104.0"
+poetry add "pydantic-ai==1.104.0"
 ```
 
 If you want a smaller install, use `pydantic-ai-slim` and add extras for the providers you actually use:
 
 ```bash
-python -m pip install "pydantic-ai-slim[openai]==1.67.0"
-python -m pip install "pydantic-ai-slim[anthropic]==1.67.0"
-python -m pip install "pydantic-ai-slim[logfire]==1.67.0"
+python -m pip install "pydantic-ai-slim[openai]==1.104.0"
+python -m pip install "pydantic-ai-slim[anthropic]==1.104.0"
+python -m pip install "pydantic-ai-slim[logfire]==1.104.0"
 ```
 
 The most common setup mistake is installing `pydantic-ai-slim` without the provider extra you need, then trying to use a model integration that is not installed.
@@ -199,6 +199,33 @@ print(second.output)
 
 The message history docs also cover serializing messages to JSON and restoring them later.
 
+### Stream model output
+
+Use `agent.run_stream()` for incremental text or structured deltas as the model produces them:
+
+```python
+import asyncio
+
+from pydantic_ai import Agent
+
+agent = Agent(
+    "openai:gpt-4o",
+    instructions="Answer concisely.",
+)
+
+
+async def main() -> None:
+    async with agent.run_stream("List three primary colors.") as result:
+        async for chunk in result.stream_text(delta=True):
+            print(chunk, end="", flush=True)
+        print()
+
+
+asyncio.run(main())
+```
+
+For lower-level access to model events (tool calls, partial outputs, run-graph nodes), use `agent.run_stream_events()` or `agent.iter()`. The streaming docs describe how to combine streamed text with validated structured output.
+
 ## Testing Agents
 
 Use the built-in test models instead of calling live providers in unit tests:
@@ -226,12 +253,13 @@ Use `FunctionModel` when you need deterministic behavior for tool execution or o
 - `run_sync()` blocks the current thread. In FastAPI or other async runtimes, use `await agent.run(...)` instead.
 - Provider credentials are separate from the framework itself. Installing the package does not configure `OPENAI_API_KEY` or any other provider secret.
 
-## Version Notes For 1.67.0
+## Version Notes For 1.104.0
 
-- This guide targets `pydantic-ai` `1.67.0`.
+- This guide targets `pydantic-ai` `1.104.0`.
+- PyPI metadata for `1.104.0` requires Python `>=3.10` and lists support through `3.14`.
 - The official version policy describes the `1.x` line as stable and avoids intentional breaking changes in minor releases.
-- Some ecosystem surfaces are documented separately and may have different stability notes than the core `Agent` APIs.
-- If you are migrating from older examples, prefer the current naming and result-handling patterns: `Agent`, `instructions`, `output_type`, `RunContext`, and `result.output`.
+- Some ecosystem surfaces (MCP integration, graph execution, Logfire evals) are documented separately and may have different stability notes than the core `Agent` APIs.
+- If you are migrating from older examples, prefer the current naming and result-handling patterns: `Agent`, `instructions`, `output_type`, `RunContext`, and `result.output`. Older `result_type` / `result.data` examples predate the rename and should not be copied.
 
 ## Official Sources
 


### PR DESCRIPTION
docs(mcp, pydantic-ai): refresh to mcp 1.27.2 / pydantic-ai 1.104.0

Updates the Model Context Protocol Python SDK and the pydantic-ai docs to
the current PyPI versions.

- mcp 1.26.0 → 1.27.2; calls out 1.27.x additions: streamable HTTP idle
  timeouts, RFC 8707 resource validation in the OAuth client, session-to-
  principal binding, and `AccessToken` subject/claims
- pydantic-ai 1.67.0 → 1.104.0; adds `agent.run_stream()` section,
  references `run_stream_events()` and `agent.iter()`; documents the rename
  from `result_type`/`result.data` → `output_type`/`result.output`
- `revision` bumped and `updated-on: 2026-05-29`

Verified versions against PyPI.
