### PR TITLE
docs(pandas, numpy, polars, duckdb): refresh Python data-stack docs

### DIFF
--- a/content/duckdb/docs/package/python/DOC.md
+++ b/content/duckdb/docs/package/python/DOC.md
@@ -1,220 +1,242 @@
 ---
 name: package
-description: "DuckDB Python package guide for embedded SQL analytics, DataFrames, and file-backed workflows"
+description: "DuckDB Python package guide for 1.5.3: in-process API, connect, execute/sql/df, read_parquet/csv, pandas/polars/arrow integration"
 metadata:
   languages: "python"
-  versions: "1.5.0"
-  revision: 1
-  updated-on: "2026-03-12"
+  versions: "1.5.3"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
-  tags: "duckdb,python,sql,analytics,dataframe,parquet"
+  tags: "duckdb,python,sql,analytics,parquet,pandas,polars,arrow"
 ---
 
 # duckdb Python Package Guide
 
 ## Golden Rule
 
-Use an explicit `duckdb.connect(...)` connection for application code, persistent databases, and threaded work. Reserve top-level `duckdb.sql(...)` for short interactive queries.
+Use `duckdb.connect(...)` for application code, persistent databases, and threaded work. Reserve top-level `duckdb.sql(...)` for short interactive queries.
 
-## What It Is
+## In-Process API
 
-`duckdb` embeds DuckDB inside your Python process. Common uses:
+`duckdb` runs DuckDB inside your Python process — no server, no socket. It can:
 
-- run SQL directly over local Parquet, CSV, and JSON files
-- query Pandas, Arrow, Polars, and NumPy data without moving data into a separate server
-- keep an in-memory database for analysis or a `.duckdb` file for local persistence
-- read from object storage such as S3 once extensions and credentials are configured
+- run SQL over local Parquet/CSV/JSON via `read_*`
+- query pandas/polars/arrow objects by variable name
+- persist to a `.duckdb` file or stay in memory
+- read from S3-compatible storage with extensions and secrets
 
 ## Install
 
 ```bash
-pip install duckdb==1.5.0
+pip install duckdb==1.5.3
 ```
-
-Check the installed version:
 
 ```bash
 python -c "import duckdb; print(duckdb.__version__)"
 ```
 
-Notes:
+Requires Python 3.9+.
 
-- The DuckDB Python client requires Python 3.9 or newer.
-
-## Quick Start
-
-### Ad hoc query
+## duckdb.connect
 
 ```python
 import duckdb
 
-result = duckdb.sql("SELECT 42 AS answer").fetchone()
-print(result[0])
-```
+# in-memory (private to this connection)
+con = duckdb.connect()
 
-### Persistent database file
-
-```python
-import duckdb
-
+# persistent file
 con = duckdb.connect("app.duckdb")
 
-con.execute("""
-    CREATE TABLE IF NOT EXISTS events (
-        id INTEGER,
-        kind VARCHAR,
-        created_at TIMESTAMP
-    )
-""")
+# read-only (safe when another process has the file)
+con = duckdb.connect("app.duckdb", read_only=True)
 
-con.execute(
-    "INSERT INTO events VALUES (?, ?, current_timestamp)",
-    [1, "signup"],
+# with engine config
+con = duckdb.connect(
+    "app.duckdb",
+    config={"threads": 4, "memory_limit": "4GB"},
 )
 
-rows = con.execute(
-    "SELECT id, kind FROM events WHERE kind = ?",
-    ["signup"],
-).fetchall()
+# shared named in-memory database (cross-connection state)
+con_a = duckdb.connect("file::memory:?cache=shared&name=analytics")
 
-print(rows)
 con.close()
 ```
 
-### Connection configuration
+Use a dedicated connection per unit of work or per thread.
 
-Pass engine settings at connect time:
+## execute / sql / df
 
-```python
-import duckdb
-
-con = duckdb.connect(
-    "app.duckdb",
-    config={
-        "threads": 4,
-        "memory_limit": "4GB",
-    },
-)
-```
-
-Use `read_only=True` when another process may already have the same database file open:
+### `execute()` — parameterized, returns the cursor
 
 ```python
-import duckdb
-
-con = duckdb.connect("app.duckdb", read_only=True)
-```
-
-## Core Usage Patterns
-
-### Query files directly
-
-DuckDB can query files without a load step:
-
-```python
-import duckdb
-
 con = duckdb.connect()
 
-count = con.execute("""
-    SELECT count(*)
-    FROM read_parquet('data/orders/*.parquet')
-    WHERE order_date >= DATE '2026-01-01'
-""").fetchone()[0]
-
-print(count)
-```
-
-The SQL shell syntax also works for some formats:
-
-```python
-import duckdb
-
-rows = duckdb.sql("SELECT * FROM 'data/example.parquet' LIMIT 5").fetchall()
-```
-
-### Query a Pandas DataFrame without registering it
-
-DuckDB's Python integration can discover DataFrames by variable name:
-
-```python
-import duckdb
-import pandas as pd
-
-orders = pd.DataFrame(
-    [
-        {"customer_id": 1, "total": 25},
-        {"customer_id": 2, "total": 50},
-        {"customer_id": 1, "total": 30},
-    ]
-)
-
-summary = duckdb.sql("""
-    SELECT customer_id, sum(total) AS total_spend
-    FROM orders
-    GROUP BY customer_id
-    ORDER BY total_spend DESC
-""").df()
-
-print(summary)
-```
-
-If you need persistence or indexes, materialize the DataFrame into a table:
-
-```python
-import duckdb
-import pandas as pd
-
-orders_df = pd.DataFrame([{"customer_id": 1, "total": 25}])
-
-con = duckdb.connect("analytics.duckdb")
-con.execute("CREATE OR REPLACE TABLE orders AS SELECT * FROM orders_df")
-```
-
-### Fetch results in the format you need
-
-```python
-import duckdb
-
-rel = duckdb.sql("SELECT * FROM range(5)")
-
-rows = rel.fetchall()
-df = rel.df()
-arrow_table = rel.fetch_arrow_table()
-numpy_cols = rel.fetchnumpy()
-```
-
-Use:
-
-- `fetchall()` or `fetchone()` for DB-API style results
-- `.df()` when the next step is Pandas
-- `.fetch_arrow_table()` for Arrow pipelines
-- `.fetchnumpy()` for NumPy-oriented code
-
-### Parameter binding
-
-Prefer parameters over string interpolation:
-
-```python
-import duckdb
-
-con = duckdb.connect()
-
-rows = con.execute(
+con.execute(
     "SELECT * FROM range(?) WHERE range < ?",
     [100, 10],
 ).fetchall()
+
+con.execute(
+    "SELECT * FROM range($n) WHERE range < $m",
+    {"n": 100, "m": 10},
+).fetchall()
 ```
 
-## Extensions, Remote Storage, and Credentials
+Use parameters; do not interpolate user input into SQL.
 
-Local files need no authentication. Remote object storage does.
+### `sql()` — returns a relation
 
-For S3 and S3-compatible storage, DuckDB recommends secrets-based configuration:
+```python
+rel = duckdb.sql("SELECT * FROM range(5)")
+
+rel.fetchall()
+rel.fetchone()
+rel.df()                  # pandas DataFrame
+rel.pl()                  # polars DataFrame
+rel.fetch_arrow_table()   # pyarrow Table
+rel.fetchnumpy()          # dict of numpy arrays
+```
+
+Relations are composable:
+
+```python
+rel = duckdb.sql("SELECT * FROM 'data/orders.parquet'")
+rel.filter("amount > 100").project("user_id, amount").order("amount DESC").df()
+```
+
+### Cursor on a specific connection
+
+```python
+con = duckdb.connect("app.duckdb")
+con.execute("SELECT count(*) FROM events").fetchone()
+con.sql("SELECT * FROM events LIMIT 10").df()
+```
+
+## Reading Parquet and CSV
 
 ```python
 import duckdb
 
+con = duckdb.connect()
+
+# Parquet
+con.sql("SELECT * FROM read_parquet('data/orders/*.parquet')").df()
+con.sql("SELECT * FROM 'data/orders/*.parquet'").df()  # shorthand for some formats
+
+# CSV
+con.sql("""
+    SELECT *
+    FROM read_csv('data/events.csv',
+                  header=true,
+                  delim=',',
+                  sample_size=100000)
+""").df()
+
+# JSON / NDJSON
+con.sql("SELECT * FROM read_json_auto('data/payload.json')").df()
+
+# Filter pushdown into Parquet
+con.sql("""
+    SELECT user_id, sum(amount) AS total
+    FROM read_parquet('data/orders/*.parquet')
+    WHERE order_date >= DATE '2026-01-01'
+    GROUP BY user_id
+""").df()
+```
+
+Glob patterns, partition discovery, and Hive partitioning are all SQL-side options on `read_parquet`.
+
+## Writing
+
+```python
+con.execute("""
+    COPY (SELECT * FROM events WHERE kind = 'signup')
+    TO 'out/signups.parquet'
+    (FORMAT PARQUET, COMPRESSION ZSTD)
+""")
+
+con.execute("COPY events TO 'out/events.csv' (HEADER, DELIMITER ',')")
+```
+
+## Integration With pandas / polars / arrow
+
+DuckDB queries Python variables by name in the current scope:
+
+```python
+import duckdb
+import pandas as pd
+import polars as pl
+import pyarrow as pa
+
+orders_pd = pd.DataFrame([{"user_id": 1, "total": 25}, {"user_id": 2, "total": 50}])
+orders_pl = pl.DataFrame({"user_id": [1, 2], "total": [25, 50]})
+orders_arrow = pa.table({"user_id": [1, 2], "total": [25, 50]})
+
+# Each works the same way — variable name becomes the table name
+duckdb.sql("SELECT user_id, sum(total) AS s FROM orders_pd GROUP BY user_id").df()
+duckdb.sql("SELECT * FROM orders_pl WHERE total > 30").pl()
+duckdb.sql("SELECT * FROM orders_arrow").fetch_arrow_table()
+```
+
+For long-lived registration on a specific connection:
+
+```python
+con = duckdb.connect()
+con.register("orders", orders_pd)
+con.sql("SELECT count(*) FROM orders").fetchone()
+con.unregister("orders")
+```
+
+Materialize into a real table when later queries should not depend on Python scope:
+
+```python
+con.execute("CREATE OR REPLACE TABLE orders AS SELECT * FROM orders_pd")
+```
+
+## Persistent vs In-Memory
+
+- `duckdb.connect()` — private in-memory database per connection
+- `duckdb.connect(":memory:")` — same as above
+- `duckdb.connect("file::memory:?cache=shared&name=analytics")` — named in-memory DB, sharable across connections that use the same name
+- `duckdb.connect("app.duckdb")` — persistent file
+- `duckdb.connect("app.duckdb", read_only=True)` — concurrent-safe reads
+
+Choose persistence early. Switching from `:memory:` to a file mid-project requires either re-running the bootstrap or exporting/loading tables.
+
+## Basic SQL
+
+DuckDB supports standard PostgreSQL-flavored SQL with strong analytics features:
+
+```sql
+-- CTEs
+WITH recent AS (
+    SELECT * FROM events WHERE created_at >= now() - INTERVAL 7 DAY
+)
+SELECT kind, count(*) FROM recent GROUP BY kind;
+
+-- Window functions
+SELECT
+    user_id,
+    amount,
+    sum(amount) OVER (PARTITION BY user_id ORDER BY ts) AS running_total
+FROM orders;
+
+-- Struct / list / map types
+SELECT {'name': 'a', 'qty': 3} AS rec;
+SELECT [1, 2, 3] AS nums;
+SELECT unnest([10, 20, 30]) AS n;
+
+-- DESCRIBE / SUMMARIZE
+DESCRIBE orders;
+SUMMARIZE orders;
+```
+
+DuckDB also supports `EXPORT DATABASE` / `IMPORT DATABASE` and `ATTACH 'other.duckdb'` for cross-database queries.
+
+## S3 / HTTP With Secrets
+
+```python
 con = duckdb.connect()
 con.execute("INSTALL httpfs")
 con.execute("LOAD httpfs")
@@ -227,77 +249,62 @@ con.execute("""
     )
 """)
 
-df = con.execute("""
+con.sql("""
     SELECT *
-    FROM read_parquet('s3://my-bucket/path/data.parquet')
+    FROM read_parquet('s3://bucket/path/data.parquet')
     LIMIT 10
 """).df()
 ```
 
-Practical notes:
-
-- `credential_chain` uses the standard AWS credential resolution flow. Prefer it over hard-coding keys.
-- Keep remote access setup inside the connection bootstrap path so queries fail early if extensions or credentials are missing.
-- If a project depends on extensions, pin DuckDB and test extension loading in CI.
+`credential_chain` uses the standard AWS credential resolution flow.
 
 ## Common Pitfalls
 
 ### `duckdb.sql(...)` uses a shared default connection
 
-The module-level helpers operate on a global in-memory connection. That is convenient in notebooks, but it is the wrong default for request handlers, background jobs, and threaded code. Use a dedicated `duckdb.connect(...)` per unit of work or per thread.
+Top-level helpers operate on a global in-memory connection. Wrong default for request handlers, background jobs, and threaded code.
 
-### `cursor()` helps with concurrent work, but it is not a substitute for connection design
+### Threads
 
-DuckDB's DB-API docs describe `cursor()` as a way to create a second connection to an existing database, which can help with parallel threads. The same section also notes that a single connection is thread-safe but locked while queries run, so you should still design concurrency explicitly and not rely on one shared connection for throughput.
+A single connection is thread-safe but locked while a query runs. Use `con.cursor()` or per-thread connections for parallelism.
 
-### `:memory:` and named in-memory databases behave differently
+### `:memory:` vs named in-memory
 
-- `:memory:` creates a private in-memory database per connection.
-- A named in-memory database such as `:memory:analytics` shares state across connections that use the same name.
+`:memory:` is private per connection. A named in-memory database can share state — use only when intentional.
 
-Use a file-backed database or explicitly named in-memory connection only when shared state is intentional.
+### `executemany()` is not the bulk-load path
 
-### Direct DataFrame scans are convenient, but they are not persisted
+For bulk ingest, prefer:
 
-Querying a Python variable by name is great for analysis, but the underlying DataFrame is still a Python object. Create a table with `CREATE TABLE ... AS SELECT * FROM df_name` when later queries must not depend on Python variable scope.
+- `CREATE TABLE t AS SELECT * FROM df_name`
+- `INSERT INTO t SELECT * FROM df_name`
+- `read_parquet(...)`, `read_csv(...)`, `COPY`
 
-### `executemany()` is not the fast path for large bulk inserts
+### DataFrame scan is not a persisted table
 
-DuckDB's DB-API docs explicitly warn against using `executemany()` for large data loads. For bulk ingestion, prefer:
+Querying a Python variable by name is great for analysis but the underlying object is still in Python scope. Use `CREATE TABLE ... AS SELECT ...` for durability.
 
-- `CREATE TABLE ... AS SELECT * FROM df_name`
-- `INSERT INTO target SELECT * FROM df_name`
-- `read_parquet(...)`, `read_csv(...)`, or `COPY`
+### NumPy worker-thread import
 
-### Python worker-thread imports can matter
+If threaded code fetches pandas/numpy results, import `numpy.core.multiarray` before spawning threads.
 
-The DuckDB known-issues page documents a NumPy import issue in worker threads. If threaded code fetches Pandas or NumPy results, import `numpy.core.multiarray` before starting threads.
+### Notebook DESCRIBE/SUMMARIZE
 
-### Notebook display oddities are documented upstream
+Wrap in a subquery if results render empty: `FROM (DESCRIBE tbl)`.
 
-The known-issues page notes that `DESCRIBE` and `SUMMARIZE` can appear empty in some Jupyter paths. The documented workaround is to wrap them in a subquery, for example `FROM (DESCRIBE tbl)`.
+## Version-Sensitive Notes For 1.5.3
 
-## Version-Sensitive Notes For 1.5.0
+- `1.5.x` switched the `httpfs` extension backend from `httplib` to `curl`. Re-test proxy, TLS, and remote filesystem behavior when upgrading from 1.4.x.
+- The single-arrow lambda syntax is deprecated; DuckDB 2.0 will disable it by default. Use `lambda x: ...` syntax in new SQL.
+- Pin DuckDB and test extension loading in CI when your project relies on extensions.
 
-- This entry targets package version `1.5.0`. If a project is pinned to `1.4.x`, check the LTS docs before copying examples.
-- DuckDB's 1.5 release notes call out a change in the `httpfs` extension backend from `httplib` to `curl`. Re-test proxy, TLS, and remote filesystem behavior when upgrading from earlier releases.
-- The 1.5 release notes also warn that the single-arrow lambda syntax is deprecated and DuckDB 2.0 will disable it by default. Prefer `lambda x: ...` syntax in new SQL.
+## Official Sources
 
-## Recommended Agent Workflow
-
-1. Install the exact package version used by the project.
-2. Decide early whether you need an ephemeral in-memory connection or a persistent `.duckdb` file.
-3. Use parameterized SQL and explicit connections in non-interactive code.
-4. For DataFrames and files, push work into DuckDB SQL instead of row-by-row Python loops.
-5. For S3 or HTTP-backed reads, validate extension loading and credentials before writing query logic.
-
-## Official Sources Used
-
-- DuckDB Python client overview: `https://duckdb.org/docs/stable/clients/python/overview`
-- DuckDB Python DB-API reference: `https://duckdb.org/docs/stable/clients/python/dbapi`
-- DuckDB Python conversion and result methods: `https://duckdb.org/docs/stable/clients/python/conversion`
-- DuckDB guide for SQL on Pandas: `https://duckdb.org/docs/stable/guides/python/import_pandas`
-- DuckDB known Python issues: `https://duckdb.org/docs/stable/clients/python/known_issues`
-- DuckDB S3 API / secrets guidance: `https://duckdb.org/docs/stable/core_extensions/httpfs/s3api`
-- DuckDB 1.5.0 release notes: `https://duckdb.org/2026/03/09/announcing-duckdb-150`
-- PyPI package page: `https://pypi.org/project/duckdb/`
+- Python client overview: https://duckdb.org/docs/stable/clients/python/overview
+- DB-API reference: https://duckdb.org/docs/stable/clients/python/dbapi
+- Conversion / result methods: https://duckdb.org/docs/stable/clients/python/conversion
+- pandas integration: https://duckdb.org/docs/stable/guides/python/import_pandas
+- polars integration: https://duckdb.org/docs/stable/guides/python/polars
+- Known Python issues: https://duckdb.org/docs/stable/clients/python/known_issues
+- S3 / secrets: https://duckdb.org/docs/stable/core_extensions/httpfs/s3api
+- PyPI: https://pypi.org/project/duckdb/

--- a/content/numpy/docs/package/python/DOC.md
+++ b/content/numpy/docs/package/python/DOC.md
@@ -1,293 +1,307 @@
 ---
 name: package
-description: "NumPy package guide for Python array computing, broadcasting, typing, random generation, and NumPy 2.x migration"
+description: "NumPy package guide for Python 2.4.6: ndarray, dtype, shape, indexing, broadcasting, ufuncs, random, linalg"
 metadata:
   languages: "python"
-  versions: "2.4.3"
-  revision: 1
-  updated-on: "2026-03-11"
+  versions: "2.4.6"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
-  tags: "numpy,python,array,ndarray,numerical,scientific-computing,linear-algebra,random"
+  tags: "numpy,python,ndarray,dtype,broadcasting,ufunc,random,linalg"
 ---
 
 # NumPy Python Package Guide
 
 ## Golden Rule
 
-**Use `import numpy as np`, operate on whole arrays instead of Python loops when possible, and check shapes, dtypes, and copy semantics before assuming behavior.**
-
-NumPy is the core Python package for n-dimensional arrays, vectorized math, broadcasting, linear algebra helpers, and random number generation. For most projects, it is the foundation that other scientific and data libraries build on top of.
+`import numpy as np`. Operate on whole arrays. Check `.shape` and `.dtype` before assuming a result; check view-vs-copy before mutating.
 
 ## Installation
 
-Install with `pip`:
-
 ```bash
-python -m pip install numpy==2.4.3
+python -m pip install numpy==2.4.6
 ```
-
-If you use Conda or Miniconda, install from the `conda-forge` channel:
 
 ```bash
 conda install -c conda-forge numpy
 ```
 
-Verify the environment and version:
+Verify:
 
 ```bash
-python - <<'PY'
-import numpy as np
-print(np.__version__)
-PY
+python -c "import numpy as np; print(np.__version__)"
 ```
 
-## Initialize And Create Arrays
-
-Most code starts with one of:
+## ndarray
 
 ```python
 import numpy as np
 
-a = np.array([1, 2, 3], dtype=np.int64)
-b = np.asarray([1.0, 2.0, 3.0], dtype=np.float64)
-c = np.zeros((2, 3))
-d = np.ones((2, 3), dtype=np.float32)
-e = np.arange(0, 10, 2)
-f = np.linspace(0.0, 1.0, num=5)
+a = np.array([1, 2, 3])
+b = np.array([[1, 2, 3], [4, 5, 6]])
+
+a.shape   # (3,)
+a.ndim    # 1
+a.dtype   # int64 (or platform default int)
+a.size    # 3
+a.nbytes
 ```
 
-Check the properties that control behavior:
+### Constructors
 
 ```python
-arr = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int32)
-
-print(arr.shape)   # (2, 3)
-print(arr.ndim)    # 2
-print(arr.dtype)   # int32
-print(arr.size)    # 6
+np.zeros((2, 3))
+np.ones((2, 3), dtype=np.float32)
+np.full((2, 2), 7)
+np.empty((3,))
+np.arange(0, 10, 2)
+np.linspace(0.0, 1.0, num=5)
+np.eye(3)
+np.identity(3)
 ```
 
-Use `np.asarray(...)` when you want an array view of array-like input without forcing an unnecessary copy. In NumPy 2.x, `copy=False` is strict and raises if a copy would be required; use `copy=None` to allow a copy when needed, or `copy=True` to force one.
+### From Python data without unnecessary copies
 
 ```python
-data = [[1, 2], [3, 4]]
-arr = np.asarray(data, dtype=np.float64, copy=None)
+arr = np.asarray([[1, 2], [3, 4]], dtype=np.float64, copy=None)
 ```
 
-## Core Usage Patterns
+In NumPy 2.x, `copy=False` is strict and raises if a copy would be required. Use `copy=None` for "copy only if needed".
 
-### Elementwise math and reductions
-
-NumPy operations usually apply elementwise:
+## dtype
 
 ```python
-import numpy as np
+a = np.array([1, 2, 3], dtype=np.int32)
+b = a.astype(np.float64)        # makes a copy
+c = a.astype(np.float64, copy=False)  # share if possible
 
-x = np.array([1.0, 2.0, 3.0])
-y = np.array([10.0, 20.0, 30.0])
-
-print(x + y)        # [11. 22. 33.]
-print(x * y)        # [10. 40. 90.]
-print(np.sqrt(y))   # elementwise ufunc
-print(x.sum())      # scalar reduction
-print(y.mean())     # scalar reduction
+np.int8, np.int16, np.int32, np.int64
+np.uint8, np.uint16, np.uint32, np.uint64
+np.float32, np.float64
+np.complex64, np.complex128
+np.bool_
 ```
 
-Use `axis=` for row/column reductions:
+Be explicit about dtype before mixing scalars and arrays. In-place ops with mismatched dtypes can raise:
 
 ```python
-matrix = np.array([[1, 2, 3], [4, 5, 6]])
-
-print(matrix.sum(axis=0))   # column sums
-print(matrix.sum(axis=1))   # row sums
+arr = np.array([1, 2, 3], dtype=np.int64)
+arr += 0.5   # raises: cannot cast float to int64 safely
 ```
 
-### Matrix multiplication
-
-`*` is elementwise multiplication, not matrix multiplication. Use `@` or `np.matmul(...)`:
-
-```python
-a = np.array([[1, 2], [3, 4]])
-b = np.array([[5, 6], [7, 8]])
-
-print(a @ b)
-```
-
-### Reshaping and stacking
+## Shape / Reshape
 
 ```python
 arr = np.arange(12)
-grid = arr.reshape(3, 4)
-flat = grid.ravel()
-stacked = np.stack([grid, grid])
+
+arr.reshape(3, 4)
+arr.reshape(2, -1)        # -1 infers
+arr.reshape(3, 4).ravel() # flatten (view if possible)
+arr.reshape(3, 4).flatten()  # always copy
+
+np.transpose(arr.reshape(3, 4))
+arr.reshape(3, 4).T
+
+np.expand_dims(arr, axis=0)
+np.squeeze(np.zeros((1, 3, 1)))
+
+np.concatenate([a, b], axis=0)
+np.stack([a, b])             # new axis
+np.hstack, np.vstack
 ```
 
-Use `reshape(...)` only when the element count matches the target shape.
+`reshape` requires the element count to match.
 
-## Indexing, Slicing, And Broadcasting
+## Indexing / Slicing / Boolean Masks
 
-### Basic indexing
+### Basic
 
 ```python
 arr = np.arange(10)
 
-print(arr[0])      # first element
-print(arr[-1])     # last element
-print(arr[2:7:2])  # slice
+arr[0]
+arr[-1]
+arr[2:7]
+arr[2:7:2]
+arr[::-1]
 ```
 
-For multidimensional arrays:
+### Multi-dim
 
 ```python
 grid = np.arange(12).reshape(3, 4)
 
-print(grid[1, 2])   # row 1, col 2
-print(grid[:, 0])   # first column
-print(grid[1:3, :2])
+grid[1, 2]
+grid[:, 0]
+grid[1:3, :2]
+grid[..., 0]        # ellipsis = "all remaining axes"
 ```
 
-### Broadcasting
+### Boolean masks (copies)
 
-Broadcasting lets NumPy apply operations to arrays with compatible shapes without materializing repeated copies:
+```python
+arr = np.array([1, 2, 3, 4, 5])
+arr[arr > 2]          # [3 4 5]
+arr[(arr > 1) & (arr < 5)]
+```
+
+### Fancy indexing (copies)
+
+```python
+arr[[0, 2, 4]]
+grid[[0, 2], [1, 3]]   # picks (0,1) and (2,3)
+np.where(arr > 2, arr, 0)
+```
+
+### Views vs copies
+
+```python
+arr = np.array([1, 2, 3, 4])
+view = arr[1:3]    # view: shares memory
+view[0] = 99
+arr                # [1, 99, 3, 4]
+
+copy = arr[[1, 3]] # fancy index: independent copy
+copy[0] = 0
+arr                # unchanged
+```
+
+## Broadcasting
 
 ```python
 data = np.array([[1.0, 2.0, 3.0],
                  [4.0, 5.0, 6.0]])
 offset = np.array([10.0, 20.0, 30.0])
 
-print(data + offset)
+data + offset         # offset broadcast across rows
+
+col = np.array([[1.0], [10.0]])
+data * col            # col broadcast across columns
 ```
 
-Broadcasting works when dimensions are equal or one of them is `1`, compared from the trailing dimensions backward. If shapes are incompatible, NumPy raises `ValueError: operands could not be broadcast together`.
+Rules, compared from trailing dims backward:
 
-## Random Number Generation
+- equal dims, or
+- one of them is `1`
 
-Prefer `np.random.default_rng(...)` and a `Generator` instance for new code:
+If incompatible: `ValueError: operands could not be broadcast together`.
+
+## Ufuncs
+
+Elementwise functions over arrays:
 
 ```python
-import numpy as np
+np.sqrt(x)
+np.exp(x)
+np.log(x)
+np.sin(x), np.cos(x)
+np.abs(x)
+np.maximum(x, y)
+np.add(x, y)        # same as x + y
+np.multiply(x, y)
 
-rng = np.random.default_rng(seed=42)
+# Use out= to reuse memory
+out = np.empty_like(x)
+np.multiply(x, 2.0, out=out)
 
-samples = rng.normal(loc=0.0, scale=1.0, size=(2, 3))
-ints = rng.integers(low=0, high=10, size=5)
+# Reductions
+np.sum(x), np.prod(x)
+np.cumsum(x), np.cumprod(x)
 ```
 
-This is better than using legacy global functions such as `np.random.seed(...)` and `np.random.rand(...)` in new code. If you need reproducibility, keep the seed explicit. NumPy documents no compatibility guarantee for the `Generator` bit stream across versions.
+## Common Math / Stats
+
+```python
+x = np.array([1.0, 2.0, 3.0, 4.0])
+
+x.sum(); x.mean(); x.std(); x.var()
+x.min(); x.max(); x.argmin(); x.argmax()
+np.median(x); np.percentile(x, 95); np.quantile(x, 0.5)
+
+m = np.array([[1, 2], [3, 4]])
+m.sum(axis=0)     # column sums
+m.sum(axis=1)     # row sums
+m.mean(axis=0, keepdims=True)
+```
+
+## Random (default_rng)
+
+```python
+rng = np.random.default_rng(seed=42)
+
+rng.integers(low=0, high=10, size=5)
+rng.random(size=(2, 3))
+rng.normal(loc=0.0, scale=1.0, size=(2, 3))
+rng.uniform(0.0, 1.0, size=10)
+rng.choice([10, 20, 30], size=5, replace=True)
+rng.shuffle(arr)
+rng.permutation(10)
+```
+
+Prefer `default_rng()` over the legacy `np.random.seed` / `np.random.rand` API for new code.
+
+## Linalg Basics
+
+```python
+a = np.array([[1, 2], [3, 4]], dtype=np.float64)
+b = np.array([[5, 6], [7, 8]], dtype=np.float64)
+
+a @ b                  # matrix multiply
+np.matmul(a, b)
+np.dot(a[0], b[:, 0])  # vector dot
+
+np.linalg.inv(a)
+np.linalg.det(a)
+np.linalg.norm(a)
+np.linalg.eig(a)
+np.linalg.svd(a)
+np.linalg.qr(a)
+
+# Solve A x = b without explicit inverse
+x = np.linalg.solve(a, np.array([1.0, 2.0]))
+```
+
+`*` is elementwise; use `@` or `np.matmul` for matrix multiplication.
 
 ## Typing
 
-Use `numpy.typing` for type hints:
-
 ```python
-from typing import Any
 import numpy as np
 import numpy.typing as npt
 
 def normalize(x: npt.ArrayLike) -> npt.NDArray[np.float64]:
     arr = np.asarray(x, dtype=np.float64)
-    denom = np.linalg.norm(arr)
-    return arr if denom == 0.0 else arr / denom
+    n = np.linalg.norm(arr)
+    return arr if n == 0.0 else arr / n
 ```
 
-Useful typing names:
-
-- `npt.ArrayLike` for function inputs that can become arrays
-- `npt.NDArray[dtype]` for ndarray return types
-
-If you run `mypy`, NumPy provides a plugin (`numpy.typing.mypy_plugin`) to resolve platform-specific scalar precisions more accurately.
-
-## Configuration And Environment Notes
-
-NumPy itself does not use API authentication.
-
-The main things that behave like "configuration" for coding tasks are:
-
-- `dtype=`: controls numeric precision and casting behavior
-- `copy=`: controls whether data may be shared or must be copied
-- `order=`: memory layout (`"C"` or `"F"`) for some constructors and conversions
-- RNG seed: controls reproducibility in random workflows
-- `np.set_printoptions(...)`: useful when tests or logs need stable array rendering
-
-For isolated projects, install NumPy into a virtual environment or Conda environment instead of the system interpreter.
+- `npt.ArrayLike` for inputs
+- `npt.NDArray[dtype]` for return types
 
 ## Common Pitfalls
 
-### Views vs copies
+- Views vs copies: basic slicing returns views; fancy/boolean indexing returns copies.
+- `np.arange` with float steps has precision artifacts. Use `np.linspace`.
+- In-place ops with incompatible dtypes raise in NumPy 2.x.
+- Shape bugs cause most runtime errors. `assert arr.shape == (...)` early.
+- `copy=False` in `np.asarray` means "never copy" and raises if conversion would require one.
 
-Basic slicing usually creates a **view**, so writing through the slice can mutate the original array:
+## Version-Sensitive Notes For NumPy 2.4.6
 
-```python
-arr = np.array([1, 2, 3, 4])
-view = arr[1:3]
-view[0] = 99
+- Current PyPI release as of 2026-05-29 is `2.4.6`.
+- NumPy 2.0 changed type-promotion behavior and `np.asarray` semantics (`copy=`, `device=`).
+- Legacy aliases and compatibility shims were removed in 2.x.
+- C-API extension modules need a 2.x-compatible build.
 
-print(arr)   # [ 1 99  3  4]
-```
+## Official Sources
 
-Advanced indexing creates a **copy**, not a view:
-
-```python
-arr = np.array([1, 2, 3, 4])
-copy = arr[[1, 3]]
-copy[0] = 99
-
-print(arr)   # unchanged
-```
-
-### `np.arange(...)` with float steps
-
-`np.arange(...)` is fine for integer ranges. For evenly spaced floats, prefer `np.linspace(...)` to avoid surprising endpoint and precision behavior.
-
-### Dtype promotion and in-place operations
-
-Mixed dtypes can change result dtypes, and in-place writes can fail if NumPy would need an unsafe cast:
-
-```python
-arr = np.array([1, 2, 3], dtype=np.int64)
-
-# This can raise because the float result cannot be cast back safely.
-arr += 0.5
-```
-
-Be explicit about the dtype you want before combining arrays or scalars with different numeric types.
-
-### Shape mismatches
-
-Most runtime NumPy bugs are shape bugs. Inspect `.shape` before assuming broadcasting or matrix multiplication will work:
-
-```python
-assert features.ndim == 2
-assert weights.shape == (features.shape[1],)
-```
-
-## Version-Sensitive Notes For NumPy 2.x
-
-- The version used here for this package session is `2.4.3`, and PyPI lists `2.4.3` as the current release.
-- NumPy 2.0 changed type-promotion behavior in some mixed-dtype operations. If a project was written against 1.x behavior, check the NumPy 2.0 migration guide before "fixing" results by guesswork.
-- NumPy 2.0 changed `np.asarray(...)` semantics by adding `copy=` and `device=` keyword arguments. `copy=False` now means "never copy" and can raise if the conversion cannot honor that requirement.
-- Several legacy aliases and compatibility shims were removed in 2.x. Old blog posts or snippets may fail even if the overall idea is still correct.
-- For extension modules that compile against the NumPy C API, NumPy 2.0 is a binary-compatibility boundary. Pure Python code using public NumPy APIs is usually much less affected.
-
-## Practical Workflow For Agents
-
-1. Install `numpy` into the active project environment and confirm `np.__version__`.
-2. Convert external inputs with `np.asarray(...)` only once near the boundary.
-3. Check `.shape` and `.dtype` before writing vectorized operations.
-4. Prefer array expressions, ufuncs, and reductions over Python loops.
-5. Use `default_rng(...)` for new random code.
-6. When behavior looks surprising, inspect broadcasting rules and whether you are working with a view or a copy.
-7. If the project recently moved from NumPy 1.x to 2.x, check the migration guide before assuming a bug is in your own code.
-
-## Official Sources Used
-
-- NumPy install guide: https://numpy.org/install
-- NumPy absolute beginners guide: https://numpy.org/doc/stable/user/absolute_beginners.html
-- NumPy quickstart: https://numpy.org/doc/stable/user/quickstart.html
-- NumPy broadcasting guide: https://numpy.org/doc/stable/user/basics.broadcasting.html
-- NumPy copies and views guide: https://numpy.org/doc/stable/user/basics.copies.html
-- `numpy.asarray` reference: https://numpy.org/doc/stable/reference/generated/numpy.asarray.html
-- Random `Generator` reference: https://numpy.org/doc/stable/reference/random/generator.html
-- NumPy typing reference: https://numpy.org/doc/stable/reference/typing.html
-- NumPy 2.0 migration guide: https://numpy.org/doc/stable/numpy_2_0_migration_guide.html
-- PyPI package page: https://pypi.org/project/numpy/
+- Install: https://numpy.org/install
+- Quickstart: https://numpy.org/doc/stable/user/quickstart.html
+- Broadcasting: https://numpy.org/doc/stable/user/basics.broadcasting.html
+- Copies/views: https://numpy.org/doc/stable/user/basics.copies.html
+- Indexing: https://numpy.org/doc/stable/user/basics.indexing.html
+- Random Generator: https://numpy.org/doc/stable/reference/random/generator.html
+- linalg reference: https://numpy.org/doc/stable/reference/routines.linalg.html
+- Typing reference: https://numpy.org/doc/stable/reference/typing.html
+- 2.0 migration guide: https://numpy.org/doc/stable/numpy_2_0_migration_guide.html
+- PyPI: https://pypi.org/project/numpy/

--- a/content/pandas/docs/package/python/DOC.md
+++ b/content/pandas/docs/package/python/DOC.md
@@ -1,58 +1,46 @@
 ---
 name: package
-description: "pandas package guide for Python 3.0.1: installation, DataFrame workflows, IO, options, and 3.0 migration notes"
+description: "pandas package guide for Python 3.0.3: DataFrame/Series, IO, selection, groupby, joins, reshape, datetime, and missing data"
 metadata:
   languages: "python"
-  versions: "3.0.1"
-  revision: 1
-  updated-on: "2026-03-11"
+  versions: "3.0.3"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
-  tags: "pandas,dataframe,data-analysis,io,timeseries,pyarrow"
+  tags: "pandas,dataframe,series,io,groupby,join,reshape,datetime"
 ---
 
 # pandas Python Package Guide
 
 ## Golden Rule
 
-Use `pandas` when you need labeled tabular data in Python: `Series` for 1D data and `DataFrame` for 2D data. Treat the official getting started, user guide, and API reference as the source of truth for method behavior and optional IO dependencies.
+Use `pandas` when you need labeled tabular data in Python. `Series` is 1D, `DataFrame` is 2D. Prefer vectorized operations over `apply`/`map` over Python loops.
 
 ## Installation
 
-### pip
-
 ```bash
-pip install pandas==3.0.1
+pip install pandas==3.0.3
 ```
-
-### conda-forge
 
 ```bash
 conda install -c conda-forge pandas
 ```
 
-### Common optional extras
+Common extras:
 
 ```bash
+pip install "pandas[parquet]"
 pip install "pandas[excel]"
 pip install "pandas[performance]"
-pip install "pandas[aws]"
-pip install "pandas[parquet]"
 pip install "pandas[all]"
 ```
 
-Use extras only when the workflow needs them. pandas raises `ImportError` when you call a method that depends on an optional package you did not install.
-
-Examples from the official docs:
-
-- Excel IO needs engines such as `openpyxl`, `python-calamine`, or `xlsxwriter`
-- SQL workflows commonly use `sqlalchemy`
-- Remote filesystem URLs rely on `fsspec`-style backends
-- Performance-sensitive work can benefit from `numexpr`, `bottleneck`, and `numba`
-
-## Initialize And Inspect Data
+## DataFrame And Series
 
 ```python
 import pandas as pd
+
+s = pd.Series([1, 2, 3], name="x", index=["a", "b", "c"])
 
 df = pd.DataFrame(
     {
@@ -62,222 +50,219 @@ df = pd.DataFrame(
     }
 )
 
-print(df.dtypes)
-print(df.head())
-print(df.describe(include="all"))
+df.dtypes
+df.shape
+df.head()
+df.describe(include="all")
 ```
 
-Use `DataFrame` for table-shaped data and `Series` for a single labeled column. The package overview and API reference organize pandas around `Series`, `DataFrame`, `GroupBy`, `Resampling`, `Window`, IO, and options/settings.
+## IO
 
-## Core Workflows
-
-### Read and write tabular data
+### CSV
 
 ```python
-import pandas as pd
-
-df = pd.read_csv("input.csv")
-df.to_parquet("output.parquet", index=False)
+df = pd.read_csv("input.csv", parse_dates=["date"], dtype={"id": "int64"})
+df.to_csv("out.csv", index=False)
 ```
 
-`read_*` and `to_*` cover CSV, Excel, JSON, HTML, XML, Parquet, Feather, SQL, and more.
-
-If you need Excel:
+### Parquet
 
 ```python
-df = pd.read_excel("input.xlsx")
-df.to_excel("output.xlsx", index=False)
+df = pd.read_parquet("input.parquet")
+df.to_parquet("out.parquet", index=False, compression="zstd")
 ```
 
-Make sure the matching engine is installed first.
-
-### Select, filter, and assign
+### SQL
 
 ```python
-active = df.loc[df["sales"] > 8, ["city", "sales"]]
-first_two_rows = df.iloc[:2, :]
+from sqlalchemy import create_engine
 
-df.loc[:, "sales_with_tax"] = df["sales"] * 1.1
+engine = create_engine("postgresql+psycopg://user:pass@host/db")
+df = pd.read_sql("select * from orders where created_at > %(d)s", engine, params={"d": "2026-01-01"})
+df.to_sql("orders_copy", engine, if_exists="replace", index=False)
 ```
 
-Use:
+For closer database type round-trips, pass `dtype_backend="pyarrow"`.
+
+## Selection
+
+```python
+df["sales"]                  # single column -> Series
+df[["city", "sales"]]        # multiple columns -> DataFrame
+
+df.loc[0, "sales"]           # label-based
+df.loc[df.index[:2], ["city", "sales"]]
+
+df.iloc[0, 1]                # position-based
+df.iloc[:2, :]
+df.iloc[-1]
+```
+
+Rule of thumb:
 
 - `[]` for simple column access
 - `loc` for label-based row/column selection
 - `iloc` for position-based selection
 
-### Aggregate with groupby
+## Filtering
 
 ```python
-summary = (
-    df.groupby("city", dropna=False)["sales"]
-    .agg(["count", "sum", "mean"])
-    .sort_values("sum", ascending=False)
-)
+df[df["sales"] > 8]
+df[(df["sales"] > 8) & (df["city"] != "NYC")]
+df.query("sales > 8 and city != 'NYC'")
+df[df["city"].isin(["SF", "SEA"])]
+df[df["city"].str.startswith("S")]
 ```
 
-`groupby` is the main split-apply-combine tool. Use `value_counts()` for quick category counts.
+Use `&`, `|`, `~` with parentheses, not Python `and`/`or`/`not`.
 
-### Join and reshape
+## GroupBy / Agg
+
+```python
+df.groupby("city")["sales"].sum()
+
+df.groupby("city").agg(
+    total=("sales", "sum"),
+    n=("sales", "count"),
+    avg=("sales", "mean"),
+)
+
+df.groupby(["city", df["date"].dt.month]).agg({"sales": ["sum", "mean"]})
+```
+
+`groupby` is the split-apply-combine tool. Use `dropna=False` to keep NaN groups. Use `value_counts()` for category counts.
+
+## Merge / Join / Concat
 
 ```python
 customers = pd.DataFrame({"customer_id": [1, 2], "name": ["A", "B"]})
 orders = pd.DataFrame({"customer_id": [1, 1, 2], "total": [25, 30, 20]})
 
-joined = customers.merge(orders, on="customer_id", how="left")
+# merge on key column
+customers.merge(orders, on="customer_id", how="left")
+
+# join on index
+customers.set_index("customer_id").join(orders.set_index("customer_id"), how="inner")
+
+# stack DataFrames
+pd.concat([df1, df2], axis=0, ignore_index=True)  # rows
+pd.concat([df1, df2], axis=1)                     # columns
 ```
 
-Use `merge`, `join`, `concat`, `pivot`, `pivot_table`, `stack`, and `unstack` for relational and reporting-style transforms.
+`how=` accepts `"inner"`, `"left"`, `"right"`, `"outer"`, `"cross"`.
 
-### Time series
+## Reshape
 
 ```python
-ts = (
-    df.set_index("date")
-    .sort_index()
-    .resample("MS")["sales"]
-    .sum()
-)
+# wide -> long
+long_df = df.melt(id_vars=["city"], value_vars=["sales"], var_name="metric", value_name="val")
+
+# long -> wide
+wide_df = long_df.pivot(index="city", columns="metric", values="val")
+
+# aggregated pivot
+pd.pivot_table(df, index="city", columns="date", values="sales", aggfunc="sum")
+
+# multi-index reshape
+df.set_index(["city", "date"]).unstack("date")
 ```
 
-Use `to_datetime`, `date_range`, timezone-aware dtypes, rolling windows, and `resample()` for date-based pipelines.
+## Datetime
 
-### Expression-based column creation
+```python
+df["date"] = pd.to_datetime(df["date"], utc=True)
+df["month"] = df["date"].dt.month
+df["dow"] = df["date"].dt.day_name()
 
-`pandas 3.0` added `pd.col()` for expression-style column references:
+# date range
+pd.date_range("2026-01-01", "2026-12-31", freq="MS")
+
+# resample needs a datetime index
+ts = df.set_index("date").sort_index()
+ts["sales"].resample("MS").sum()
+ts["sales"].rolling("7D").mean()
+```
+
+## Missing Data
+
+```python
+df.isna()
+df.isna().sum()
+df.dropna(subset=["sales"])
+df.fillna({"sales": 0, "city": "unknown"})
+df["sales"].ffill()
+df["sales"].bfill()
+```
+
+In pandas 3.0 the default string dtype changed; do not assume `object` dtype or a specific missing sentinel. Use `pd.NA`-aware checks.
+
+## Apply / Map vs Vectorized
+
+Vectorized first. Reach for `apply`/`map` only when no vectorized form exists.
+
+```python
+# Vectorized (fast)
+df["sales_with_tax"] = df["sales"] * 1.1
+df["city_lower"] = df["city"].str.lower()
+
+# Series.map: per-element scalar -> scalar
+df["region"] = df["city"].map({"SF": "west", "NYC": "east", "SEA": "west"})
+
+# Series.apply: when no vectorized form exists
+df["sales_str"] = df["sales"].apply(lambda v: f"${v:,.2f}")
+
+# DataFrame.apply along axis: slow; avoid when possible
+df["row_total"] = df[["sales"]].apply(sum, axis=1)
+```
+
+For column expressions, pandas 3.0 supports `pd.col()`:
 
 ```python
 df = df.assign(double_sales=pd.col("sales") * 2)
 ```
 
-This is useful in `assign`, `loc`, and similar places that accept callables returning a `Series`.
-
-## Config And Backend Integration
-
-### Display and runtime options
-
-Use the options API for temporary or global formatting changes:
-
-```python
-import pandas as pd
-
-pd.set_option("display.max_rows", 200)
-
-with pd.option_context("display.max_columns", 20, "display.width", 120):
-    print(df)
-```
-
-Important options APIs:
-
-- `pd.get_option()`
-- `pd.set_option()`
-- `pd.reset_option()`
-- `pd.describe_option()`
-- `pd.option_context()`
-
-Use full option names in code. Short patterns can become ambiguous across releases.
-
-### Remote files and cloud storage
-
-pandas itself does not have package-level authentication. Credentials come from the underlying storage or database backend.
-
-For remote files, use URL-aware readers and pass backend configuration through `storage_options` when needed:
-
-```python
-import pandas as pd
-
-df = pd.read_csv(
-    "s3://my-bucket/path/data.csv",
-    storage_options={"anon": False},
-)
-```
-
-The IO guide also shows passing backend-specific client settings via `storage_options`, for example `client_kwargs` for S3-compatible endpoints.
-
-### SQL connections
-
-```python
-import pandas as pd
-from sqlalchemy import create_engine
-
-engine = create_engine("postgresql+psycopg://user:pass@host/db")
-df = pd.read_sql("select * from orders", engine)
-```
-
-Put connection credentials in your database URL, driver config, environment, or secret manager. pandas reads through the DBAPI/SQLAlchemy connection you provide.
-
-If you care about preserving database types more closely, the IO guide recommends `dtype_backend="pyarrow"` for `read_sql()` round-trips.
-
 ## Common Pitfalls
 
-### Missing optional dependencies
+### Chained assignment
 
-Many pandas methods work only when their backend package is installed. Typical failures:
-
-- `read_excel()` without an Excel engine
-- `read_parquet()` without Parquet support
-- `read_csv("s3://...")` without the appropriate filesystem backend
-- `to_markdown()` without `tabulate`
-
-Install the matching extra or dependency before changing code.
-
-### Chained assignment changed in pandas 3.0
-
-In pandas 3.0, chained assignment no longer works as a mutation pattern. Old code like this is wrong:
+In pandas 3.0, chained assignment will not mutate.
 
 ```python
+# Wrong
 df[df["sales"] > 0]["sales"] = 0
-```
 
-Write the mutation in one step instead:
-
-```python
+# Right
 df.loc[df["sales"] > 0, "sales"] = 0
 ```
 
-### String dtype assumptions changed
+### SettingWithCopyWarning replaced by Copy-on-Write
 
-The pandas 3.0 release notes call out a new default string dtype. Code that assumes string columns stay `object` dtype, or code that depends on a specific missing-value sentinel, can break after upgrading.
+Operations that used to silently mutate views now produce independent objects. Reassign rather than mutate.
 
-### Be explicit with indexes before joins and resampling
+### Boolean operators on Series
 
-`merge`, `groupby`, and `resample` are easier to reason about when you normalize dtypes first and make the relevant key or timestamp column explicit.
+Use `&`/`|`/`~` with parentheses around comparisons.
 
-```python
-df["date"] = pd.to_datetime(df["date"], utc=True)
-df["customer_id"] = df["customer_id"].astype("int64")
-```
+### Optional IO dependencies
 
-### Large-data performance is opt-in
+`read_excel`, `read_parquet`, `to_markdown`, S3/GCS URLs, and SQLAlchemy backends each need their own packages.
 
-pandas is flexible, not magically distributed. For large datasets:
+## Version-Sensitive Notes For 3.0.3
 
-- install performance extras
-- prefer vectorized operations over Python loops
-- choose columnar formats like Parquet when possible
-- use `dtype_backend="pyarrow"` selectively when it improves downstream interoperability
-
-## Version-Sensitive Notes For 3.0.1
-
-- `pandas 3.0.0` was released on January 21, 2026 and introduced breaking behavior around Copy-on-Write semantics and chained assignment.
-- `pandas 3.0.0` also introduced `pd.col()` expression support.
-- `pandas 3.0.1` was released on February 17, 2026 and fixes early 3.0 regressions, including:
-  - unary operators on `pd.col()`
-  - some pyarrow-backed string operations
-  - a `merge()` bug involving `NaN` values in pyarrow-backed string join keys on Windows with pyarrow 21
-  - Copy-on-Write handling in some constructor paths
-
-If you are on `3.0.0` and using `pd.col()`, pyarrow-backed strings, or Windows joins, prefer `3.0.1`.
+- `3.0.0` (Jan 2026) introduced Copy-on-Write defaults, removed chained-assignment as a mutation pattern, added `pd.col()`, and changed the default string dtype.
+- `3.0.1` and later patch releases fix `pd.col()` unary operator edge cases, pyarrow string operation regressions, and `merge()` issues with NaN keys on pyarrow-backed strings.
+- If a project mixes pyarrow-backed strings with joins or unary `pd.col()`, prefer the latest 3.0.x.
 
 ## Official Sources
 
 - Docs root: https://pandas.pydata.org/docs/
 - API reference: https://pandas.pydata.org/docs/reference/index.html
 - Installation: https://pandas.pydata.org/docs/getting_started/install.html
-- Package overview: https://pandas.pydata.org/docs/getting_started/overview.html
-- Tutorials index: https://pandas.pydata.org/docs/getting_started/intro_tutorials/index.html
 - IO guide: https://pandas.pydata.org/docs/user_guide/io.html
-- Options guide: https://pandas.pydata.org/docs/user_guide/options.html
+- GroupBy guide: https://pandas.pydata.org/docs/user_guide/groupby.html
+- Merge/join: https://pandas.pydata.org/docs/user_guide/merging.html
+- Reshape: https://pandas.pydata.org/docs/user_guide/reshaping.html
+- Time series: https://pandas.pydata.org/docs/user_guide/timeseries.html
+- Missing data: https://pandas.pydata.org/docs/user_guide/missing_data.html
 - Release notes 3.0.0: https://pandas.pydata.org/docs/whatsnew/v3.0.0.html
-- Release notes 3.0.1: https://pandas.pydata.org/docs/whatsnew/v3.0.1.html
-- PyPI package: https://pypi.org/project/pandas/3.0.1/
+- PyPI package: https://pypi.org/project/pandas/

--- a/content/polars/docs/package/python/DOC.md
+++ b/content/polars/docs/package/python/DOC.md
@@ -1,61 +1,41 @@
 ---
 name: package
-description: "polars package guide for Python DataFrame, LazyFrame, expressions, IO, and cloud-backed analytics workflows"
+description: "polars package guide for Python 1.41.2: DataFrame, LazyFrame, expressions, scan_*, group_by, joins, SQL, and lazy execution"
 metadata:
   languages: "python"
-  versions: "1.38.1"
-  revision: 1
-  updated-on: "2026-03-12"
+  versions: "1.41.2"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
-  tags: "polars,dataframe,lazyframe,columnar,parquet,sql"
+  tags: "polars,dataframe,lazyframe,expressions,parquet,sql,lazy"
 ---
 
 # polars Python Package Guide
 
-## What It Is
+## Golden Rule
 
-`polars` is a columnar DataFrame library for Python built around expressions, lazy query planning, and fast parquet/csv/ndjson/database-style data workflows.
-
-Use it when you need:
-
-- DataFrame operations that stay vectorized instead of row-by-row Python loops
-- lazy query planning with predicate and projection pushdown
-- efficient parquet and IPC/Arrow interop
-- SQL-style analytics on local files, in-memory frames, or cloud-backed datasets
-
-For new code, prefer the expression API and the lazy API unless you specifically need eager materialization.
+Stay in the expression API. Use `LazyFrame` + `scan_*` for file pipelines, `.collect()` at the boundary. Avoid `apply`/Python loops.
 
 ## Install
 
-Base install:
-
 ```bash
-python -m pip install polars==1.38.1
+python -m pip install polars==1.41.2
 ```
 
-Common alternatives:
-
 ```bash
-uv add polars==1.38.1
-poetry add polars==1.38.1
-conda install -c conda-forge polars=1.38.1
+uv add polars==1.41.2
+conda install -c conda-forge polars=1.41.2
 ```
 
-Useful optional extras from the official package metadata:
+Extras:
 
 ```bash
-python -m pip install "polars[numpy,fsspec]==1.38.1"
-python -m pip install "polars[pyarrow]==1.38.1"
-python -m pip install "polars[all]==1.38.1"
+python -m pip install "polars[pyarrow]==1.41.2"
+python -m pip install "polars[numpy,fsspec]==1.41.2"
+python -m pip install "polars[all]==1.41.2"
 ```
 
-Notes:
-
-- `fsspec` is commonly needed for filesystem integrations and some remote-storage workflows.
-- `pyarrow` is optional for many `polars` tasks, but it is useful when a codebase already depends on Arrow or pandas/Arrow interchange.
-- The PyPI page also documents runtime compatibility wheels such as `rtcompat` and `rt64` for specific environments; use them only when the upstream install guidance calls for them.
-
-## Import And First Frame
+## DataFrame And LazyFrame
 
 ```python
 import polars as pl
@@ -68,227 +48,235 @@ df = pl.DataFrame(
     }
 )
 
-print(df)
-print(df.schema)
+# eager -> lazy
+lf = df.lazy()
+
+# lazy -> eager
+df2 = lf.collect()
 ```
 
-`polars` uses a few core types repeatedly:
+Core types:
 
-- `pl.DataFrame` for eager tabular data
-- `pl.LazyFrame` for deferred query execution
-- `pl.Series` for a single column
-- `pl.Expr` for reusable column expressions inside `select`, `with_columns`, `filter`, `group_by`, and joins
+- `pl.DataFrame` — eager, materialized
+- `pl.LazyFrame` — deferred plan
+- `pl.Series` — single column
+- `pl.Expr` — reusable column expression
 
-## Core Usage
+## scan_csv / scan_parquet
 
-### Expressions First
+Lazy readers enable predicate and projection pushdown.
 
-The official user guide treats expressions as the main building block. Write transformations with `pl.col(...)`, literals, and expression methods instead of Python loops.
+```python
+lf = pl.scan_parquet("data/events/*.parquet")
+lf = pl.scan_csv("data/events.csv", try_parse_dates=True, infer_schema_length=10_000)
+lf = pl.scan_ndjson("data/events.ndjson")
+lf = pl.scan_ipc("data/events.arrow")
+```
+
+Do not use `pl.read_csv(...).lazy()` — the file is already read eagerly.
+
+## select / filter / with_columns / group_by / agg
 
 ```python
 import polars as pl
 
 result = (
-    df
-    .filter(pl.col("active"))
+    pl.scan_parquet("data/events/*.parquet")
+    .filter(pl.col("event_date") >= pl.date(2026, 1, 1))
     .with_columns(
         count_doubled=pl.col("count") * 2,
         city_upper=pl.col("city").str.to_uppercase(),
     )
-    .select("city_upper", "count_doubled")
-)
-```
-
-`DataFrame.with_columns(...)` returns a new frame but does not copy existing data buffers just to add or replace derived columns.
-
-### Prefer Lazy Execution For Pipelines
-
-Use `scan_*` for file-backed work and keep the query lazy until the end.
-
-```python
-import polars as pl
-
-q = (
-    pl.scan_parquet("data/events/*.parquet")
-    .filter(pl.col("event_date") >= pl.date(2026, 1, 1))
+    .select("event_date", "user_id", "city_upper", "count_doubled")
     .group_by("user_id")
     .agg(
         events=pl.len(),
-        total_amount=pl.col("amount").sum(),
+        total=pl.col("count_doubled").sum(),
+        first_city=pl.col("city_upper").first(),
     )
-    .sort("total_amount", descending=True)
+    .sort("total", descending=True)
+    .collect()
 )
-
-result = q.collect()
 ```
 
-Why this matters:
+- `select` — pick/derive columns (replaces output schema)
+- `with_columns` — add/replace columns (keeps existing)
+- `filter` — row filter; expressions returning Boolean
+- `group_by` + `agg` — split-apply-combine
+- `sort`, `unique`, `drop_nulls`, `head`, `tail`, `slice`
 
-- `scan_parquet`, `scan_csv`, and similar lazy readers allow predicate/projection pushdown
-- the optimizer can remove unused columns and push filters closer to the source
-- `read_csv(...).lazy()` is usually the wrong starting point because the file was already read eagerly
+## Expressions
 
-For large pipelines, the upstream docs also expose streaming execution on supported plans via `collect(engine="streaming")` and sink APIs.
+```python
+pl.col("amount")
+pl.col("amount") * 1.1
+pl.col("name").str.to_lowercase().str.strip_chars()
+pl.col("ts").dt.year()
 
-### Read And Write Files
+pl.when(pl.col("amount") > 100).then(pl.lit("big")).otherwise(pl.lit("small"))
 
-Eager read when the data is small and immediate materialization is fine:
+pl.col("amount").sum().over("user_id")   # window
+pl.col("amount").rank(descending=True)
+pl.col("ts").is_between(pl.date(2026, 1, 1), pl.date(2026, 12, 31))
+
+pl.col("tags").list.contains("vip")
+pl.col("payload").struct.field("price")
+```
+
+Combine, reuse, and pass expressions as variables. `pl.len()` for row count.
+
+## Joins
+
+```python
+orders = pl.DataFrame({"user_id": [1, 1, 2, 3], "amount": [40, 60, 10, 25]})
+users = pl.DataFrame({"user_id": [1, 2, 3], "plan": ["pro", "free", "pro"]})
+
+orders.join(users, on="user_id", how="left")
+orders.join(users, left_on="user_id", right_on="user_id", how="inner")
+orders.join(users, on="user_id", how="anti")
+orders.join(users, on="user_id", how="semi")
+orders.join(users, on="user_id", how="full", coalesce=True)
+
+# time-aware joins
+orders_sorted = orders.sort("ts")
+prices_sorted = prices.sort("ts")
+orders_sorted.join_asof(prices_sorted, on="ts", by="symbol", strategy="backward")
+```
+
+## SQL Interface
 
 ```python
 import polars as pl
 
-df = pl.read_csv(
-    "input.csv",
-    try_parse_dates=True,
-    infer_schema_length=10_000,
+ctx = pl.SQLContext(orders=orders_lf, users=users_lf)
+
+result = ctx.execute(
+    """
+    select u.plan, sum(o.amount) as total
+    from orders o
+    join users u using (user_id)
+    group by u.plan
+    order by total desc
+    """,
+    eager=True,
 )
 ```
 
-Lazy read when the dataset is large or you will filter/select before collecting:
+Or inline:
 
 ```python
-import polars as pl
-
-q = pl.scan_csv(
-    "input.csv",
-    try_parse_dates=True,
-)
-
-result = q.select("id", "ts", "value").filter(pl.col("value") > 0).collect()
-```
-
-Write parquet for downstream analytics:
-
-```python
-import polars as pl
-
-df.write_parquet(
-    "output.parquet",
-    compression="zstd",
-    statistics=True,
+pl.sql(
+    "select user_id, sum(amount) as total from orders group by user_id",
+    eager=True,
 )
 ```
 
-### Grouping, Joins, And Windowed Logic
+Expression API is the primary interface; SQL is a convenience layer.
+
+## sink_parquet (and friends)
+
+Stream results to disk without materializing the whole frame:
 
 ```python
-import polars as pl
-
-orders = pl.DataFrame(
-    {
-        "user_id": [1, 1, 2, 3],
-        "amount": [40, 60, 10, 25],
-    }
-)
-
-users = pl.DataFrame(
-    {
-        "user_id": [1, 2, 3],
-        "plan": ["pro", "free", "pro"],
-    }
-)
-
-summary = (
-    orders
+(
+    pl.scan_parquet("raw/*.parquet")
+    .filter(pl.col("status") == "ok")
     .group_by("user_id")
-    .agg(total_amount=pl.col("amount").sum())
-    .join(users, on="user_id", how="left")
-    .with_columns(
-        amount_rank=pl.col("total_amount").rank(descending=True)
-    )
+    .agg(total=pl.col("amount").sum())
+    .sink_parquet("out/user_totals.parquet", compression="zstd")
 )
 ```
 
-`polars` also supports SQL via `SQLContext`, but the expression API is the primary interface and is usually the best default for generated code.
+Also: `sink_csv`, `sink_ndjson`, `sink_ipc`. These run the plan in streaming mode where supported.
 
-### Pandas And Arrow Interop
+For in-memory writes from a `DataFrame`:
+
+```python
+df.write_parquet("out.parquet", compression="zstd", statistics=True)
+df.write_csv("out.csv")
+df.write_ipc("out.arrow")
+```
+
+## Lazy Execution Model
+
+A `LazyFrame` is a query plan, not data. Steps:
+
+1. Build with `scan_*` and expression methods.
+2. Inspect plan: `lf.explain()` (logical), `lf.explain(optimized=True)`.
+3. Execute: `lf.collect()` (in-memory) or `lf.sink_*` (streaming to disk).
+
+The optimizer applies:
+
+- predicate pushdown
+- projection pushdown
+- common subexpression elimination
+- slice pushdown
+
+Schema access on a lazy plan:
+
+```python
+lf.collect_schema()    # preferred; cheap
+# Avoid lf.schema / lf.columns / lf.dtypes on lazy frames — can do work and warn.
+```
+
+Streaming engine (opt-in, plan-dependent):
+
+```python
+lf.collect(engine="streaming")
+```
+
+## Pandas / Arrow Interop
 
 ```python
 import pandas as pd
 import polars as pl
+import pyarrow as pa
 
-pandas_df = pd.DataFrame({"x": [1, 2, 3]})
-pl_df = pl.from_pandas(pandas_df)
+pl_df = pl.from_pandas(pd.DataFrame({"x": [1, 2, 3]}))
+pl_df.to_pandas()
 
-round_trip = pl_df.to_pandas()
+pl.from_arrow(pa.table({"x": [1, 2, 3]}))
+pl_df.to_arrow()
 ```
 
-Use Arrow/pandas interop when a surrounding library requires it, but keep your main transformation pipeline in native `polars` when possible.
+Convert at the edges, not in the middle of a pipeline.
 
-## Config And Auth
-
-`polars` has no service-level authentication model for ordinary local DataFrame work. The main configuration surfaces are display/runtime settings and storage credentials for remote IO.
-
-### Display And Session Config
-
-Use `pl.Config` to adjust table formatting or set temporary display behavior:
+## Cloud Storage
 
 ```python
-import polars as pl
-
-with pl.Config(tbl_rows=20, fmt_str_lengths=80):
-    print(df)
-```
-
-For debugging environment issues, the API reference also exposes `pl.show_versions()`.
-
-### Cloud And Remote Storage Credentials
-
-Remote readers/writers such as `scan_parquet`, `read_parquet`, and related APIs support `storage_options=` and, for credentialed workflows, `credential_provider=`.
-
-Typical shape:
-
-```python
-import polars as pl
-
-q = pl.scan_parquet(
-    "s3://analytics-bucket/events/date=2026-03-12/*.parquet",
-    storage_options={
-        "aws_region": "us-west-2",
-    },
+lf = pl.scan_parquet(
+    "s3://bucket/events/date=2026-05-29/*.parquet",
+    storage_options={"aws_region": "us-west-2"},
 )
 ```
 
-If the codebase needs a shared default credential source, `pl.Config.set_default_credential_provider(...)` is the official API surface to look at. In practice, many projects rely on provider-native environment variables and let the underlying cloud auth chain resolve credentials.
+`credential_provider=` is available for codebases that need a programmatic credential source. For shared defaults, see `pl.Config.set_default_credential_provider(...)`.
 
 ## Common Pitfalls
 
-- Eager-vs-lazy confusion: do not start with `read_csv(...).lazy()` when `scan_csv(...)` can avoid unnecessary upfront IO.
-- Python loops: avoid `for`-loop row processing and `DataFrame.apply`-style patterns when an expression exists. Generated code should stay inside the expression engine whenever possible.
-- Schema inference surprises: for CSV and loosely typed input, set `schema=`, `schema_overrides=`, or a larger `infer_schema_length` when type stability matters.
-- Row orientation: when constructing a frame from row-like records in ambiguous cases, pass `orient="row"` explicitly.
-- Strict casting and construction: version 1 tightened several behaviors. Expect invalid values to error unless you intentionally opt into non-strict behavior.
-- Lazy schema access: on modern Polars, `LazyFrame.schema`, `dtypes`, `columns`, and `width` can trigger work and generate performance warnings. Prefer `collect_schema()` when you need schema information for a lazy plan.
-- String/object assumptions from pandas: Polars is stricter about dtypes and null handling than pandas. Cast deliberately instead of assuming implicit coercion.
-- SQL is optional: SQL support exists, but most docs, optimizations, and community examples are built around expressions. If SQL and expression examples disagree, prefer the expression-native API.
+- `read_csv(...).lazy()` defeats the point. Use `scan_csv(...)`.
+- Python loops / `DataFrame.map_rows` are slow. Stay in expressions.
+- CSV schema inference: pass `schema=`, `schema_overrides=`, or a larger `infer_schema_length=`.
+- Ambiguous row records: pass `orient="row"` to `pl.DataFrame(...)`.
+- Lazy schema warnings: use `collect_schema()` instead of `.schema` on lazy frames.
+- Strict casting: invalid values raise; opt into non-strict explicitly.
+- pandas habits: Polars is stricter on dtypes and nulls; cast deliberately.
 
 ## Version-Sensitive Notes
 
-- The version used here `1.38.1` matches the current PyPI release as of `2026-03-12`.
-- The Python API reference URL in this package brief is the stable docs root, not a version-pinned `1.38.1` snapshot. Re-check the changelog or release notes before copying behavior into code that must exactly match older releases.
-- The official Version 1 upgrade guide is still relevant for current code because it changed strictness defaults and several APIs that older blog posts still use.
-- From the Version 1 guide, the constructor is stricter, ambiguous row-oriented construction should use `orient="row"`, many `replace` patterns moved to `replace_strict`, and lazy schema inspection should use `collect_schema()`.
-- Streaming execution is opt-in and plan-dependent. Do not assume every lazy query automatically runs in streaming mode.
-
-## Practical Guidance For Agents
-
-1. Start with `import polars as pl` and keep transformations in `select`, `with_columns`, `filter`, `group_by`, and joins.
-2. Use `scan_parquet` / `scan_csv` for file pipelines, then `.collect()` only at the boundary where materialized results are actually needed.
-3. Prefer explicit casts and schema overrides when reading CSV, JSON, or heterogeneous Python objects.
-4. Keep cloud IO auth simple: start with provider-native environment credentials, then add `storage_options` or `credential_provider` only when the upstream docs require it.
-5. If a project mixes pandas and Polars, convert at the edges rather than bouncing repeatedly between the two in the middle of a pipeline.
+- This guide targets `1.41.2`, the current PyPI release on 2026-05-29.
+- The Version 1 upgrade guide still applies: stricter constructors, `replace_strict`, `orient="row"`, `collect_schema()`.
+- Streaming execution is opt-in via `collect(engine="streaming")` or `sink_*` and is plan-dependent.
 
 ## Official Sources
 
-- Docs root: `https://docs.pola.rs/`
-- Installation: `https://docs.pola.rs/user-guide/installation/`
-- User guide: `https://docs.pola.rs/user-guide/`
-- Expressions and contexts: `https://docs.pola.rs/user-guide/concepts/expressions-and-contexts/`
-- SQL interface: `https://docs.pola.rs/user-guide/sql/intro/`
-- Python API reference: `https://docs.pola.rs/api/python/stable/reference/`
-- `LazyFrame` reference: `https://docs.pola.rs/api/python/stable/reference/lazyframe/`
-- `scan_parquet`: `https://docs.pola.rs/api/python/stable/reference/api/polars.scan_parquet.html`
-- `Config.set_default_credential_provider`: `https://docs.pola.rs/api/python/stable/reference/api/polars.Config.set_default_credential_provider.html`
-- `show_versions`: `https://docs.pola.rs/api/python/stable/reference/api/polars.show_versions.html`
-- Version 1 upgrade guide: `https://docs.pola.rs/releases/upgrade/1/`
-- PyPI package page: `https://pypi.org/project/polars/`
+- Docs: https://docs.pola.rs/
+- User guide: https://docs.pola.rs/user-guide/
+- Expressions: https://docs.pola.rs/user-guide/concepts/expressions-and-contexts/
+- Lazy API: https://docs.pola.rs/user-guide/lazy/
+- SQL: https://docs.pola.rs/user-guide/sql/intro/
+- Python API: https://docs.pola.rs/api/python/stable/reference/
+- `scan_parquet`: https://docs.pola.rs/api/python/stable/reference/api/polars.scan_parquet.html
+- `sink_parquet`: https://docs.pola.rs/api/python/stable/reference/api/polars.LazyFrame.sink_parquet.html
+- Version 1 upgrade: https://docs.pola.rs/releases/upgrade/1/
+- PyPI: https://pypi.org/project/polars/


### PR DESCRIPTION
docs(pandas, numpy, polars, duckdb): refresh Python data-stack docs

- pandas 3.0.1 → 3.0.3; rewritten around DataFrame/Series, IO
  (CSV/Parquet/SQL), selection (loc/iloc), filtering, groupby/agg,
  merge/join/concat, reshape (pivot/melt), datetime, missing data,
  apply/map vs vectorized
- numpy 2.4.3 → 2.4.6; rewritten around ndarray construction, dtype,
  shape/reshape, indexing/slicing/boolean masks, broadcasting, ufuncs,
  common math/stats, `default_rng`, linalg basics
- polars 1.38.1 → 1.41.2; covers DataFrame/LazyFrame, `scan_csv` /
  `scan_parquet`, select/filter/with_columns/group_by/agg, expressions,
  joins (incl. `join_asof`), SQL interface, `sink_parquet`, lazy execution
- duckdb 1.5.0 → 1.5.3; covers in-process API, `duckdb.connect`,
  execute/sql/df, `read_parquet`/`read_csv`, pandas/polars/arrow
  integration, persistent vs in-memory, basic SQL
- `revision` bumped and `updated-on: 2026-05-29`

Verified versions against PyPI.
