### PR TITLE
docs(redux, zustand): refresh to Redux Toolkit 2.12.0 / Zustand 5.0.14

### DIFF
--- a/content/redux/docs/redux/javascript/DOC.md
+++ b/content/redux/docs/redux/javascript/DOC.md
@@ -4,17 +4,19 @@ description: "Core Redux APIs for creating stores, reducers, middleware, and sub
 metadata:
   languages: "javascript"
   versions: "5.0.1"
-  revision: 1
-  updated-on: "2026-03-13"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "redux,state,store,reducer,middleware,javascript"
 ---
 
 # Redux Core Guide
 
-This guide covers the standalone `redux` core package.
+This guide covers the standalone `redux` core package at version `5.0.1`.
 
-For most new Redux application code, the Redux maintainers recommend `@reduxjs/toolkit` instead of building directly on `createStore`. Use the core `redux` package when you want the low-level store primitives directly, are learning the Redux data flow, or are integrating Redux into a library.
+For new application code, the Redux maintainers recommend **Redux Toolkit** (`@reduxjs/toolkit`) instead of building directly on the core package. Toolkit is the standard, batteries-included way to write Redux today: it sets up the store, generates action creators and reducers from `createSlice`, integrates Immer, configures dev middleware, and ships RTK Query for data fetching.
+
+Use the core `redux` package when you want the low-level store primitives directly, you are learning the Redux data flow, or you are integrating Redux into a library.
 
 ## Install
 
@@ -26,7 +28,7 @@ npm install redux
 
 ## Create a Store
 
-In Redux 5, `createStore` is deprecated in favor of Redux Toolkit. If you intentionally want the core store API, import `legacy_createStore` and alias it locally.
+In Redux 5, `createStore` is deprecated in favor of Redux Toolkit's `configureStore`. If you intentionally want the core store API, import `legacy_createStore` and alias it locally.
 
 ```javascript
 import { legacy_createStore as createStore } from "redux";
@@ -57,6 +59,23 @@ unsubscribe();
 ```
 
 Use `store.getState()` to read the current state, `store.dispatch()` to send actions, and `store.subscribe()` to react after every dispatch.
+
+For new code, prefer this Redux Toolkit equivalent:
+
+```javascript
+import { configureStore, createSlice } from "@reduxjs/toolkit";
+
+const counterSlice = createSlice({
+  name: "counter",
+  initialState: { count: 0 },
+  reducers: {
+    increment: (state) => { state.count += 1; },
+    add: (state, action) => { state.count += action.payload; },
+  },
+});
+
+const store = configureStore({ reducer: { counter: counterSlice.reducer } });
+```
 
 ## Hydrate Initial State
 
@@ -261,6 +280,6 @@ Replacing the reducer dispatches an internal action so newly added reducers can 
 
 ## Version Notes for `redux@5`
 
-- `createStore` is intentionally marked deprecated; use `legacy_createStore` if you still need the core store API.
+- `createStore` is intentionally marked deprecated; use `legacy_createStore` if you still need the core store API, or migrate to `configureStore` from Redux Toolkit.
 - `redux@5` exports `isAction()` and `isPlainObject()` utility guards if you need to validate inputs in custom integrations.
-- The TypeScript `AnyAction` type is deprecated in the package declarations in favor of stricter action typing.
+- The TypeScript `AnyAction` type is deprecated in the package declarations in favor of stricter action typing with `UnknownAction`.

--- a/content/redux/docs/toolkit/javascript/DOC.md
+++ b/content/redux/docs/toolkit/javascript/DOC.md
@@ -3,16 +3,16 @@ name: toolkit
 description: "Redux Toolkit for configuring Redux stores, creating slice reducers, handling async logic, and using RTK Query in JavaScript apps"
 metadata:
   languages: "javascript"
-  versions: "2.11.2"
-  revision: 1
-  updated-on: "2026-03-13"
+  versions: "2.12.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "redux,redux-toolkit,state-management,rtk-query,javascript"
 ---
 
 # Redux Toolkit for JavaScript
 
-Use `@reduxjs/toolkit` to build Redux stores with `configureStore`, feature state with `createSlice`, async flows with `createAsyncThunk`, and data fetching with RTK Query. For React apps, pair it with `react-redux`.
+Use `@reduxjs/toolkit` (version `2.12.0`) to build Redux stores with `configureStore`, feature state with `createSlice`, async flows with `createAsyncThunk`, and data fetching with RTK Query. For React apps, pair it with `react-redux`.
 
 ## Golden Rules
 
@@ -42,9 +42,26 @@ If you use RTK Query against an HTTP API, set your app's API base URL however yo
 export VITE_API_URL="https://api.example.com"
 ```
 
-## Create a Store and Slice
+## configureStore
 
 `configureStore` is the standard entry point. When `reducer` is an object, it combines those slice reducers under the same keys. It also adds Redux Thunk and the default development middleware checks for immutable and serializable state, and enables Redux DevTools.
+
+`src/app/store.js`
+
+```javascript
+import { configureStore } from "@reduxjs/toolkit";
+import counterReducer from "../features/counter/counterSlice";
+
+export const store = configureStore({
+  reducer: {
+    counter: counterReducer,
+  },
+});
+```
+
+## createSlice
+
+`createSlice` generates action creators and a reducer from one definition. Reducer logic uses Immer, so you can write mutating-looking code and Toolkit produces an immutable update.
 
 `src/features/counter/counterSlice.js`
 
@@ -76,19 +93,6 @@ export const { increment, decrement, incrementByAmount, reset } =
   counterSlice.actions;
 
 export default counterSlice.reducer;
-```
-
-`src/app/store.js`
-
-```javascript
-import { configureStore } from "@reduxjs/toolkit";
-import counterReducer from "../features/counter/counterSlice";
-
-export const store = configureStore({
-  reducer: {
-    counter: counterReducer,
-  },
-});
 ```
 
 ## Connect Redux to React
@@ -138,7 +142,7 @@ export function Counter() {
 }
 ```
 
-## Handle Async Logic with `createAsyncThunk`
+## createAsyncThunk
 
 Use `createAsyncThunk` when you want explicit `pending` / `fulfilled` / `rejected` action types and reducer cases.
 
@@ -151,11 +155,13 @@ const apiBaseUrl = import.meta.env.VITE_API_URL ?? "http://localhost:3000";
 
 export const fetchUserById = createAsyncThunk(
   "users/fetchById",
-  async (userId) => {
-    const response = await fetch(`${apiBaseUrl}/users/${userId}`);
+  async (userId, thunkApi) => {
+    const response = await fetch(`${apiBaseUrl}/users/${userId}`, {
+      signal: thunkApi.signal,
+    });
 
     if (!response.ok) {
-      throw new Error(`Request failed with status ${response.status}`);
+      return thunkApi.rejectWithValue({ status: response.status });
     }
 
     return response.json();
@@ -248,9 +254,11 @@ export const store = configureStore({
 
 Only disable a check when your app really needs it. The defaults are helpful for catching accidental state mutations and non-serializable values during development.
 
-## Use RTK Query for API Data
+## RTK Query
 
-RTK Query is included in Redux Toolkit. In React apps, create an API slice with `createApi`, add its reducer and middleware to the store, call `setupListeners`, and use the generated hooks.
+RTK Query is included in Redux Toolkit. In React apps, create an API slice with `createApi`, declare endpoints, add its reducer and middleware to the store, call `setupListeners`, and use the generated hooks.
+
+### createApi and endpoints
 
 `src/services/postsApi.js`
 
@@ -264,9 +272,18 @@ export const postsApi = createApi({
   baseQuery: fetchBaseQuery({
     baseUrl: apiBaseUrl,
   }),
+  tagTypes: ["Post"],
   endpoints: (builder) => ({
     getPosts: builder.query({
       query: () => "/posts",
+      providesTags: (result = []) => [
+        "Post",
+        ...result.map(({ id }) => ({ type: "Post", id })),
+      ],
+    }),
+    getPostById: builder.query({
+      query: (id) => `/posts/${id}`,
+      providesTags: (_result, _error, id) => [{ type: "Post", id }],
     }),
     addPost: builder.mutation({
       query: (body) => ({
@@ -274,12 +291,19 @@ export const postsApi = createApi({
         method: "POST",
         body,
       }),
+      invalidatesTags: ["Post"],
     }),
   }),
 });
 
-export const { useGetPostsQuery, useAddPostMutation } = postsApi;
+export const {
+  useGetPostsQuery,
+  useGetPostByIdQuery,
+  useAddPostMutation,
+} = postsApi;
 ```
+
+### Wire RTK Query into the store
 
 `src/app/store.js`
 
@@ -300,6 +324,8 @@ export const store = configureStore({
 
 setupListeners(store.dispatch);
 ```
+
+### Use generated hooks in components
 
 `src/features/posts/PostsList.jsx`
 
@@ -354,6 +380,42 @@ export function PostsList() {
 
 Call `setupListeners(store.dispatch)` once after store creation if you want RTK Query features such as `refetchOnFocus` and `refetchOnReconnect`.
 
+## TypeScript: RootState and AppDispatch
+
+In TypeScript projects, derive `RootState` and `AppDispatch` from the configured store, then expose typed hooks. This keeps `useSelector` and `useDispatch` correctly typed against your actual store shape, including RTK Query state and thunk dispatch.
+
+`src/app/store.ts`
+
+```typescript
+import { configureStore } from "@reduxjs/toolkit";
+import counterReducer from "../features/counter/counterSlice";
+import { postsApi } from "../services/postsApi";
+
+export const store = configureStore({
+  reducer: {
+    counter: counterReducer,
+    [postsApi.reducerPath]: postsApi.reducer,
+  },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(postsApi.middleware),
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;
+```
+
+`src/app/hooks.ts`
+
+```typescript
+import { useDispatch, useSelector } from "react-redux";
+import type { AppDispatch, RootState } from "./store";
+
+export const useAppDispatch = useDispatch.withTypes<AppDispatch>();
+export const useAppSelector = useSelector.withTypes<RootState>();
+```
+
+Use `useAppSelector` and `useAppDispatch` in components instead of the untyped hooks.
+
 ## Pitfalls
 
 - Reducers created with `createSlice` may appear to mutate state because Redux Toolkit uses Immer internally. That only applies inside reducer logic. Outside reducers, treat state as immutable.
@@ -361,3 +423,4 @@ Call `setupListeners(store.dispatch)` once after store creation if you want RTK 
 - Non-serializable values such as functions, class instances, DOM nodes, `Map`, `Set`, or promises can trigger the default middleware warnings.
 - RTK Query needs both `postsApi.reducer` and `postsApi.middleware` added to the store. Missing either one causes broken cache behavior.
 - Generated RTK Query hooks come from `@reduxjs/toolkit/query/react`. If you import from `@reduxjs/toolkit/query`, you do not get React hooks.
+- Define `RootState` and `AppDispatch` once from the configured store; do not hand-roll the types, or RTK Query and thunks will be missing from the union.

--- a/content/zustand/docs/zustand/javascript/DOC.md
+++ b/content/zustand/docs/zustand/javascript/DOC.md
@@ -3,9 +3,9 @@ name: zustand
 description: "Zustand state management for JavaScript/TypeScript with React hook stores, vanilla stores, persistence, and middleware"
 metadata:
   languages: "javascript"
-  versions: "5.0.11"
-  revision: 1
-  updated-on: "2026-03-13"
+  versions: "5.0.14"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "zustand,state,react,store,javascript"
 ---
@@ -17,7 +17,7 @@ Use the official `zustand` package for both React state and non-React stores. Zu
 - `create` from `zustand` for React hook-based stores
 - `createStore` from `zustand/vanilla` for framework-agnostic stores
 
-This guide targets `zustand` `5.0.11`.
+This guide targets `zustand` `5.0.14`.
 
 ## Installation and Prerequisites
 
@@ -31,21 +31,28 @@ For React usage, create stores with `create` and read them in components. For no
 
 ## Create a React Store
 
-Create a store once at module scope and export the hook.
+Create a store once at module scope and export the hook. The initializer receives `set` and `get`: `set` updates state (shallow-merged by default), and `get` reads the current state from inside an action.
 
 ```javascript
 // stores/counter-store.js
 import { create } from 'zustand'
 
-export const useCounterStore = create((set) => ({
+export const useCounterStore = create((set, get) => ({
   count: 0,
   increment: () => set((state) => ({ count: state.count + 1 })),
   incrementBy: (amount) => set((state) => ({ count: state.count + amount })),
+  doubleAndLog: () => {
+    const current = get().count
+    set({ count: current * 2 })
+    console.log('doubled from', current)
+  },
   reset: () => set({ count: 0 }),
 }))
 ```
 
-Use selectors in components so each component subscribes only to the state it needs.
+## Selectors
+
+In components, select the smallest slice you need so each component only re-renders when that slice changes.
 
 ```jsx
 // components/Counter.jsx
@@ -66,17 +73,44 @@ export function Counter() {
 }
 ```
 
-Zustand does not require a provider for this basic pattern.
+### Selecting multiple values with `useShallow`
+
+If you return an object or array from a selector, the default equality check is reference equality and the component will re-render on every store update. Wrap the selector with `useShallow` from `zustand/react/shallow` to compare the result shallowly.
+
+```jsx
+import { useShallow } from 'zustand/react/shallow'
+import { useCounterStore } from '../stores/counter-store'
+
+export function CounterControls() {
+  const { increment, reset } = useCounterStore(
+    useShallow((state) => ({
+      increment: state.increment,
+      reset: state.reset,
+    })),
+  )
+
+  return (
+    <>
+      <button onClick={increment}>+</button>
+      <button onClick={reset}>Reset</button>
+    </>
+  )
+}
+```
+
+For vanilla stores or `subscribe` callbacks, use the lower-level `shallow` comparator from `zustand/shallow`.
 
 ## Read and Update a Store Outside React
 
-Stores created with `create` also expose the store API on the returned hook. This is useful for event handlers, non-React modules, or debugging code.
+Stores created with `create` also expose the store API on the returned hook. This is useful for event handlers, non-React modules, tests, or debugging code.
 
 ```javascript
 import { useCounterStore } from './stores/counter-store'
 
-const unsubscribe = useCounterStore.subscribe((state) => {
-  console.log('count changed:', state.count)
+const unsubscribe = useCounterStore.subscribe((state, previousState) => {
+  if (state.count !== previousState.count) {
+    console.log('count changed:', state.count)
+  }
 })
 
 useCounterStore.getState().increment()
@@ -84,6 +118,8 @@ useCounterStore.setState({ count: 10 })
 
 unsubscribe()
 ```
+
+`useCounterStore.getState()` and `useCounterStore.setState()` work the same outside React, which makes it easy to share state between React components and non-React modules without a separate vanilla store.
 
 ## Async Actions
 
@@ -109,7 +145,10 @@ export const useUserStore = create((set) => ({
       const user = await response.json()
       set({ user, loading: false })
     } catch (error) {
-      set({ error: error instanceof Error ? error.message : String(error), loading: false })
+      set({
+        error: error instanceof Error ? error.message : String(error),
+        loading: false,
+      })
     }
   },
 }))
@@ -139,6 +178,39 @@ export function UserProfile({ userId }) {
 }
 ```
 
+## Split Large Stores into Slices
+
+When a store grows, split it into slice creators and compose them into one store with spread.
+
+```javascript
+import { create } from 'zustand'
+
+const createBearSlice = (set, get) => ({
+  bears: 0,
+  addBear: () => set((state) => ({ bears: state.bears + 1 })),
+})
+
+const createFishSlice = (set, get) => ({
+  fish: 0,
+  addFish: () => set((state) => ({ fish: state.fish + 1 })),
+})
+
+const createSharedSlice = (set, get) => ({
+  feedAll: () => {
+    get().addBear()
+    get().addFish()
+  },
+})
+
+export const useZooStore = create((...args) => ({
+  ...createBearSlice(...args),
+  ...createFishSlice(...args),
+  ...createSharedSlice(...args),
+}))
+```
+
+Each slice creator receives the full `set` and `get`, so a slice can read and write any part of the combined state.
+
 ## Persist State
 
 Use `persist` from `zustand/middleware` to save store data to browser storage. If you omit `storage`, `persist` uses `localStorage`.
@@ -160,6 +232,7 @@ export const useSessionStore = create(
       name: 'app-session',
       storage: createJSONStorage(() => sessionStorage),
       partialize: (state) => ({ token: state.token, theme: state.theme }),
+      version: 1,
     },
   ),
 )
@@ -167,9 +240,41 @@ export const useSessionStore = create(
 
 Use `partialize` to persist only the fields that should survive reloads. Do not persist transient flags like in-flight loading state unless you explicitly want that behavior.
 
+## Immer Middleware for Nested Updates
+
+`set` shallow-merges object updates by default, so deeply nested updates require manual spreading. Wrap the initializer with `immer` to write mutating-looking updates safely.
+
+```javascript
+import { create } from 'zustand'
+import { immer } from 'zustand/middleware/immer'
+
+export const useProfileStore = create(
+  immer((set) => ({
+    user: {
+      id: null,
+      profile: {
+        displayName: '',
+        preferences: { theme: 'light' },
+      },
+    },
+    setDisplayName: (displayName) =>
+      set((state) => {
+        state.user.profile.displayName = displayName
+      }),
+    toggleTheme: () =>
+      set((state) => {
+        state.user.profile.preferences.theme =
+          state.user.profile.preferences.theme === 'light' ? 'dark' : 'light'
+      }),
+  })),
+)
+```
+
+`immer` composes with other middleware. A common stack is `persist(immer(...))` or `devtools(persist(immer(...)))`.
+
 ## Create a Vanilla Store
 
-For non-React usage, create a store with `createStore`.
+For non-React usage, create a store with `createStore`. This is the same API surface as the React `create` hook, minus the React binding.
 
 ```javascript
 // stores/counter-store.js
@@ -276,53 +381,14 @@ positionStore.getState().setPosition(10, 20)
 unsubscribe()
 ```
 
-## Split Large Stores into Slices
-
-When a store grows, split it into slice creators and compose them into one store.
-
-```javascript
-import { create } from 'zustand'
-
-const createBearSlice = (set) => ({
-  bears: 0,
-  addBear: () => set((state) => ({ bears: state.bears + 1 })),
-})
-
-const createFishSlice = (set) => ({
-  fish: 0,
-  addFish: () => set((state) => ({ fish: state.fish + 1 })),
-})
-
-export const useZooStore = create((...args) => ({
-  ...createBearSlice(...args),
-  ...createFishSlice(...args),
-}))
-```
-
-This keeps actions and state grouped without forcing everything into one large initializer function.
-
 ## Important Notes and Pitfalls
 
-- `set` shallow-merges object updates by default. For nested objects, copy the nested object yourself.
+- `set` shallow-merges object updates by default. For nested objects, copy the nested object yourself or use the `immer` middleware.
 - `setState(nextState, true)` replaces the entire state object instead of merging. If you replace state, include everything you need to keep, including action functions.
-- In React components, subscribe to the smallest possible slice. Avoid selecting a large object if a component only needs one field or one action.
+- In React components, subscribe to the smallest possible slice. When selecting multiple values into an object or array, use `useShallow` to avoid spurious re-renders.
 - `persist` uses browser storage. Choose storage intentionally and avoid assuming `localStorage` or `sessionStorage` exists in server-rendered or test environments.
 - In server-rendered React apps, do not share a module-scoped store instance across requests for request-specific data. Create per-request stores or keep request-specific state on the client.
 - If you copy older examples from blogs, issues, or gists, confirm they match Zustand v5 APIs before using them in production code.
-
-Nested updates should stay immutable:
-
-```javascript
-set((state) => ({
-  user: {
-    ...state.user,
-    profile: {
-      ...state.user.profile,
-      displayName: 'Ada',
-    },
-  },
-}))
-```
 
 ## Useful Links
 
@@ -331,4 +397,5 @@ set((state) => ({
 - `create` API: `https://zustand.docs.pmnd.rs/apis/create`
 - `createStore` API: `https://zustand.docs.pmnd.rs/apis/create-store`
 - Persist middleware: `https://zustand.docs.pmnd.rs/integrations/persisting-store-data`
+- Immer middleware: `https://zustand.docs.pmnd.rs/integrations/immer-middleware`
 - Devtools middleware: `https://zustand.docs.pmnd.rs/middlewares/devtools`


### PR DESCRIPTION
docs(redux, zustand): refresh to Redux Toolkit 2.12.0 / Zustand 5.0.14

- redux 5.0.1 unchanged (already `latest`); sharpens guidance that RTK is
  the recommended path while keeping the core store/reducer/dispatch
  examples; notes `UnknownAction` replacing `AnyAction`
- @reduxjs/toolkit 2.11.2 → 2.12.0; reorganized into explicit
  `configureStore` / `createSlice` / `createAsyncThunk` / RTK Query
  (createApi + endpoints + tags + hooks); TypeScript section with
  `RootState`, `AppDispatch`, typed `useAppSelector` / `useAppDispatch`
  via `withTypes`
- zustand 5.0.11 → 5.0.14; adds `get`, `useShallow` selectors, slice
  composition example, `immer` middleware section; `persist` example now
  includes `version`
- `revision` bumped and `updated-on: 2026-05-29`

Verified versions against npm `latest`.
