### PR TITLE
docs(stripe, supabase): refresh to Stripe 22.2.0 / 15.2.0, Supabase 2.106.2 / 2.30.1

### DIFF
--- a/content/stripe/docs/api/DOC.md
+++ b/content/stripe/docs/api/DOC.md
@@ -1,28 +1,27 @@
 ---
 name: api
-description: "Payment processing platform with comprehensive payment and billing features including Payment Intents, Subscriptions, Checkout, customer management, webhooks, and Connect for marketplaces"
+description: "Broad Stripe API surface for Node.js: Customers, Products/Prices, Invoices, Refunds, search, expansions, idempotency, pagination, and error handling"
 metadata:
   languages: "javascript"
-  versions: "19.1.0"
-  revision: 1
-  updated-on: "2025-10-28"
+  versions: "22.2.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "stripe,api,payments,billing"
 ---
-# Stripe API Coding Guide
+# Stripe API Coding Guide (Node.js)
 
 ## 1. Golden Rule
 
-**Always use the official Stripe SDK packages:**
-- Server-side: `stripe` (Node.js library for Stripe API)
-- Client-side: `@stripe/stripe-js` (ES module for browser)
-- React: `@stripe/react-stripe-js` (React components and hooks)
+Use the official Stripe Node SDK on the server and let Stripe.js / Elements / Checkout handle anything sensitive on the client. The same SDK that handles payments also exposes the broader Stripe API surface — Customers, Products, Prices, Invoices, Refunds, search, and more.
 
-**Never use deprecated or unofficial libraries.** These are the only supported Stripe packages maintained by Stripe, Inc.
+- Server-side: `stripe` (Node.js library)
+- Client-side: `@stripe/stripe-js` (loader for Stripe.js)
+- React: `@stripe/react-stripe-js` (Elements, hooks)
 
-**Current SDK Version:** v19.1.0 (Node.js server library)
+**Current SDK Version:** `stripe` v22.2.0 (Node).
 
-**API Version:** Stripe uses date-based API versioning (e.g., 2025-02-24). Your account is automatically pinned to the API version from your first request. You can override this per-request or upgrade in the Stripe Dashboard.
+**API Version:** Stripe pins API versions by date. The current released version is `2026-05-27.dahlia`. Your account is pinned to the version of your first request; override per-request via `apiVersion` on the SDK constructor.
 
 ## 2. Installation
 
@@ -40,7 +39,7 @@ yarn add stripe
 pnpm add stripe
 ```
 
-**Requirements:** Node.js 16+ (support for Node 16 is deprecated; use Node 18+ for production)
+**Requirements:** Node.js 18+ (Node 18 LTS is the minimum supported; Node 20 or 22 is recommended for production).
 
 ### Client-Side (Browser)
 
@@ -71,7 +70,7 @@ STRIPE_PUBLISHABLE_KEY=pk_test_51H...  # Safe for client-side use
 
 # Optional
 STRIPE_WEBHOOK_SECRET=whsec_...  # For webhook signature verification
-STRIPE_API_VERSION=2025-02-24  # Override default API version
+STRIPE_API_VERSION=2026-05-27.dahlia  # Override default API version
 ```
 
 **CRITICAL:** Never commit secret keys to version control. Use environment variables or secure secret management systems.
@@ -91,7 +90,7 @@ const stripe = Stripe(process.env.STRIPE_SECRET_KEY);
 import Stripe from 'stripe';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  apiVersion: '2025-02-24',
+  apiVersion: '2026-05-27.dahlia',
 });
 ```
 
@@ -99,7 +98,7 @@ const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
 
 ```javascript
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: '2025-02-24',
+  apiVersion: '2026-05-27.dahlia',
   maxNetworkRetries: 2,
   timeout: 80000, // 80 seconds
   telemetry: true,
@@ -131,7 +130,7 @@ const stripePromise = loadStripe(
   {
     locale: 'en',
     betas: ['some_beta_feature'],
-    apiVersion: '2025-02-24',
+    apiVersion: '2026-05-27.dahlia',
   }
 );
 ```
@@ -1427,7 +1426,7 @@ module.exports = {
     secretKey: process.env.STRIPE_SECRET_KEY,
     publishableKey: process.env.STRIPE_PUBLISHABLE_KEY,
     webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
-    apiVersion: '2025-02-24',
+    apiVersion: '2026-05-27.dahlia',
   },
 
   // Validate required environment variables
@@ -1574,7 +1573,7 @@ async function createMultipleCustomers(customerData) {
 import Stripe from 'stripe';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  apiVersion: '2025-02-24',
+  apiVersion: '2026-05-27.dahlia',
 });
 
 // Full type inference

--- a/content/stripe/docs/package/python/DOC.md
+++ b/content/stripe/docs/package/python/DOC.md
@@ -3,9 +3,9 @@ name: package
 description: "Stripe Python package guide for authenticating, calling the Stripe API, handling webhooks, and working with StripeClient"
 metadata:
   languages: "python"
-  versions: "14.4.1"
-  revision: 1
-  updated-on: "2026-03-12"
+  versions: "15.2.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "stripe,payments,billing,api,webhooks,checkout"
 ---
@@ -21,20 +21,20 @@ Use the official `stripe` PyPI package, initialize it with a secret key from the
 Pin the version your project expects:
 
 ```bash
-python -m pip install "stripe==14.4.1"
+python -m pip install "stripe==15.2.0"
 ```
 
 Common alternatives:
 
 ```bash
-uv add "stripe==14.4.1"
-poetry add "stripe==14.4.1"
+uv add "stripe==15.2.0"
+poetry add "stripe==15.2.0"
 ```
 
 If you plan to use the async client helpers, install the async extra:
 
 ```bash
-python -m pip install "stripe[async]==14.4.1"
+python -m pip install "stripe[async]==15.2.0"
 ```
 
 ## Authentication And Setup
@@ -152,7 +152,7 @@ client = StripeClient("sk_test_platform_...")
 charges = client.v1.charges.list(
     options={
         "stripe_account": "acct_123",
-        "stripe_version": "2026-02-25.clover",
+        "stripe_version": "2026-05-27.dahlia",
     }
 )
 ```
@@ -253,13 +253,12 @@ Webhook rules that matter in practice:
 - Do not mix account-level API version assumptions with SDK defaults. Webhook payload shapes and typed objects can differ if your endpoint or request overrides the Stripe version.
 - Do not treat test mode and live mode objects as interchangeable; IDs and data are isolated by environment.
 
-## Version-Sensitive Notes For `14.4.1`
+## Version-Sensitive Notes For `15.2.0`
 
-- PyPI lists `14.4.1` as the current release as of March 12, 2026, so the version used here does not appear stale.
-- The `14.4.1` changelog entry is a patch release on top of `14.4.0`. The `14.4.0` release changed the SDK's pinned API version to `2026-02-25.clover`.
-- That means `14.4.1` code examples should assume the post-`2026-02-25.clover` API surface unless you explicitly override `stripe_version`.
-- Stripe's Python wiki notes that the `v1` namespace on `StripeClient` arrived in major version `13`, so pre-v13 upgrade guides and older blog posts can have materially different call shapes.
-- Stripe's type annotations can change in minor releases even when runtime behavior remains semver-compatible. If strict type checking matters, pin to a minor line such as `~=14.4`.
+- PyPI lists `15.2.0` as the current release as of May 29, 2026.
+- `15.x` ships a pinned default Stripe API version aligned with the current `2026-05-27.dahlia` release. `15.2.0` code examples should assume that API surface unless you explicitly override `stripe_version`.
+- The `v1` namespace on `StripeClient` arrived in major version `13`, so pre-v13 upgrade guides and older blog posts can have materially different call shapes (`client.customers.create(...)` vs. `client.v1.customers.create(...)`).
+- Stripe's type annotations can change in minor releases even when runtime behavior remains semver-compatible. If strict type checking matters, pin to a minor line such as `~=15.2`.
 
 ## Official Sources
 

--- a/content/stripe/docs/payments/DOC.md
+++ b/content/stripe/docs/payments/DOC.md
@@ -3,25 +3,25 @@ name: payments
 description: "Payment processing platform with comprehensive payment and billing features including Payment Intents, Subscriptions, Checkout, customer management, webhooks, and Connect for marketplaces"
 metadata:
   languages: "javascript"
-  versions: "19.1.0"
-  updated-on: "2025-10-28"
+  versions: "22.2.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "stripe,api,payments,billing"
 ---
-# Stripe API Coding Guide
+# Stripe Payments Coding Guide (Node.js)
 
 ## 1. Golden Rule
 
-**Always use the official Stripe SDK packages:**
-- Server-side: `stripe` (Node.js library for Stripe API)
-- Client-side: `@stripe/stripe-js` (ES module for browser)
-- React: `@stripe/react-stripe-js` (React components and hooks)
+Use the official Stripe SDK packages and let Stripe handle every sensitive piece of card data. Never send raw PAN/CVC to your server; collect it through Stripe.js / Elements and hand back PaymentMethod or PaymentIntent IDs.
 
-**Never use deprecated or unofficial libraries.** These are the only supported Stripe packages maintained by Stripe, Inc.
+- Server-side: `stripe` (Node.js library)
+- Client-side: `@stripe/stripe-js` (loader for Stripe.js)
+- React: `@stripe/react-stripe-js` (Elements, hooks)
 
-**Current SDK Version:** v19.1.0 (Node.js server library)
+**Current SDK Version:** `stripe` v22.2.0 (Node).
 
-**API Version:** Stripe uses date-based API versioning (e.g., 2025-02-24). Your account is automatically pinned to the API version from your first request. You can override this per-request or upgrade in the Stripe Dashboard.
+**API Version:** Stripe pins API versions by date. The current released version is `2026-05-27.dahlia`. Your account is pinned to the version of your first request; you can override per-request via `apiVersion` on the SDK constructor, or upgrade in the Dashboard. The SDK ships with a pinned default — keep that in sync with code paths that read webhook payloads.
 
 ## 2. Installation
 
@@ -39,7 +39,7 @@ yarn add stripe
 pnpm add stripe
 ```
 
-**Requirements:** Node.js 16+ (support for Node 16 is deprecated; use Node 18+ for production)
+**Requirements:** Node.js 18+ (Node 18 LTS is the minimum supported; Node 20 or 22 is recommended for production).
 
 ### Client-Side (Browser)
 
@@ -70,7 +70,7 @@ STRIPE_PUBLISHABLE_KEY=pk_test_51H...  # Safe for client-side use
 
 # Optional
 STRIPE_WEBHOOK_SECRET=whsec_...  # For webhook signature verification
-STRIPE_API_VERSION=2025-02-24  # Override default API version
+STRIPE_API_VERSION=2026-05-27.dahlia  # Override default API version
 ```
 
 **CRITICAL:** Never commit secret keys to version control. Use environment variables or secure secret management systems.
@@ -90,7 +90,7 @@ const stripe = Stripe(process.env.STRIPE_SECRET_KEY);
 import Stripe from 'stripe';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  apiVersion: '2025-02-24',
+  apiVersion: '2026-05-27.dahlia',
 });
 ```
 
@@ -98,7 +98,7 @@ const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
 
 ```javascript
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: '2025-02-24',
+  apiVersion: '2026-05-27.dahlia',
   maxNetworkRetries: 2,
   timeout: 80000, // 80 seconds
   telemetry: true,
@@ -130,7 +130,7 @@ const stripePromise = loadStripe(
   {
     locale: 'en',
     betas: ['some_beta_feature'],
-    apiVersion: '2025-02-24',
+    apiVersion: '2026-05-27.dahlia',
   }
 );
 ```
@@ -1426,7 +1426,7 @@ module.exports = {
     secretKey: process.env.STRIPE_SECRET_KEY,
     publishableKey: process.env.STRIPE_PUBLISHABLE_KEY,
     webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
-    apiVersion: '2025-02-24',
+    apiVersion: '2026-05-27.dahlia',
   },
 
   // Validate required environment variables
@@ -1573,7 +1573,7 @@ async function createMultipleCustomers(customerData) {
 import Stripe from 'stripe';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  apiVersion: '2025-02-24',
+  apiVersion: '2026-05-27.dahlia',
 });
 
 // Full type inference

--- a/content/supabase/docs/client/DOC.md
+++ b/content/supabase/docs/client/DOC.md
@@ -3,8 +3,9 @@ name: client
 description: "Open-source Firebase alternative with PostgreSQL backend, authentication, storage, realtime subscriptions, and edge functions"
 metadata:
   languages: "javascript"
-  versions: "2.76.1"
-  updated-on: "2025-10-26"
+  versions: "2.106.2"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "supabase,sdk,database,auth,storage,realtime"
 ---
@@ -21,7 +22,7 @@ Always use the official Supabase JavaScript SDK (`@supabase/supabase-js`) for al
 
 - **Library Name:** Supabase JavaScript SDK
 - **NPM Package:** `@supabase/supabase-js`
-- **Current Version:** 2.76.1
+- **Current Version:** 2.106.2
 - **Legacy Libraries:** Do not use `@supabase/auth-js`, `@supabase/postgrest-js`, `@supabase/storage-js`, or other individual packages directly - these are bundled in the main SDK
 
 **Installation:**
@@ -308,6 +309,8 @@ const { data, error } = await supabase.auth.exchangeCodeForSession(code)
 ## Database Queries
 
 The Supabase SDK uses PostgREST for database operations with a chainable API.
+
+> **Row-Level Security (RLS):** Every query made with the `anon` key is filtered by your table's RLS policies. If a query returns `[]` or "permission denied" when you expect data, RLS is almost always the cause. Verify policies in the Supabase Dashboard under Authentication > Policies, and only use the `service_role` key in trusted backend code (it bypasses RLS).
 
 ### Select All Rows
 

--- a/content/supabase/docs/package/python/DOC.md
+++ b/content/supabase/docs/package/python/DOC.md
@@ -3,9 +3,9 @@ name: package
 description: "Supabase Python client for Postgres queries, auth, storage, edge functions, and realtime"
 metadata:
   languages: "python"
-  versions: "2.28.0"
-  revision: 1
-  updated-on: "2026-03-12"
+  versions: "2.30.1"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "supabase,postgres,auth,storage,realtime,edge-functions,python"
 ---
@@ -21,19 +21,19 @@ Use the official `supabase` package, initialize it with your project URL and key
 Pin the version your project expects:
 
 ```bash
-python -m pip install "supabase==2.28.0"
+python -m pip install "supabase==2.30.1"
 ```
 
 Common alternatives:
 
 ```bash
-uv add "supabase==2.28.0"
-poetry add "supabase==2.28.0"
+uv add "supabase==2.30.1"
+poetry add "supabase==2.30.1"
 ```
 
 Version note:
 
-- The Supabase install page still says Python `>3.8`, but PyPI metadata for `2.28.0` requires Python `>=3.9`. Follow PyPI for the package constraint you actually install.
+- The Supabase install page still says Python `>3.8`, but PyPI metadata for `2.30.1` requires Python `>=3.9`. Follow PyPI for the package constraint you actually install.
 
 ## Initialize The Client
 
@@ -281,11 +281,11 @@ Use a separate admin client rather than reusing a user-scoped client with mixed 
 - Realtime subscriptions should be removed explicitly in workers, daemons, and async applications instead of relying only on server-side cleanup.
 - Keep `service_role` keys strictly on the backend. The admin API bypasses normal end-user constraints and should be treated as a secret.
 
-## Version-Sensitive Notes For 2.28.0
+## Version-Sensitive Notes For 2.30.1
 
-- PyPI lists `2.28.0` as the current release and requires Python `>=3.9`.
+- PyPI lists `2.30.1` as the current release and requires Python `>=3.9`.
 - The release history shows several yanked `2.19.0` to `2.23.3` builds because of dependency issues or minor breaking auth changes. If you find examples pinned in that range, prefer `2.24.0` or later unless the project is already locked to an older wheel.
-- The `auth.get_user()` reference for `2.28.0` documents additional user fields such as `is_anonymous`, `factors`, `app_metadata`, `user_metadata`, and `identities`. If your code inspects user objects from older examples, re-check the returned shape before relying on it.
+- The `auth.get_user()` reference for `2.30.1` documents additional user fields such as `is_anonymous`, `factors`, `app_metadata`, `user_metadata`, and `identities`. If your code inspects user objects from older examples, re-check the returned shape before relying on it.
 
 ## Official Sources
 


### PR DESCRIPTION
docs(stripe, supabase): refresh to Stripe 22.2.0 / 15.2.0, Supabase 2.106.2 / 2.30.1

Updates the Stripe and Supabase docs.

- Stripe Node SDK 19.1.0 → 22.2.0 (payments + api docs); swaps API version
  `2025-02-24` → `2026-05-27.dahlia`; Node engine note raised to 18+
- Stripe Python SDK 14.4.1 → 15.2.0; bumps `stripe_version` example to
  `2026-05-27.dahlia`
- Supabase JS 2.76.1 → 2.106.2; adds short RLS callout at the top of the
  Database Queries section
- Supabase Python 2.28.0 → 2.30.1 (Python ≥3.9)
- `revision` bumped and `updated-on: 2026-05-29`

Verified versions against npm and PyPI.
