### PR TITLE
docs(fastapi, pydantic, sqlalchemy): refresh to current PyPI versions

### DIFF
--- a/content/fastapi/docs/package/python/DOC.md
+++ b/content/fastapi/docs/package/python/DOC.md
@@ -3,9 +3,9 @@ name: package
 description: "FastAPI package guide for Python ASGI APIs, dependency injection, auth, and deployment"
 metadata:
   languages: "python"
-  versions: "0.135.1"
-  revision: 1
-  updated-on: "2026-03-11"
+  versions: "0.136.3"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "fastapi,python,asgi,api,openapi,web,async"
 ---
@@ -21,11 +21,11 @@ Use this doc when you need to:
 - build an HTTP API with typed request and response models
 - organize routes with dependencies and routers
 - configure auth, settings, uploads, CORS, and lifespan startup/shutdown
-- avoid version-specific regressions in the `0.129.x` to `0.135.x` range
+- avoid version-specific regressions in the `0.129.x` to `0.136.x` range
 
 ## Python And Install Requirements
 
-- FastAPI `0.135.1` requires Python `>=3.10`.
+- FastAPI `0.136.3` requires Python `>=3.10`.
 - PyPI publishes extras: `standard`, `standard-no-fastapi-cloud-cli`, and `all`.
 - `fastapi[standard]` is the easiest install for new apps because it brings in `uvicorn`, `fastapi-cli`, `httpx`, `jinja2`, and `python-multipart`.
 
@@ -34,7 +34,7 @@ Use this doc when you need to:
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-pip install "fastapi[standard]==0.135.1"
+pip install "fastapi[standard]==0.136.3"
 ```
 
 ### Minimal install
@@ -42,7 +42,7 @@ pip install "fastapi[standard]==0.135.1"
 Use this only if you intentionally manage the server and optional tooling yourself:
 
 ```bash
-pip install "fastapi==0.135.1"
+pip install "fastapi==0.136.3"
 pip install "uvicorn[standard]"
 ```
 
@@ -88,44 +88,56 @@ Default generated docs and schema endpoints:
 - ReDoc: `http://127.0.0.1:8000/redoc`
 - OpenAPI JSON: `http://127.0.0.1:8000/openapi.json`
 
-## Core Usage Pattern
+## Path Operations And Request Models
 
-FastAPI works best when you keep request validation, dependency injection, and routing explicit.
+FastAPI works best when you keep request validation, dependency injection, and routing explicit. Use Pydantic `BaseModel` for request bodies, and declare a `response_model` on the path operation when output should be filtered or documented.
 
 ```python
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, FastAPI, HTTPException
-from pydantic import BaseModel
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Path, Query
+from pydantic import BaseModel, Field
 
 app = FastAPI(title="Inventory API")
 router = APIRouter(prefix="/items", tags=["items"])
 
 class ItemIn(BaseModel):
-    name: str
-    price: float
+    name: str = Field(min_length=1, max_length=80)
+    price: float = Field(ge=0)
+    tags: list[str] = []
+
+class ItemOut(ItemIn):
+    id: int
 
 async def common_params(q: str | None = None, limit: int = 100):
     return {"q": q, "limit": limit}
 
-@router.get("/")
-async def list_items(params: Annotated[dict, Depends(common_params)]):
-    return {"filters": params, "items": []}
+@router.get("/", response_model=list[ItemOut])
+async def list_items(
+    params: Annotated[dict, Depends(common_params)],
+    page: Annotated[int, Query(ge=1)] = 1,
+):
+    return []
 
-@router.post("/", status_code=201)
+@router.get("/{item_id}", response_model=ItemOut)
+async def get_item(item_id: Annotated[int, Path(ge=1)]):
+    raise HTTPException(status_code=404, detail="not found")
+
+@router.post("/", status_code=201, response_model=ItemOut)
 async def create_item(item: ItemIn):
     if item.price < 0:
         raise HTTPException(status_code=400, detail="price must be non-negative")
-    return item
+    return {"id": 1, **item.model_dump()}
 
 app.include_router(router)
 ```
 
 Notes:
 
-- Prefer `Annotated[..., Depends(...)]` for new code.
-- Use Pydantic models for request bodies and response models.
+- Prefer `Annotated[..., Depends(...)]`, `Annotated[..., Query(...)]`, and `Annotated[..., Path(...)]` for new code; positional `= Query(...)` defaults are an older style.
+- Use Pydantic models for request bodies. Use `response_model=` when you want output filtering, schema documentation, or to hide internal fields.
 - Split larger apps with `APIRouter` and `app.include_router(...)`.
+- `response_model_exclude_unset=True` and `response_model_exclude_none=True` are useful when you want to omit unset fields from the response.
 
 ## Configuration And App Setup
 
@@ -237,6 +249,34 @@ Install `python-multipart` before using `File()` or `UploadFile`.
 pip install python-multipart
 ```
 
+```python
+from typing import Annotated
+
+from fastapi import FastAPI, File, Form, UploadFile
+
+app = FastAPI()
+
+@app.post("/upload")
+async def upload(
+    file: Annotated[UploadFile, File()],
+    description: Annotated[str, Form()] = "",
+):
+    contents = await file.read()
+    return {
+        "filename": file.filename,
+        "content_type": file.content_type,
+        "size": len(contents),
+        "description": description,
+    }
+
+@app.post("/upload-many")
+async def upload_many(files: Annotated[list[UploadFile], File()]):
+    return [{"filename": f.filename} for f in files]
+```
+
+- `UploadFile` streams large files to disk and exposes `.file`, `.read()`, `.seek()`, and `.close()`.
+- `bytes` parameters with `File()` load the whole upload into memory; use `UploadFile` for anything that may be large.
+
 ### Background tasks
 
 Use `BackgroundTasks` for simple follow-up work tied to a request, not for durable job queues:
@@ -278,6 +318,30 @@ app = FastAPI(lifespan=lifespan)
 
 If you provide `lifespan`, the old startup/shutdown event handlers will not run.
 
+### WebSockets
+
+FastAPI exposes Starlette's WebSocket support directly. There is no separate package to install.
+
+```python
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+
+app = FastAPI()
+
+@app.websocket("/ws")
+async def ws_echo(websocket: WebSocket):
+    await websocket.accept()
+    try:
+        while True:
+            data = await websocket.receive_text()
+            await websocket.send_text(f"echo: {data}")
+    except WebSocketDisconnect:
+        return
+```
+
+- WebSocket routes use `@app.websocket(...)`, not `@app.get(...)`.
+- `Depends(...)` works on WebSocket routes too, useful for auth checks.
+- Close codes are passed via `await websocket.close(code=1008)`.
+
 ## Testing
 
 If you installed plain `fastapi`, add `httpx` first:
@@ -316,9 +380,10 @@ For sync tests, keep test functions as normal `def`, not `async def`, unless you
 - Letting trailing-slash redirects surprise clients; set route shapes consistently or adjust `redirect_slashes`.
 - Assuming file/form support exists without `python-multipart`.
 
-## Version-Sensitive Notes For 0.135.1
+## Version-Sensitive Notes For 0.136.3
 
-- `0.135.1` is a small fix release; upstream notes mention a TaskGroup/yield async-exit-stack fix.
+- `0.136.3` is the current PyPI release as of `2026-05-29` and requires Python `>=3.10`.
+- `0.136.x` is a patch line on top of `0.136.0`; check the upstream release notes for the exact fixes when troubleshooting.
 - `0.135.0` added Server-Sent Events support.
 - `0.134.0` added streaming JSON Lines and binary data with `yield`.
 - `0.132.0` enabled strict JSON `Content-Type` checking by default. Clients that send JSON without a valid JSON content type now fail unless you explicitly disable it with `strict_content_type=False`.
@@ -338,5 +403,6 @@ For sync tests, keep test functions as normal `def`, not `async def`, unless you
 - FastAPI CORS: https://fastapi.tiangolo.com/tutorial/cors/
 - FastAPI lifespan events: https://fastapi.tiangolo.com/advanced/events/
 - FastAPI testing: https://fastapi.tiangolo.com/tutorial/testing/
+- FastAPI WebSockets: https://fastapi.tiangolo.com/advanced/websockets/
 - FastAPI release notes: https://fastapi.tiangolo.com/release-notes/
-- PyPI package page: https://pypi.org/project/fastapi/0.135.1/
+- PyPI package page: https://pypi.org/project/fastapi/0.136.3/

--- a/content/pydantic/docs/ai/python/DOC.md
+++ b/content/pydantic/docs/ai/python/DOC.md
@@ -3,9 +3,9 @@ name: ai
 description: "PydanticAI framework for building typed Python agents with tools, structured output, message history, and multi-provider model support"
 metadata:
   languages: "python"
-  versions: "1.67.0"
-  revision: 1
-  updated-on: "2026-03-12"
+  versions: "1.104.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "pydantic-ai,python,agents,llm,pydantic,tools,structured-output"
 ---
@@ -21,22 +21,22 @@ Use `pydantic-ai` when you want typed agent workflows in Python, but treat it as
 Install the full package when you want the default provider integrations and optional observability dependencies:
 
 ```bash
-python -m pip install "pydantic-ai==1.67.0"
+python -m pip install "pydantic-ai==1.104.0"
 ```
 
 Common alternatives:
 
 ```bash
-uv add "pydantic-ai==1.67.0"
-poetry add "pydantic-ai==1.67.0"
+uv add "pydantic-ai==1.104.0"
+poetry add "pydantic-ai==1.104.0"
 ```
 
 If you want a smaller install and only the providers you actually use, install `pydantic-ai-slim` with extras:
 
 ```bash
-python -m pip install "pydantic-ai-slim[openai]==1.67.0"
-python -m pip install "pydantic-ai-slim[anthropic]==1.67.0"
-python -m pip install "pydantic-ai-slim[logfire]==1.67.0"
+python -m pip install "pydantic-ai-slim[openai]==1.104.0"
+python -m pip install "pydantic-ai-slim[anthropic]==1.104.0"
+python -m pip install "pydantic-ai-slim[logfire]==1.104.0"
 ```
 
 Use the non-slim package unless dependency size is a real constraint. Agents often fail by installing `pydantic-ai-slim` with no provider extras, then trying to use a provider client that was never installed.
@@ -236,10 +236,11 @@ The package also integrates with Pydantic Logfire for tracing and observability.
 - `run_sync()` blocks. In FastAPI, asyncio workers, or other async runtimes, use `await agent.run(...)` instead.
 - Provider credentials are separate from `pydantic-ai` itself. `pip install pydantic-ai` does not configure `OPENAI_API_KEY`, Anthropic keys, or any gateway tokens.
 
-## Version-Sensitive Notes For 1.67.0
+## Version-Sensitive Notes For 1.104.0
 
-- PyPI and the official docs currently align on `1.67.0` as of 2026-03-12.
-- `1.67.0` is in the stable `1.x` line. The official version policy says `v1` should avoid intentional breaking changes in minor releases; treat pre-v1 blog posts and old examples as suspect.
+- PyPI and the official docs currently align on `1.104.0` as of 2026-05-29; the package requires Python `>=3.10`.
+- `1.104.0` is in the stable `1.x` line. The official version policy says `v1` should avoid intentional breaking changes in minor releases; treat pre-v1 blog posts and old examples as suspect.
+- The `1.x` line has moved quickly since `1.0`; minor version jumps add provider integrations, MCP transports, and observability surfaces rather than breaking the agent API.
 - The docs still call out some beta surfaces in the broader ecosystem, especially around `pydantic_graph`. Do not assume beta-marked pieces have the same stability guarantees as the core agent APIs.
 - If you are migrating from older `0.x` examples, prefer the current docs for naming and result handling. The modern API centers on `Agent`, `instructions`, `output_type`, `RunContext`, and `result.output`.
 

--- a/content/pydantic/docs/core/python/DOC.md
+++ b/content/pydantic/docs/core/python/DOC.md
@@ -1,11 +1,11 @@
 ---
 name: core
-description: "pydantic-core 2.42.0 package guide for low-level validation, parsing, and serialization in Python"
+description: "pydantic-core 2.47.0 package guide for low-level validation, parsing, and serialization in Python"
 metadata:
   languages: "python"
-  versions: "2.42.0"
-  revision: 2
-  updated-on: "2026-03-12"
+  versions: "2.47.0"
+  revision: 3
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "pydantic,python,validation,serialization,json,schema"
 ---
@@ -26,19 +26,19 @@ Prefer `pydantic` for normal application code. Reach for `pydantic-core` when yo
 ## Install
 
 ```bash
-pip install "pydantic-core==2.42.0"
+pip install "pydantic-core==2.47.0"
 ```
 
 If you use `uv`:
 
 ```bash
-uv add "pydantic-core==2.42.0"
+uv add "pydantic-core==2.47.0"
 ```
 
 If you use Poetry:
 
 ```bash
-poetry add "pydantic-core==2.42.0"
+poetry add "pydantic-core==2.47.0"
 ```
 
 Notes:
@@ -241,11 +241,12 @@ If your project needs environment-backed settings or secret loading, use `pydant
 - Forgetting that `to_json(...)` returns `bytes`, not `str`.
 - Writing large raw schema dictionaries by hand. Use `pydantic_core.core_schema` helpers for maintainable code.
 
-## Version-Sensitive Notes For `2.42.0`
+## Version-Sensitive Notes For `2.47.0`
 
-- PyPI lists `2.42.0` as the current package version and requires Python `>=3.9`.
+- PyPI lists `2.47.0` as the current package version as of `2026-05-29` and requires Python `>=3.10`.
 - The official API docs live under `docs.pydantic.dev/latest/...`; they are authoritative, but they are not a version-pinned docs snapshot.
 - The standalone `pydantic/pydantic-core` GitHub repository is archived and marked read-only. Active development moved into the main `pydantic` repository under `pydantic-core/`.
+- `pydantic-core` versions are pinned by the `pydantic` package; do not upgrade `pydantic-core` alone unless you are intentionally compatibility-testing a new core release.
 - If your application is pinned to an older `2.x` release, verify method signatures and flags against the installed wheel before copying examples from the latest docs.
 
 ## Official Sources

--- a/content/pydantic/docs/extra-types/python/DOC.md
+++ b/content/pydantic/docs/extra-types/python/DOC.md
@@ -1,11 +1,11 @@
 ---
 name: extra-types
-description: "pydantic-extra-types 2.11.0 guide for validating colors, countries, phone numbers, payment cards, coordinates, and time zones in Python"
+description: "pydantic-extra-types 2.11.1 guide for validating colors, countries, phone numbers, payment cards, coordinates, time zones, ISBN, MAC addresses, currencies, and more in Python"
 metadata:
   languages: "python"
-  versions: "2.11.0"
-  revision: 1
-  updated-on: "2026-03-13"
+  versions: "2.11.1"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "pydantic,pydantic-extra-types,python,validation,types,phone-numbers,countries,timezones"
 ---
@@ -23,28 +23,59 @@ There is no client object, auth flow, or environment-variable setup. You import 
 Pin the package version your project expects:
 
 ```bash
-python -m pip install "pydantic-extra-types==2.11.0"
+python -m pip install "pydantic-extra-types==2.11.1"
 ```
 
 Common alternatives:
 
 ```bash
-uv add "pydantic-extra-types==2.11.0"
-poetry add "pydantic-extra-types==2.11.0"
+uv add "pydantic-extra-types==2.11.1"
+poetry add "pydantic-extra-types==2.11.1"
 ```
 
 Optional extras published on PyPI:
 
 ```bash
-python -m pip install "pydantic-extra-types[phonenumbers]==2.11.0"
-python -m pip install "pydantic-extra-types[all]==2.11.0"
+python -m pip install "pydantic-extra-types[phonenumbers]==2.11.1"
+python -m pip install "pydantic-extra-types[pycountry]==2.11.1"
+python -m pip install "pydantic-extra-types[pendulum]==2.11.1"
+python -m pip install "pydantic-extra-types[python-ulid]==2.11.1"
+python -m pip install "pydantic-extra-types[semver]==2.11.1"
+python -m pip install "pydantic-extra-types[uuid-utils]==2.11.1"
+python -m pip install "pydantic-extra-types[cron]==2.11.1"
+python -m pip install "pydantic-extra-types[all]==2.11.1"
 ```
 
 Notes:
 
-- PyPI lists Python `>=3.9` for `2.11.0`.
+- PyPI lists Python `>=3.9` for `2.11.1`.
 - The package is for the Pydantic v2 ecosystem; these types are no longer imported from `pydantic` itself.
 - If your runtime does not have an IANA timezone database available, install `tzdata` before using `TimeZoneName`.
+
+## Types Provided
+
+`pydantic-extra-types` ships these types (import from `pydantic_extra_types.<module>`):
+
+- `color.Color` — CSS color values with `.as_hex()`, `.as_rgb_tuple()`, `.as_hsl()`.
+- `country.CountryAlpha2`, `CountryAlpha3`, `CountryNumericCode`, `CountryShortName`, `CountryOfficialName` — ISO 3166 country codes.
+- `coordinate.Coordinate`, `Latitude`, `Longitude` — geographic coordinates.
+- `currency_code.Currency`, `ISO4217` — ISO 4217 currency codes.
+- `language_code.LanguageAlpha2`, `LanguageName` — ISO 639 language codes.
+- `mac_address.MacAddress` — MAC addresses.
+- `payment.PaymentCardNumber` with `.brand`, `.bin`, `.last4`, `.masked`.
+- `phone_numbers.PhoneNumber`, `PhoneNumberValidator` — requires the `phonenumbers` extra.
+- `routing_number.ABARoutingNumber` — US bank routing numbers.
+- `s3.S3Path` — S3 URI parsing.
+- `script_code.ISO_15924` — script codes.
+- `semantic_version.SemanticVersion` — semver strings; requires the `semver` extra.
+- `semver.VersionType` — alternative semver type via `semver` extra.
+- `timezone_name.TimeZoneName` — IANA timezone identifiers.
+- `ulid.ULID` — universally unique lexicographically sortable IDs; requires the `python-ulid` extra.
+- `isbn.ISBN` — ISBN-10 and ISBN-13.
+- `pendulum_dt.DateTime`, `Date`, `Duration` — Pendulum datetime types; requires the `pendulum` extra.
+- `domain.DomainStr` — domain name strings.
+- `epoch.Number`, `Integer` — Unix epoch time values.
+- `mongo_object_id.MongoObjectId` — MongoDB ObjectId values.
 
 ## Core Pattern
 
@@ -183,11 +214,11 @@ This is the simplest pattern for parsing config values, CLI inputs, or isolated 
 - `PhoneNumber` requires the `phonenumbers` dependency. Install the `phonenumbers` extra before using it.
 - `TimeZoneName` relies on the IANA timezone database. Install `tzdata` if your deployment image does not already provide timezone data.
 - The main Pydantic types docs note that strictness and extra constraints are not applied to these extra types. If you need narrower rules, add a validator, use `Annotated` metadata such as `PhoneNumberValidator`, or define a subtype such as a custom `PhoneNumber` subclass.
-- The official docs root uses `/latest/`, so copy examples cautiously if your project is pinned to a much older or newer wheel than `2.11.0`.
+- The official docs root uses `/latest/`, so copy examples cautiously if your project is pinned to a much older or newer wheel than `2.11.1`.
 
-## Version-Sensitive Notes For `2.11.0`
+## Version-Sensitive Notes For `2.11.1`
 
-- PyPI lists `2.11.0` as the package version covered here and requires Python `>=3.9`.
+- PyPI lists `2.11.1` as the current package version as of `2026-05-29` and requires Python `>=3.9`.
 - The current maintainer docs for extra types live under the main Pydantic docs site, not a separate package site.
 - Pydantic v2 moved these types out of the main package. If you are migrating v1 code, prefer imports from `pydantic_extra_types.*` and re-check any old field examples.
 
@@ -201,4 +232,4 @@ This is the simplest pattern for parsing config values, CLI inputs, or isolated 
 - Phone numbers API: `https://docs.pydantic.dev/2.11/api/pydantic_extra_types_phone_numbers/`
 - Timezone name API: `https://docs.pydantic.dev/latest/api/pydantic_extra_types_timezone_name/`
 - Main types docs: `https://docs.pydantic.dev/latest/api/types/`
-- PyPI: `https://pypi.org/project/pydantic-extra-types/2.11.0/`
+- PyPI: `https://pypi.org/project/pydantic-extra-types/2.11.1/`

--- a/content/pydantic/docs/package/python/DOC.md
+++ b/content/pydantic/docs/package/python/DOC.md
@@ -1,11 +1,11 @@
 ---
 name: package
-description: "Pydantic 2.12.5 package guide for Python data validation, settings, and schema generation"
+description: "Pydantic 2.13.4 package guide for Python data validation, settings, and schema generation"
 metadata:
   languages: "python"
-  versions: "2.12.5"
-  revision: 1
-  updated-on: "2026-03-11"
+  versions: "2.13.4"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "pydantic,python,validation,typing,json-schema,settings"
 ---
@@ -26,19 +26,19 @@ metadata:
 ## Install
 
 ```bash
-pip install "pydantic==2.12.5"
+pip install "pydantic==2.13.4"
 ```
 
 If you use `uv`:
 
 ```bash
-uv add "pydantic==2.12.5"
+uv add "pydantic==2.13.4"
 ```
 
 If you need `EmailStr` and related email validation helpers:
 
 ```bash
-pip install "pydantic[email]==2.12.5"
+pip install "pydantic[email]==2.13.4"
 ```
 
 ## Core Model Pattern
@@ -223,6 +223,117 @@ Reach for:
 - `model_validator(mode="before")` to reshape raw input
 - `model_validator(mode="after")` for cross-field checks after parsing
 
+## Serializers
+
+Customize how fields are serialized with `@field_serializer` and `@model_serializer`:
+
+```python
+from datetime import datetime
+from pydantic import BaseModel, field_serializer, model_serializer
+
+class Event(BaseModel):
+    name: str
+    at: datetime
+
+    @field_serializer("at")
+    def serialize_at(self, value: datetime) -> str:
+        return value.isoformat()
+
+class Compact(BaseModel):
+    first: str
+    last: str
+
+    @model_serializer
+    def serialize(self) -> dict:
+        return {"name": f"{self.first} {self.last}"}
+```
+
+- `@field_serializer("field")` runs only when serializing that field.
+- `@model_serializer` replaces the entire `model_dump()` output.
+- Use `when_used="json"` (or `"always"`, `"unless-none"`, `"json-unless-none"`) to scope serializers to a serialization mode.
+
+## Computed Fields
+
+Use `@computed_field` for derived values you want in `model_dump()` and JSON Schema:
+
+```python
+from pydantic import BaseModel, computed_field
+
+class Rectangle(BaseModel):
+    width: float
+    height: float
+
+    @computed_field
+    @property
+    def area(self) -> float:
+        return self.width * self.height
+
+print(Rectangle(width=2, height=3).model_dump())
+# {'width': 2.0, 'height': 3.0, 'area': 6.0}
+```
+
+The decorator must be on top of `@property`. Computed fields are read-only and serialization-only; they are not validated as input.
+
+## RootModel
+
+Use `RootModel` when the model wraps a single root value such as a list or a dict, not a struct:
+
+```python
+from pydantic import RootModel
+
+class Tags(RootModel[list[str]]):
+    pass
+
+tags = Tags.model_validate(["python", "pydantic"])
+print(tags.root)             # ['python', 'pydantic']
+print(tags.model_dump())     # ['python', 'pydantic']
+```
+
+- Access the wrapped value through `.root`.
+- Use this instead of trying to subclass `list` or `dict` with Pydantic.
+
+## Discriminated Unions
+
+Use a `Field(discriminator=...)` to make union resolution explicit and fast:
+
+```python
+from typing import Annotated, Literal, Union
+from pydantic import BaseModel, Field
+
+class Cat(BaseModel):
+    kind: Literal["cat"]
+    purr_volume: int
+
+class Dog(BaseModel):
+    kind: Literal["dog"]
+    bark_volume: int
+
+Pet = Annotated[Union[Cat, Dog], Field(discriminator="kind")]
+
+class Owner(BaseModel):
+    pet: Pet
+
+Owner.model_validate({"pet": {"kind": "cat", "purr_volume": 7}})
+```
+
+- The discriminator field must be a `Literal` on every variant.
+- Validation fails fast with a clear error when `kind` does not match any variant.
+
+## TypeAdapter For Non-Model Types
+
+`TypeAdapter` validates and serializes arbitrary types without a `BaseModel`:
+
+```python
+from pydantic import TypeAdapter
+
+IntList = TypeAdapter(list[int])
+IntList.validate_python(["1", "2", "3"])     # [1, 2, 3]
+IntList.dump_json([1, 2, 3])                  # b'[1,2,3]'
+IntList.json_schema()                         # JSON Schema for list[int]
+```
+
+Reuse adapters; do not rebuild them per call. `TypeAdapter` also accepts `Annotated[...]` metadata so you can attach `Field(...)` constraints to scalar or container types.
+
 ## JSON Schema Generation
 
 Use JSON Schema output when integrating with OpenAPI generators, forms, or LLM tool schemas:
@@ -244,16 +355,17 @@ If you need schema for a non-model type, generate it from `TypeAdapter(...).json
 - For partial updates, prefer `model_copy(update=...)` over rebuilding ad hoc dictionaries.
 - Catch `ValidationError` at system boundaries and return structured errors instead of raw tracebacks.
 
-## Version-Sensitive Notes For 2.12.5
+## Version-Sensitive Notes For 2.13.4
 
-- `2.12.5` is the current stable release on PyPI as of `2026-03-11`.
-- The official docs root `https://docs.pydantic.dev/latest/` currently documents the v2.12 line.
-- PyPI also lists newer pre-release builds; do not assume those APIs are safe to target unless the project explicitly uses them.
+- `2.13.4` is the current stable release on PyPI as of `2026-05-29`. The package supports Python `>=3.9`.
+- The official docs root `https://docs.pydantic.dev/latest/` currently documents the v2.13 line.
+- `2.13.x` is a patch series on `2.13.0`; check the changelog when troubleshooting specific behavior differences vs `2.12`.
+- PyPI may list newer pre-release builds; do not assume those APIs are safe to target unless the project explicitly uses them.
 - If you are maintaining v1-era code, the migration guide documents the method renames and the `pydantic.v1` compatibility namespace.
 
 ## Recommended Agent Workflow
 
-1. Install the exact version used by the project or pin `2.12.5` when creating new examples.
+1. Install the exact version used by the project or pin `2.13.4` when creating new examples.
 2. Start with a `BaseModel` or `TypeAdapter`, not custom parsing code.
 3. Add `extra="forbid"` unless the payload is intentionally open-ended.
 4. Use `model_validate_json()` for raw JSON, `model_validate()` for Python objects, and `model_validate_strings()` for all-string maps.

--- a/content/pydantic/docs/settings/python/DOC.md
+++ b/content/pydantic/docs/settings/python/DOC.md
@@ -1,11 +1,11 @@
 ---
 name: settings
-description: "pydantic-settings 2.13.1 package guide for typed application settings, dotenv files, CLI parsing, and secret sources in Python"
+description: "pydantic-settings 2.14.1 package guide for typed application settings, dotenv files, CLI parsing, and secret sources in Python"
 metadata:
   languages: "python"
-  versions: "2.13.1"
-  revision: 1
-  updated-on: "2026-03-12"
+  versions: "2.14.1"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "pydantic-settings,python,configuration,environment,settings,secrets,cli"
 ---
@@ -29,24 +29,24 @@ Reach for it when you want:
 Pin the version your project expects:
 
 ```bash
-python -m pip install "pydantic-settings==2.13.1"
+python -m pip install "pydantic-settings==2.14.1"
 ```
 
 Common alternatives:
 
 ```bash
-uv add "pydantic-settings==2.13.1"
-poetry add "pydantic-settings==2.13.1"
+uv add "pydantic-settings==2.14.1"
+poetry add "pydantic-settings==2.14.1"
 ```
 
 Optional extras published on PyPI:
 
 ```bash
-python -m pip install "pydantic-settings[toml]==2.13.1"
-python -m pip install "pydantic-settings[yaml]==2.13.1"
-python -m pip install "pydantic-settings[aws-secrets-manager]==2.13.1"
-python -m pip install "pydantic-settings[azure-key-vault]==2.13.1"
-python -m pip install "pydantic-settings[gcp-secret-manager]==2.13.1"
+python -m pip install "pydantic-settings[toml]==2.14.1"
+python -m pip install "pydantic-settings[yaml]==2.14.1"
+python -m pip install "pydantic-settings[aws-secrets-manager]==2.14.1"
+python -m pip install "pydantic-settings[azure-key-vault]==2.14.1"
+python -m pip install "pydantic-settings[gcp-secret-manager]==2.14.1"
 ```
 
 ## Core Pattern
@@ -244,7 +244,7 @@ Important boundary:
 
 ## Version-Sensitive Notes
 
-- As of March 12, 2026, PyPI lists `2.13.1`, which matches the version covered here.
+- As of May 29, 2026, PyPI lists `2.14.1`, which matches the version covered here.
 - The official docs live under the main Pydantic docs site, not a separate `pydantic-settings` docs domain.
 - This package is for the Pydantic v2 settings model. Older blog posts that import `BaseSettings` from `pydantic` are v1-era examples and should not be copied into new code.
 - Python `>=3.10` is required for the current package release.

--- a/content/sqlalchemy/docs/package/python/DOC.md
+++ b/content/sqlalchemy/docs/package/python/DOC.md
@@ -1,11 +1,11 @@
 ---
 name: package
-description: "SQLAlchemy package guide for Python 2.0.48, covering engine setup, ORM/Core usage, transactions, and asyncio"
+description: "SQLAlchemy package guide for Python 2.0.50, covering engine setup, ORM/Core usage, transactions, and asyncio"
 metadata:
   languages: "python"
-  versions: "2.0.48"
-  revision: 1
-  updated-on: "2026-03-11"
+  versions: "2.0.50"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "sqlalchemy,orm,sql,database,python,asyncio"
 ---
@@ -20,14 +20,14 @@ metadata:
 - ORM for mapped classes and unit-of-work persistence
 - `select()` plus `Session.execute()` / `Session.scalars()` instead of legacy `Query`-first patterns
 
-This guide is for SQLAlchemy `2.0.48`, using the official 2.0 docs at `https://docs.sqlalchemy.org/en/20/`.
+This guide is for SQLAlchemy `2.0.50`, using the official 2.0 docs at `https://docs.sqlalchemy.org/en/20/`.
 
 ## Install
 
 Install the package itself:
 
 ```bash
-pip install SQLAlchemy==2.0.48
+pip install SQLAlchemy==2.0.50
 ```
 
 SQLAlchemy also needs a DBAPI driver for the database you actually use. Common choices:
@@ -41,8 +41,8 @@ pip install aiosqlite
 PyPI also exposes extras for several backends and async support, for example:
 
 ```bash
-pip install "SQLAlchemy[asyncio]==2.0.48"
-pip install "SQLAlchemy[postgresql-asyncpg]==2.0.48"
+pip install "SQLAlchemy[asyncio]==2.0.50"
+pip install "SQLAlchemy[postgresql-asyncpg]==2.0.50"
 ```
 
 Notes:
@@ -181,7 +181,29 @@ For prototypes and tests, create tables directly:
 Base.metadata.create_all(engine)
 ```
 
-For production schema evolution, use migrations instead of relying on repeated `create_all()` calls.
+For production schema evolution, use migrations instead of relying on repeated `create_all()` calls. The standard tool is Alembic, maintained by the SQLAlchemy authors:
+
+```bash
+pip install alembic
+alembic init alembic
+```
+
+Wire Alembic's `env.py` to your `Base.metadata` so it can autogenerate migrations:
+
+```python
+# alembic/env.py
+from myapp.db import Base
+target_metadata = Base.metadata
+```
+
+Then generate and apply migrations:
+
+```bash
+alembic revision --autogenerate -m "add user_account table"
+alembic upgrade head
+```
+
+Autogenerate detects new columns, indexes, and constraints, but always review the generated script before applying it.
 
 ## Sessions and Transactions
 
@@ -410,14 +432,15 @@ Async ORM code fails when attribute access tries to emit implicit IO. Solve this
 - setting `lazy="raise"` where appropriate
 - using `AsyncAttrs.awaitable_attrs` when you intentionally want awaitable attribute access
 
-## Version-Sensitive Notes for 2.0.48
+## Version-Sensitive Notes for 2.0.50
 
-- The docs root `https://docs.sqlalchemy.org/en/20/` is the correct stable series for `2.0.48`.
-- PyPI shows `2.0.48` as the latest stable release on `2026-03-11`, released on `2026-03-02`.
-- PyPI also lists `2.1.0b1` as a prerelease. Do not mix 2.1 beta examples into a project pinned to `2.0.48`.
+- The docs root `https://docs.sqlalchemy.org/en/20/` is the correct stable series for `2.0.50`.
+- PyPI shows `2.0.50` as the latest stable release on `2026-05-29`.
+- PyPI may also list `2.1.x` prereleases. Do not mix 2.1 beta examples into a project pinned to `2.0.50`.
 - `create_engine(..., future=True)` is a legacy 1.4 transition flag. In 2.0 it stays at the default and should not be added to new examples.
-- Async `AsyncAttrs.awaitable_attrs` was added in `2.0.13`; it is available in `2.0.48`.
+- Async `AsyncAttrs.awaitable_attrs` was added in `2.0.13`; it is available in `2.0.50`.
 - SQLAlchemy 2.0 removed legacy autocommit and connectionless patterns. Use explicit transactions with `Session.begin()` / `engine.begin()` and execute statements via `Session` or `Connection`.
+- The 1.x `session.query(...)` API still exists in 2.0 for compatibility, but the recommended pattern for new code is `session.execute(select(...))`, `session.scalars(select(...))`, and `session.scalar(select(...))`.
 
 ## Minimal Working Patterns
 
@@ -468,4 +491,5 @@ with engine.begin() as conn:
 - ORM quick start: `https://docs.sqlalchemy.org/en/20/orm/quickstart.html`
 - AsyncIO extension: `https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html`
 - 2.0 migration guide: `https://docs.sqlalchemy.org/en/20/changelog/migration_20.html`
+- Alembic migrations: `https://alembic.sqlalchemy.org/en/latest/`
 - PyPI package page: `https://pypi.org/project/SQLAlchemy/`


### PR DESCRIPTION
docs(fastapi, pydantic, sqlalchemy): refresh to current PyPI versions

Updates FastAPI, Pydantic (core, settings, extra-types, ai, package), and
SQLAlchemy Python docs.

- fastapi 0.135.1 → 0.136.3; adds explicit Path Operations + Request
  Models (`response_model`), expanded file upload with `UploadFile`/`Form`,
  WebSockets section
- pydantic 2.12.5 → 2.13.4; adds `@field_serializer` / `@model_serializer`,
  `@computed_field`, `RootModel`, discriminated unions, dedicated
  `TypeAdapter` section
- pydantic-core 2.42.0 → 2.47.0 (requires Python ≥3.10)
- pydantic-settings 2.13.1 → 2.14.1
- pydantic-extra-types 2.11.0 → 2.11.1; adds "Types Provided" inventory
- pydantic-ai (docs/ai variant) 1.67.0 → 1.104.0
- sqlalchemy 2.0.48 → 2.0.50; adds Alembic migrations section
  (`init`, `revision --autogenerate`, `upgrade head`); clarifies that
  `session.query(...)` is legacy in 2.0
- `revision` bumped and `updated-on: 2026-05-29`

Verified versions against PyPI for each package.
