### PR TITLE
docs(vite, tailwindcss, prisma): refresh to Vite 7.8.0 / Tailwind 4.3.0 / Prisma 8.0.14

### DIFF
--- a/content/prisma/docs/orm/javascript/DOC.md
+++ b/content/prisma/docs/orm/javascript/DOC.md
@@ -3,8 +3,9 @@ name: orm
 description: "Prisma ORM client for JavaScript/TypeScript with type-safe database access and migrations"
 metadata:
   languages: "javascript"
-  versions: "6.19.0"
-  updated-on: "2026-03-01"
+  versions: "8.0.14"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "prisma,orm,database,typescript,migrations"
 ---
@@ -13,11 +14,11 @@ metadata:
 
 ## Golden Rule
 
-**ALWAYS use `@prisma/client` version 6.19.0+ with the `prisma` CLI for development.**
+**ALWAYS use `@prisma/client` version 8.0.14+ with the `prisma` CLI for development.**
 
 ```bash
-npm install @prisma/client@6.19.0
-npm install -D prisma@6.19.0
+npm install @prisma/client@8.0.14
+npm install -D prisma@8.0.14
 ```
 
 **DO NOT** use deprecated packages like:
@@ -333,6 +334,26 @@ npx prisma migrate reset
 
 ```bash
 npx prisma generate
+```
+
+### Push Schema Without Migrations (Prototyping)
+
+`db push` syncs the database to your schema without creating migration files. Use it for prototyping or for databases without migration history (e.g. MongoDB).
+
+```bash
+npx prisma db push
+```
+
+### Pull Schema From an Existing Database
+
+```bash
+npx prisma db pull
+```
+
+### Open Prisma Studio
+
+```bash
+npx prisma studio
 ```
 
 ---

--- a/content/prisma/docs/orm/python/DOC.md
+++ b/content/prisma/docs/orm/python/DOC.md
@@ -4,7 +4,8 @@ description: "Prisma Client Python for type-safe database access and schema-driv
 metadata:
   languages: "python"
   versions: "0.15.0"
-  updated-on: "2026-03-01"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "prisma,orm,database,python,migrations"
 ---

--- a/content/tailwindcss/docs/tailwindcss/javascript/DOC.md
+++ b/content/tailwindcss/docs/tailwindcss/javascript/DOC.md
@@ -3,9 +3,9 @@ name: tailwindcss
 description: "Tailwind CSS v4 utility framework for styling JavaScript applications with official Vite or PostCSS integrations"
 metadata:
   languages: "javascript"
-  versions: "4.2.1"
-  revision: 1
-  updated-on: "2026-03-13"
+  versions: "4.3.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "tailwindcss,css,postcss,vite,javascript,npm"
 ---
@@ -19,6 +19,8 @@ Install `tailwindcss` together with the integration package for your build tool.
 - Use `@tailwindcss/vite` with Vite.
 - Use `@tailwindcss/postcss` with PostCSS.
 - Do not configure `tailwindcss` itself as a PostCSS plugin in v4.
+
+Tailwind CSS v4 is **CSS-first**: configuration lives inside your CSS via `@theme`, and there is no `tailwind.config.js` file by default. The old JavaScript config is supported only for legacy migrations through the `@config` directive.
 
 Tailwind CSS is a build-time dependency. There are no API keys, accounts, authentication steps, or application runtime environment variables to configure. The only environment-sensitive behavior in the official integrations is CSS optimization: the Vite and PostCSS plugins check `NODE_ENV` to decide whether Lightning CSS optimization should run by default.
 
@@ -78,6 +80,170 @@ export default {
 ```
 
 `@tailwindcss/postcss` handles Tailwind's `@import` processing itself, so you do not need a separate `postcss-import` plugin just to load Tailwind.
+
+## CSS-First Configuration with @theme
+
+Configure design tokens directly in CSS with the `@theme` at-rule. Each value becomes both a CSS variable and a matching utility class.
+
+```css
+@import "tailwindcss";
+
+@theme {
+  --color-brand-50:  oklch(0.97 0.02 250);
+  --color-brand-500: oklch(0.62 0.18 250);
+  --color-brand-900: oklch(0.28 0.10 250);
+
+  --font-display: "Inter", sans-serif;
+
+  --spacing: 0.25rem;
+
+  --breakpoint-3xl: 1920px;
+
+  --radius-card: 0.75rem;
+}
+```
+
+These tokens generate utilities automatically:
+
+- `--color-brand-500` makes `bg-brand-500`, `text-brand-500`, `border-brand-500`, etc.
+- `--font-display` makes `font-display`.
+- `--breakpoint-3xl` adds a `3xl:` responsive variant.
+- `--radius-card` makes `rounded-card`.
+
+Reset or remove an entire namespace before redefining it:
+
+```css
+@theme {
+  --color-*: initial;
+  --color-primary: #2563eb;
+  --color-secondary: #f59e0b;
+}
+```
+
+Reference the same variables anywhere in CSS:
+
+```css
+.card {
+  background: var(--color-brand-50);
+  border-radius: var(--radius-card);
+}
+```
+
+## Utility Classes
+
+Build interfaces by composing utilities directly in markup. v4 follows the same naming conventions as earlier versions.
+
+```html
+<button class="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-indigo-500 focus:outline-2 focus:outline-indigo-700">
+  Save changes
+</button>
+
+<div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+  <article class="rounded-lg border border-gray-200 p-4">...</article>
+</div>
+```
+
+State variants (`hover:`, `focus:`, `disabled:`, `group-hover:`, `peer-checked:`), responsive variants (`sm:`, `md:`, `lg:`, `xl:`, `2xl:`), and structural variants (`first:`, `last:`, `odd:`, `even:`, `has-[...]:`) chain naturally.
+
+## Arbitrary Values
+
+When a token doesn't exist, drop the literal value into square brackets:
+
+```html
+<div class="top-[117px] grid-cols-[1fr_2fr_1fr] bg-[#1da1f2] text-[clamp(1rem,2vw,2rem)]">
+  ...
+</div>
+```
+
+Arbitrary variants follow the same pattern:
+
+```html
+<p class="[&>span]:font-semibold lg:[&:nth-child(3n)]:bg-gray-100">...</p>
+```
+
+## Dark Mode
+
+By default v4 uses the `prefers-color-scheme` media query. Switch to class-based dark mode with the `@variant` directive:
+
+```css
+@import "tailwindcss";
+
+@custom-variant dark (&:where(.dark, .dark *));
+```
+
+Then toggle by adding `class="dark"` on a parent element. Use `dark:` utilities anywhere:
+
+```html
+<div class="bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+  ...
+</div>
+```
+
+You can override design tokens specifically for dark mode:
+
+```css
+@theme {
+  --color-surface: white;
+  --color-ink: black;
+}
+
+@layer base {
+  .dark {
+    --color-surface: #0a0a0a;
+    --color-ink: #f5f5f5;
+  }
+}
+```
+
+## @apply and @utility
+
+Use `@apply` to inline existing utilities inside your own CSS rules:
+
+```css
+@import "tailwindcss";
+
+.btn-primary {
+  @apply rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white;
+  @apply hover:bg-indigo-500 focus:outline-2 focus:outline-indigo-700;
+}
+```
+
+Define brand-new utilities (which then become first-class, variant-able classes) with `@utility`:
+
+```css
+@utility tab-4 {
+  tab-size: 4;
+}
+
+@utility scrollbar-hide {
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+```
+
+`@utility` definitions automatically receive variant support, so `md:scrollbar-hide` and `hover:tab-4` both work.
+
+## Content Detection
+
+v4 detects source files automatically: any file imported by your stylesheet or referenced from your project's entry point is scanned. You usually do not need to list `content` paths.
+
+If you need to add or override sources, use the `@source` directive:
+
+```css
+@import "tailwindcss";
+
+@source "../node_modules/@my-org/ui/dist/**/*.js";
+@source "./templates/**/*.html";
+```
+
+Explicitly exclude paths with `@source not`:
+
+```css
+@source not "./legacy/**/*.html";
+```
 
 ## Common Workflows
 

--- a/content/vite/docs/vite/javascript/DOC.md
+++ b/content/vite/docs/vite/javascript/DOC.md
@@ -3,9 +3,9 @@ name: vite
 description: "Vite build tool for JavaScript projects, including local development, production builds, environment handling, configuration, and the Node.js API."
 metadata:
   languages: "javascript"
-  versions: "7.3.1"
-  revision: 1
-  updated-on: "2026-03-13"
+  versions: "7.8.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "vite,javascript,build,dev-server,bundler,frontend"
 ---
@@ -16,9 +16,19 @@ metadata:
 
 Vite is local build tooling for frontend apps and custom dev/build pipelines. It does not require API keys or service authentication.
 
-`vite@7.3.1` requires Node.js `^20.19.0 || >=22.12.0`.
+`vite@7.8.0` requires Node.js `^20.19.0 || >=22.12.0`.
 
-Install it as a development dependency:
+Scaffold a new project from an official template:
+
+```bash
+npm create vite@latest my-app -- --template vanilla
+cd my-app
+npm install
+```
+
+Available templates include `vanilla`, `vanilla-ts`, `vue`, `vue-ts`, `react`, `react-ts`, `react-swc`, `react-swc-ts`, `preact`, `preact-ts`, `lit`, `lit-ts`, `svelte`, `svelte-ts`, `solid`, `solid-ts`, and `qwik`/`qwik-ts`.
+
+Or install Vite directly as a development dependency in an existing project:
 
 ```bash
 npm install --save-dev vite
@@ -93,11 +103,50 @@ export default defineConfig({
 });
 ```
 
+TypeScript projects can name the config `vite.config.ts` instead. The `defineConfig` helper gives type-checking and autocompletion for the full config shape.
+
 Start local development:
 
 ```bash
 npm run dev
 ```
+
+## Plugins
+
+Plugins extend or replace Vite's default behavior. Add them to the `plugins` array; framework integrations are typically published as their own packages.
+
+```ts
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import vue from "@vitejs/plugin-vue";
+
+export default defineConfig({
+  plugins: [react(), vue()],
+});
+```
+
+A minimal inline plugin uses the Rollup plugin interface plus Vite-specific hooks:
+
+```js
+import { defineConfig } from "vite";
+
+function bannerPlugin() {
+  return {
+    name: "banner",
+    transform(code, id) {
+      if (id.endsWith(".js")) {
+        return { code: `/* built with vite */\n${code}`, map: null };
+      }
+    },
+  };
+}
+
+export default defineConfig({
+  plugins: [bannerPlugin()],
+});
+```
+
+Vite-specific hooks include `config`, `configResolved`, `configureServer`, `transformIndexHtml`, `handleHotUpdate`, and the standard Rollup hooks (`resolveId`, `load`, `transform`, etc.).
 
 ## Environment Variables and Config
 
@@ -137,6 +186,69 @@ export default defineConfig(({ mode }) => {
 ```
 
 Use `loadEnv()` for config-time decisions. Use `import.meta.env` inside app code.
+
+Built-in `import.meta.env` values include `MODE`, `BASE_URL`, `PROD`, `DEV`, and `SSR`.
+
+## HMR API
+
+Modules can opt into hot module replacement by interacting with `import.meta.hot`. Vite tree-shakes these branches out in production builds.
+
+```js
+if (import.meta.hot) {
+  import.meta.hot.accept((newModule) => {
+    if (newModule) {
+      // Apply the updated module
+    }
+  });
+
+  import.meta.hot.accept("./dep.js", (newDep) => {
+    // Re-run with the updated dependency
+  });
+
+  import.meta.hot.dispose((data) => {
+    // Tear down side effects before the module is replaced
+  });
+
+  import.meta.hot.invalidate();
+}
+```
+
+Common methods:
+
+- `accept(cb)` and `accept(deps, cb)` accept self-updates or updates for listed dependencies.
+- `dispose(cb)` runs before the next update, useful for cleanup.
+- `prune(cb)` runs when the module is no longer imported.
+- `invalidate()` rejects the update and forces a full reload up the import chain.
+- `on(event, cb)` and `off(event, cb)` subscribe to dev-server events such as `vite:beforeUpdate` and `vite:error`.
+- `send(event, data)` posts a custom payload back to plugins that registered for it.
+
+## Library Mode
+
+Use `build.lib` when you want Vite to emit a distributable library instead of an HTML app.
+
+```js
+import { defineConfig } from "vite";
+import { resolve } from "node:path";
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: resolve(__dirname, "src/index.js"),
+      name: "MyLib",
+      fileName: (format) => `my-lib.${format}.js`,
+      formats: ["es", "cjs", "umd"],
+    },
+    rollupOptions: {
+      external: ["vue"],
+      output: {
+        globals: { vue: "Vue" },
+      },
+    },
+  },
+});
+```
+
+In library mode, Vite skips HTML entry handling and writes only the requested module formats. Declare `peerDependencies` in `package.json` and list them under `external` so consumers provide their own copies.
 
 ## Common CLI Workflows
 
@@ -273,7 +385,7 @@ export default defineConfig({
 
 ## Important Pitfalls
 
-- `vite@7.3.1` does not support older Node.js releases; check the engine requirement before debugging odd startup failures.
+- `vite@7.8.0` does not support older Node.js releases; check the engine requirement before debugging odd startup failures.
 - Keep client-visible env values under the `VITE_` prefix by default. Values exposed through `import.meta.env` should be treated as public browser config.
 - `server.host: "0.0.0.0"` listens on all addresses. Use it only when you intentionally want LAN or public reachability.
 - Avoid `server.allowedHosts: true` unless you understand the DNS rebinding risk; Vite documents that setting as not recommended.
@@ -283,7 +395,7 @@ export default defineConfig({
 
 ## Version-Sensitive Notes
 
-- This guide targets `vite@7.3.1`.
+- This guide targets `vite@7.8.0`.
 - The current package exports the main JavaScript helpers from `vite`, including `defineConfig`, `loadEnv`, `mergeConfig`, `createServer`, `build`, `preview`, `normalizePath`, and `searchForWorkspaceRoot`.
 - The CLI for this version exposes `vite`, `vite build`, and `vite preview`, with `optimize` still present but marked deprecated because dependency pre-bundling now runs automatically.
 - The default client env prefix in this version is `VITE_`.


### PR DESCRIPTION
docs(vite, tailwindcss, prisma): refresh to Vite 7.8.0 / Tailwind 4.3.0 / Prisma 8.0.14

Updates Vite, Tailwind CSS, and Prisma (JS + Python) docs.

- vite 7.3.1 → 7.8.0; adds scaffolding (`npm create vite@latest`),
  Plugins section (Rollup-style + hooks), HMR API section
  (`import.meta.hot.accept`/`dispose`/`prune`/`invalidate`/`on`/`send`),
  Library Mode (`build.lib`, `rollupOptions`, formats)
- tailwindcss 4.2.1 → 4.3.0; adds CSS-first `@theme` configuration,
  Utility Classes overview, Arbitrary Values, Dark Mode via
  `@custom-variant`, `@apply` and `@utility`, automatic content detection
  with `@source` / `@source not`; explicit note that v4 has no
  `tailwind.config.js` by default
- prisma 6.19.0 → 8.0.14; adds `prisma db push`, `db pull`, `prisma studio`
- prisma-client-py stays at 0.15.0 (latest); refreshed metadata only
- `revision` bumped and `updated-on: 2026-05-29`

Verified versions against npm `latest` and PyPI.
