### PR TITLE
docs(requests, httpx): refresh to requests 2.34.2 / httpx 0.28.1

### DIFF
--- a/content/httpx/docs/package/python/DOC.md
+++ b/content/httpx/docs/package/python/DOC.md
@@ -1,27 +1,36 @@
 ---
 name: package
-description: "HTTPX package guide for Python with sync and async clients, auth, transports, and 0.28.1 migration notes"
+description: "HTTPX package guide for Python with sync Client, AsyncClient, timeouts, streaming, HTTP/2, and transports"
 metadata:
   languages: "python"
   versions: "0.28.1"
-  revision: 1
-  updated-on: "2026-03-11"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
-  tags: "httpx,http,client,async,python,requests"
+  tags: "httpx,http,client,async,python,http2,transports"
 ---
 
 # HTTPX Python Package Guide
 
 ## When To Use HTTPX
 
-Use `httpx` when Python code needs:
+`httpx` is a modern HTTP client with both sync and async APIs. It offers:
 
-- a modern HTTP client with both sync and async APIs
-- connection pooling, timeouts, streaming, redirects, cookies, and auth
-- HTTP/2 support
-- transport adapters for testing WSGI or ASGI apps in-process
+- `Client` (sync) and `AsyncClient` (async) with shared configuration
+- connection pooling, configurable timeouts, streaming, redirects, cookies, and auth
+- HTTP/2 via the `http2` extra
+- pluggable transports including `WSGITransport`, `ASGITransport`, and `MockTransport`
 
-`httpx` is the maintained successor-style choice when you want a `requests`-like API plus async support and more explicit client configuration.
+Use it when you want a `requests`-like API plus async support and explicit client configuration.
+
+## Version Covered
+
+- Package: `httpx`
+- Ecosystem: `pypi`
+- Version: `0.28.1`
+- Python support: `>=3.8` (per PyPI metadata for `0.28.1`)
+- Registry: https://pypi.org/project/httpx/
+- Docs root: https://www.python-httpx.org/
 
 ## Install
 
@@ -29,7 +38,7 @@ Use `httpx` when Python code needs:
 pip install httpx==0.28.1
 ```
 
-Common optional extras from the official package metadata:
+Common extras:
 
 ```bash
 pip install "httpx[http2]==0.28.1"
@@ -38,22 +47,16 @@ pip install "httpx[brotli]==0.28.1"
 pip install "httpx[zstd]==0.28.1"
 ```
 
-Version-sensitive runtime note:
-
-- PyPI metadata for `0.28.1` declares `Requires-Python >=3.8`.
-- The current docs homepage now says Python `3.9+`.
-- Treat the homepage as the latest upstream docs, not a strict guarantee for `0.28.1`. If you are pinned to `0.28.x`, prefer the package metadata and the `0.28.0` / `0.28.1` release notes for behavior changes.
-
 ## Golden Rules
 
-- Prefer `httpx.Client()` or `httpx.AsyncClient()` for anything beyond a single one-off request.
-- Reuse one client instead of creating a new client inside a hot loop.
-- Call `response.raise_for_status()` when non-2xx responses should fail the workflow.
-- Redirects are **not** followed unless you set `follow_redirects=True`.
-- For `0.28.x`, use `proxy=` or `mounts=`. The old `proxies=` argument was removed.
-- For app testing and in-process calls, use `WSGITransport` or `ASGITransport`. The old `app=` shortcut was removed.
+- Use `httpx.Client()` or `httpx.AsyncClient()` for anything beyond a one-off request.
+- Reuse one client; do not construct a fresh client inside a hot loop.
+- Call `response.raise_for_status()` when non-2xx must fail.
+- Redirects are off by default. Pass `follow_redirects=True` to enable.
+- Use `proxy=` or `mounts=`. The `proxies=` argument was removed in `0.28.0`.
+- For in-process app testing, use `WSGITransport` or `ASGITransport`. The `app=` shortcut was removed in `0.28.0`.
 
-## Basic Sync Usage
+## Sync Client
 
 ```python
 import httpx
@@ -71,13 +74,24 @@ with httpx.Client(
     print(items)
 ```
 
-Useful client behavior:
+Client behavior:
 
-- `base_url` lets you use relative paths like `"/items"`.
-- Client-level headers, query params, and cookies merge with request-level values.
-- A client keeps connections open and reuses them across requests.
+- `base_url` lets you call relative paths.
+- Client-level headers, params, and cookies merge with request-level values.
+- Connections are pooled and reused across requests.
 
-## Sending JSON, Form Data, and Files
+### Top-Level Helpers
+
+```python
+import httpx
+
+response = httpx.get("https://api.example.com/items", timeout=10.0)
+response.raise_for_status()
+```
+
+The top-level `httpx.get` / `httpx.post` helpers create a temporary client per call. Use them only for ad-hoc scripts.
+
+## Sending JSON, Form Data, And Files
 
 ```python
 import httpx
@@ -92,20 +106,70 @@ with httpx.Client() as client:
 ```python
 import httpx
 
-with open("report.csv", "rb") as f:
-    files = {"file": ("report.csv", f, "text/csv")}
-    response = httpx.post("https://api.example.com/upload", files=files)
+with httpx.Client() as client:
+    response = client.post(
+        "https://api.example.com/search",
+        data={"q": "python", "page": "1"},
+    )
     response.raise_for_status()
 ```
 
-Use the request body arguments deliberately:
+```python
+import httpx
+
+with open("report.csv", "rb") as f:
+    files = {"file": ("report.csv", f, "text/csv")}
+    with httpx.Client() as client:
+        response = client.post("https://api.example.com/upload", files=files)
+        response.raise_for_status()
+```
+
+Body argument map:
 
 - `json=` for JSON bodies
 - `data=` for HTML form data
 - `files=` for multipart uploads
 - `content=` for raw bytes or text when you need full control
+- `params=` for query string parameters
 
-## Async Usage
+## Headers
+
+```python
+import httpx
+
+with httpx.Client(
+    base_url="https://api.example.com",
+    headers={"Authorization": "Bearer YOUR_TOKEN"},
+) as client:
+    response = client.get("/me", headers={"X-Request-Id": "abc-123"})
+    response.raise_for_status()
+```
+
+Per-request headers merge with client-level headers; per-request keys override client keys.
+
+## Response Objects
+
+```python
+import httpx
+
+response = httpx.get("https://api.example.com/items", timeout=10.0)
+
+response.status_code            # int
+response.is_success             # status_code < 400
+response.headers["content-type"]
+response.text                   # decoded body
+response.content                # raw bytes
+response.json()                 # parsed JSON
+response.url                    # httpx.URL, not a str
+response.http_version           # e.g. "HTTP/2"
+response.elapsed                # timedelta
+response.cookies
+response.raise_for_status()
+```
+
+`response.url` is an `httpx.URL`. Convert with `str(response.url)` when you need a plain string.
+
+## Async Client
 
 ```python
 import asyncio
@@ -123,7 +187,51 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-For streaming responses:
+Concurrent requests with one client:
+
+```python
+import asyncio
+import httpx
+
+async def fetch(client: httpx.AsyncClient, path: str) -> dict:
+    response = await client.get(path)
+    response.raise_for_status()
+    return response.json()
+
+async def main() -> None:
+    async with httpx.AsyncClient(base_url="https://api.example.com") as client:
+        results = await asyncio.gather(
+            fetch(client, "/a"),
+            fetch(client, "/b"),
+            fetch(client, "/c"),
+        )
+        print(results)
+
+asyncio.run(main())
+```
+
+Async pitfalls:
+
+- Keep one long-lived `AsyncClient` per service when possible.
+- Always use `async with` (or call `aclose()` explicitly) so connections close cleanly.
+- Mixing sync `Client` and async `AsyncClient` in the same code path is fine; pick one per call site.
+
+## Streaming
+
+Sync streaming:
+
+```python
+import httpx
+
+with httpx.Client() as client:
+    with client.stream("GET", "https://example.com/large.bin") as response:
+        response.raise_for_status()
+        with open("large.bin", "wb") as f:
+            for chunk in response.iter_bytes():
+                f.write(chunk)
+```
+
+Async streaming:
 
 ```python
 import asyncio
@@ -140,15 +248,18 @@ async def download(url: str, output_path: str) -> None:
 asyncio.run(download("https://example.com/large.bin", "large.bin"))
 ```
 
-Async pitfalls:
+Streaming iterators:
 
-- Keep one long-lived `AsyncClient` where possible.
-- Do not instantiate clients repeatedly inside request handlers unless that is the intended lifecycle.
-- If you use manual streaming mode, you must eventually call `Response.aclose()`.
+- `iter_bytes()` / `aiter_bytes()` for raw chunks
+- `iter_text()` / `aiter_text()` for decoded text
+- `iter_lines()` / `aiter_lines()` for line iteration
+- `iter_raw()` / `aiter_raw()` for undecoded content
+
+If you call `stream()` without a context manager, you must call `response.close()` (or `aclose()`) when done.
 
 ## Authentication
 
-Basic auth:
+Basic auth via a tuple:
 
 ```python
 import httpx
@@ -173,127 +284,161 @@ with httpx.Client(
     response.raise_for_status()
 ```
 
-Upstream auth options to know about:
+Other auth options:
 
-- Basic auth via a `(username, password)` tuple
-- `httpx.DigestAuth(...)`
-- `httpx.NetRCAuth()` for local `.netrc` credentials
-- custom auth flows by subclassing `httpx.Auth`
+- `httpx.BasicAuth(username, password)`
+- `httpx.DigestAuth(username, password)`
+- `httpx.NetRCAuth()` for local `.netrc`
+- subclass `httpx.Auth` for custom flows (e.g. OAuth refresh)
 
-For bearer tokens or API keys, set a header on the client:
+For bearer tokens, set a client header:
 
 ```python
 import httpx
 
-token = "YOUR_TOKEN"
-
 with httpx.Client(
     base_url="https://api.example.com",
-    headers={"Authorization": f"Bearer {token}"},
+    headers={"Authorization": "Bearer YOUR_TOKEN"},
 ) as client:
     response = client.get("/me")
     response.raise_for_status()
 ```
 
-## Timeouts, Limits, and Retries
+## Timeouts
 
-HTTPX enforces timeouts by default. Configure them explicitly for production code.
+HTTPX has default timeouts. Configure them explicitly in production.
 
 ```python
 import httpx
 
-timeout = httpx.Timeout(10.0, connect=2.0, read=20.0, write=20.0, pool=5.0)
-limits = httpx.Limits(max_connections=100, max_keepalive_connections=20)
+timeout = httpx.Timeout(
+    10.0,            # default for all categories
+    connect=2.0,
+    read=20.0,
+    write=20.0,
+    pool=5.0,
+)
 
-with httpx.Client(timeout=timeout, limits=limits) as client:
+with httpx.Client(timeout=timeout) as client:
     response = client.get("https://api.example.com/health")
     response.raise_for_status()
 ```
 
-Notes:
+Categories:
 
-- The docs describe HTTPX timeouts as inactivity timeouts, not a single total request deadline.
-- Resource limits matter for high-concurrency code and async services.
-- HTTPX does not provide the same built-in retry layer you may know from `urllib3`; implement retries at your application boundary or transport layer when needed.
+- `connect`: time to establish a TCP connection
+- `read`: time to read a chunk from the socket
+- `write`: time to write a chunk to the socket
+- `pool`: time to acquire a connection from the pool
 
-## Proxies and Environment Variables
+`httpx.Timeout(None)` disables timeouts; do not use that in production.
 
-Explicit proxy:
+Per-request override:
+
+```python
+response = client.get("/slow", timeout=30.0)
+```
+
+HTTPX timeouts are inactivity timeouts, not a single end-to-end deadline. HTTPX does not provide a built-in retry layer.
+
+## Connection Limits
 
 ```python
 import httpx
 
-with httpx.Client(proxy="http://localhost:8030") as client:
-    response = client.get("https://example.com")
+limits = httpx.Limits(
+    max_connections=100,
+    max_keepalive_connections=20,
+    keepalive_expiry=5.0,
+)
+
+with httpx.Client(limits=limits) as client:
+    response = client.get("https://api.example.com/health")
     response.raise_for_status()
 ```
 
-Environment-driven proxy behavior is enabled by default via `trust_env=True`. Officially documented variables include:
-
-- `HTTP_PROXY`
-- `HTTPS_PROXY`
-- `ALL_PROXY`
-- `NO_PROXY`
-- `SSL_CERT_FILE`
-- `SSL_CERT_DIR`
-
-Disable environment-derived proxy and certificate settings when you need deterministic behavior:
+## Error Handling
 
 ```python
 import httpx
 
-with httpx.Client(trust_env=False) as client:
-    response = client.get("https://example.com")
+try:
+    response = httpx.get("https://api.example.com/items", timeout=5.0)
     response.raise_for_status()
+except httpx.HTTPStatusError as exc:
+    print(f"Bad status {exc.response.status_code}")
+except httpx.TimeoutException:
+    print("Request timed out")
+except httpx.ConnectError as exc:
+    print(f"Connection failed: {exc}")
+except httpx.RequestError as exc:
+    print(f"Transport error: {exc}")
 ```
 
-## SSL / TLS Configuration
+Key types:
 
-For `0.28.x`, the release notes deprecate string-style `verify=` and the `cert=` shortcut. Prefer an explicit `ssl.SSLContext`.
-
-```python
-import ssl
-import certifi
-import httpx
-
-ctx = ssl.create_default_context(cafile=certifi.where())
-
-with httpx.Client(verify=ctx) as client:
-    response = client.get("https://example.com")
-    response.raise_for_status()
-```
-
-If you want system certificate stores on newer Python environments, the official SSL docs recommend `truststore`:
-
-```python
-import ssl
-import httpx
-import truststore
-
-ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-
-with httpx.Client(verify=ctx) as client:
-    response = client.get("https://example.com")
-    response.raise_for_status()
-```
+- `httpx.HTTPError`: top-level base
+- `httpx.RequestError`: transport-layer base (`ConnectError`, `ReadError`, `WriteError`, `PoolTimeout`, etc.)
+- `httpx.TimeoutException`: base for `ConnectTimeout`, `ReadTimeout`, `WriteTimeout`, `PoolTimeout`
+- `httpx.HTTPStatusError`: raised by `raise_for_status()`
+- `httpx.InvalidURL`, `httpx.CookieConflict`, `httpx.StreamError`
 
 ## HTTP/2
 
-Install the extra and enable it on the client:
+Install the extra and enable per-client:
 
 ```python
 import httpx
 
 with httpx.Client(http2=True) as client:
     response = client.get("https://example.com")
-    print(response.http_version)
+    print(response.http_version)  # "HTTP/2" when negotiated
 ```
 
-`http2=True` is not enough unless the `http2` extra is installed.
+HTTP/2 negotiation requires ALPN over TLS. `http2=True` is a no-op unless the `http2` extra is installed.
 
-## Transports and In-Process App Calls
+## Transports
 
-For tests and in-process service integration, use the transport APIs directly:
+Transports sit beneath the client and execute requests. Override them to route in-process or mock the network.
+
+### HTTPTransport
+
+The default transport. Use it to tune low-level behavior:
+
+```python
+import httpx
+
+transport = httpx.HTTPTransport(
+    retries=1,            # connection-establish retries only (not response retries)
+    http2=True,
+    local_address="0.0.0.0",
+)
+
+with httpx.Client(transport=transport) as client:
+    response = client.get("https://example.com")
+    response.raise_for_status()
+```
+
+`retries` on the transport only retries connection failures during establishment, not response status codes.
+
+### Mounts For Per-Scheme Routing
+
+```python
+import httpx
+
+mounts = {
+    "http://": httpx.HTTPTransport(),
+    "https://internal.example.com": httpx.HTTPTransport(verify="/path/ca.pem"),
+}
+
+with httpx.Client(mounts=mounts) as client:
+    response = client.get("https://internal.example.com/health")
+    response.raise_for_status()
+```
+
+### WSGITransport And ASGITransport
+
+For in-process tests of Python web apps:
 
 ```python
 import httpx
@@ -314,65 +459,96 @@ async def main() -> None:
         print(response.json())
 ```
 
-Use this pattern for `0.28.1`. The deprecated `app=` shortcut was removed in `0.28.0`.
+For a sync WSGI app, use `httpx.WSGITransport(app=wsgi_app)` with `httpx.Client`.
 
-## Error Handling
-
-`httpx.HTTPError` is the broad top-level exception. The most useful subclasses in normal application code are:
-
-- `httpx.HTTPStatusError` for `raise_for_status()` failures
-- `httpx.RequestError` for transport-level failures
-- `httpx.TimeoutException` and subclasses for timeout failures
+### MockTransport
 
 ```python
 import httpx
 
-try:
-    response = httpx.get("https://api.example.com/items", timeout=5.0)
+def handler(request: httpx.Request) -> httpx.Response:
+    return httpx.Response(200, json={"ok": True})
+
+transport = httpx.MockTransport(handler)
+
+with httpx.Client(transport=transport, base_url="https://api.example.com") as client:
+    response = client.get("/anything")
+    assert response.json() == {"ok": True}
+```
+
+## Proxies And Environment Variables
+
+```python
+import httpx
+
+with httpx.Client(proxy="http://localhost:8030") as client:
+    response = client.get("https://example.com")
     response.raise_for_status()
-except httpx.HTTPStatusError as exc:
-    print("Bad status:", exc.response.status_code)
-except httpx.TimeoutException:
-    print("Request timed out")
-except httpx.RequestError as exc:
-    print("Transport error:", exc)
+```
+
+`trust_env=True` (the default) honors `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `NO_PROXY`, `SSL_CERT_FILE`, and `SSL_CERT_DIR`. Set `trust_env=False` for deterministic behavior.
+
+## SSL / TLS
+
+`0.28.x` deprecates string-style `verify=` and the `cert=` shortcut. Prefer an explicit `ssl.SSLContext`:
+
+```python
+import ssl
+import certifi
+import httpx
+
+ctx = ssl.create_default_context(cafile=certifi.where())
+
+with httpx.Client(verify=ctx) as client:
+    response = client.get("https://example.com")
+    response.raise_for_status()
+```
+
+To use the OS trust store on newer Python:
+
+```python
+import ssl
+import httpx
+import truststore
+
+ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+
+with httpx.Client(verify=ctx) as client:
+    response = client.get("https://example.com")
+    response.raise_for_status()
 ```
 
 ## Requests Compatibility Notes
 
-HTTPX is intentionally similar to `requests`, but not identical:
+- Redirects are off by default in HTTPX.
+- `response.url` is an `httpx.URL` object, not a string.
+- Cookies should usually live on the client; pass per-request only when needed.
+- Streaming uses `Client.stream(...)` / `AsyncClient.stream(...)`, not `stream=True`.
 
-- Redirects are off by default.
-- `response.url` is an `httpx.URL` object, not a plain string.
-- Cookies should normally live on the client, not be passed ad hoc on individual request calls.
-- Streaming uses `Client.stream(...)` / `AsyncClient.stream(...)` instead of the exact `requests` interface.
+## Version Notes For 0.28.1
 
-If you are porting code from `requests`, check the compatibility guide before assuming every edge-case matches exactly.
-
-## Version-Sensitive Notes For 0.28.1
-
-- `0.28.0` removed the deprecated `proxies` argument. Use `proxy=` for a single proxy or `mounts=` for per-scheme routing.
-- `0.28.0` removed the deprecated `app` argument. Use `WSGITransport` or `ASGITransport`.
+- `0.28.0` removed the deprecated `proxies=` argument. Use `proxy=` or `mounts=`.
+- `0.28.0` removed the deprecated `app=` shortcut. Use `WSGITransport` or `ASGITransport`.
 - `0.28.0` deprecated string-style `verify=` and the `cert=` argument. Prefer `ssl.SSLContext`.
-- `0.28.0` changed JSON request body serialization to a more compact representation.
-- `0.28.1` fixed a bug involving `verify=False` together with client-side certificates.
+- `0.28.0` changed JSON request body serialization to a more compact form.
+- `0.28.1` fixed a bug involving `verify=False` together with client-side certificates and reintroduced the `URLTypes` shortcut.
+- `0.28.1` remains the current PyPI release as of 2026-05-29.
 
 ## Official Sources
 
-- Docs root: `https://www.python-httpx.org/`
-- Quickstart: `https://www.python-httpx.org/quickstart/`
-- Clients: `https://www.python-httpx.org/advanced/clients/`
-- Authentication: `https://www.python-httpx.org/advanced/authentication/`
-- Timeouts: `https://www.python-httpx.org/advanced/timeouts/`
-- Resource limits: `https://www.python-httpx.org/advanced/resource-limits/`
-- Proxies: `https://www.python-httpx.org/advanced/proxies/`
-- SSL: `https://www.python-httpx.org/advanced/ssl/`
-- Environment variables: `https://www.python-httpx.org/environment_variables/`
-- Async support: `https://www.python-httpx.org/async/`
-- HTTP/2: `https://www.python-httpx.org/http2/`
-- Requests compatibility: `https://www.python-httpx.org/compatibility/`
-- Exceptions: `https://www.python-httpx.org/exceptions/`
-- Transports: `https://www.python-httpx.org/advanced/transports/`
-- PyPI package metadata: `https://pypi.org/project/httpx/0.28.1/`
-- Releases: `https://github.com/encode/httpx/releases/tag/0.28.0`
-- Releases: `https://github.com/encode/httpx/releases/tag/0.28.1`
+- Docs root: https://www.python-httpx.org/
+- Quickstart: https://www.python-httpx.org/quickstart/
+- Clients: https://www.python-httpx.org/advanced/clients/
+- Authentication: https://www.python-httpx.org/advanced/authentication/
+- Timeouts: https://www.python-httpx.org/advanced/timeouts/
+- Resource limits: https://www.python-httpx.org/advanced/resource-limits/
+- Proxies: https://www.python-httpx.org/advanced/proxies/
+- SSL: https://www.python-httpx.org/advanced/ssl/
+- Environment variables: https://www.python-httpx.org/environment_variables/
+- Async support: https://www.python-httpx.org/async/
+- HTTP/2: https://www.python-httpx.org/http2/
+- Transports: https://www.python-httpx.org/advanced/transports/
+- Requests compatibility: https://www.python-httpx.org/compatibility/
+- Exceptions: https://www.python-httpx.org/exceptions/
+- PyPI: https://pypi.org/project/httpx/
+- Releases: https://github.com/encode/httpx/releases

--- a/content/requests/docs/package/python/DOC.md
+++ b/content/requests/docs/package/python/DOC.md
@@ -1,52 +1,53 @@
 ---
 name: package
-description: "Requests HTTP client for Python with practical guidance for sessions, auth, TLS, proxies, and common pitfalls"
+description: "Requests HTTP client for Python with practical guidance for sessions, auth, timeouts, retries, streaming, and uploads"
 metadata:
   languages: "python"
-  versions: "2.32.5"
-  revision: 1
-  updated-on: "2026-03-11"
+  versions: "2.34.2"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
-  tags: "requests,http,python,client,auth,tls,proxies"
+  tags: "requests,http,python,client,auth,session,retries"
 ---
 
 # Requests Python Package Guide
 
 ## What It Is
 
-`requests` is the standard synchronous HTTP client used in many Python projects. It is a blocking HTTP/1.1 client with:
+`requests` is a synchronous HTTP/1.1 client for Python. It provides:
 
-- per-method helpers like `get`, `post`, `put`, and `delete`
+- per-method helpers: `get`, `post`, `put`, `patch`, `delete`, `head`, `options`
 - `Session` objects for shared headers, cookies, and connection pooling
-- built-in Basic and Digest auth support
-- TLS verification, proxies, multipart uploads, and streamed downloads
+- Basic and Digest auth support
+- TLS verification, proxies, multipart uploads, and streamed responses
+- pluggable `HTTPAdapter` for retries and transport tuning via `urllib3`
 
-Use it when you need straightforward synchronous HTTP calls from Python code.
+Use it for straightforward blocking HTTP calls from Python.
 
 ## Version Covered
 
 - Package: `requests`
 - Ecosystem: `pypi`
-- Version: `2.32.5`
-- Python support: `>=3.9`
+- Version: `2.34.2`
+- Python support: `>=3.10`
 - Registry: https://pypi.org/project/requests/
-- Docs root used for this guide: https://requests.readthedocs.io/en/stable/
+- Docs root: https://requests.readthedocs.io/en/stable/
 
 ## Install
 
 ```bash
-python -m pip install requests==2.32.5
+python -m pip install requests==2.34.2
 ```
 
 Optional SOCKS proxy support:
 
 ```bash
-python -m pip install "requests[socks]==2.32.5"
+python -m pip install "requests[socks]==2.34.2"
 ```
 
-## Core Usage
+## Method Helpers
 
-Prefer the method helpers (`get`, `post`, `put`, `patch`, `delete`) and always set a timeout explicitly.
+Use the per-method helpers and always pass `timeout=`.
 
 ```python
 import requests
@@ -62,15 +63,13 @@ events = response.json()
 print(events[0]["type"])
 ```
 
-Notes:
-
-- `timeout` can be a float or a `(connect_timeout, read_timeout)` tuple.
-- `response.json()` can still succeed on an HTTP error response. Check `status_code` or call `raise_for_status()`.
-- If you omit `timeout`, Requests will wait indefinitely.
+- `params=` builds the query string.
+- `timeout=` can be a float or `(connect_timeout, read_timeout)` tuple. Omitting it blocks indefinitely.
+- `response.json()` does not check the HTTP status. Pair it with `raise_for_status()` or check `response.status_code`.
 
 ### POST JSON
 
-Use `json=` for JSON APIs instead of manually serializing `data=`.
+Use `json=` for JSON bodies.
 
 ```python
 import requests
@@ -83,13 +82,96 @@ response = requests.post(
     timeout=30,
 )
 response.raise_for_status()
-
 print(response.json()["json"])
 ```
 
 `json=` is ignored if you also pass `data=` or `files=`.
 
-### Form Data And Files
+### Form Data
+
+```python
+import requests
+
+response = requests.post(
+    "https://httpbin.org/post",
+    data={"source": "daily-job", "count": "3"},
+    timeout=30,
+)
+response.raise_for_status()
+```
+
+Pass `data=` as a dict for `application/x-www-form-urlencoded`, or as bytes/string for a raw body.
+
+### Headers
+
+```python
+import requests
+
+response = requests.get(
+    "https://api.example.com/items",
+    headers={
+        "Accept": "application/json",
+        "Authorization": "Bearer YOUR_TOKEN",
+        "User-Agent": "my-service/1.0",
+    },
+    timeout=30,
+)
+response.raise_for_status()
+```
+
+## Response Objects
+
+```python
+import requests
+
+response = requests.get("https://api.github.com/events", timeout=30)
+
+response.status_code        # int, e.g. 200
+response.ok                 # True when status_code < 400
+response.reason             # e.g. "OK"
+response.headers["Content-Type"]
+response.text               # decoded body using response.encoding
+response.content            # raw bytes
+response.json()             # parsed JSON, raises requests.JSONDecodeError on failure
+response.url                # final URL after redirects
+response.history            # list of intermediate responses
+response.cookies            # RequestsCookieJar
+response.elapsed            # timedelta from request to response headers
+response.raise_for_status() # raises HTTPError when status_code >= 400
+```
+
+`response.text` decodes with `response.encoding`. If the server omits a charset, Requests may guess; set `response.encoding = "utf-8"` explicitly when you know the encoding.
+
+## Sessions
+
+Use `Session` for repeated calls to the same host. A session persists cookies, reuses TCP/TLS connections via `urllib3`, and centralizes headers, auth, and TLS settings.
+
+```python
+import requests
+
+with requests.Session() as session:
+    session.headers.update({
+        "User-Agent": "my-service/1.0",
+        "Accept": "application/json",
+    })
+    session.params = {"api_version": "2026-01-01"}
+    session.auth = ("user", "pass")
+
+    response = session.get(
+        "https://httpbin.org/get",
+        timeout=(3.05, 30),
+    )
+    response.raise_for_status()
+```
+
+Per-request values merge with session-level values. Use a session for:
+
+- shared headers, auth, or cookies across requests
+- connection reuse for lower latency to the same host
+
+## File Upload
+
+Use `files=` for multipart uploads. Provide a tuple of `(filename, fileobj, content_type)` for explicit control.
 
 ```python
 import requests
@@ -104,38 +186,20 @@ with open("report.csv", "rb") as fh:
     response.raise_for_status()
 ```
 
-## Sessions And Shared Configuration
-
-Use `Session` when you make multiple calls to the same service. A session persists cookies, reuses TCP connections through `urllib3`, and lets you centralize headers, auth, or TLS settings.
+Multiple files:
 
 ```python
 import requests
 
-with requests.Session() as session:
-    session.headers.update(
-        {
-            "User-Agent": "my-service/1.0",
-            "Accept": "application/json",
-        }
-    )
-    session.params = {"api_version": "2025-01-01"}
-
-    response = session.get(
-        "https://httpbin.org/get",
-        timeout=(3.05, 30),
-    )
-    response.raise_for_status()
+files = [
+    ("attachments", ("a.txt", open("a.txt", "rb"), "text/plain")),
+    ("attachments", ("b.txt", open("b.txt", "rb"), "text/plain")),
+]
+response = requests.post("https://httpbin.org/post", files=files, timeout=30)
+response.raise_for_status()
 ```
 
-Use a session for:
-
-- shared headers or auth across many requests
-- cookie persistence
-- lower latency when repeatedly calling the same host
-
-## Authentication
-
-### Basic Auth
+## Basic Auth
 
 ```python
 import requests
@@ -148,7 +212,7 @@ response = requests.get(
 response.raise_for_status()
 ```
 
-### Digest Auth
+Digest auth via `requests.auth.HTTPDigestAuth`:
 
 ```python
 import requests
@@ -162,113 +226,43 @@ response = requests.get(
 response.raise_for_status()
 ```
 
-### `netrc`
+If you do not pass `auth=`, Requests may load Basic credentials from `~/.netrc`. Set `session.trust_env = False` to disable that.
 
-If you do not pass `auth=`, Requests can load Basic Auth credentials from `~/.netrc`, `~/_netrc`, or the file pointed to by `NETRC`.
-
-Disable that behavior when you need predictable credentials or want to avoid environment-derived auth:
+## Timeouts
 
 ```python
 import requests
 
-with requests.Session() as session:
-    session.trust_env = False
-    response = session.get("https://example.com", timeout=30)
+# single value: applies to both connect and read
+requests.get("https://example.com", timeout=10)
+
+# tuple: (connect_timeout, read_timeout)
+requests.get("https://example.com", timeout=(3.05, 30))
 ```
 
-## TLS, Certificates, And Proxies
+Notes:
 
-### TLS Verification
+- Without `timeout=`, the request blocks indefinitely.
+- Timeouts are per-read inactivity, not a total deadline.
+- A connect timeout slightly larger than a multiple of 3 (e.g. `3.05`) avoids racing TCP retransmit windows.
 
-TLS verification is enabled by default and should stay enabled in normal code.
+## Streaming Responses
 
-```python
-import requests
-
-response = requests.get(
-    "https://example.com",
-    verify="/path/to/ca-bundle.pem",
-    timeout=30,
-)
-response.raise_for_status()
-```
-
-Useful options:
-
-- `verify=True`: default behavior
-- `verify="/path/to/ca-bundle.pem"`: trust a custom CA bundle
-- `verify=False`: only for local testing; this disables certificate and hostname checks
-
-Requests also honors:
-
-- `REQUESTS_CA_BUNDLE`
-- `CURL_CA_BUNDLE`
-
-Requests uses `certifi` for trusted CA roots.
-
-### Client Certificates
-
-```python
-import requests
-
-response = requests.get(
-    "https://example.com",
-    cert=("/path/client.cert", "/path/client.key"),
-    timeout=30,
-)
-response.raise_for_status()
-```
-
-The client private key must be unencrypted.
-
-### Proxies
-
-Per-request proxy configuration is safer than relying on `session.proxies`, because environment proxy settings can override session-level proxy values.
-
-```python
-import requests
-
-proxies = {
-    "http": "http://proxy.internal:3128",
-    "https": "http://proxy.internal:3128",
-}
-
-response = requests.get(
-    "https://example.com",
-    proxies=proxies,
-    timeout=30,
-)
-response.raise_for_status()
-```
-
-Requests also reads standard environment variables:
-
-- `HTTP_PROXY`
-- `HTTPS_PROXY`
-- `ALL_PROXY`
-- `NO_PROXY`
-
-For SOCKS proxies, install `requests[socks]` and use `socks5://...` or `socks5h://...`. `socks5h` resolves DNS on the proxy side.
-
-## Streaming Downloads And Responses
-
-Use `stream=True` for large responses or streaming APIs.
+Set `stream=True` to avoid loading the whole body into memory.
 
 ```python
 import requests
 
 with requests.get("https://httpbin.org/stream/20", stream=True, timeout=30) as response:
     response.raise_for_status()
-
     if response.encoding is None:
         response.encoding = "utf-8"
-
     for line in response.iter_lines(decode_unicode=True):
         if line:
             print(line)
 ```
 
-For file downloads:
+File download:
 
 ```python
 import requests
@@ -281,61 +275,130 @@ with requests.get("https://example.com/archive.tar.gz", stream=True, timeout=30)
                 fh.write(chunk)
 ```
 
-Important details:
+- Prefer `iter_content()` over `response.raw`.
+- Always close the response (the `with` block does this) or the connection will not be returned to the pool.
+- `iter_lines()` is not reentrant safe. Create the iterator once.
 
-- `iter_content()` is preferred over `response.raw` for most code.
-- With `stream=True`, consume the body or close the response, or the connection will not be returned to the pool.
-- `iter_lines()` is not reentrant safe. Create the iterator once and share that iterator if multiple consumers are involved.
+## Retries With HTTPAdapter
 
-## Error Handling
-
-Catch `RequestException` for broad transport errors and narrower subclasses when you need to branch.
+Requests does not retry by default. Mount a custom `HTTPAdapter` backed by `urllib3.util.Retry`.
 
 ```python
 import requests
-from requests.exceptions import HTTPError, JSONDecodeError, RequestException, Timeout
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+retry = Retry(
+    total=5,
+    backoff_factor=0.5,
+    status_forcelist=(429, 500, 502, 503, 504),
+    allowed_methods=frozenset(["GET", "HEAD", "OPTIONS", "PUT", "DELETE"]),
+    respect_retry_after_header=True,
+    raise_on_status=False,
+)
+adapter = HTTPAdapter(max_retries=retry)
+
+with requests.Session() as session:
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    response = session.get("https://httpbin.org/status/503", timeout=(3.05, 30))
+    response.raise_for_status()
+```
+
+Notes:
+
+- `backoff_factor=0.5` produces sleeps of `0.5, 1.0, 2.0, 4.0, ...` seconds between retries.
+- `allowed_methods` excludes `POST` by default; add it deliberately for idempotent endpoints.
+- `Retry` lives in `urllib3.util.retry`. Requests `2.30+` supports `urllib3 2.x`.
+
+## Errors
+
+```python
+import requests
+from requests.exceptions import (
+    ConnectionError,
+    HTTPError,
+    JSONDecodeError,
+    RequestException,
+    SSLError,
+    Timeout,
+)
 
 try:
     response = requests.get("https://api.github.com/events", timeout=(3.05, 30))
     response.raise_for_status()
     data = response.json()
 except Timeout:
-    print("The server was too slow to respond.")
+    print("Request timed out.")
+except SSLError as exc:
+    print(f"TLS error: {exc}")
+except ConnectionError as exc:
+    print(f"Connection error: {exc}")
 except HTTPError as exc:
-    print(f"HTTP error: {exc.response.status_code}")
+    print(f"HTTP {exc.response.status_code}")
 except JSONDecodeError:
-    print("The response body was not valid JSON.")
+    print("Response body was not valid JSON.")
 except RequestException as exc:
-    print(f"Network or Requests error: {exc}")
+    print(f"Requests error: {exc}")
 ```
 
-Common exception families to remember:
+Hierarchy to remember:
 
-- `RequestException`: base class for Requests errors
-- `Timeout`: request took too long
-- `ConnectionError`: DNS, TCP, or connection failures
+- `RequestException`: base for Requests errors
+- `Timeout`: split into `ConnectTimeout` and `ReadTimeout`
+- `ConnectionError`: DNS, TCP, connection reset
+- `SSLError`: TLS verification or certificate problems
 - `HTTPError`: raised by `raise_for_status()`
 - `JSONDecodeError`: invalid JSON in `response.json()`
-- `SSLError`: TLS verification or certificate problems
+- `TooManyRedirects`: redirect cap exceeded
+
+## TLS And Proxies
+
+TLS verification is on by default.
+
+```python
+import requests
+
+# custom CA bundle
+requests.get("https://example.com", verify="/path/to/ca-bundle.pem", timeout=30)
+
+# client certificate (key must be unencrypted)
+requests.get(
+    "https://example.com",
+    cert=("/path/client.cert", "/path/client.key"),
+    timeout=30,
+)
+```
+
+Per-request proxies:
+
+```python
+import requests
+
+proxies = {
+    "http": "http://proxy.internal:3128",
+    "https": "http://proxy.internal:3128",
+}
+requests.get("https://example.com", proxies=proxies, timeout=30)
+```
+
+Requests honors `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `NO_PROXY`, `REQUESTS_CA_BUNDLE`, and `CURL_CA_BUNDLE`. Disable env lookup with `session.trust_env = False`.
 
 ## Common Pitfalls
 
-- Always set `timeout`. Requests does not choose one for you.
-- Do not treat `response.json()` as an HTTP success check.
+- Always set `timeout=`. There is no default.
+- `response.json()` does not check status. Use `raise_for_status()` first.
 - Do not use `verify=False` in production.
-- Do not assume Requests is non-blocking; response reading is blocking even when using streaming APIs.
-- Do not rely on `session.proxies` if environment proxies may be present.
-- When you hand-build a `PreparedRequest`, merge environment settings if you still need env-based proxies or CA bundle behavior.
-- If you partially read a streamed response and never close it, connection reuse suffers.
-- Custom `Authorization` headers can be overridden by `.netrc` or `auth=`.
+- Streaming responses must be closed; use `with` blocks.
+- `Retry.allowed_methods` excludes `POST` by default.
+- `session.proxies` can be overridden by environment proxies; pass `proxies=` per request for deterministic behavior.
 
-## Version-Sensitive Notes For 2.32.x
+## Version Notes For 2.34.x
 
-- `2.32.5` is the current PyPI release as of 2026-03-11. It reverted the SSLContext caching behavior introduced in `2.32.0`, added Python `3.14` support, and dropped Python `3.8`.
-- `2.32.4` fixed `CVE-2024-47081`, where a malicious URL combined with trusted environment settings could pull `.netrc` credentials for the wrong host. If you are pinned below `2.32.4`, upgrade or set `session.trust_env = False` where appropriate.
-- `2.32.0` and `2.32.1` were yanked on PyPI because of issues related to the `CVE-2024-35195` mitigation. Avoid pinning those versions.
-- If you subclass `HTTPAdapter`, review the `2.32.2` change that introduced `get_connection_with_tls_context` and deprecated `get_connection` for adapters affected by the 2.32.0 TLS-related changes.
-- Requests `2.30.0+` supports `urllib3 2.x`. If an older project is tightly pinned to `urllib3 1.x`, test upgrades carefully.
+- `2.34.2` is the current PyPI release as of 2026-05-29.
+- The `2.34.x` series drops Python `3.9` and requires Python `>=3.10`.
+- Requests `2.30.0+` supports `urllib3 2.x`. If you are still on `urllib3 1.x`, retest after upgrade.
+- If you subclass `HTTPAdapter`, use `get_connection_with_tls_context` (introduced in `2.32.2`) instead of the deprecated `get_connection`.
 
 ## Official Sources
 


### PR DESCRIPTION
docs(requests, httpx): refresh to requests 2.34.2 / httpx 0.28.1

- requests 2.32.5 → 2.34.2 (Python ≥3.10); reorganized around method
  helpers, params/data/json, headers, response object, Session, file
  upload, basic auth, timeouts, streaming, HTTPAdapter + urllib3 Retry,
  error hierarchy
- httpx 0.28.1 unchanged (latest); strengthened coverage of sync `Client`
  vs `AsyncClient` with `async with`, params/data/json/files, headers,
  `httpx.Timeout`, `client.stream`, error types, HTTP/2, transports
  (`HTTPTransport`, `WSGITransport`/`ASGITransport`, `MockTransport`,
  mounts)
- `revision` bumped and `updated-on: 2026-05-29`

Verified versions against PyPI.
