### PR TITLE
docs(astro, svelte, vue): refresh to Astro 6.4.2 / Svelte 5.56.0 / Vue 3.5.35

### DIFF
--- a/content/astro/docs/astro/javascript/DOC.md
+++ b/content/astro/docs/astro/javascript/DOC.md
@@ -3,9 +3,9 @@ name: astro
 description: "Astro 6 guide for building fast, content-focused websites with islands architecture, file-based routing, content collections, and zero client JS by default"
 metadata:
   languages: "javascript"
-  versions: "6.0.7"
-  revision: 1
-  updated-on: "2026-03-20"
+  versions: "6.4.2"
+  revision: 2
+  updated-on: "2026-05-29"
   source: community
   tags: "astro,javascript,ssg,ssr,islands,content,vite"
 ---
@@ -31,7 +31,7 @@ npm run dev
 To add Astro to an existing project:
 
 ```bash
-npm install astro@6.0.7
+npm install astro@6.4.2
 ```
 
 Add scripts to `package.json`:
@@ -298,6 +298,68 @@ export default defineConfig({
 
 Then use `.jsx`/`.tsx` components in Astro pages with `client:*` directives for interactivity.
 
+## View Transitions
+
+Add SPA-like cross-page transitions with `<ClientRouter />` from `astro:transitions`. Place it in the `<head>` of a shared layout to enable transitions across the whole site.
+
+```astro
+---
+import { ClientRouter } from 'astro:transitions';
+---
+
+<html lang="en">
+  <head>
+    <title>My Site</title>
+    <ClientRouter />
+  </head>
+  <body>
+    <slot />
+  </body>
+</html>
+```
+
+Use `transition:name` to pair elements across navigations and `transition:animate` to pick built-in animations.
+
+```astro
+<img src={hero} alt="" transition:name={`hero-${slug}`} transition:animate="slide" />
+```
+
+Listen for transition lifecycle events in client scripts:
+
+```js
+document.addEventListener('astro:before-preparation', (event) => { /* before fetch */ });
+document.addEventListener('astro:after-swap', () => { /* after DOM swap */ });
+document.addEventListener('astro:page-load', () => { /* every page navigation */ });
+```
+
+## Server Endpoints And Middleware
+
+Server endpoints (in `src/pages/api/`) export HTTP method handlers. The handler receives an `APIContext` with `request`, `params`, `cookies`, `redirect`, and `locals`.
+
+```js
+// src/pages/api/login.js
+export async function POST({ request, cookies, redirect }) {
+  const data = await request.formData();
+  const token = await signIn(data.get('email'), data.get('password'));
+  cookies.set('session', token, { httpOnly: true, path: '/' });
+  return redirect('/dashboard', 303);
+}
+```
+
+Middleware runs on every request. Define it in `src/middleware.js`:
+
+```js
+import { defineMiddleware } from 'astro:middleware';
+
+export const onRequest = defineMiddleware(async (context, next) => {
+  const token = context.cookies.get('session')?.value;
+  context.locals.user = token ? await getUser(token) : null;
+  return next();
+});
+```
+
+Read `Astro.locals.user` (or `context.locals.user` in endpoints) downstream.
+
 ## Styling
 
 ### Scoped Styles
@@ -477,10 +539,11 @@ For SSR builds, use the appropriate adapter and follow its deployment guide.
 
 ## Version-Sensitive Notes
 
-- This guide targets `astro@6.0.7`.
+- This guide targets `astro@6.4.2`.
 - Astro 5+ moved content collection config from `src/content/config.ts` to `src/content.config.js` (project root level for content layer).
 - Astro 5+ uses `render()` from `astro:content` instead of calling `.render()` on entries.
 - `hybrid` output mode was removed in Astro 5. Use `output: 'server'` with `export const prerender = true` on individual pages instead.
+- View transitions are available via the `<ClientRouter />` component from `astro:transitions` (renamed from `<ViewTransitions />` in Astro 5).
 
 ## Official Sources
 

--- a/content/svelte/docs/svelte/javascript/DOC.md
+++ b/content/svelte/docs/svelte/javascript/DOC.md
@@ -3,9 +3,9 @@ name: svelte
 description: "Svelte JavaScript package guide for building reactive UI with Svelte 5 components, runes, stores, and Vite"
 metadata:
   languages: "javascript"
-  versions: "5.53.10"
-  revision: 1
-  updated-on: "2026-03-13"
+  versions: "5.56.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "svelte,javascript,ui,frontend,components,vite"
 ---
@@ -32,7 +32,7 @@ npm run dev
 To add Svelte to an existing Vite project manually:
 
 ```bash
-npm install -D svelte@5.53.10 vite @sveltejs/vite-plugin-svelte
+npm install -D svelte@5.56.0 vite @sveltejs/vite-plugin-svelte
 ```
 
 Svelte has no package-specific authentication step and no required environment variables.
@@ -242,6 +242,128 @@ Use `onMount(...)` for browser-only work such as `fetch`, `window`, or `localSto
 
 `onMount(...)` only runs in the browser. If the same component is rendered on the server, code inside `onMount(...)` is skipped there.
 
+## Two-Way Bound Props With `$bindable`
+
+A child can opt a specific prop into two-way binding by marking it with `$bindable(...)`. The parent then uses `bind:` to keep its own state in sync.
+
+`src/lib/TextField.svelte`:
+
+```svelte
+<script>
+  let { value = $bindable(''), placeholder = '' } = $props()
+</script>
+
+<input bind:value placeholder={placeholder} />
+```
+
+`App.svelte`:
+
+```svelte
+<script>
+  import TextField from './lib/TextField.svelte'
+
+  let name = $state('')
+</script>
+
+<TextField bind:value={name} placeholder="Your name" />
+<p>Hello, {name}</p>
+```
+
+Only props declared with `$bindable(...)` can be bound from the parent. The optional argument to `$bindable(...)` is the default value when the parent does not bind.
+
+## Snippets
+
+Snippets are reusable chunks of markup defined inside a component with `{#snippet}` and rendered with `{@render}`. They replace most uses of named slots from Svelte 4.
+
+```svelte
+<script>
+  let items = $state(['apples', 'oranges', 'pears'])
+</script>
+
+{#snippet row(item, index)}
+  <li>{index + 1}. {item}</li>
+{/snippet}
+
+<ul>
+  {#each items as item, i}
+    {@render row(item, i)}
+  {/each}
+</ul>
+```
+
+A parent can pass a snippet down as a prop. The default `children` prop is the component's body.
+
+`src/lib/Card.svelte`:
+
+```svelte
+<script>
+  let { title, children, footer } = $props()
+</script>
+
+<section class="card">
+  <h2>{title}</h2>
+  <div>{@render children()}</div>
+  {#if footer}
+    <footer>{@render footer()}</footer>
+  {/if}
+</section>
+```
+
+`App.svelte`:
+
+```svelte
+<script>
+  import Card from './lib/Card.svelte'
+</script>
+
+<Card title="Hello">
+  <p>Body content goes here.</p>
+
+  {#snippet footer()}
+    <small>Posted today</small>
+  {/snippet}
+</Card>
+```
+
+## Debug With `$inspect`
+
+`$inspect(...)` logs values whenever any tracked dependency changes. It is stripped from production builds.
+
+```svelte
+<script>
+  let count = $state(0)
+  let doubled = $derived(count * 2)
+
+  $inspect(count, doubled)
+  // Or with a custom handler:
+  $inspect(count).with((type, value) => {
+    console.log(type, value) // type is "init" or "update"
+  })
+</script>
+```
+
+## Transitions And Animations
+
+Built-in transitions live in `svelte/transition`. Use `transition:`, `in:`, or `out:` directives on elements inside conditional or keyed blocks.
+
+```svelte
+<script>
+  import { fade, fly } from 'svelte/transition'
+
+  let visible = $state(true)
+</script>
+
+<button onclick={() => (visible = !visible)}>Toggle</button>
+
+{#if visible}
+  <p in:fly={{ y: 20, duration: 300 }} out:fade={{ duration: 200 }}>
+    Hello
+  </p>
+{/if}
+```
+
+The `animate:flip` directive from `svelte/animate` smoothly relocates items in a keyed `{#each}` block when they reorder.
+
 ## Shared State With Stores
 
 Rune state is the default inside components, but Svelte stores are still useful when state must live in a separate module or be shared across unrelated components.
@@ -294,6 +416,6 @@ If you call `hydrate(...)` on empty markup, or `mount(...)` on server-rendered m
 - `onMount(...)` is browser-only. Do not read `window`, `document`, or `localStorage` at module evaluation time if the component can also render on the server.
 - Store auto-subscriptions like `$theme` only work inside `.svelte` files.
 
-## Version Notes For 5.53.10
+## Version Notes For 5.56.0
 
-This guide targets `svelte@5.53.10` and the Svelte 5 rune APIs. If you are maintaining older Svelte 4 code, you may still see legacy syntax in existing apps, but new Svelte 5 code should follow the rune-based patterns shown here.
+This guide targets `svelte@5.56.0` and the Svelte 5 rune APIs. If you are maintaining older Svelte 4 code, you may still see legacy syntax in existing apps, but new Svelte 5 code should follow the rune-based patterns shown here.

--- a/content/vue/docs/vue/javascript/DOC.md
+++ b/content/vue/docs/vue/javascript/DOC.md
@@ -3,9 +3,9 @@ name: vue
 description: "Vue 3 runtime for building reactive component UIs in JavaScript with the Composition API, single-file components, and app-level configuration."
 metadata:
   languages: "javascript"
-  versions: "3.5.30"
-  revision: 1
-  updated-on: "2026-03-13"
+  versions: "3.5.35"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "vue,javascript,ui,components,reactivity,composition-api"
 ---
@@ -252,6 +252,176 @@ if (!apiBaseUrl) {
 </template>
 ```
 
+### Two-way bind props with `defineModel()`
+
+`defineModel()` is the stable `<script setup>` macro for declaring a `v-model`-compatible prop. The returned ref reads the prop and emits `update:modelValue` (or `update:<name>`) on write.
+
+```vue
+<!-- components/EmailField.vue -->
+<script setup>
+const email = defineModel({ type: String, default: "" });
+const optIn = defineModel("optIn", { type: Boolean, default: false });
+</script>
+
+<template>
+  <label>
+    Email
+    <input v-model="email" type="email" />
+  </label>
+
+  <label>
+    <input v-model="optIn" type="checkbox" />
+    Subscribe
+  </label>
+</template>
+```
+
+```vue
+<!-- Parent -->
+<script setup>
+import { ref } from "vue";
+import EmailField from "./components/EmailField.vue";
+
+const email = ref("");
+const optIn = ref(false);
+</script>
+
+<template>
+  <EmailField v-model="email" v-model:optIn="optIn" />
+</template>
+```
+
+### Run side effects with lifecycle hooks
+
+Import lifecycle hooks from `vue` and call them synchronously inside `<script setup>`.
+
+```vue
+<script setup>
+import { onMounted, onBeforeUnmount, onUpdated } from "vue";
+
+let timerId;
+
+onMounted(() => {
+  timerId = setInterval(() => console.log("tick"), 1000);
+});
+
+onBeforeUnmount(() => {
+  clearInterval(timerId);
+});
+
+onUpdated(() => {
+  console.log("DOM updated");
+});
+</script>
+```
+
+Common hooks: `onBeforeMount`, `onMounted`, `onBeforeUpdate`, `onUpdated`, `onBeforeUnmount`, `onUnmounted`, `onErrorCaptured`.
+
+### Render async children with `<Suspense>`
+
+`<Suspense>` waits for async dependencies (top-level `await` in `<script setup>` or async components) before showing the default slot. Use the `fallback` slot for the loading state.
+
+```vue
+<!-- components/UserProfile.vue -->
+<script setup>
+const props = defineProps({ userId: { type: Number, required: true } });
+
+const response = await fetch(`/api/users/${props.userId}`);
+const user = await response.json();
+</script>
+
+<template>
+  <p>{{ user.name }}</p>
+</template>
+```
+
+```vue
+<!-- Parent -->
+<script setup>
+import UserProfile from "./components/UserProfile.vue";
+</script>
+
+<template>
+  <Suspense>
+    <UserProfile :user-id="1" />
+    <template #fallback>
+      <p>Loading user...</p>
+    </template>
+  </Suspense>
+</template>
+```
+
+### Render into a different DOM node with `<Teleport>`
+
+`<Teleport>` moves its children to a target element outside the current component tree. This is useful for modals, toasts, and tooltips that need to escape parent overflow or stacking contexts.
+
+```vue
+<script setup>
+import { ref } from "vue";
+
+const open = ref(false);
+</script>
+
+<template>
+  <button type="button" @click="open = true">Open modal</button>
+
+  <Teleport to="body">
+    <div v-if="open" class="modal">
+      <p>I render directly under &lt;body&gt;.</p>
+      <button type="button" @click="open = false">Close</button>
+    </div>
+  </Teleport>
+</template>
+```
+
+### Centralize state with Pinia (optional)
+
+For state that must be shared across many components, the Vue team recommends Pinia. Install separately and register as a plugin.
+
+```bash
+npm install pinia
+```
+
+```javascript
+// src/main.js
+import { createApp } from "vue";
+import { createPinia } from "pinia";
+import App from "./App.vue";
+
+createApp(App).use(createPinia()).mount("#app");
+```
+
+```javascript
+// src/stores/counter.js
+import { defineStore } from "pinia";
+import { computed, ref } from "vue";
+
+export const useCounterStore = defineStore("counter", () => {
+  const count = ref(0);
+  const doubled = computed(() => count.value * 2);
+
+  function increment() {
+    count.value += 1;
+  }
+
+  return { count, doubled, increment };
+});
+```
+
+```vue
+<script setup>
+import { useCounterStore } from "./stores/counter";
+
+const counter = useCounterStore();
+</script>
+
+<template>
+  <button type="button" @click="counter.increment">
+    {{ counter.count }} (doubled: {{ counter.doubled }})
+  </button>
+</template>
+```
+
 ### Access DOM elements with template refs
 
 In Vue 3.5, `useTemplateRef()` provides a concise way to read a template ref from `<script setup>`.
@@ -283,8 +453,9 @@ onMounted(() => {
 
 ## Version-Sensitive Notes
 
-- This guide targets `vue==3.5.30`.
+- This guide targets `vue==3.5.35`.
 - `useTemplateRef()` is part of the Vue 3.5 API. Older Vue 3 code often uses `const el = ref(null)` for the same job.
+- `defineModel()` is a stable `<script setup>` macro for two-way bound props (`v-model`).
 - Use `createSSRApp()` rather than `createApp()` when hydrating HTML that was rendered on the server.
 
 ## Official Sources


### PR DESCRIPTION
docs(astro, svelte, vue): refresh to Astro 6.4.2 / Svelte 5.56.0 / Vue 3.5.35

Updates the Astro, Svelte, and Vue JS docs to the current npm versions.

- astro 6.0.7 → 6.4.2; adds View Transitions section
  (`<ClientRouter />` from `astro:transitions`, `transition:name`,
  `transition:animate`, lifecycle events) and Server Endpoints +
  Middleware (`APIContext` handler, `defineMiddleware`); notes the
  `<ViewTransitions />` → `<ClientRouter />` rename
- svelte 5.53.10 → 5.56.0; adds `$bindable`, snippets
  (`{#snippet}` / `{@render}`, including `children` prop pattern),
  `$inspect`, transitions/animations
- vue 3.5.30 → 3.5.35; adds `defineModel()`, lifecycle hooks reference,
  `<Suspense>` with async `<script setup>`, `<Teleport>`, and a minimal
  Pinia store example
- `revision` bumped and `updated-on: 2026-05-29`

Verified versions against npm `latest`.
