### PR TITLE
docs(next, react): refresh to Next 16.2.6 / React 19.2.6

### DIFF
--- a/content/next/docs/next/javascript/DOC.md
+++ b/content/next/docs/next/javascript/DOC.md
@@ -1,11 +1,11 @@
 ---
 name: next
-description: "Next.js 16 JavaScript guide for App Router apps, including installation, project structure, client components, route handlers, environment variables, images, and production builds"
+description: "Next.js 16 JavaScript guide for App Router apps, covering installation, server and client components, server actions, route handlers, streaming, metadata, middleware, image/font/script, and production builds"
 metadata:
   languages: "javascript"
-  versions: "16.1.6"
-  revision: 1
-  updated-on: "2026-03-13"
+  versions: "16.2.6"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "next,nextjs,javascript,react,app-router,ssr"
 ---
@@ -14,7 +14,7 @@ metadata:
 
 ## Golden Rule
 
-For new work in `next@16.1.6`, use the App Router:
+For new work in `next@16.2.6`, use the App Router:
 
 - put routes under `app/`
 - treat components as Server Components by default
@@ -36,7 +36,7 @@ npm run dev
 To add Next.js to an existing project, install the framework with React:
 
 ```bash
-npm install next@16.1.6 react react-dom
+npm install next@16.2.6 react react-dom
 ```
 
 Add the standard scripts to `package.json`:
@@ -132,6 +132,80 @@ export default function HomePage() {
 ```
 
 Use `'use client'` only where needed. Adding it too high in the tree turns more of your component graph into client-side code than necessary.
+
+## Server Actions
+
+Use Server Actions for form submissions and mutations that run on the server. Mark a function with `'use server'` and pass it to a form's `action` prop or invoke it from a Client Component.
+
+`app/actions.js`:
+
+```js
+'use server';
+
+import { revalidatePath } from 'next/cache';
+
+export async function createPost(formData) {
+  const title = formData.get('title');
+
+  // persist somewhere…
+  await Promise.resolve({ title });
+
+  revalidatePath('/posts');
+}
+```
+
+`app/posts/new/page.js`:
+
+```js
+import { createPost } from '../../actions';
+
+export default function NewPostPage() {
+  return (
+    <form action={createPost}>
+      <input name="title" required />
+      <button type="submit">Create</button>
+    </form>
+  );
+}
+```
+
+Server Actions can also be called from Client Components, and they integrate with React's `useActionState` for pending and error states.
+
+## Streaming With Suspense
+
+The App Router streams rendered HTML. Wrap slow data with `Suspense` to send a fallback first and stream the rest as it resolves.
+
+```js
+import { Suspense } from 'react';
+
+async function SlowFeed() {
+  const response = await fetch('https://example.com/api/feed', {
+    next: { revalidate: 30 },
+  });
+  const items = await response.json();
+
+  return (
+    <ul>
+      {items.map((item) => (
+        <li key={item.id}>{item.title}</li>
+      ))}
+    </ul>
+  );
+}
+
+export default function DashboardPage() {
+  return (
+    <main>
+      <h1>Dashboard</h1>
+      <Suspense fallback={<p>Loading feed…</p>}>
+        <SlowFeed />
+      </Suspense>
+    </main>
+  );
+}
+```
+
+You can also place a `loading.js` next to a `page.js`. The App Router uses it as the Suspense fallback for that segment automatically.
 
 ## Environment Variables
 
@@ -235,6 +309,48 @@ export default function SettingsPage() {
 }
 ```
 
+For dynamic metadata, export `generateMetadata`:
+
+```js
+export async function generateMetadata({ params }) {
+  const post = await fetch(`https://example.com/api/posts/${params.id}`).then(
+    (response) => response.json(),
+  );
+
+  return {
+    title: post.title,
+    description: post.excerpt,
+  };
+}
+```
+
+## Middleware
+
+Put a `middleware.js` file at the project root to run code before a request completes. Use it for redirects, rewrites, authentication, and request/response headers.
+
+`middleware.js`:
+
+```js
+import { NextResponse } from 'next/server';
+
+export function middleware(request) {
+  const session = request.cookies.get('session');
+
+  if (!session && request.nextUrl.pathname.startsWith('/dashboard')) {
+    const loginUrl = new URL('/login', request.url);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/dashboard/:path*'],
+};
+```
+
+Middleware runs on the Edge runtime. Keep it small and avoid Node-only APIs.
+
 ## Images
 
 Use `next/image` for optimized images. If you load remote images, allow their hosts in `next.config.mjs`.
@@ -276,6 +392,53 @@ export default function Avatar() {
 
 If you forget to configure the remote host, remote image rendering fails at runtime.
 
+## Fonts
+
+Use `next/font` to load fonts at build time with no extra network round trips and automatic CSS variable wiring.
+
+`app/layout.js`:
+
+```js
+import { Inter } from 'next/font/google';
+
+const inter = Inter({
+  subsets: ['latin'],
+  display: 'swap',
+});
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en" className={inter.className}>
+      <body>{children}</body>
+    </html>
+  );
+}
+```
+
+For local fonts, import from `next/font/local` and point at a font file under your project.
+
+## Scripts
+
+Use `next/script` to load third-party scripts with a loading strategy instead of dropping raw `<script>` tags into your tree.
+
+```js
+import Script from 'next/script';
+
+export default function AnalyticsLayout({ children }) {
+  return (
+    <>
+      {children}
+      <Script
+        src="https://example.com/analytics.js"
+        strategy="afterInteractive"
+      />
+    </>
+  );
+}
+```
+
+Common strategies: `beforeInteractive`, `afterInteractive` (default), and `lazyOnload`.
+
 ## Production Build And Standalone Output
 
 Create a production build:
@@ -314,7 +477,7 @@ npm run build
 
 ## Version-Sensitive Notes
 
-- This guide targets `next@16.1.6`.
+- This guide targets `next@16.2.6`.
 - The examples here use the App Router and file conventions from the current official Next.js docs.
 - If you maintain an older Pages Router app under `pages/`, follow that router's conventions consistently instead of mixing patterns across routers.
 

--- a/content/react/docs/react-dom/javascript/DOC.md
+++ b/content/react/docs/react-dom/javascript/DOC.md
@@ -3,9 +3,9 @@ name: react-dom
 description: "React DOM runtime for browser roots, hydration, portals, synchronous DOM flushes, and server rendering in JavaScript apps."
 metadata:
   languages: "javascript"
-  versions: "19.2.4"
-  revision: 1
-  updated-on: "2026-03-13"
+  versions: "19.2.6"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "react,react-dom,dom,hydration,ssr,portal"
 ---
@@ -222,6 +222,21 @@ app.listen(3000, () => {
 
 Hydrate the resulting HTML on the client with `hydrateRoot(...)` and use the same `identifierPrefix` if your tree uses `useId`.
 
+## Render to a String (Non-Streaming)
+
+Use `renderToString` for the simplest synchronous server render. It produces a full HTML string in one call. It does not support Suspense for data, so prefer `renderToPipeableStream` or `renderToReadableStream` for real apps.
+
+```javascript
+import { renderToString } from "react-dom/server";
+import App from "./src/App.js";
+
+export function renderHtml() {
+  const body = renderToString(<App />);
+
+  return `<!doctype html><html><body><div id="root">${body}</div><script type="module" src="/client.js"></script></body></html>`;
+}
+```
+
 ## Stream HTML in Web Streams Runtimes
 
 Use `renderToReadableStream` in runtimes that return a standard `Response`, such as edge or worker-style servers.
@@ -256,7 +271,7 @@ export default async function handleRequest() {
 
 ## Version Notes
 
-This guide covers the stable `react-dom` npm package at `19.2.4`.
+This guide covers the stable `react-dom` npm package at `19.2.6`.
 
 The stable React DOM reference groups the runtime APIs by entry point:
 

--- a/content/react/docs/react/javascript/DOC.md
+++ b/content/react/docs/react/javascript/DOC.md
@@ -3,9 +3,9 @@ name: react
 description: "React runtime for building component UIs in JavaScript with hooks, context, Suspense, and lazy loading."
 metadata:
   languages: "javascript"
-  versions: "19.2.4"
-  revision: 1
-  updated-on: "2026-03-13"
+  versions: "19.2.6"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "react,javascript,ui,components,hooks,context,suspense"
 ---
@@ -244,6 +244,271 @@ export function ProductSearch() {
 
 `useMemo` is a performance optimization. Your code should still be correct if React recalculates the value.
 
+### Group related state transitions with `useReducer`
+
+Use `useReducer` when state updates are non-trivial or several actions update the same state in different ways.
+
+```jsx
+import { useReducer } from "react";
+
+const initialState = { count: 0 };
+
+function reducer(state, action) {
+  switch (action.type) {
+    case "increment":
+      return { count: state.count + 1 };
+    case "decrement":
+      return { count: state.count - 1 };
+    case "reset":
+      return initialState;
+    default:
+      throw new Error(`Unknown action: ${action.type}`);
+  }
+}
+
+export function Counter() {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  return (
+    <>
+      <p>Count: {state.count}</p>
+      <button onClick={() => dispatch({ type: "increment" })}>+</button>
+      <button onClick={() => dispatch({ type: "decrement" })}>-</button>
+      <button onClick={() => dispatch({ type: "reset" })}>Reset</button>
+    </>
+  );
+}
+```
+
+### Stabilize callback identity with `useCallback`
+
+Wrap a function in `useCallback` when a referentially stable callback matters, such as when passing it to a memoized child component or as a dependency to another hook.
+
+```jsx
+import { useCallback, useState } from "react";
+
+export function TodoList({ todos }) {
+  const [filter, setFilter] = useState("");
+
+  const handleChange = useCallback((event) => {
+    setFilter(event.target.value);
+  }, []);
+
+  return (
+    <>
+      <input value={filter} onChange={handleChange} />
+      <ul>
+        {todos
+          .filter((todo) => todo.text.includes(filter))
+          .map((todo) => (
+            <li key={todo.id}>{todo.text}</li>
+          ))}
+      </ul>
+    </>
+  );
+}
+```
+
+### Hold mutable values and DOM nodes with `useRef`
+
+Use `useRef` to keep a mutable value across renders without triggering a re-render, or to hold a DOM node reference.
+
+```jsx
+import { useEffect, useRef } from "react";
+
+export function AutoFocusInput() {
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  return <input ref={inputRef} />;
+}
+```
+
+### Keep the UI responsive with `useTransition`
+
+Mark non-urgent state updates with `useTransition` so React can keep the previous UI visible while it computes the new one.
+
+```jsx
+import { useState, useTransition } from "react";
+
+export function TabSwitcher({ tabs, renderTab }) {
+  const [activeTab, setActiveTab] = useState(tabs[0]);
+  const [isPending, startTransition] = useTransition();
+
+  function selectTab(tab) {
+    startTransition(() => {
+      setActiveTab(tab);
+    });
+  }
+
+  return (
+    <>
+      <nav>
+        {tabs.map((tab) => (
+          <button key={tab} onClick={() => selectTab(tab)}>
+            {tab}
+          </button>
+        ))}
+      </nav>
+
+      {isPending ? <p>Loading…</p> : renderTab(activeTab)}
+    </>
+  );
+}
+```
+
+### Defer expensive re-renders with `useDeferredValue`
+
+`useDeferredValue` lets a slow part of the tree render with a stale value while a more important update finishes.
+
+```jsx
+import { useDeferredValue, useState } from "react";
+import { SearchResults } from "./SearchResults.jsx";
+
+export function SearchBox() {
+  const [query, setQuery] = useState("");
+  const deferredQuery = useDeferredValue(query);
+
+  return (
+    <>
+      <input value={query} onChange={(event) => setQuery(event.target.value)} />
+      <SearchResults query={deferredQuery} />
+    </>
+  );
+}
+```
+
+### Show optimistic UI with `useOptimistic`
+
+`useOptimistic` lets you render a temporary "optimistic" state during an async action and roll back automatically if the action throws.
+
+```jsx
+import { useOptimistic, useState } from "react";
+
+async function sendMessage(text) {
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  return { id: crypto.randomUUID(), text };
+}
+
+export function Thread() {
+  const [messages, setMessages] = useState([]);
+  const [optimisticMessages, addOptimisticMessage] = useOptimistic(
+    messages,
+    (current, pending) => [...current, { id: "pending", text: pending, pending: true }],
+  );
+
+  async function submit(formData) {
+    const text = formData.get("text");
+    addOptimisticMessage(text);
+    const saved = await sendMessage(text);
+    setMessages((current) => [...current, saved]);
+  }
+
+  return (
+    <>
+      <ul>
+        {optimisticMessages.map((message) => (
+          <li key={message.id} style={{ opacity: message.pending ? 0.5 : 1 }}>
+            {message.text}
+          </li>
+        ))}
+      </ul>
+
+      <form action={submit}>
+        <input name="text" required />
+        <button type="submit">Send</button>
+      </form>
+    </>
+  );
+}
+```
+
+### Track form action state with `useActionState`
+
+`useActionState` wraps a server or client action and exposes the latest result plus pending state.
+
+```jsx
+import { useActionState } from "react";
+
+async function subscribe(_previousState, formData) {
+  const email = formData.get("email");
+
+  if (!email.includes("@")) {
+    return { ok: false, message: "Please enter a valid email" };
+  }
+
+  return { ok: true, message: `Subscribed ${email}` };
+}
+
+export function SubscribeForm() {
+  const [state, formAction, isPending] = useActionState(subscribe, null);
+
+  return (
+    <form action={formAction}>
+      <input name="email" type="email" required />
+      <button type="submit" disabled={isPending}>
+        {isPending ? "Submitting…" : "Subscribe"}
+      </button>
+      {state ? <p>{state.message}</p> : null}
+    </form>
+  );
+}
+```
+
+### Read promises and context with `use`
+
+`use` reads a Promise or a Context inside a component. When given a Promise, it suspends until the promise resolves.
+
+```jsx
+import { Suspense, use } from "react";
+
+function UserProfile({ userPromise }) {
+  const user = use(userPromise);
+  return <h2>{user.name}</h2>;
+}
+
+export function UserPage({ userPromise }) {
+  return (
+    <Suspense fallback={<p>Loading…</p>}>
+      <UserProfile userPromise={userPromise} />
+    </Suspense>
+  );
+}
+```
+
+Unlike other hooks, `use` may be called inside loops and conditionals.
+
+### Catch render errors with an error boundary
+
+React does not provide a hook for catching errors. Use a class component with `componentDidCatch` or `getDerivedStateFromError`, or use a library such as `react-error-boundary`.
+
+```jsx
+import { Component } from "react";
+
+export class ErrorBoundary extends Component {
+  state = { error: null };
+
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+
+  componentDidCatch(error, info) {
+    console.error("Render error", error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.error) {
+      return <p>Something went wrong.</p>;
+    }
+
+    return this.props.children;
+  }
+}
+```
+
 ### Split code with `lazy` and `Suspense`
 
 Use `lazy` for component-level code splitting and wrap the lazy component in `Suspense` with a fallback UI.
@@ -270,6 +535,19 @@ export function SettingsPage() {
 }
 ```
 
+## React Server Components
+
+React 19 ships first-class support for React Server Components (RSC). A framework such as Next.js (App Router) is responsible for bundling, the RSC payload, and serving server modules.
+
+Quick rules:
+
+- Server Components are the default in RSC frameworks. They run on the server, can `await` data, and never ship to the browser.
+- Hooks that depend on the browser (`useState`, `useEffect`, refs, event handlers) are not allowed in Server Components.
+- Mark a file with `'use client'` at the top to opt into a Client Component module.
+- Mark a module function with `'use server'` to expose it as a Server Action callable from a Client Component or `<form action={...}>`.
+
+`react` itself only provides the building blocks. Use a framework integration to actually render Server Components.
+
 ## Important Pitfalls
 
 - `react` does not create or hydrate browser roots. Import `createRoot` or `hydrateRoot` from `react-dom/client`.
@@ -282,7 +560,7 @@ export function SettingsPage() {
 
 ## Version-Sensitive Notes
 
-- This guide targets `react==19.2.4`.
+- This guide targets `react@19.2.6`.
 - Pair `react` with a matching React 19 `react-dom` release in browser apps.
 - The React 19 reference documents context providers using the context object directly, for example `<ThemeContext value={theme}>`.
 - The React 19 reference also includes newer hooks such as `useActionState`, `useOptimistic`, and `use` in addition to the long-standing core hooks.


### PR DESCRIPTION
docs(next, react): refresh to Next 16.2.6 / React 19.2.6

Updates Next.js and React/React-DOM JS docs to the current npm versions.

- next 16.1.6 → 16.2.6; adds App Router coverage for Server Actions,
  streaming with Suspense, `generateMetadata`, middleware via
  `middleware.js` with `NextResponse`, `next/font`, `next/script`
- react 19.2.4 → 19.2.6; expands hooks tour (`useReducer`, `useCallback`,
  `useRef`, `useTransition`, `useDeferredValue`, `useOptimistic`,
  `useActionState`, `use`); adds error-boundary example and RSC /
  `'use server'` section
- react-dom 19.2.4 → 19.2.6; adds `renderToString` section to round out the
  `react-dom/server` coverage
- `revision` bumped and `updated-on: 2026-05-29`

Verified versions against npm `latest` dist-tag.
