### PR TITLE
docs(redis, mongodb): refresh to redis-py 8.0.0 / node-redis 6.0.0 / mongodb 7.2.0

### DIFF
--- a/content/mongodb/docs/atlas/DOC.md
+++ b/content/mongodb/docs/atlas/DOC.md
@@ -3,63 +3,64 @@ name: atlas
 description: "MongoDB Node.js driver for interacting with MongoDB Atlas databases using the official JavaScript/TypeScript SDK."
 metadata:
   languages: "javascript"
-  versions: "6.20.0"
-  updated-on: "2026-03-01"
+  versions: "7.2.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "mongodb,atlas,database,nosql,driver"
 ---
 
 # MongoDB Atlas Coding Guidelines (JavaScript/TypeScript)
 
-You are a MongoDB Atlas coding expert. Help me with writing code using the MongoDB Node.js driver calling the official libraries and SDKs.
+You are a MongoDB Atlas coding expert. Help me with writing code using the MongoDB Node.js driver, calling the official libraries and SDKs.
 
-## Golden Rule: Use the Correct and Current SDK
+## Golden Rule: Use The Official Driver
 
 Always use the official MongoDB Node.js driver for all MongoDB Atlas interactions.
 
-- **Library Name:** MongoDB Node.js Driver
-- **NPM Package:** `mongodb`
+- **Library name:** MongoDB Node.js Driver
+- **NPM package:** `mongodb`
 - **GitHub:** https://github.com/mongodb/node-mongodb-native
-
-**Installation:**
+- **Current `latest` dist-tag (May 29, 2026):** `7.2.0`
 
 ```bash
-npm install mongodb
+npm install mongodb@7
 ```
 
-**Import Patterns:**
+When upgrading from `mongodb@6`, watch for changes around server selection, BSON imports, and removed legacy callback APIs.
+
+### Import patterns
 
 ```javascript
-// ES6 import (recommended)
+// ES module (recommended)
 import { MongoClient } from 'mongodb';
 
-// CommonJS require
+// CommonJS
 const { MongoClient } = require('mongodb');
 
-// Additional utilities
-import { MongoClient, ObjectId, Timestamp } from 'mongodb';
+// Common utilities
+import { MongoClient, ObjectId, Timestamp, ServerApiVersion } from 'mongodb';
 ```
 
-**Do NOT use:**
-- Deprecated MongoDB packages
-- Third-party MongoDB wrappers (unless specifically requested)
-- Old connection patterns from MongoDB driver v2 or v3
+### Do not use
 
-## Installation and Environment Setup
+- Deprecated MongoDB packages (`mongodb-core`, `mongodb-legacy` callback-style helpers unless you need them explicitly)
+- Third-party MongoDB wrappers unless they are required by your team
+- Connection patterns from driver v2/v3 (callbacks, `MongoClient.connect(url, cb)` factory style)
+
+## Installation And Environment Setup
 
 ```bash
-npm install mongodb
+npm install mongodb@7
 ```
 
-**Environment Variables Setup:**
-
-Create a `.env` file in your project root:
+`.env` for an Atlas cluster:
 
 ```bash
 MONGODB_URI=mongodb+srv://username:password@cluster.mongodb.net/database?retryWrites=true&w=majority
 ```
 
-**Using dotenv for environment variables:**
+Atlas connection strings use the `mongodb+srv://` scheme, which performs DNS SRV lookups against your cluster's seed host to discover replica set members and TLS settings.
 
 ```bash
 npm install dotenv
@@ -72,11 +73,11 @@ import { MongoClient } from 'mongodb';
 const uri = process.env.MONGODB_URI;
 ```
 
-## Initialization and Connection
+## Initialization And Connection
 
-The MongoDB driver requires creating a `MongoClient` instance for all database operations.
+`MongoClient` is the entry point. Call `connect()` once per process and reuse the client; it manages an internal connection pool.
 
-**Basic Connection:**
+### Basic connect
 
 ```javascript
 import { MongoClient } from 'mongodb';
@@ -87,13 +88,11 @@ const client = new MongoClient(uri);
 async function main() {
   try {
     await client.connect();
-    console.log('Connected to MongoDB Atlas');
 
     const database = client.db('myDatabase');
     const collection = database.collection('myCollection');
 
-    // Perform operations...
-
+    // ...operations
   } finally {
     await client.close();
   }
@@ -102,55 +101,41 @@ async function main() {
 main().catch(console.error);
 ```
 
-**Connection with Options:**
+### Connect with Stable API options
 
 ```javascript
 import { MongoClient, ServerApiVersion } from 'mongodb';
 
-const uri = process.env.MONGODB_URI;
-
-const client = new MongoClient(uri, {
+const client = new MongoClient(process.env.MONGODB_URI, {
   serverApi: {
     version: ServerApiVersion.v1,
     strict: true,
     deprecationErrors: true,
-  }
+  },
 });
 
-async function run() {
-  try {
-    await client.connect();
-    await client.db('admin').command({ ping: 1 });
-    console.log('Pinged your deployment. Successfully connected to MongoDB!');
-  } finally {
-    await client.close();
-  }
-}
-
-run().catch(console.error);
+await client.connect();
+await client.db('admin').command({ ping: 1 });
 ```
 
-**Reusable Connection Pattern:**
+### Reusable client (long-lived process)
 
 ```javascript
 import { MongoClient } from 'mongodb';
 
-let client;
-let clientPromise;
-
 const uri = process.env.MONGODB_URI;
 const options = {};
 
+let clientPromise;
+
 if (process.env.NODE_ENV === 'development') {
-  // In development mode, use a global variable to preserve connection
   if (!global._mongoClientPromise) {
-    client = new MongoClient(uri, options);
+    const client = new MongoClient(uri, options);
     global._mongoClientPromise = client.connect();
   }
   clientPromise = global._mongoClientPromise;
 } else {
-  // In production mode, create a new client
-  client = new MongoClient(uri, options);
+  const client = new MongoClient(uri, options);
   clientPromise = client.connect();
 }
 
@@ -159,1883 +144,756 @@ export default clientPromise;
 
 ## CRUD Operations
 
-### Insert Documents
-
-**Insert One Document:**
+### Insert
 
 ```javascript
-import { MongoClient } from 'mongodb';
+const database = client.db('sample_db');
+const users = database.collection('users');
 
-const client = new MongoClient(process.env.MONGODB_URI);
+await users.insertOne({
+  name: 'John Doe',
+  email: 'john@example.com',
+  age: 30,
+  createdAt: new Date(),
+});
 
-async function insertDocument() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
+const result = await users.insertMany([
+  { name: 'Alice', email: 'alice@example.com', age: 25 },
+  { name: 'Bob',   email: 'bob@example.com',   age: 32 },
+]);
 
-    const doc = {
-      name: 'John Doe',
-      email: 'john@example.com',
-      age: 30,
-      createdAt: new Date()
-    };
+console.log(result.insertedCount, result.insertedIds);
 
-    const result = await collection.insertOne(doc);
-    console.log(`Document inserted with _id: ${result.insertedId}`);
-
-  } finally {
-    await client.close();
-  }
-}
-
-insertDocument().catch(console.error);
+await users.insertOne(
+  { name: 'David', email: 'david@example.com' },
+  { writeConcern: { w: 'majority', wtimeout: 5000 } },
+);
 ```
 
-**Insert Multiple Documents:**
+### Find
 
 ```javascript
-async function insertMultipleDocuments() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
+const users = client.db('sample_db').collection('users');
 
-    const docs = [
-      { name: 'Alice', email: 'alice@example.com', age: 25 },
-      { name: 'Bob', email: 'bob@example.com', age: 32 },
-      { name: 'Charlie', email: 'charlie@example.com', age: 28 }
-    ];
+const allDocs = await users.find({}).toArray();
+const adults = await users.find({ age: { $gt: 25 } }).toArray();
+const one = await users.findOne({ email: 'john@example.com' });
 
-    const result = await collection.insertMany(docs);
-    console.log(`${result.insertedCount} documents inserted`);
-    console.log('Inserted IDs:', result.insertedIds);
+const projected = await users
+  .find({ age: { $gte: 25 } }, { projection: { _id: 0, name: 1, email: 1 } })
+  .toArray();
 
-  } finally {
-    await client.close();
-  }
-}
-
-insertMultipleDocuments().catch(console.error);
+const paged = await users
+  .find({})
+  .sort({ age: -1 })
+  .skip(5)
+  .limit(10)
+  .toArray();
 ```
 
-**Insert with Options:**
+#### Offset pagination
 
 ```javascript
-async function insertWithOptions() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
+async function page(coll, pageNum = 1, pageSize = 10) {
+  const documents = await coll
+    .find({})
+    .sort({ createdAt: -1 })
+    .skip((pageNum - 1) * pageSize)
+    .limit(pageSize)
+    .toArray();
 
-    const doc = { name: 'David', email: 'david@example.com' };
+  const total = await coll.countDocuments({});
 
-    const result = await collection.insertOne(doc, {
-      writeConcern: { w: 'majority', wtimeout: 5000 }
-    });
-
-    console.log(`Document inserted: ${result.insertedId}`);
-
-  } finally {
-    await client.close();
-  }
+  return {
+    documents,
+    page: pageNum,
+    pageSize,
+    totalPages: Math.ceil(total / pageSize),
+    totalDocuments: total,
+  };
 }
-
-insertWithOptions().catch(console.error);
 ```
 
-### Find Documents
-
-**Find All Documents:**
+#### Cursor-based pagination (recommended at scale)
 
 ```javascript
-async function findAllDocuments() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
+async function pageByCursor(coll, lastId = null, pageSize = 10) {
+  const query = lastId ? { _id: { $gt: lastId } } : {};
 
-    const cursor = collection.find({});
-    const documents = await cursor.toArray();
+  const documents = await coll
+    .find(query)
+    .sort({ _id: 1 })
+    .limit(pageSize)
+    .toArray();
 
-    console.log('All documents:', documents);
-
-  } finally {
-    await client.close();
-  }
+  return {
+    documents,
+    nextCursor: documents.length ? documents[documents.length - 1]._id : null,
+  };
 }
-
-findAllDocuments().catch(console.error);
 ```
 
-**Find with Filter:**
+### Update
 
 ```javascript
-async function findWithFilter() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
+const users = client.db('sample_db').collection('users');
 
-    // Find users older than 25
-    const query = { age: { $gt: 25 } };
-    const cursor = collection.find(query);
-    const results = await cursor.toArray();
+await users.updateOne(
+  { email: 'john@example.com' },
+  { $set: { age: 31, updatedAt: new Date() } },
+);
 
-    console.log('Users older than 25:', results);
+await users.updateMany(
+  { age: { $lt: 30 } },
+  { $set: { category: 'young', updatedAt: new Date() } },
+);
 
-  } finally {
-    await client.close();
-  }
-}
+await users.updateOne(
+  { email: 'newuser@example.com' },
+  {
+    $set: {
+      name: 'New User',
+      email: 'newuser@example.com',
+      createdAt: new Date(),
+    },
+  },
+  { upsert: true },
+);
 
-findWithFilter().catch(console.error);
+await users.updateOne(
+  { email: 'john@example.com' },
+  {
+    $set: { status: 'active' },
+    $inc: { loginCount: 1 },
+    $push: { tags: 'premium' },
+    $currentDate: { lastModified: true },
+  },
+);
+
+await users.replaceOne(
+  { email: 'john@example.com' },
+  {
+    name: 'John Doe Updated',
+    email: 'john@example.com',
+    age: 31,
+    status: 'active',
+    updatedAt: new Date(),
+  },
+);
+
+const after = await users.findOneAndUpdate(
+  { email: 'john@example.com' },
+  { $inc: { age: 1 } },
+  { returnDocument: 'after' },
+);
 ```
 
-**Find One Document:**
+### Delete
 
 ```javascript
-async function findOneDocument() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
-
-    const query = { email: 'john@example.com' };
-    const user = await collection.findOne(query);
-
-    if (user) {
-      console.log('Found user:', user);
-    } else {
-      console.log('User not found');
-    }
-
-  } finally {
-    await client.close();
-  }
-}
-
-findOneDocument().catch(console.error);
-```
-
-**Find with Projection:**
-
-```javascript
-async function findWithProjection() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
-
-    const query = { age: { $gte: 25 } };
-    const options = {
-      projection: { _id: 0, name: 1, email: 1 }
-    };
-
-    const cursor = collection.find(query, options);
-    const results = await cursor.toArray();
-
-    console.log('Users (name and email only):', results);
-
-  } finally {
-    await client.close();
-  }
-}
-
-findWithProjection().catch(console.error);
-```
-
-**Find with Sort, Limit, and Skip:**
-
-```javascript
-async function findWithSortLimitSkip() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
-
-    const cursor = collection.find({})
-      .sort({ age: -1 })  // Sort by age descending
-      .limit(10)          // Limit to 10 results
-      .skip(5);           // Skip first 5 results
-
-    const results = await cursor.toArray();
-
-    console.log('Sorted and paginated results:', results);
-
-  } finally {
-    await client.close();
-  }
-}
-
-findWithSortLimitSkip().catch(console.error);
-```
-
-**Pagination Pattern:**
-
-```javascript
-async function paginateDocuments(page = 1, pageSize = 10) {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
-
-    const skip = (page - 1) * pageSize;
-
-    const cursor = collection.find({})
-      .sort({ createdAt: -1 })
-      .skip(skip)
-      .limit(pageSize);
-
-    const documents = await cursor.toArray();
-    const total = await collection.countDocuments({});
-
-    return {
-      documents,
-      page,
-      pageSize,
-      totalPages: Math.ceil(total / pageSize),
-      totalDocuments: total
-    };
-
-  } finally {
-    await client.close();
-  }
-}
-
-paginateDocuments(1, 20).then(console.log).catch(console.error);
-```
-
-**Cursor-Based Pagination (Better Performance):**
-
-```javascript
-async function cursorPagination(lastId = null, pageSize = 10) {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
-
-    const query = lastId ? { _id: { $gt: lastId } } : {};
-
-    const cursor = collection.find(query)
-      .sort({ _id: 1 })
-      .limit(pageSize);
-
-    const documents = await cursor.toArray();
-
-    return {
-      documents,
-      nextCursor: documents.length > 0
-        ? documents[documents.length - 1]._id
-        : null
-    };
-
-  } finally {
-    await client.close();
-  }
-}
-
-cursorPagination(null, 20).then(console.log).catch(console.error);
-```
-
-### Update Documents
-
-**Update One Document:**
-
-```javascript
-async function updateOneDocument() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
-
-    const filter = { email: 'john@example.com' };
-    const update = {
-      $set: { age: 31, updatedAt: new Date() }
-    };
-
-    const result = await collection.updateOne(filter, update);
-
-    console.log(`${result.matchedCount} document(s) matched the filter`);
-    console.log(`${result.modifiedCount} document(s) updated`);
-
-  } finally {
-    await client.close();
-  }
-}
-
-updateOneDocument().catch(console.error);
-```
-
-**Update Multiple Documents:**
-
-```javascript
-async function updateManyDocuments() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
-
-    const filter = { age: { $lt: 30 } };
-    const update = {
-      $set: { category: 'young', updatedAt: new Date() }
-    };
-
-    const result = await collection.updateMany(filter, update);
-
-    console.log(`${result.matchedCount} document(s) matched`);
-    console.log(`${result.modifiedCount} document(s) updated`);
-
-  } finally {
-    await client.close();
-  }
-}
-
-updateManyDocuments().catch(console.error);
-```
-
-**Update with Upsert:**
-
-```javascript
-async function updateWithUpsert() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
-
-    const filter = { email: 'newuser@example.com' };
-    const update = {
-      $set: {
-        name: 'New User',
-        email: 'newuser@example.com',
-        age: 22,
-        createdAt: new Date()
-      }
-    };
-
-    const options = { upsert: true };
-    const result = await collection.updateOne(filter, update, options);
-
-    if (result.upsertedId) {
-      console.log(`Document inserted with _id: ${result.upsertedId}`);
-    } else {
-      console.log(`${result.modifiedCount} document(s) updated`);
-    }
-
-  } finally {
-    await client.close();
-  }
-}
-
-updateWithUpsert().catch(console.error);
-```
-
-**Update Operators:**
-
-```javascript
-async function updateOperators() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
-
-    const filter = { email: 'john@example.com' };
-    const update = {
-      $set: { status: 'active' },
-      $inc: { loginCount: 1 },
-      $push: { tags: 'premium' },
-      $currentDate: { lastModified: true }
-    };
-
-    const result = await collection.updateOne(filter, update);
-    console.log(`${result.modifiedCount} document(s) updated`);
-
-  } finally {
-    await client.close();
-  }
-}
-
-updateOperators().catch(console.error);
-```
-
-**Replace Document:**
-
-```javascript
-async function replaceDocument() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
-
-    const filter = { email: 'john@example.com' };
-    const replacement = {
-      name: 'John Doe Updated',
-      email: 'john@example.com',
-      age: 31,
-      status: 'active',
-      updatedAt: new Date()
-    };
-
-    const result = await collection.replaceOne(filter, replacement);
-    console.log(`${result.modifiedCount} document(s) replaced`);
-
-  } finally {
-    await client.close();
-  }
-}
-
-replaceDocument().catch(console.error);
-```
-
-**Find and Modify:**
-
-```javascript
-async function findAndModify() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
-
-    const filter = { email: 'john@example.com' };
-    const update = { $inc: { age: 1 } };
-    const options = {
-      returnDocument: 'after',  // Return the updated document
-      upsert: false
-    };
-
-    const result = await collection.findOneAndUpdate(filter, update, options);
-
-    if (result) {
-      console.log('Updated document:', result);
-    }
-
-  } finally {
-    await client.close();
-  }
-}
-
-findAndModify().catch(console.error);
-```
-
-### Delete Documents
-
-**Delete One Document:**
-
-```javascript
-async function deleteOneDocument() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
-
-    const filter = { email: 'john@example.com' };
-    const result = await collection.deleteOne(filter);
-
-    console.log(`${result.deletedCount} document(s) deleted`);
-
-  } finally {
-    await client.close();
-  }
-}
-
-deleteOneDocument().catch(console.error);
-```
-
-**Delete Multiple Documents:**
-
-```javascript
-async function deleteManyDocuments() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
-
-    const filter = { age: { $lt: 18 } };
-    const result = await collection.deleteMany(filter);
-
-    console.log(`${result.deletedCount} document(s) deleted`);
-
-  } finally {
-    await client.close();
-  }
-}
-
-deleteManyDocuments().catch(console.error);
-```
-
-**Find and Delete:**
-
-```javascript
-async function findAndDelete() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
-
-    const filter = { email: 'john@example.com' };
-    const options = {
-      sort: { createdAt: -1 }
-    };
-
-    const result = await collection.findOneAndDelete(filter, options);
-
-    if (result) {
-      console.log('Deleted document:', result);
-    } else {
-      console.log('No document found to delete');
-    }
-
-  } finally {
-    await client.close();
-  }
-}
-
-findAndDelete().catch(console.error);
+const users = client.db('sample_db').collection('users');
+
+await users.deleteOne({ email: 'john@example.com' });
+await users.deleteMany({ age: { $lt: 18 } });
+
+const deleted = await users.findOneAndDelete(
+  { email: 'john@example.com' },
+  { sort: { createdAt: -1 } },
+);
 ```
 
 ## Aggregation Pipeline
 
-**Basic Aggregation:**
-
 ```javascript
-async function basicAggregation() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
+const users = client.db('sample_db').collection('users');
 
-    const pipeline = [
-      { $match: { age: { $gte: 25 } } },
-      { $group: {
-          _id: '$status',
-          count: { $sum: 1 },
-          avgAge: { $avg: '$age' }
-        }
-      },
-      { $sort: { count: -1 } }
-    ];
-
-    const results = await collection.aggregate(pipeline).toArray();
-    console.log('Aggregation results:', results);
-
-  } finally {
-    await client.close();
-  }
-}
-
-basicAggregation().catch(console.error);
+const summary = await users.aggregate([
+  { $match: { age: { $gte: 25 } } },
+  {
+    $group: {
+      _id: '$status',
+      count: { $sum: 1 },
+      avgAge: { $avg: '$age' },
+    },
+  },
+  { $sort: { count: -1 } },
+]).toArray();
 ```
 
-**Advanced Aggregation with Multiple Stages:**
+### Multi-stage report
 
 ```javascript
-async function advancedAggregation() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('orders');
+const orders = client.db('sample_db').collection('orders');
 
-    const pipeline = [
-      {
-        $match: {
-          status: 'completed',
-          createdAt: { $gte: new Date('2024-01-01') }
-        }
-      },
-      {
-        $group: {
-          _id: {
-            year: { $year: '$createdAt' },
-            month: { $month: '$createdAt' }
+const monthly = await orders.aggregate([
+  {
+    $match: {
+      status: 'completed',
+      createdAt: { $gte: new Date('2026-01-01') },
+    },
+  },
+  {
+    $group: {
+      _id: { year: { $year: '$createdAt' }, month: { $month: '$createdAt' } },
+      totalSales: { $sum: '$amount' },
+      orderCount: { $sum: 1 },
+      avgOrderValue: { $avg: '$amount' },
+    },
+  },
+  { $sort: { '_id.year': 1, '_id.month': 1 } },
+  {
+    $project: {
+      _id: 0,
+      year: '$_id.year',
+      month: '$_id.month',
+      totalSales: 1,
+      orderCount: 1,
+      avgOrderValue: { $round: ['$avgOrderValue', 2] },
+    },
+  },
+]).toArray();
+```
+
+### `$lookup` join
+
+```javascript
+const orders = client.db('sample_db').collection('orders');
+
+const withUser = await orders.aggregate([
+  {
+    $lookup: {
+      from: 'users',
+      localField: 'userId',
+      foreignField: '_id',
+      as: 'userDetails',
+    },
+  },
+  { $unwind: '$userDetails' },
+  {
+    $project: {
+      orderNumber: 1,
+      amount: 1,
+      userName: '$userDetails.name',
+      userEmail: '$userDetails.email',
+    },
+  },
+]).toArray();
+```
+
+### `$facet` for multiple pipelines
+
+```javascript
+const products = client.db('sample_db').collection('products');
+
+const analytics = await products.aggregate([
+  {
+    $facet: {
+      categoryCounts: [
+        { $group: { _id: '$category', count: { $sum: 1 } } },
+        { $sort: { count: -1 } },
+      ],
+      priceStats: [
+        {
+          $group: {
+            _id: null,
+            avgPrice: { $avg: '$price' },
+            minPrice: { $min: '$price' },
+            maxPrice: { $max: '$price' },
           },
-          totalSales: { $sum: '$amount' },
-          orderCount: { $sum: 1 },
-          avgOrderValue: { $avg: '$amount' }
-        }
-      },
-      {
-        $sort: { '_id.year': 1, '_id.month': 1 }
-      },
-      {
-        $project: {
-          _id: 0,
-          year: '$_id.year',
-          month: '$_id.month',
-          totalSales: 1,
-          orderCount: 1,
-          avgOrderValue: { $round: ['$avgOrderValue', 2] }
-        }
-      }
-    ];
-
-    const results = await collection.aggregate(pipeline).toArray();
-    console.log('Sales report:', results);
-
-  } finally {
-    await client.close();
-  }
-}
-
-advancedAggregation().catch(console.error);
+        },
+      ],
+      topProducts: [
+        { $sort: { sales: -1 } },
+        { $limit: 5 },
+        { $project: { name: 1, sales: 1, price: 1 } },
+      ],
+    },
+  },
+]).toArray();
 ```
 
-**Aggregation with $lookup (Join):**
+### Atlas Vector Search
+
+Atlas exposes vector search as the `$vectorSearch` aggregation stage. Define a `vectorSearch` index in the Atlas UI or via the management API, then query it from the driver:
 
 ```javascript
-async function aggregationWithLookup() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('orders');
+const docs = client.db('sample_db').collection('docs');
 
-    const pipeline = [
-      {
-        $lookup: {
-          from: 'users',
-          localField: 'userId',
-          foreignField: '_id',
-          as: 'userDetails'
-        }
-      },
-      {
-        $unwind: '$userDetails'
-      },
-      {
-        $project: {
-          orderNumber: 1,
-          amount: 1,
-          userName: '$userDetails.name',
-          userEmail: '$userDetails.email'
-        }
-      }
-    ];
-
-    const results = await collection.aggregate(pipeline).toArray();
-    console.log('Orders with user details:', results);
-
-  } finally {
-    await client.close();
-  }
-}
-
-aggregationWithLookup().catch(console.error);
+const matches = await docs.aggregate([
+  {
+    $vectorSearch: {
+      index: 'docs_embedding_index',
+      path: 'embedding',
+      queryVector: queryEmbedding,         // number[]
+      numCandidates: 200,
+      limit: 10,
+      // optional pre-filter on indexed fields
+      filter: { category: 'guide' },
+    },
+  },
+  {
+    $project: {
+      _id: 1,
+      title: 1,
+      score: { $meta: 'vectorSearchScore' },
+    },
+  },
+]).toArray();
 ```
 
-**Aggregation with $facet (Multiple Pipelines):**
-
-```javascript
-async function aggregationWithFacet() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('products');
-
-    const pipeline = [
-      {
-        $facet: {
-          categoryCounts: [
-            { $group: { _id: '$category', count: { $sum: 1 } } },
-            { $sort: { count: -1 } }
-          ],
-          priceStats: [
-            {
-              $group: {
-                _id: null,
-                avgPrice: { $avg: '$price' },
-                minPrice: { $min: '$price' },
-                maxPrice: { $max: '$price' }
-              }
-            }
-          ],
-          topProducts: [
-            { $sort: { sales: -1 } },
-            { $limit: 5 },
-            { $project: { name: 1, sales: 1, price: 1 } }
-          ]
-        }
-      }
-    ];
-
-    const results = await collection.aggregate(pipeline).toArray();
-    console.log('Product analytics:', results[0]);
-
-  } finally {
-    await client.close();
-  }
-}
-
-aggregationWithFacet().catch(console.error);
-```
+`$vectorSearch` requires an Atlas cluster with a vector search index defined for the queried path; it is not available on self-hosted MongoDB without Atlas Search.
 
 ## Indexes
 
-**Create Single Field Index:**
-
 ```javascript
-async function createIndex() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
+const users = client.db('sample_db').collection('users');
 
-    const result = await collection.createIndex({ email: 1 });
-    console.log(`Index created: ${result}`);
+await users.createIndex({ email: 1 });
+await users.createIndex({ lastName: 1, firstName: 1 });
+await users.createIndex({ email: 1 }, { unique: true });
 
-  } finally {
-    await client.close();
-  }
-}
+const articles = client.db('sample_db').collection('articles');
+await articles.createIndex({ title: 'text', content: 'text' });
 
-createIndex().catch(console.error);
-```
+const search = await articles
+  .find(
+    { $text: { $search: 'mongodb tutorial' } },
+    { projection: { score: { $meta: 'textScore' } } },
+  )
+  .sort({ score: { $meta: 'textScore' } })
+  .toArray();
 
-**Create Compound Index:**
+const locations = client.db('sample_db').collection('locations');
+await locations.createIndex({ location: '2dsphere' });
 
-```javascript
-async function createCompoundIndex() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
+const nearby = await locations.find({
+  location: {
+    $near: {
+      $geometry: { type: 'Point', coordinates: [-73.9667, 40.78] },
+      $maxDistance: 5000,
+    },
+  },
+}).limit(10).toArray();
 
-    const result = await collection.createIndex(
-      { lastName: 1, firstName: 1 }
-    );
-    console.log(`Compound index created: ${result}`);
-
-  } finally {
-    await client.close();
-  }
-}
-
-createCompoundIndex().catch(console.error);
-```
-
-**Create Unique Index:**
-
-```javascript
-async function createUniqueIndex() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
-
-    const result = await collection.createIndex(
-      { email: 1 },
-      { unique: true }
-    );
-    console.log(`Unique index created: ${result}`);
-
-  } finally {
-    await client.close();
-  }
-}
-
-createUniqueIndex().catch(console.error);
-```
-
-**Create Text Index:**
-
-```javascript
-async function createTextIndex() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('articles');
-
-    const result = await collection.createIndex(
-      { title: 'text', content: 'text' }
-    );
-    console.log(`Text index created: ${result}`);
-
-  } finally {
-    await client.close();
-  }
-}
-
-createTextIndex().catch(console.error);
-```
-
-**Text Search Query:**
-
-```javascript
-async function textSearch() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('articles');
-
-    const query = { $text: { $search: 'mongodb tutorial' } };
-    const projection = { score: { $meta: 'textScore' } };
-
-    const cursor = collection
-      .find(query, { projection })
-      .sort({ score: { $meta: 'textScore' } });
-
-    const results = await cursor.toArray();
-    console.log('Search results:', results);
-
-  } finally {
-    await client.close();
-  }
-}
-
-textSearch().catch(console.error);
-```
-
-**Create 2dsphere Index (Geospatial):**
-
-```javascript
-async function createGeospatialIndex() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('locations');
-
-    const result = await collection.createIndex(
-      { location: '2dsphere' }
-    );
-    console.log(`Geospatial index created: ${result}`);
-
-  } finally {
-    await client.close();
-  }
-}
-
-createGeospatialIndex().catch(console.error);
-```
-
-**Geospatial Query ($near):**
-
-```javascript
-async function geospatialNearQuery() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('locations');
-
-    const query = {
-      location: {
-        $near: {
-          $geometry: {
-            type: 'Point',
-            coordinates: [-73.9667, 40.78]  // [longitude, latitude]
-          },
-          $maxDistance: 5000  // 5km in meters
-        }
-      }
-    };
-
-    const results = await collection.find(query).limit(10).toArray();
-    console.log('Nearby locations:', results);
-
-  } finally {
-    await client.close();
-  }
-}
-
-geospatialNearQuery().catch(console.error);
-```
-
-**Geospatial Query ($geoWithin):**
-
-```javascript
-async function geospatialWithinQuery() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('locations');
-
-    const query = {
-      location: {
-        $geoWithin: {
-          $geometry: {
-            type: 'Polygon',
-            coordinates: [[
-              [-74.0, 40.7],
-              [-73.9, 40.7],
-              [-73.9, 40.8],
-              [-74.0, 40.8],
-              [-74.0, 40.7]
-            ]]
-          }
-        }
-      }
-    };
-
-    const results = await collection.find(query).toArray();
-    console.log('Locations within polygon:', results);
-
-  } finally {
-    await client.close();
-  }
-}
-
-geospatialWithinQuery().catch(console.error);
-```
-
-**List Indexes:**
-
-```javascript
-async function listIndexes() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
-
-    const indexes = await collection.listIndexes().toArray();
-    console.log('Indexes:', indexes);
-
-  } finally {
-    await client.close();
-  }
-}
-
-listIndexes().catch(console.error);
-```
-
-**Drop Index:**
-
-```javascript
-async function dropIndex() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
-
-    const result = await collection.dropIndex('email_1');
-    console.log('Index dropped:', result);
-
-  } finally {
-    await client.close();
-  }
-}
-
-dropIndex().catch(console.error);
-```
-
-## Bulk Write Operations
-
-**Bulk Write with Mixed Operations:**
-
-```javascript
-async function bulkWrite() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
-
-    const operations = [
-      {
-        insertOne: {
-          document: { name: 'User 1', email: 'user1@example.com' }
-        }
+const within = await locations.find({
+  location: {
+    $geoWithin: {
+      $geometry: {
+        type: 'Polygon',
+        coordinates: [[
+          [-74.0, 40.7], [-73.9, 40.7], [-73.9, 40.8], [-74.0, 40.8], [-74.0, 40.7],
+        ]],
       },
-      {
-        updateOne: {
-          filter: { email: 'john@example.com' },
-          update: { $set: { status: 'active' } }
-        }
-      },
-      {
-        updateMany: {
-          filter: { age: { $lt: 25 } },
-          update: { $set: { category: 'young' } }
-        }
-      },
-      {
-        deleteOne: {
-          filter: { email: 'old@example.com' }
-        }
-      },
-      {
-        replaceOne: {
-          filter: { email: 'replace@example.com' },
-          replacement: { name: 'Replaced', email: 'replace@example.com', age: 40 }
-        }
-      }
-    ];
+    },
+  },
+}).toArray();
 
-    const result = await collection.bulkWrite(operations);
-
-    console.log(`${result.insertedCount} documents inserted`);
-    console.log(`${result.modifiedCount} documents modified`);
-    console.log(`${result.deletedCount} documents deleted`);
-    console.log(`${result.upsertedCount} documents upserted`);
-
-  } finally {
-    await client.close();
-  }
-}
-
-bulkWrite().catch(console.error);
+const indexes = await users.listIndexes().toArray();
+await users.dropIndex('email_1');
 ```
 
-**Ordered vs Unordered Bulk Write:**
+## Bulk Write
 
 ```javascript
-async function orderedVsUnorderedBulk() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
+const users = client.db('sample_db').collection('users');
 
-    const operations = [
-      { insertOne: { document: { name: 'User A' } } },
-      { insertOne: { document: { name: 'User B' } } }
-    ];
+const result = await users.bulkWrite([
+  { insertOne: { document: { name: 'User 1', email: 'user1@example.com' } } },
+  {
+    updateOne: {
+      filter: { email: 'john@example.com' },
+      update: { $set: { status: 'active' } },
+    },
+  },
+  {
+    updateMany: {
+      filter: { age: { $lt: 25 } },
+      update: { $set: { category: 'young' } },
+    },
+  },
+  { deleteOne: { filter: { email: 'old@example.com' } } },
+  {
+    replaceOne: {
+      filter: { email: 'replace@example.com' },
+      replacement: { name: 'Replaced', email: 'replace@example.com', age: 40 },
+    },
+  },
+]);
 
-    // Ordered (default): stops on first error
-    const orderedResult = await collection.bulkWrite(operations, { ordered: true });
+console.log(
+  result.insertedCount,
+  result.modifiedCount,
+  result.deletedCount,
+  result.upsertedCount,
+);
+```
 
-    // Unordered: continues on errors, may execute in parallel
-    const unorderedResult = await collection.bulkWrite(operations, { ordered: false });
+Ordered (default) bulk writes stop at the first error. Unordered bulk writes continue and may run operations in parallel:
 
-    console.log('Ordered result:', orderedResult);
-    console.log('Unordered result:', unorderedResult);
-
-  } finally {
-    await client.close();
-  }
-}
-
-orderedVsUnorderedBulk().catch(console.error);
+```javascript
+await users.bulkWrite(operations, { ordered: false });
 ```
 
 ## Transactions
 
-**Transaction with Session (Convenient API):**
+Transactions require a replica set or sharded cluster — Atlas provides both.
+
+### `withTransaction` (recommended)
+
+`withTransaction` handles commit retry on `TransientTransactionError` and `UnknownTransactionCommitResult` for you.
 
 ```javascript
-async function transactionExample() {
+async function transferFunds() {
   const session = client.startSession();
-
   try {
-    await client.connect();
     const database = client.db('sample_db');
 
     const result = await session.withTransaction(async () => {
       const accounts = database.collection('accounts');
       const transactions = database.collection('transactions');
 
-      // Deduct from account A
       await accounts.updateOne(
         { accountId: 'A' },
         { $inc: { balance: -100 } },
-        { session }
+        { session },
       );
 
-      // Add to account B
       await accounts.updateOne(
         { accountId: 'B' },
         { $inc: { balance: 100 } },
-        { session }
+        { session },
       );
 
-      // Record transaction
       await transactions.insertOne(
-        {
-          from: 'A',
-          to: 'B',
-          amount: 100,
-          timestamp: new Date()
-        },
-        { session }
+        { from: 'A', to: 'B', amount: 100, timestamp: new Date() },
+        { session },
       );
 
-      return 'Transaction completed';
+      return 'ok';
     });
 
-    console.log(result);
-
+    return result;
   } finally {
     await session.endSession();
-    await client.close();
   }
 }
-
-transactionExample().catch(console.error);
 ```
 
-**Transaction with Core API (Manual Control):**
+### Manual start/commit/abort
 
 ```javascript
 async function manualTransaction() {
   const session = client.startSession();
-
   try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const accounts = database.collection('accounts');
-
-    // Start transaction
     session.startTransaction({
       readConcern: { level: 'snapshot' },
-      writeConcern: { w: 'majority' }
+      writeConcern: { w: 'majority' },
     });
 
-    try {
-      // Perform operations within transaction
-      await accounts.updateOne(
-        { accountId: 'A' },
-        { $inc: { balance: -100 } },
-        { session }
-      );
+    const accounts = client.db('sample_db').collection('accounts');
 
-      await accounts.updateOne(
-        { accountId: 'B' },
-        { $inc: { balance: 100 } },
-        { session }
-      );
+    await accounts.updateOne(
+      { accountId: 'A' },
+      { $inc: { balance: -100 } },
+      { session },
+    );
+    await accounts.updateOne(
+      { accountId: 'B' },
+      { $inc: { balance: 100 } },
+      { session },
+    );
 
-      // Commit transaction
-      await session.commitTransaction();
-      console.log('Transaction committed');
-
-    } catch (error) {
-      // Abort transaction on error
-      await session.abortTransaction();
-      console.error('Transaction aborted:', error);
-      throw error;
-    }
-
+    await session.commitTransaction();
+  } catch (err) {
+    await session.abortTransaction();
+    throw err;
   } finally {
     await session.endSession();
-    await client.close();
   }
 }
-
-manualTransaction().catch(console.error);
-```
-
-**Transaction with Retry Logic:**
-
-```javascript
-async function transactionWithRetry() {
-  const session = client.startSession();
-
-  async function runTransactionWithRetry(txnFunc, session) {
-    while (true) {
-      try {
-        return await txnFunc(session);
-      } catch (error) {
-        if (error.hasErrorLabel('TransientTransactionError')) {
-          console.log('TransientTransactionError, retrying transaction...');
-          continue;
-        }
-        throw error;
-      }
-    }
-  }
-
-  async function commitWithRetry(session) {
-    while (true) {
-      try {
-        await session.commitTransaction();
-        console.log('Transaction committed');
-        break;
-      } catch (error) {
-        if (error.hasErrorLabel('UnknownTransactionCommitResult')) {
-          console.log('UnknownTransactionCommitResult, retrying commit...');
-          continue;
-        }
-        throw error;
-      }
-    }
-  }
-
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-
-    await runTransactionWithRetry(async (session) => {
-      session.startTransaction();
-
-      const accounts = database.collection('accounts');
-
-      await accounts.updateOne(
-        { accountId: 'A' },
-        { $inc: { balance: -50 } },
-        { session }
-      );
-
-      await accounts.updateOne(
-        { accountId: 'B' },
-        { $inc: { balance: 50 } },
-        { session }
-      );
-
-      await commitWithRetry(session);
-    }, session);
-
-  } finally {
-    await session.endSession();
-    await client.close();
-  }
-}
-
-transactionWithRetry().catch(console.error);
 ```
 
 ## Change Streams
 
-**Watch Collection for Changes:**
-
 ```javascript
-async function watchCollection() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
+const users = client.db('sample_db').collection('users');
 
-    const changeStream = collection.watch();
+const changeStream = users.watch();
 
-    console.log('Watching for changes...');
+changeStream.on('change', (change) => {
+  console.log('Change:', change);
+});
 
-    changeStream.on('change', (change) => {
-      console.log('Change detected:', change);
-    });
-
-    changeStream.on('error', (error) => {
-      console.error('Change stream error:', error);
-    });
-
-    // Keep the connection open
-    // In production, you'd handle this differently
-
-  } catch (error) {
-    console.error(error);
-  }
-}
-
-watchCollection().catch(console.error);
+changeStream.on('error', (error) => {
+  console.error('Change stream error:', error);
+});
 ```
 
-**Watch with Filter Pipeline:**
+With a filter pipeline and `for await`:
 
 ```javascript
-async function watchWithFilter() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
+const stream = users.watch([
+  {
+    $match: {
+      operationType: { $in: ['insert', 'update'] },
+      'fullDocument.age': { $gte: 18 },
+    },
+  },
+]);
 
-    const pipeline = [
-      {
-        $match: {
-          'operationType': { $in: ['insert', 'update'] },
-          'fullDocument.age': { $gte: 18 }
-        }
-      }
-    ];
-
-    const changeStream = collection.watch(pipeline);
-
-    console.log('Watching for adult user changes...');
-
-    for await (const change of changeStream) {
-      console.log('Change:', change);
-
-      if (change.operationType === 'insert') {
-        console.log('New user inserted:', change.fullDocument);
-      } else if (change.operationType === 'update') {
-        console.log('User updated:', change.documentKey);
-      }
-    }
-
-  } catch (error) {
-    console.error(error);
+for await (const change of stream) {
+  if (change.operationType === 'insert') {
+    console.log('Inserted:', change.fullDocument);
+  } else if (change.operationType === 'update') {
+    console.log('Updated:', change.documentKey);
   }
 }
-
-watchWithFilter().catch(console.error);
 ```
 
-**Watch Database for Changes:**
+Database- and cluster-level streams:
 
 ```javascript
-async function watchDatabase() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-
-    const changeStream = database.watch();
-
-    console.log('Watching database for changes...');
-
-    changeStream.on('change', (change) => {
-      console.log(`Change in collection ${change.ns.coll}:`, change);
-    });
-
-  } catch (error) {
-    console.error(error);
-  }
-}
-
-watchDatabase().catch(console.error);
+client.db('sample_db').watch();
+client.watch();
 ```
 
 ## ObjectId Utilities
 
-**Working with ObjectId:**
-
 ```javascript
 import { ObjectId } from 'mongodb';
 
-async function objectIdExamples() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
+const users = client.db('sample_db').collection('users');
 
-    // Generate new ObjectId
-    const newId = new ObjectId();
-    console.log('New ObjectId:', newId.toString());
+const newId = new ObjectId();
 
-    // Insert with custom ObjectId
-    await collection.insertOne({
-      _id: new ObjectId(),
-      name: 'User with custom ID'
-    });
+await users.insertOne({ _id: new ObjectId(), name: 'User with custom ID' });
 
-    // Find by ObjectId string
-    const userId = '507f1f77bcf86cd799439011';
-    const user = await collection.findOne({
-      _id: new ObjectId(userId)
-    });
+const user = await users.findOne({ _id: new ObjectId('507f1f77bcf86cd799439011') });
 
-    // Get timestamp from ObjectId
-    if (user) {
-      const timestamp = user._id.getTimestamp();
-      console.log('Document created at:', timestamp);
-    }
-
-    // Validate ObjectId
-    const isValid = ObjectId.isValid('507f1f77bcf86cd799439011');
-    console.log('Is valid ObjectId:', isValid);
-
-  } finally {
-    await client.close();
-  }
+if (user) {
+  const timestamp = user._id.getTimestamp();
+  console.log(timestamp);
 }
 
-objectIdExamples().catch(console.error);
+ObjectId.isValid('507f1f77bcf86cd799439011');
 ```
 
 ## Error Handling
 
-**Comprehensive Error Handling:**
-
 ```javascript
 import { MongoClient, MongoServerError } from 'mongodb';
 
-async function errorHandlingExample() {
-  const client = new MongoClient(process.env.MONGODB_URI);
-
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
-
-    // Attempt operation
-    await collection.insertOne({
-      email: 'duplicate@example.com'
-    });
-
-  } catch (error) {
-    if (error instanceof MongoServerError) {
-      switch (error.code) {
-        case 11000:
-          console.error('Duplicate key error:', error.message);
-          break;
-        case 121:
-          console.error('Document validation failed:', error.message);
-          break;
-        default:
-          console.error('MongoDB server error:', error.message);
-      }
-    } else if (error.name === 'MongoNetworkError') {
-      console.error('Network error - cannot connect to MongoDB:', error.message);
-    } else if (error.name === 'MongoParseError') {
-      console.error('Invalid connection string:', error.message);
-    } else {
-      console.error('Unexpected error:', error);
+try {
+  await client.db('sample_db').collection('users').insertOne({
+    email: 'duplicate@example.com',
+  });
+} catch (error) {
+  if (error instanceof MongoServerError) {
+    switch (error.code) {
+      case 11000:
+        console.error('Duplicate key:', error.message);
+        break;
+      case 121:
+        console.error('Document validation failed:', error.message);
+        break;
+      default:
+        console.error('MongoDB server error:', error.message);
     }
-  } finally {
-    await client.close();
+  } else if (error.name === 'MongoNetworkError') {
+    console.error('Network error:', error.message);
+  } else if (error.name === 'MongoParseError') {
+    console.error('Invalid connection string:', error.message);
+  } else {
+    throw error;
   }
 }
-
-errorHandlingExample().catch(console.error);
 ```
 
-**Retry Logic for Transient Errors:**
+### Retry helper
 
 ```javascript
-async function retryOperation(operation, maxRetries = 3) {
+async function withRetry(operation, maxRetries = 3) {
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
       return await operation();
     } catch (error) {
-      if (attempt === maxRetries) {
-        throw error;
-      }
-
       const isRetryable =
         error.name === 'MongoNetworkError' ||
         error.code === 'ETIMEDOUT' ||
         error.code === 'ECONNRESET';
 
-      if (!isRetryable) {
+      if (!isRetryable || attempt === maxRetries) {
         throw error;
       }
 
-      const delay = Math.pow(2, attempt) * 1000;
-      console.log(`Attempt ${attempt} failed, retrying in ${delay}ms...`);
-      await new Promise(resolve => setTimeout(resolve, delay));
+      await new Promise((r) => setTimeout(r, 2 ** attempt * 1000));
     }
   }
 }
-
-async function useRetryLogic() {
-  const client = new MongoClient(process.env.MONGODB_URI);
-
-  try {
-    await retryOperation(async () => {
-      await client.connect();
-      const database = client.db('sample_db');
-      const collection = database.collection('users');
-
-      return await collection.findOne({ email: 'test@example.com' });
-    });
-
-  } finally {
-    await client.close();
-  }
-}
-
-useRetryLogic().catch(console.error);
 ```
 
 ## Query Operators
 
-**Comparison Operators:**
+### Comparison
 
 ```javascript
-async function comparisonOperators() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('products');
-
-    // $eq (equal)
-    const equal = await collection.find({ price: { $eq: 99 } }).toArray();
-
-    // $ne (not equal)
-    const notEqual = await collection.find({ status: { $ne: 'discontinued' } }).toArray();
-
-    // $gt, $gte (greater than, greater than or equal)
-    const greaterThan = await collection.find({ price: { $gt: 50 } }).toArray();
-    const greaterOrEqual = await collection.find({ stock: { $gte: 100 } }).toArray();
-
-    // $lt, $lte (less than, less than or equal)
-    const lessThan = await collection.find({ price: { $lt: 100 } }).toArray();
-    const lessOrEqual = await collection.find({ rating: { $lte: 3 } }).toArray();
-
-    // $in (in array)
-    const inArray = await collection.find({
-      category: { $in: ['electronics', 'computers'] }
-    }).toArray();
-
-    // $nin (not in array)
-    const notInArray = await collection.find({
-      status: { $nin: ['discontinued', 'out-of-stock'] }
-    }).toArray();
-
-    console.log('Query results:', equal, notEqual, greaterThan);
-
-  } finally {
-    await client.close();
-  }
-}
-
-comparisonOperators().catch(console.error);
+collection.find({ price: { $eq: 99 } });
+collection.find({ status: { $ne: 'discontinued' } });
+collection.find({ price: { $gt: 50 } });
+collection.find({ stock: { $gte: 100 } });
+collection.find({ price: { $lt: 100 } });
+collection.find({ rating: { $lte: 3 } });
+collection.find({ category: { $in: ['electronics', 'computers'] } });
+collection.find({ status: { $nin: ['discontinued', 'out-of-stock'] } });
 ```
 
-**Logical Operators:**
+### Logical
 
 ```javascript
-async function logicalOperators() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('products');
+collection.find({
+  $and: [{ price: { $lt: 100 } }, { stock: { $gt: 0 } }],
+});
 
-    // $and
-    const andQuery = await collection.find({
-      $and: [
-        { price: { $lt: 100 } },
-        { stock: { $gt: 0 } }
-      ]
-    }).toArray();
+collection.find({
+  $or: [{ category: 'electronics' }, { featured: true }],
+});
 
-    // $or
-    const orQuery = await collection.find({
-      $or: [
-        { category: 'electronics' },
-        { featured: true }
-      ]
-    }).toArray();
+collection.find({ price: { $not: { $gt: 100 } } });
 
-    // $not
-    const notQuery = await collection.find({
-      price: { $not: { $gt: 100 } }
-    }).toArray();
-
-    // $nor
-    const norQuery = await collection.find({
-      $nor: [
-        { status: 'discontinued' },
-        { stock: 0 }
-      ]
-    }).toArray();
-
-    console.log('Logical query results:', andQuery.length, orQuery.length);
-
-  } finally {
-    await client.close();
-  }
-}
-
-logicalOperators().catch(console.error);
+collection.find({
+  $nor: [{ status: 'discontinued' }, { stock: 0 }],
+});
 ```
 
-**Element Operators:**
+### Element
 
 ```javascript
-async function elementOperators() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
-
-    // $exists
-    const hasPhone = await collection.find({
-      phone: { $exists: true }
-    }).toArray();
-
-    // $type
-    const stringEmails = await collection.find({
-      email: { $type: 'string' }
-    }).toArray();
-
-    console.log('Element query results:', hasPhone.length, stringEmails.length);
-
-  } finally {
-    await client.close();
-  }
-}
-
-elementOperators().catch(console.error);
+collection.find({ phone: { $exists: true } });
+collection.find({ email: { $type: 'string' } });
 ```
 
-**Array Operators:**
+### Array
 
 ```javascript
-async function arrayOperators() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
-
-    // $all
-    const allTags = await collection.find({
-      tags: { $all: ['premium', 'verified'] }
-    }).toArray();
-
-    // $elemMatch
-    const elemMatch = await collection.find({
-      scores: { $elemMatch: { $gte: 80, $lt: 90 } }
-    }).toArray();
-
-    // $size
-    const exactSize = await collection.find({
-      tags: { $size: 3 }
-    }).toArray();
-
-    console.log('Array query results:', allTags.length, elemMatch.length);
-
-  } finally {
-    await client.close();
-  }
-}
-
-arrayOperators().catch(console.error);
+collection.find({ tags: { $all: ['premium', 'verified'] } });
+collection.find({ scores: { $elemMatch: { $gte: 80, $lt: 90 } } });
+collection.find({ tags: { $size: 3 } });
 ```
 
 ## Advanced Patterns
 
-**Connection Pooling:**
+### Connection pool tuning
 
 ```javascript
-import { MongoClient } from 'mongodb';
-
-const uri = process.env.MONGODB_URI;
-
-const client = new MongoClient(uri, {
+const client = new MongoClient(process.env.MONGODB_URI, {
   maxPoolSize: 50,
   minPoolSize: 10,
-  maxIdleTimeMS: 30000,
-  waitQueueTimeoutMS: 5000
+  maxIdleTimeMS: 30_000,
+  waitQueueTimeoutMS: 5_000,
+});
+```
+
+### Database and collection management
+
+```javascript
+const adminDb = client.db().admin();
+const dbList = await adminDb.listDatabases();
+
+const database = client.db('sample_db');
+const collections = await database.listCollections().toArray();
+
+await database.createCollection('newCollection', {
+  validator: {
+    $jsonSchema: {
+      bsonType: 'object',
+      required: ['name', 'email'],
+      properties: {
+        name:  { bsonType: 'string' },
+        email: { bsonType: 'string', pattern: '^.+@.+$' },
+      },
+    },
+  },
 });
 
-let isConnected = false;
-
-async function getDatabase() {
-  if (!isConnected) {
-    await client.connect();
-    isConnected = true;
-  }
-  return client.db('sample_db');
-}
-
-export { getDatabase, client };
+// await database.collection('oldCollection').drop();
 ```
 
-**Database and Collection Management:**
+### Schema validation
 
 ```javascript
-async function databaseManagement() {
-  try {
-    await client.connect();
-
-    // List databases
-    const adminDb = client.db().admin();
-    const dbList = await adminDb.listDatabases();
-    console.log('Databases:', dbList.databases);
-
-    // List collections
-    const database = client.db('sample_db');
-    const collections = await database.listCollections().toArray();
-    console.log('Collections:', collections);
-
-    // Create collection with options
-    await database.createCollection('newCollection', {
-      validator: {
-        $jsonSchema: {
-          bsonType: 'object',
-          required: ['name', 'email'],
-          properties: {
-            name: {
-              bsonType: 'string',
-              description: 'must be a string and is required'
-            },
-            email: {
-              bsonType: 'string',
-              pattern: '^.+@.+$',
-              description: 'must be a valid email'
-            }
-          }
-        }
-      }
-    });
-
-    // Drop collection
-    // await database.collection('oldCollection').drop();
-
-  } finally {
-    await client.close();
-  }
-}
-
-databaseManagement().catch(console.error);
-```
-
-**Schema Validation:**
-
-```javascript
-async function addSchemaValidation() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-
-    await database.command({
-      collMod: 'users',
-      validator: {
-        $jsonSchema: {
-          bsonType: 'object',
-          required: ['name', 'email', 'age'],
-          properties: {
-            name: {
-              bsonType: 'string',
-              description: 'must be a string and is required'
-            },
-            email: {
-              bsonType: 'string',
-              pattern: '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$',
-              description: 'must be a valid email and is required'
-            },
-            age: {
-              bsonType: 'int',
-              minimum: 0,
-              maximum: 150,
-              description: 'must be an integer between 0 and 150'
-            },
-            status: {
-              enum: ['active', 'inactive', 'suspended'],
-              description: 'can only be one of the enum values'
-            }
-          }
-        }
+await client.db('sample_db').command({
+  collMod: 'users',
+  validator: {
+    $jsonSchema: {
+      bsonType: 'object',
+      required: ['name', 'email', 'age'],
+      properties: {
+        name:  { bsonType: 'string' },
+        email: { bsonType: 'string', pattern: '^[\\w.%+-]+@[\\w.-]+\\.[A-Za-z]{2,}$' },
+        age:   { bsonType: 'int', minimum: 0, maximum: 150 },
+        status: { enum: ['active', 'inactive', 'suspended'] },
       },
-      validationLevel: 'moderate',
-      validationAction: 'error'
-    });
-
-    console.log('Schema validation added');
-
-  } finally {
-    await client.close();
-  }
-}
-
-addSchemaValidation().catch(console.error);
+    },
+  },
+  validationLevel: 'moderate',
+  validationAction: 'error',
+});
 ```
 
-**Time Series Collections:**
+### Time series collections
 
 ```javascript
-async function createTimeSeriesCollection() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
+await client.db('sample_db').createCollection('sensor_data', {
+  timeseries: {
+    timeField: 'timestamp',
+    metaField: 'sensorId',
+    granularity: 'seconds',
+  },
+});
 
-    await database.createCollection('sensor_data', {
-      timeseries: {
-        timeField: 'timestamp',
-        metaField: 'sensorId',
-        granularity: 'seconds'
-      }
-    });
-
-    const collection = database.collection('sensor_data');
-
-    // Insert time series data
-    await collection.insertMany([
-      {
-        sensorId: 'sensor1',
-        timestamp: new Date('2024-01-01T00:00:00Z'),
-        temperature: 22.5,
-        humidity: 60
-      },
-      {
-        sensorId: 'sensor1',
-        timestamp: new Date('2024-01-01T00:01:00Z'),
-        temperature: 22.7,
-        humidity: 59
-      }
-    ]);
-
-    console.log('Time series data inserted');
-
-  } finally {
-    await client.close();
-  }
-}
-
-createTimeSeriesCollection().catch(console.error);
+await client.db('sample_db').collection('sensor_data').insertMany([
+  { sensorId: 'sensor1', timestamp: new Date('2026-05-29T00:00:00Z'), temperature: 22.5, humidity: 60 },
+  { sensorId: 'sensor1', timestamp: new Date('2026-05-29T00:01:00Z'), temperature: 22.7, humidity: 59 },
+]);
 ```
 
-**Read and Write Concerns:**
+### Read and write concerns
 
 ```javascript
-async function readWriteConcerns() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
+await collection.insertOne(
+  { name: 'John', email: 'john@example.com' },
+  { writeConcern: { w: 'majority', j: true, wtimeout: 5000 } },
+);
 
-    // Write concern
-    const insertResult = await collection.insertOne(
-      { name: 'John', email: 'john@example.com' },
-      {
-        writeConcern: {
-          w: 'majority',
-          j: true,
-          wtimeout: 5000
-        }
-      }
-    );
-
-    // Read concern
-    const findResult = await collection.findOne(
-      { email: 'john@example.com' },
-      {
-        readConcern: { level: 'majority' }
-      }
-    );
-
-    console.log('Insert result:', insertResult);
-    console.log('Find result:', findResult);
-
-  } finally {
-    await client.close();
-  }
-}
-
-readWriteConcerns().catch(console.error);
+await collection.findOne(
+  { email: 'john@example.com' },
+  { readConcern: { level: 'majority' } },
+);
 ```
 
-**Count Documents:**
+### Counts and distinct
 
 ```javascript
-async function countExamples() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
+await collection.countDocuments({});
+await collection.countDocuments({ status: 'active' });
+await collection.estimatedDocumentCount();   // fast, may be stale
 
-    // Count all documents
-    const totalCount = await collection.countDocuments({});
-    console.log('Total documents:', totalCount);
-
-    // Count with filter
-    const activeCount = await collection.countDocuments({ status: 'active' });
-    console.log('Active users:', activeCount);
-
-    // Estimated count (faster but less accurate)
-    const estimatedCount = await collection.estimatedDocumentCount();
-    console.log('Estimated count:', estimatedCount);
-
-  } finally {
-    await client.close();
-  }
-}
-
-countExamples().catch(console.error);
+await collection.distinct('city');
+await collection.distinct('city', { status: 'active' });
 ```
 
-**Distinct Values:**
+## Version Notes
 
-```javascript
-async function distinctValues() {
-  try {
-    await client.connect();
-    const database = client.db('sample_db');
-    const collection = database.collection('users');
+- `mongodb` npm `7.2.0` is the current `latest` dist-tag as of May 29, 2026.
+- v6 is still actively maintained at `6.21.0` for projects that haven't migrated.
+- The driver uses `mongodb+srv://` connection strings for Atlas SRV discovery.
+- The Stable API (`serverApi: { version: 'v1' }`) protects you from server-side behavior drift across MongoDB releases.
+- Atlas Vector Search requires a `vectorSearch` index defined in Atlas; the driver only sends the aggregation stage.
 
-    // Get distinct values
-    const cities = await collection.distinct('city');
-    console.log('Distinct cities:', cities);
+## Official Sources
 
-    // Get distinct values with filter
-    const activeCities = await collection.distinct('city', { status: 'active' });
-    console.log('Cities with active users:', activeCities);
-
-  } finally {
-    await client.close();
-  }
-}
-
-distinctValues().catch(console.error);
-```
+- Driver docs: https://www.mongodb.com/docs/drivers/node/current/
+- API reference: https://mongodb.github.io/node-mongodb-native/
+- GitHub: https://github.com/mongodb/node-mongodb-native
+- npm: https://www.npmjs.com/package/mongodb
+- Atlas Vector Search: https://www.mongodb.com/docs/atlas/atlas-vector-search/

--- a/content/redis/docs/key-value/javascript/DOC.md
+++ b/content/redis/docs/key-value/javascript/DOC.md
@@ -3,72 +3,48 @@ name: key-value
 description: "Redis JavaScript client (node-redis) for key-value storage, caching, and pub/sub messaging"
 metadata:
   languages: "javascript"
-  versions: "5.9.0"
-  updated-on: "2026-03-01"
+  versions: "6.0.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "redis,database,cache,key-value,pubsub"
 ---
 
 # Redis JavaScript Client (node-redis) - Complete Integration Guide
 
-## GOLDEN RULE
+## Golden Rule
 
-**ALWAYS use the official `redis` npm package (node-redis) for Redis integration.**
-
-```bash
-npm install redis
-```
-
-**DO NOT use:**
-- `ioredis` (alternative client, not official)
-- `redis-node` (unofficial package)
-- `node_redis` (deprecated naming)
-- Any other third-party Redis clients unless specifically required
-
-The official `redis` package is maintained by Redis and is the recommended client for Node.js applications.
-
----
-
-## Installation
-
-### Basic Installation
+Use the official `redis` npm package (node-redis). The current `latest` dist-tag on npm is `6.0.0`. The package ships its own TypeScript definitions; do not depend on `@types/redis`.
 
 ```bash
-npm install redis
+npm install redis@6
 ```
 
-### Installation with TypeScript Support
+Do not use `ioredis`, `redis-node`, or other unofficial clients unless your team has explicitly chosen one.
+
+## Install And Environment
 
 ```bash
-npm install redis
-npm install --save-dev @types/node
+npm install redis@6
 ```
 
-The `redis` package includes built-in TypeScript definitions.
-
-### Environment Setup
-
-Create a `.env` file in your project root:
+`.env`:
 
 ```env
 REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_PASSWORD=your_password_here
 REDIS_DB=0
-REDIS_URL=redis://username:password@localhost:6379
+REDIS_URL=redis://default:your_password_here@localhost:6379
 ```
-
-Install dotenv to load environment variables:
 
 ```bash
 npm install dotenv
 ```
 
----
-
 ## Initialization
 
-### Basic Connection (Localhost)
+### Basic connect
 
 ```javascript
 import { createClient } from 'redis';
@@ -81,81 +57,66 @@ client.on('error', (err) => {
 
 await client.connect();
 
-// Use the client...
+// ...use the client
 
 await client.quit();
 ```
 
-### Connection with Environment Variables
+`createClient()` returns an instance; commands work only after `await client.connect()`. `client.on('error', ...)` is required — without an error handler, an error event from a disconnected socket can crash the process.
+
+### From a URL
 
 ```javascript
 import { createClient } from 'redis';
-import dotenv from 'dotenv';
+import 'dotenv/config';
 
-dotenv.config();
+const client = createClient({
+  url: process.env.REDIS_URL || 'redis://localhost:6379',
+});
+
+client.on('error', (err) => console.error('Redis Client Error', err));
+await client.connect();
+```
+
+### From explicit socket options
+
+```javascript
+import { createClient } from 'redis';
 
 const client = createClient({
   socket: {
     host: process.env.REDIS_HOST || 'localhost',
-    port: parseInt(process.env.REDIS_PORT || '6379')
+    port: Number(process.env.REDIS_PORT) || 6379,
   },
+  username: 'default',
   password: process.env.REDIS_PASSWORD,
-  database: parseInt(process.env.REDIS_DB || '0')
+  database: Number(process.env.REDIS_DB) || 0,
 });
 
-client.on('error', (err) => {
-  console.error('Redis Client Error', err);
-});
-
+client.on('error', (err) => console.error('Redis Client Error', err));
 await client.connect();
 ```
 
-### Connection Using URL
+### Authentication
 
 ```javascript
-import { createClient } from 'redis';
-import dotenv from 'dotenv';
-
-dotenv.config();
-
 const client = createClient({
-  url: process.env.REDIS_URL || 'redis://localhost:6379'
+  url: 'redis://alice:foobared@redis.example.com:6380',
 });
 
-client.on('error', (err) => {
-  console.error('Redis Client Error', err);
-});
-
-await client.connect();
-```
-
-### Connection with Authentication
-
-```javascript
-import { createClient } from 'redis';
-
-const client = createClient({
-  url: 'redis://alice:foobared@awesome.redis.server:6380'
-});
-
-// Or using socket configuration
+// equivalent socket form
 const clientAlt = createClient({
-  socket: {
-    host: 'awesome.redis.server',
-    port: 6380
-  },
+  socket: { host: 'redis.example.com', port: 6380 },
   username: 'alice',
-  password: 'foobared'
+  password: 'foobared',
 });
-
-await client.connect();
 ```
 
-### Connection with TLS/SSL
+### TLS
 
 ```javascript
 import { createClient } from 'redis';
-import fs from 'fs';
+import fs from 'node:fs';
 
 const client = createClient({
   socket: {
@@ -164,565 +125,220 @@ const client = createClient({
     tls: true,
     key: fs.readFileSync('/path/to/client-key.pem'),
     cert: fs.readFileSync('/path/to/client-cert.pem'),
-    ca: [fs.readFileSync('/path/to/ca-cert.pem')]
-  }
+    ca: [fs.readFileSync('/path/to/ca-cert.pem')],
+  },
 });
 
 await client.connect();
 ```
 
-### Connection Status Checks
+### Connection state
 
 ```javascript
-// Check if client is ready to execute commands
-if (client.isReady) {
-  console.log('Client is ready');
-}
-
-// Check if underlying socket is open
-if (client.isOpen) {
-  console.log('Connection is open');
-}
+if (client.isReady) { /* commands can run */ }
+if (client.isOpen)  { /* socket is open */ }
 ```
 
-### Duplicate Connection (for Pub/Sub)
+### Duplicate (required for pub/sub)
 
 ```javascript
-const client = createClient();
-await client.connect();
-
-// Create a duplicate connection for pub/sub
 const subscriber = client.duplicate();
 await subscriber.connect();
 ```
 
-### Graceful Shutdown
+### Shutdown
 
 ```javascript
-// Graceful disconnect
-await client.quit();
-
-// Force disconnect
-await client.disconnect();
+await client.quit();        // graceful: drain pending commands, then close
+await client.disconnect();  // immediate close
 ```
 
----
-
-## Core API Surfaces
-
-## String Operations
-
-### Basic SET and GET
+## Strings
 
 ```javascript
-// Set a string value
 await client.set('key', 'value');
-
-// Get a string value
 const value = await client.get('key');
-console.log(value); // 'value'
-```
 
-### SET with Options
+await client.set('session:123', 'user_data', { EX: 3600 });   // seconds
+await client.set('temp:key', 'value', { PX: 5000 });          // milliseconds
+await client.set('key', 'value', { NX: true });
+await client.set('key', 'new_value', { XX: true });
+const oldValue = await client.set('key', 'new_value', { GET: true });
 
-```javascript
-// Set with expiration (EX = seconds)
-await client.set('session:123', 'user_data', {
-  EX: 3600 // expires in 1 hour
-});
+await client.mSet({ key1: 'value1', key2: 'value2' });
+const values = await client.mGet(['key1', 'key2']);
 
-// Set with expiration (PX = milliseconds)
-await client.set('temp:key', 'value', {
-  PX: 5000 // expires in 5 seconds
-});
-
-// Set only if key doesn't exist (NX)
-await client.set('key', 'value', {
-  NX: true
-});
-
-// Set only if key exists (XX)
-await client.set('key', 'new_value', {
-  XX: true
-});
-
-// Get old value and set new value
-const oldValue = await client.set('key', 'new_value', {
-  GET: true
-});
-```
-
-### Multiple Keys
-
-```javascript
-// Set multiple keys at once
-await client.mSet({
-  'key1': 'value1',
-  'key2': 'value2',
-  'key3': 'value3'
-});
-
-// Get multiple keys at once
-const values = await client.mGet(['key1', 'key2', 'key3']);
-console.log(values); // ['value1', 'value2', 'value3']
-```
-
-### Increment and Decrement
-
-```javascript
-// Set initial value
 await client.set('counter', 0);
-
-// Increment by 1
-await client.incr('counter'); // Returns 1
-
-// Increment by specific amount
-await client.incrBy('counter', 10); // Returns 11
-
-// Increment float
-await client.incrByFloat('price', 2.5); // Increment by 2.5
-
-// Decrement by 1
+await client.incr('counter');
+await client.incrBy('counter', 10);
+await client.incrByFloat('price', 2.5);
 await client.decr('counter');
-
-// Decrement by specific amount
 await client.decrBy('counter', 5);
+
+await client.append('message', ' World');
+await client.getRange('message', 0, 4);
+await client.strLen('message');
+await client.setRange('message', 6, 'Redis');
 ```
 
-### String Manipulation
+## Hashes
 
 ```javascript
-// Append to string
-await client.set('message', 'Hello');
-await client.append('message', ' World'); // 'Hello World'
-
-// Get substring
-const substr = await client.getRange('message', 0, 4); // 'Hello'
-
-// Get length
-const len = await client.strLen('message'); // 11
-
-// Set range
-await client.setRange('message', 6, 'Redis'); // 'Hello Redis'
-```
-
----
-
-## Hash Operations
-
-### Basic Hash Operations
-
-```javascript
-// Set a single field in a hash
 await client.hSet('user:1000', 'name', 'John Doe');
-
-// Get a single field from a hash
 const name = await client.hGet('user:1000', 'name');
-console.log(name); // 'John Doe'
 
-// Set multiple fields at once
 await client.hSet('user:1000', {
   name: 'John Doe',
-  email: '[email protected]',
-  age: 30
+  email: 'john@example.com',
+  age: 30,
 });
 
-// Get all fields and values
 const user = await client.hGetAll('user:1000');
-console.log(user);
-// { name: 'John Doe', email: '[email protected]', age: '30' }
-```
 
-### Advanced Hash Operations
-
-```javascript
-// Check if field exists
-const exists = await client.hExists('user:1000', 'email'); // true
-
-// Get all field names
-const fields = await client.hKeys('user:1000');
-// ['name', 'email', 'age']
-
-// Get all values
-const values = await client.hVals('user:1000');
-// ['John Doe', '[email protected]', '30']
-
-// Get number of fields
-const count = await client.hLen('user:1000'); // 3
-
-// Get multiple fields
-const userData = await client.hmGet('user:1000', ['name', 'email']);
-// ['John Doe', '[email protected]']
-
-// Delete fields
+await client.hExists('user:1000', 'email');
+await client.hKeys('user:1000');
+await client.hVals('user:1000');
+await client.hLen('user:1000');
+await client.hmGet('user:1000', ['name', 'email']);
 await client.hDel('user:1000', 'age');
-
-// Increment numeric field
-await client.hSet('user:1000', 'loginCount', 0);
-await client.hIncrBy('user:1000', 'loginCount', 1); // 1
-
-// Increment float field
+await client.hIncrBy('user:1000', 'loginCount', 1);
 await client.hIncrByFloat('user:1000', 'balance', 10.50);
+await client.hSetNX('user:1000', 'created', String(Date.now()));
 
-// Set only if field doesn't exist
-await client.hSetNX('user:1000', 'created', Date.now());
-```
-
-### Scan Hash Fields
-
-```javascript
-// Scan hash fields (for large hashes)
 for await (const { field, value } of client.hScanIterator('user:1000')) {
-  console.log(`${field}: ${value}`);
+  console.log(field, value);
 }
 ```
 
----
-
-## List Operations
-
-### Basic List Operations
+## Lists
 
 ```javascript
-// Push elements to the right (end) of list
 await client.rPush('tasks', 'task1');
-await client.rPush('tasks', ['task2', 'task3']); // Multiple values
-
-// Push elements to the left (beginning) of list
+await client.rPush('tasks', ['task2', 'task3']);
 await client.lPush('tasks', 'urgent_task');
-await client.lPush('tasks', ['task0', 'task-1']);
 
-// Get list length
-const length = await client.lLen('tasks');
+await client.lLen('tasks');
+await client.lRange('tasks', 0, -1);
+await client.lIndex('tasks', 0);
+await client.rPop('tasks');
+await client.lPop('tasks');
 
-// Get range of elements
-const tasks = await client.lRange('tasks', 0, -1); // Get all
-const firstThree = await client.lRange('tasks', 0, 2); // Get first 3
+await client.blPop('tasks', 10);     // wait up to 10s
+await client.brPop('tasks', 10);
 
-// Get element by index
-const task = await client.lIndex('tasks', 0);
-
-// Pop from right (end)
-const lastTask = await client.rPop('tasks');
-
-// Pop from left (beginning)
-const firstTask = await client.lPop('tasks');
-```
-
-### Advanced List Operations
-
-```javascript
-// Blocking pop (wait for element)
-const task = await client.blPop('tasks', 10); // Wait up to 10 seconds
-// Returns: { key: 'tasks', element: 'task1' }
-
-const taskRight = await client.brPop('tasks', 10);
-
-// Set element at index
 await client.lSet('tasks', 0, 'updated_task');
-
-// Insert before/after element
 await client.lInsert('tasks', 'BEFORE', 'task2', 'new_task');
-await client.lInsert('tasks', 'AFTER', 'task2', 'another_task');
-
-// Remove elements
-await client.lRem('tasks', 2, 'task1'); // Remove first 2 occurrences
-await client.lRem('tasks', -1, 'task2'); // Remove last occurrence
-await client.lRem('tasks', 0, 'task3'); // Remove all occurrences
-
-// Trim list to range
-await client.lTrim('tasks', 0, 9); // Keep only first 10 elements
-
-// Move element between lists
-const element = await client.rPopLPush('source', 'destination');
-
-// Blocking move
-const moved = await client.brPopLPush('source', 'destination', 5);
+await client.lRem('tasks', 0, 'task3');
+await client.lTrim('tasks', 0, 9);
+await client.lMove('source', 'destination', 'LEFT', 'RIGHT');
+await client.blMove('source', 'destination', 'RIGHT', 'LEFT', 5);
 ```
 
----
-
-## Set Operations
-
-### Basic Set Operations
+## Sets
 
 ```javascript
-// Add members to set
 await client.sAdd('tags', 'javascript');
 await client.sAdd('tags', ['nodejs', 'redis', 'database']);
 
-// Check if member exists
-const exists = await client.sIsMember('tags', 'nodejs'); // true
-
-// Get all members
-const allTags = await client.sMembers('tags');
-// ['javascript', 'nodejs', 'redis', 'database']
-
-// Get number of members
-const count = await client.sCard('tags'); // 4
-
-// Remove members
-await client.sRem('tags', 'database');
+await client.sIsMember('tags', 'nodejs');
+await client.sMembers('tags');
+await client.sCard('tags');
 await client.sRem('tags', ['nodejs', 'redis']);
+await client.sPop('tags');
+await client.sRandMember('tags');
+await client.sRandMemberCount('tags', 3);
 
-// Pop random member
-const randomTag = await client.sPop('tags');
-
-// Get random member without removing
-const random = await client.sRandMember('tags');
-const randomThree = await client.sRandMemberCount('tags', 3);
-```
-
-### Set Operations Between Multiple Sets
-
-```javascript
-// Create sets
-await client.sAdd('set1', ['a', 'b', 'c']);
-await client.sAdd('set2', ['b', 'c', 'd']);
-await client.sAdd('set3', ['c', 'd', 'e']);
-
-// Union (combine all unique members)
-const union = await client.sUnion(['set1', 'set2']);
-// ['a', 'b', 'c', 'd']
-
-// Store union in new set
+await client.sUnion(['set1', 'set2']);
 await client.sUnionStore('result', ['set1', 'set2']);
-
-// Intersection (common members)
-const inter = await client.sInter(['set1', 'set2']);
-// ['b', 'c']
-
-// Store intersection
+await client.sInter(['set1', 'set2']);
 await client.sInterStore('result', ['set1', 'set2']);
-
-// Difference (members in first set but not in others)
-const diff = await client.sDiff(['set1', 'set2']);
-// ['a']
-
-// Store difference
+await client.sDiff(['set1', 'set2']);
 await client.sDiffStore('result', ['set1', 'set2']);
-
-// Move member between sets
 await client.sMove('set1', 'set2', 'a');
-```
 
-### Scan Set Members
-
-```javascript
-// Scan set members (for large sets)
 for await (const member of client.sScanIterator('tags')) {
   console.log(member);
 }
 ```
 
----
-
-## Sorted Set Operations
-
-### Basic Sorted Set Operations
+## Sorted Sets
 
 ```javascript
-// Add members with scores
 await client.zAdd('leaderboard', { score: 100, value: 'player1' });
 await client.zAdd('leaderboard', [
   { score: 200, value: 'player2' },
-  { score: 150, value: 'player3' }
+  { score: 150, value: 'player3' },
 ]);
 
-// Get rank (0-based, lowest to highest)
-const rank = await client.zRank('leaderboard', 'player1'); // 0
+await client.zRank('leaderboard', 'player1');
+await client.zRevRank('leaderboard', 'player2');
+await client.zScore('leaderboard', 'player2');
+await client.zCard('leaderboard');
+await client.zIncrBy('leaderboard', 50, 'player1');
 
-// Get reverse rank (highest to lowest)
-const revRank = await client.zRevRank('leaderboard', 'player2'); // 0
-
-// Get score
-const score = await client.zScore('leaderboard', 'player2'); // 200
-
-// Get number of members
-const count = await client.zCard('leaderboard'); // 3
-
-// Increment score
-await client.zIncrBy('leaderboard', 50, 'player1'); // 150
-```
-
-### Range Queries
-
-```javascript
-// Get range by rank (lowest to highest)
-const bottom3 = await client.zRange('leaderboard', 0, 2);
-// ['player1', 'player3', 'player2']
-
-// Get range with scores
-const withScores = await client.zRangeWithScores('leaderboard', 0, 2);
-// [{ value: 'player1', score: 150 }, ...]
-
-// Get range by rank (highest to lowest)
-const top3 = await client.zRevRange('leaderboard', 0, 2);
-
-// Get range by score
-const range = await client.zRangeByScore('leaderboard', 100, 200);
-
-// Get range by score with limit
-const limited = await client.zRangeByScore('leaderboard', 100, 200, {
-  LIMIT: {
-    offset: 0,
-    count: 10
-  }
+await client.zRange('leaderboard', 0, 2);
+await client.zRangeWithScores('leaderboard', 0, 2);
+await client.zRangeByScore('leaderboard', 100, 200, {
+  LIMIT: { offset: 0, count: 10 },
 });
 
-// Get reverse range by score
-const revRange = await client.zRevRangeByScore('leaderboard', 200, 100);
-```
-
-### Advanced Sorted Set Operations
-
-```javascript
-// Count members in score range
-const count = await client.zCount('leaderboard', 100, 200);
-
-// Count members by lexicographical range
-const lexCount = await client.zLexCount('leaderboard', '[a', '[z');
-
-// Remove members
-await client.zRem('leaderboard', 'player1');
+await client.zCount('leaderboard', 100, 200);
 await client.zRem('leaderboard', ['player2', 'player3']);
-
-// Remove by rank range
-await client.zRemRangeByRank('leaderboard', 0, 1); // Remove bottom 2
-
-// Remove by score range
+await client.zRemRangeByRank('leaderboard', 0, 1);
 await client.zRemRangeByScore('leaderboard', 0, 100);
 
-// Pop highest/lowest scoring member
-const highest = await client.zPopMax('leaderboard');
-const lowest = await client.zPopMin('leaderboard');
+await client.zPopMax('leaderboard');
+await client.zPopMin('leaderboard');
+await client.bzPopMax('leaderboard', 5);
 
-// Pop with count
-const top3 = await client.zPopMax('leaderboard', 3);
+await client.zUnionStore('result', ['set1', 'set2'], { WEIGHTS: [2, 3] });
+await client.zInterStore('result', ['set1', 'set2'], { AGGREGATE: 'SUM' });
 
-// Blocking pop
-const member = await client.bzPopMax('leaderboard', 5); // Wait up to 5 sec
-const minMember = await client.bzPopMin('leaderboard', 5);
-```
-
-### Sorted Set Operations Between Multiple Sets
-
-```javascript
-// Union of sorted sets
-await client.zUnionStore('result', ['set1', 'set2']);
-
-// Union with weights
-await client.zUnionStore('result', ['set1', 'set2'], {
-  WEIGHTS: [2, 3]
-});
-
-// Union with aggregate function
-await client.zUnionStore('result', ['set1', 'set2'], {
-  AGGREGATE: 'MAX' // or 'MIN', 'SUM'
-});
-
-// Intersection
-await client.zInterStore('result', ['set1', 'set2']);
-
-// Intersection with weights and aggregate
-await client.zInterStore('result', ['set1', 'set2'], {
-  WEIGHTS: [1, 2],
-  AGGREGATE: 'SUM'
-});
-```
-
-### Scan Sorted Set
-
-```javascript
-// Scan sorted set members
 for await (const member of client.zScanIterator('leaderboard')) {
   console.log(member);
 }
 ```
 
----
-
-## Key Management Operations
-
-### Key Operations
+## Key Management
 
 ```javascript
-// Check if key exists
-const exists = await client.exists('mykey'); // 1 if exists, 0 if not
-const multiExists = await client.exists(['key1', 'key2']); // Count
-
-// Delete keys
+await client.exists('mykey');
+await client.exists(['key1', 'key2']);
 await client.del('mykey');
 await client.del(['key1', 'key2', 'key3']);
 
-// Set expiration in seconds
-await client.expire('mykey', 60); // Expire in 60 seconds
-
-// Set expiration at specific timestamp
-const timestamp = Math.floor(Date.now() / 1000) + 3600;
-await client.expireAt('mykey', timestamp);
-
-// Set expiration in milliseconds
-await client.pExpire('mykey', 60000); // 60 seconds
-
-// Get time to live in seconds
-const ttl = await client.ttl('mykey'); // -1 if no expiration, -2 if not exists
-
-// Get time to live in milliseconds
-const pttl = await client.pTtl('mykey');
-
-// Remove expiration
+await client.expire('mykey', 60);
+await client.expireAt('mykey', Math.floor(Date.now() / 1000) + 3600);
+await client.pExpire('mykey', 60_000);
+await client.ttl('mykey');     // -1 no TTL, -2 missing
+await client.pTtl('mykey');
 await client.persist('mykey');
 
-// Rename key
 await client.rename('oldkey', 'newkey');
-
-// Rename only if new key doesn't exist
-const renamed = await client.renameNX('oldkey', 'newkey');
-
-// Get key type
-const type = await client.type('mykey'); // 'string', 'list', 'set', etc.
-
-// Get random key
-const randomKey = await client.randomKey();
+await client.renameNX('oldkey', 'newkey');
+await client.type('mykey');
+await client.randomKey();
 ```
 
-### Scanning Keys
+### Scanning
 
 ```javascript
-// Scan all keys (use instead of KEYS for production)
-const keys = [];
-for await (const key of client.scanIterator()) {
-  keys.push(key);
-}
-
-// Scan with pattern
-for await (const key of client.scanIterator({
-  MATCH: 'user:*',
-  COUNT: 100
-})) {
+for await (const key of client.scanIterator({ MATCH: 'user:*', COUNT: 100 })) {
   console.log(key);
 }
 
-// Scan specific key type
-for await (const key of client.scanIterator({
-  TYPE: 'string',
-  COUNT: 100
-})) {
+for await (const key of client.scanIterator({ TYPE: 'string', COUNT: 100 })) {
   console.log(key);
 }
 ```
 
----
+Use `scanIterator` instead of `keys` in production.
 
-## Transactions
+## Transactions And Pipelining
 
-### Basic Transaction (MULTI/EXEC)
+### `MULTI / EXEC`
 
 ```javascript
-// Execute multiple commands atomically
-await client.set('another-key', 'another-value');
-
 const results = await client
   .multi()
   .set('key', 'value')
@@ -733,927 +349,12 @@ const results = await client
 console.log(results); // ['OK', 'another-value', 1]
 ```
 
-### Transaction with Error Handling
+### Per-command error handling
 
 ```javascript
-try {
-  const results = await client
-    .multi()
-    .set('key1', 'value1')
-    .set('key2', 'value2')
-    .get('key1')
-    .exec();
-
-  // Check each result
-  results.forEach((result, index) => {
-    if (result instanceof Error) {
-      console.error(`Command ${index} failed:`, result);
-    } else {
-      console.log(`Command ${index} result:`, result);
-    }
-  });
-} catch (error) {
-  console.error('Transaction failed:', error);
-}
-```
-
-### Transaction with WATCH (Optimistic Locking)
-
-```javascript
-// Watch a key for changes
-await client.watch('balance');
-
-const balance = parseInt(await client.get('balance'));
-
-if (balance >= 100) {
-  // This transaction will fail if 'balance' changed after WATCH
-  const results = await client
-    .multi()
-    .decrBy('balance', 100)
-    .incrBy('purchases', 1)
-    .exec();
-
-  if (results === null) {
-    console.log('Transaction aborted - balance was modified');
-  } else {
-    console.log('Purchase successful');
-  }
-} else {
-  await client.unwatch();
-  console.log('Insufficient balance');
-}
-```
-
-### Complex Transaction Example
-
-```javascript
-async function transferMoney(fromAccount, toAccount, amount) {
-  await client.watch([fromAccount, toAccount]);
-
-  const fromBalance = parseFloat(await client.get(fromAccount));
-
-  if (fromBalance < amount) {
-    await client.unwatch();
-    throw new Error('Insufficient funds');
-  }
-
-  const results = await client
-    .multi()
-    .decrByFloat(fromAccount, amount)
-    .incrByFloat(toAccount, amount)
-    .exec();
-
-  if (results === null) {
-    throw new Error('Transaction failed - accounts modified during transfer');
-  }
-
-  return results;
-}
-
-// Usage
-try {
-  await transferMoney('account:1', 'account:2', 50.00);
-  console.log('Transfer successful');
-} catch (error) {
-  console.error('Transfer failed:', error.message);
-}
-```
-
----
-
-## Pipelining
-
-### Automatic Pipelining
-
-Node-redis automatically pipelines commands that are queued in the same tick:
-
-```javascript
-// These commands are automatically batched and sent together
-const [result1, result2, result3] = await Promise.all([
-  client.set('key1', 'value1'),
-  client.set('key2', 'value2'),
-  client.get('key1')
-]);
-
-console.log(result1); // 'OK'
-console.log(result2); // 'OK'
-console.log(result3); // 'value1'
-```
-
-### Manual Pipelining with Multi (No Atomicity)
-
-```javascript
-// Execute commands as pipeline without transaction semantics
-const results = await client
-  .multi()
-  .set('key1', 'value1')
-  .set('key2', 'value2')
-  .get('key1')
-  .mGet(['key1', 'key2'])
-  .exec();
-
-console.log(results);
-// ['OK', 'OK', 'value1', ['value1', 'value2']]
-```
-
-### Large Batch Operations
-
-```javascript
-async function batchSetKeys(keyValuePairs) {
-  const pipeline = client.multi();
-
-  for (const [key, value] of Object.entries(keyValuePairs)) {
-    pipeline.set(key, value);
-  }
-
-  const results = await pipeline.exec();
-  return results;
-}
-
-// Usage
-const data = {
-  'user:1': 'Alice',
-  'user:2': 'Bob',
-  'user:3': 'Charlie'
-};
-
-await batchSetKeys(data);
-```
-
----
-
-## Pub/Sub
-
-### Basic Subscriber
-
-```javascript
-import { createClient } from 'redis';
-
-const client = createClient();
-await client.connect();
-
-// Create dedicated connection for subscribing
-const subscriber = client.duplicate();
-await subscriber.connect();
-
-// Subscribe to channel
-await subscriber.subscribe('notifications', (message) => {
-  console.log('Received message:', message);
-});
-
-console.log('Subscribed to notifications channel');
-```
-
-### Basic Publisher
-
-```javascript
-import { createClient } from 'redis';
-
-const publisher = createClient();
-await publisher.connect();
-
-// Publish messages
-await publisher.publish('notifications', 'Hello, World!');
-await publisher.publish('notifications', JSON.stringify({
-  type: 'alert',
-  message: 'System update'
-}));
-
-console.log('Messages published');
-```
-
-### Multiple Channels
-
-```javascript
-// Subscribe to multiple channels
-await subscriber.subscribe('channel1', (message) => {
-  console.log('Channel1:', message);
-});
-
-await subscriber.subscribe('channel2', (message) => {
-  console.log('Channel2:', message);
-});
-
-await subscriber.subscribe('channel3', (message) => {
-  console.log('Channel3:', message);
-});
-```
-
-### Pattern-Based Subscription
-
-```javascript
-// Subscribe to channels matching pattern
-await subscriber.pSubscribe('user:*', (message, channel) => {
-  console.log(`Message from ${channel}:`, message);
-});
-
-// Publish to matching channels
-await publisher.publish('user:1000', 'User 1000 logged in');
-await publisher.publish('user:2000', 'User 2000 logged out');
-```
-
-### Unsubscribe
-
-```javascript
-// Unsubscribe from specific channel
-await subscriber.unsubscribe('channel1');
-
-// Unsubscribe from all channels
-await subscriber.unsubscribe();
-
-// Unsubscribe from pattern
-await subscriber.pUnsubscribe('user:*');
-```
-
-### Complete Pub/Sub Example
-
-```javascript
-import { createClient } from 'redis';
-
-// Subscriber setup
-async function setupSubscriber() {
-  const client = createClient();
-  await client.connect();
-
-  const subscriber = client.duplicate();
-  await subscriber.connect();
-
-  await subscriber.subscribe('chat:room1', (message) => {
-    const data = JSON.parse(message);
-    console.log(`${data.user}: ${data.text}`);
-  });
-
-  return subscriber;
-}
-
-// Publisher setup
-async function setupPublisher() {
-  const publisher = createClient();
-  await publisher.connect();
-  return publisher;
-}
-
-// Usage
-const subscriber = await setupSubscriber();
-const publisher = await setupPublisher();
-
-// Publish chat messages
-await publisher.publish('chat:room1', JSON.stringify({
-  user: 'Alice',
-  text: 'Hello everyone!'
-}));
-
-await publisher.publish('chat:room1', JSON.stringify({
-  user: 'Bob',
-  text: 'Hi Alice!'
-}));
-```
-
----
-
-## Redis Streams
-
-### Add to Stream (XADD)
-
-```javascript
-// Add entry to stream
-const id = await client.xAdd('events', '*', {
-  user: 'alice',
-  action: 'login',
-  timestamp: Date.now()
-});
-
-console.log('Entry ID:', id); // '1234567890123-0'
-
-// Add with specific ID
-await client.xAdd('events', '1234567890123-1', {
-  user: 'bob',
-  action: 'logout'
-});
-
-// Add with maxLen (limit stream size)
-await client.xAdd('events', '*', {
-  user: 'charlie',
-  action: 'signup'
-}, {
-  TRIM: {
-    strategy: 'MAXLEN',
-    strategyModifier: '~', // Approximate
-    threshold: 1000
-  }
-});
-```
-
-### Read from Stream (XREAD)
-
-```javascript
-// Read new entries
-const messages = await client.xRead(
-  { key: 'events', id: '0' },
-  { COUNT: 10 }
-);
-
-console.log(messages);
-// [{ name: 'events', messages: [{ id: '...', message: {...} }] }]
-
-// Read from multiple streams
-const multiStream = await client.xRead([
-  { key: 'stream1', id: '0' },
-  { key: 'stream2', id: '0' }
-]);
-
-// Blocking read (wait for new entries)
-const newMessages = await client.xRead(
-  { key: 'events', id: '$' }, // '$' means only new messages
-  { BLOCK: 5000 } // Wait up to 5 seconds
-);
-```
-
-### Stream Range Queries
-
-```javascript
-// Read all entries
-const all = await client.xRange('events', '-', '+');
-
-// Read range with IDs
-const range = await client.xRange('events', '1234567890000', '1234567899999');
-
-// Read with limit
-const limited = await client.xRange('events', '-', '+', { COUNT: 100 });
-
-// Reverse range
-const reverse = await client.xRevRange('events', '+', '-', { COUNT: 10 });
-```
-
-### Stream Length and Info
-
-```javascript
-// Get stream length
-const length = await client.xLen('events');
-
-// Get stream info
-const info = await client.xInfo('events');
-```
-
-### Consumer Groups
-
-```javascript
-// Create consumer group
-await client.xGroupCreate('events', 'processors', '0', {
-  MKSTREAM: true // Create stream if it doesn't exist
-});
-
-// Read as consumer group
-const messages = await client.xReadGroup(
-  'processors',
-  'consumer1',
-  { key: 'events', id: '>' }, // '>' means undelivered messages
-  { COUNT: 10, BLOCK: 5000 }
-);
-
-// Process messages and acknowledge
-for (const stream of messages) {
-  for (const message of stream.messages) {
-    // Process message
-    console.log('Processing:', message.id, message.message);
-
-    // Acknowledge message
-    await client.xAck('events', 'processors', message.id);
-  }
-}
-```
-
-### Delete from Stream
-
-```javascript
-// Delete specific entries
-await client.xDel('events', ['1234567890123-0', '1234567890123-1']);
-
-// Trim stream
-await client.xTrim('events', 'MAXLEN', 1000);
-
-// Approximate trim
-await client.xTrim('events', 'MAXLEN', { strategyModifier: '~', threshold: 1000 });
-```
-
-### Complete Stream Example
-
-```javascript
-import { createClient } from 'redis';
-
-const client = createClient();
-await client.connect();
-
-// Producer
-async function addEvent(eventData) {
-  return await client.xAdd('events', '*', eventData);
-}
-
-// Consumer with consumer group
-async function processEvents() {
-  // Create group if not exists
-  try {
-    await client.xGroupCreate('events', 'workers', '0', { MKSTREAM: true });
-  } catch (err) {
-    // Group already exists
-  }
-
-  while (true) {
-    const messages = await client.xReadGroup(
-      'workers',
-      'worker1',
-      { key: 'events', id: '>' },
-      { COUNT: 10, BLOCK: 5000 }
-    );
-
-    if (messages && messages.length > 0) {
-      for (const stream of messages) {
-        for (const message of stream.messages) {
-          try {
-            // Process event
-            console.log('Processing event:', message.message);
-
-            // Acknowledge
-            await client.xAck('events', 'workers', message.id);
-          } catch (error) {
-            console.error('Error processing:', error);
-          }
-        }
-      }
-    }
-  }
-}
-
-// Usage
-await addEvent({ type: 'user_login', user: 'alice' });
-await addEvent({ type: 'user_logout', user: 'bob' });
-
-// Start consumer
-processEvents();
-```
-
----
-
-## Scripting with Lua
-
-### Basic Script Execution (EVAL)
-
-```javascript
-// Execute Lua script
-const result = await client.eval(
-  `return redis.call('SET', KEYS[1], ARGV[1])`,
-  {
-    keys: ['mykey'],
-    arguments: ['myvalue']
-  }
-);
-
-console.log(result); // 'OK'
-```
-
-### Script with Multiple Operations
-
-```javascript
-const script = `
-  local current = redis.call('GET', KEYS[1])
-  if current == false then
-    current = 0
-  end
-  local new = tonumber(current) + tonumber(ARGV[1])
-  redis.call('SET', KEYS[1], new)
-  return new
-`;
-
-const newValue = await client.eval(script, {
-  keys: ['counter'],
-  arguments: ['5']
-});
-
-console.log('New counter value:', newValue);
-```
-
-### Load and Execute Scripts (SCRIPT LOAD / EVALSHA)
-
-```javascript
-// Load script and get SHA1
-const sha = await client.scriptLoad(`
-  return redis.call('GET', KEYS[1])
-`);
-
-console.log('Script SHA:', sha);
-
-// Execute by SHA1 (more efficient for repeated calls)
-const value = await client.evalSha(sha, {
-  keys: ['mykey'],
-  arguments: []
-});
-```
-
-### Rate Limiting with Lua Script
-
-```javascript
-const rateLimitScript = `
-  local key = KEYS[1]
-  local limit = tonumber(ARGV[1])
-  local window = tonumber(ARGV[2])
-  local current = redis.call('INCR', key)
-  if current == 1 then
-    redis.call('EXPIRE', key, window)
-  end
-  if current > limit then
-    return 0
-  else
-    return 1
-  end
-`;
-
-async function checkRateLimit(userId, limit = 10, window = 60) {
-  const allowed = await client.eval(rateLimitScript, {
-    keys: [`ratelimit:${userId}`],
-    arguments: [limit.toString(), window.toString()]
-  });
-
-  return allowed === 1;
-}
-
-// Usage
-const allowed = await checkRateLimit('user:1000', 10, 60);
-if (allowed) {
-  console.log('Request allowed');
-} else {
-  console.log('Rate limit exceeded');
-}
-```
-
-### Atomic Get and Delete
-
-```javascript
-const getAndDelete = `
-  local value = redis.call('GET', KEYS[1])
-  if value then
-    redis.call('DEL', KEYS[1])
-  end
-  return value
-`;
-
-const value = await client.eval(getAndDelete, {
-  keys: ['temp:key'],
-  arguments: []
-});
-```
-
----
-
-## JSON Support (RedisJSON)
-
-### Basic JSON Operations
-
-```javascript
-// Set JSON document
-await client.json.set('user:1', '$', {
-  name: 'John Doe',
-  email: '[email protected]',
-  age: 30,
-  tags: ['developer', 'redis']
-});
-
-// Get entire JSON document
-const user = await client.json.get('user:1');
-console.log(user);
-
-// Get specific path
-const name = await client.json.get('user:1', { path: '$.name' });
-const age = await client.json.get('user:1', { path: '$.age' });
-```
-
-### Update JSON Fields
-
-```javascript
-// Set specific field
-await client.json.set('user:1', '$.email', '"[email protected]"');
-
-// Update nested field
-await client.json.set('user:1', '$.address.city', '"New York"');
-
-// Delete field
-await client.json.del('user:1', '$.age');
-```
-
-### JSON Array Operations
-
-```javascript
-// Append to array
-await client.json.arrAppend('user:1', '$.tags', '"nodejs"', '"javascript"');
-
-// Get array length
-const length = await client.json.arrLen('user:1', '$.tags');
-
-// Pop from array
-await client.json.arrPop('user:1', '$.tags', -1); // Pop last element
-
-// Insert into array
-await client.json.arrInsert('user:1', '$.tags', 0, '"beginner"');
-```
-
-### JSON Numeric Operations
-
-```javascript
-// Increment numeric value
-await client.json.numIncrBy('user:1', '$.loginCount', 1);
-
-// Multiply numeric value
-await client.json.numMultBy('user:1', '$.score', 1.5);
-```
-
----
-
-## Time Series (RedisTimeSeries)
-
-### Basic Time Series Operations
-
-```javascript
-// Create time series
-await client.ts.create('temperature:sensor1', {
-  RETENTION: 86400000, // Retain for 24 hours
-  LABELS: { sensor: 'temp', location: 'room1' }
-});
-
-// Add data points
-await client.ts.add('temperature:sensor1', '*', 22.5); // Current time
-await client.ts.add('temperature:sensor1', Date.now(), 23.0); // Specific time
-
-// Add multiple data points
-await client.ts.mAdd([
-  { key: 'temperature:sensor1', timestamp: '*', value: 22.8 },
-  { key: 'temperature:sensor2', timestamp: '*', value: 21.5 }
-]);
-```
-
-### Query Time Series
-
-```javascript
-// Get range of data
-const data = await client.ts.range('temperature:sensor1', '-', '+');
-
-// Get range with aggregation
-const hourlyAvg = await client.ts.range('temperature:sensor1', '-', '+', {
-  AGGREGATION: {
-    type: 'AVG',
-    timeBucket: 3600000 // 1 hour
-  }
-});
-
-// Get last value
-const latest = await client.ts.get('temperature:sensor1');
-```
-
----
-
-## Search and Query (RediSearch)
-
-### Create Index
-
-```javascript
-// Create index on hash
-await client.ft.create('idx:users', {
-  '$.name': {
-    type: 'TEXT',
-    AS: 'name'
-  },
-  '$.age': {
-    type: 'NUMERIC',
-    AS: 'age'
-  },
-  '$.email': {
-    type: 'TAG',
-    AS: 'email'
-  }
-}, {
-  ON: 'HASH',
-  PREFIX: 'user:'
-});
-```
-
-### Search Documents
-
-```javascript
-// Search by text
-const results = await client.ft.search('idx:users', 'John');
-
-// Search with filters
-const filtered = await client.ft.search('idx:users', '@age:[25 35]');
-
-// Search with multiple conditions
-const complex = await client.ft.search('idx:users', '@name:John @age:[20 40]');
-
-// Get search count
-const count = await client.ft.search('idx:users', '*', { LIMIT: { from: 0, size: 0 } });
-```
-
----
-
-## Geospatial Operations
-
-### Add Geo Points
-
-```javascript
-// Add location
-await client.geoAdd('locations', {
-  longitude: -122.4194,
-  latitude: 37.7749,
-  member: 'San Francisco'
-});
-
-// Add multiple locations
-await client.geoAdd('locations', [
-  { longitude: -118.2437, latitude: 34.0522, member: 'Los Angeles' },
-  { longitude: -73.9352, latitude: 40.7306, member: 'New York' }
-]);
-```
-
-### Query Geo Points
-
-```javascript
-// Get position
-const position = await client.geoPos('locations', 'San Francisco');
-console.log(position); // [{ longitude: -122.4194, latitude: 37.7749 }]
-
-// Get distance between points
-const distance = await client.geoDist('locations', 'San Francisco', 'Los Angeles', 'mi');
-console.log(`Distance: ${distance} miles`);
-
-// Search by radius
-const nearby = await client.geoRadius('locations', {
-  longitude: -122.4194,
-  latitude: 37.7749
-}, 500, 'mi');
-
-// Search by member
-const nearSF = await client.geoRadiusByMember('locations', 'San Francisco', 600, 'mi', {
-  WITHDIST: true,
-  WITHCOORD: true
-});
-```
-
----
-
-## HyperLogLog (Cardinality Estimation)
-
-```javascript
-// Add elements
-await client.pfAdd('unique:visitors', ['user1', 'user2', 'user3']);
-await client.pfAdd('unique:visitors', ['user2', 'user4']); // user2 counted once
-
-// Get count
-const count = await client.pfCount('unique:visitors'); // ~4
-
-// Merge multiple HyperLogLogs
-await client.pfMerge('combined', ['unique:visitors:day1', 'unique:visitors:day2']);
-```
-
----
-
-## Bitmap Operations
-
-```javascript
-// Set bit
-await client.setBit('login:2024-01-15', 100, 1); // User 100 logged in
-
-// Get bit
-const bit = await client.getBit('login:2024-01-15', 100); // 1
-
-// Count set bits
-const count = await client.bitCount('login:2024-01-15');
-
-// Bitwise operations
-await client.bitOp('AND', 'result', ['bitmap1', 'bitmap2']);
-await client.bitOp('OR', 'result', ['bitmap1', 'bitmap2']);
-await client.bitOp('XOR', 'result', ['bitmap1', 'bitmap2']);
-
-// Find first bit
-const pos = await client.bitPos('login:2024-01-15', 1); // First set bit
-```
-
----
-
-## Server and Connection Management
-
-### Server Information
-
-```javascript
-// Get server info
-const info = await client.info();
-console.log(info);
-
-// Get specific section
-const stats = await client.info('stats');
-const memory = await client.info('memory');
-
-// Ping server
-const pong = await client.ping(); // 'PONG'
-
-// Get server time
-const time = await client.time();
-```
-
-### Database Management
-
-```javascript
-// Select database (0-15 by default)
-await client.select(1);
-
-// Get database size
-const size = await client.dbSize();
-
-// Flush current database
-await client.flushDb();
-
-// Flush all databases
-await client.flushAll();
-
-// Save database to disk
-await client.save();
-
-// Background save
-await client.bgSave();
-
-// Get last save time
-const lastSave = await client.lastSave();
-```
-
-### Client Management
-
-```javascript
-// Get client list
-const clients = await client.clientList();
-
-// Get client ID
-const id = await client.clientId();
-
-// Set client name
-await client.clientSetName('my-app');
-
-// Get client name
-const name = await client.clientGetName();
-
-// Get client info
-const clientInfo = await client.clientInfo();
-```
-
----
-
-## Error Handling
-
-### Connection Errors
-
-```javascript
-import { createClient } from 'redis';
-
-const client = createClient({
-  socket: {
-    host: 'localhost',
-    port: 6379,
-    reconnectStrategy: (retries) => {
-      if (retries > 10) {
-        return new Error('Max retries reached');
-      }
-      return Math.min(retries * 100, 3000);
-    }
-  }
-});
-
-client.on('error', (err) => {
-  console.error('Redis error:', err);
-});
-
-client.on('connect', () => {
-  console.log('Connected to Redis');
-});
-
-client.on('reconnecting', () => {
-  console.log('Reconnecting to Redis...');
-});
-
-client.on('ready', () => {
-  console.log('Redis client ready');
-});
-
-await client.connect();
-```
-
-### Command Errors
-
-```javascript
-try {
-  await client.get('nonexistent');
-} catch (error) {
-  console.error('Command error:', error);
-}
-
-// Multiple operations with individual error handling
 const results = await client.multi()
   .set('key1', 'value1')
-  .incr('not-a-number') // This will error
+  .incr('not-a-number')
   .get('key1')
   .exec();
 
@@ -1666,43 +367,327 @@ results.forEach((result, i) => {
 });
 ```
 
----
-
-## Connection Pooling and Performance
-
-### Configure Connection Pool
+### `WATCH` optimistic locking
 
 ```javascript
+await client.watch('balance');
+const balance = parseInt(await client.get('balance') ?? '0', 10);
+
+if (balance >= 100) {
+  const results = await client
+    .multi()
+    .decrBy('balance', 100)
+    .incrBy('purchases', 1)
+    .exec();
+
+  if (results === null) {
+    console.log('Transaction aborted - balance was modified');
+  }
+} else {
+  await client.unwatch();
+}
+```
+
+### Automatic batching
+
+Commands queued in the same tick are pipelined automatically:
+
+```javascript
+const [a, b, c] = await Promise.all([
+  client.set('key1', 'value1'),
+  client.set('key2', 'value2'),
+  client.get('key1'),
+]);
+```
+
+### Manual pipeline without transaction semantics
+
+```javascript
+const results = await client
+  .multi()
+  .set('key1', 'value1')
+  .set('key2', 'value2')
+  .mGet(['key1', 'key2'])
+  .exec();
+```
+
+## Pub/Sub
+
+Pub/sub commands run on a dedicated connection. Use `client.duplicate()` for the subscriber and keep the original client for `publish`.
+
+```javascript
+import { createClient } from 'redis';
+
+const client = createClient();
+client.on('error', (err) => console.error('Redis Client Error', err));
+await client.connect();
+
+const subscriber = client.duplicate();
+subscriber.on('error', (err) => console.error('Subscriber Error', err));
+await subscriber.connect();
+
+await subscriber.subscribe('notifications', (message) => {
+  console.log('Received message:', message);
+});
+
+await client.publish('notifications', 'Hello, World!');
+```
+
+### Multiple channels
+
+```javascript
+await subscriber.subscribe('channel1', (m) => console.log('1:', m));
+await subscriber.subscribe('channel2', (m) => console.log('2:', m));
+```
+
+### Pattern subscription
+
+```javascript
+await subscriber.pSubscribe('user:*', (message, channel) => {
+  console.log(`Message from ${channel}:`, message);
+});
+
+await client.publish('user:1000', 'User 1000 logged in');
+```
+
+### Unsubscribe
+
+```javascript
+await subscriber.unsubscribe('channel1');
+await subscriber.unsubscribe();
+await subscriber.pUnsubscribe('user:*');
+```
+
+## Streams
+
+```javascript
+const id = await client.xAdd('events', '*', {
+  user: 'alice',
+  action: 'login',
+  timestamp: String(Date.now()),
+});
+
+await client.xAdd('events', '*', { user: 'charlie' }, {
+  TRIM: { strategy: 'MAXLEN', strategyModifier: '~', threshold: 1000 },
+});
+
+const messages = await client.xRead(
+  { key: 'events', id: '0' },
+  { COUNT: 10 },
+);
+
+await client.xRead(
+  { key: 'events', id: '$' },
+  { BLOCK: 5000 },
+);
+
+await client.xRange('events', '-', '+', { COUNT: 100 });
+await client.xRevRange('events', '+', '-', { COUNT: 10 });
+await client.xLen('events');
+await client.xInfo('events');
+
+try {
+  await client.xGroupCreate('events', 'processors', '0', { MKSTREAM: true });
+} catch (_err) {
+  // group already exists
+}
+
+const consumed = await client.xReadGroup(
+  'processors', 'consumer1',
+  { key: 'events', id: '>' },
+  { COUNT: 10, BLOCK: 5000 },
+);
+
+for (const stream of consumed ?? []) {
+  for (const message of stream.messages) {
+    // process...
+    await client.xAck('events', 'processors', message.id);
+  }
+}
+
+await client.xDel('events', [id]);
+await client.xTrim('events', 'MAXLEN', 1000);
+```
+
+## Lua Scripts
+
+```javascript
+const result = await client.eval(
+  `return redis.call('SET', KEYS[1], ARGV[1])`,
+  { keys: ['mykey'], arguments: ['myvalue'] },
+);
+
+const sha = await client.scriptLoad(`return redis.call('GET', KEYS[1])`);
+const value = await client.evalSha(sha, { keys: ['mykey'], arguments: [] });
+```
+
+Rate limiting:
+
+```javascript
+const rateLimitScript = `
+  local current = redis.call('INCR', KEYS[1])
+  if current == 1 then redis.call('EXPIRE', KEYS[1], ARGV[2]) end
+  if current > tonumber(ARGV[1]) then return 0 else return 1 end
+`;
+
+async function isAllowed(userId, limit = 10, window = 60) {
+  const allowed = await client.eval(rateLimitScript, {
+    keys: [`ratelimit:${userId}`],
+    arguments: [String(limit), String(window)],
+  });
+  return allowed === 1;
+}
+```
+
+## Optional Modules
+
+The following sections require Redis Stack or the relevant server-side module to be installed and enabled.
+
+### JSON (RedisJSON)
+
+```javascript
+await client.json.set('user:1', '$', {
+  name: 'John Doe',
+  email: 'john@example.com',
+  age: 30,
+  tags: ['developer', 'redis'],
+});
+
+const user = await client.json.get('user:1');
+const name = await client.json.get('user:1', { path: '$.name' });
+
+await client.json.set('user:1', '$.email', '"new@example.com"');
+await client.json.del('user:1', '$.age');
+
+await client.json.arrAppend('user:1', '$.tags', '"javascript"');
+await client.json.arrLen('user:1', '$.tags');
+await client.json.arrPop('user:1', '$.tags', -1);
+
+await client.json.numIncrBy('user:1', '$.loginCount', 1);
+```
+
+### Time Series
+
+```javascript
+await client.ts.create('temperature:sensor1', {
+  RETENTION: 86_400_000,
+  LABELS: { sensor: 'temp', location: 'room1' },
+});
+
+await client.ts.add('temperature:sensor1', '*', 22.5);
+await client.ts.mAdd([
+  { key: 'temperature:sensor1', timestamp: '*', value: 22.8 },
+  { key: 'temperature:sensor2', timestamp: '*', value: 21.5 },
+]);
+
+await client.ts.range('temperature:sensor1', '-', '+', {
+  AGGREGATION: { type: 'AVG', timeBucket: 3_600_000 },
+});
+
+await client.ts.get('temperature:sensor1');
+```
+
+### Search (RediSearch)
+
+```javascript
+await client.ft.create('idx:users', {
+  '$.name':  { type: 'TEXT',    AS: 'name' },
+  '$.age':   { type: 'NUMERIC', AS: 'age' },
+  '$.email': { type: 'TAG',     AS: 'email' },
+}, { ON: 'JSON', PREFIX: 'user:' });
+
+await client.ft.search('idx:users', 'John');
+await client.ft.search('idx:users', '@age:[25 35]');
+```
+
+## Geospatial
+
+```javascript
+await client.geoAdd('locations', {
+  longitude: -122.4194, latitude: 37.7749, member: 'San Francisco',
+});
+
+await client.geoAdd('locations', [
+  { longitude: -118.2437, latitude: 34.0522, member: 'Los Angeles' },
+  { longitude: -73.9352,  latitude: 40.7306, member: 'New York' },
+]);
+
+await client.geoPos('locations', 'San Francisco');
+await client.geoDist('locations', 'San Francisco', 'Los Angeles', 'mi');
+
+await client.geoRadius('locations',
+  { longitude: -122.4194, latitude: 37.7749 }, 500, 'mi');
+
+await client.geoRadiusByMember(
+  'locations', 'San Francisco', 600, 'mi',
+  { WITHDIST: true, WITHCOORD: true },
+);
+```
+
+## HyperLogLog And Bitmaps
+
+```javascript
+await client.pfAdd('unique:visitors', ['user1', 'user2', 'user3']);
+await client.pfCount('unique:visitors');
+await client.pfMerge('combined', ['unique:day1', 'unique:day2']);
+
+await client.setBit('login:2026-05-29', 100, 1);
+await client.getBit('login:2026-05-29', 100);
+await client.bitCount('login:2026-05-29');
+await client.bitOp('AND', 'result', ['bitmap1', 'bitmap2']);
+await client.bitPos('login:2026-05-29', 1);
+```
+
+## Server, Database, And Client Management
+
+```javascript
+await client.info();
+await client.info('memory');
+await client.ping();
+await client.time();
+
+await client.select(1);
+await client.dbSize();
+await client.flushDb();
+await client.flushAll();
+await client.save();
+await client.bgSave();
+await client.lastSave();
+
+await client.clientList();
+await client.clientId();
+await client.clientSetName('my-app');
+await client.clientGetName();
+await client.clientInfo();
+```
+
+## Error Handling And Reconnection
+
+```javascript
+import { createClient } from 'redis';
+
 const client = createClient({
   socket: {
     host: 'localhost',
     port: 6379,
-    connectTimeout: 5000,
-    keepAlive: 5000
+    reconnectStrategy: (retries) => {
+      if (retries > 10) return new Error('Max retries reached');
+      return Math.min(retries * 100, 3000);
+    },
   },
-  password: 'your_password'
-});
-```
-
-### Readonly Replicas
-
-```javascript
-const client = createClient({
-  socket: {
-    host: 'localhost',
-    port: 6379
-  }
 });
 
-// Send read commands to replicas
-await client.sendCommand(['READONLY']);
+client.on('error', (err) => console.error('Redis error:', err));
+client.on('connect', () => console.log('Connected'));
+client.on('reconnecting', () => console.log('Reconnecting...'));
+client.on('ready', () => console.log('Ready'));
+
+await client.connect();
 ```
 
----
+`client.on('error', ...)` must be registered before `connect()` to avoid unhandled error events.
 
-## Cluster Support
-
-### Connect to Cluster
+## Cluster
 
 ```javascript
 import { createCluster } from 'redis';
@@ -1711,41 +696,34 @@ const cluster = createCluster({
   rootNodes: [
     { url: 'redis://localhost:7000' },
     { url: 'redis://localhost:7001' },
-    { url: 'redis://localhost:7002' }
-  ]
+    { url: 'redis://localhost:7002' },
+  ],
 });
 
 cluster.on('error', (err) => console.error('Cluster error:', err));
-
 await cluster.connect();
 
-// Use cluster like regular client
 await cluster.set('key', 'value');
-const value = await cluster.get('key');
+await cluster.get('key');
 
 await cluster.quit();
 ```
-
----
 
 ## Complete Application Example
 
 ```javascript
 import { createClient } from 'redis';
-import dotenv from 'dotenv';
-
-dotenv.config();
+import 'dotenv/config';
 
 class RedisManager {
   constructor() {
     this.client = null;
-    this.subscriber = null;
   }
 
   async connect() {
     this.client = createClient({
       url: process.env.REDIS_URL || 'redis://localhost:6379',
-      password: process.env.REDIS_PASSWORD
+      password: process.env.REDIS_PASSWORD,
     });
 
     this.client.on('error', (err) => {
@@ -1753,7 +731,6 @@ class RedisManager {
     });
 
     await this.client.connect();
-    console.log('Connected to Redis');
   }
 
   async cacheGet(key) {
@@ -1765,7 +742,7 @@ class RedisManager {
     await this.client.set(key, JSON.stringify(value), { EX: ttl });
   }
 
-  async invalidateCache(pattern) {
+  async invalidate(pattern) {
     const keys = [];
     for await (const key of this.client.scanIterator({ MATCH: pattern })) {
       keys.push(key);
@@ -1775,77 +752,59 @@ class RedisManager {
     }
   }
 
-  async trackUserActivity(userId, action) {
+  async trackActivity(userId, action) {
     const key = `activity:${userId}:${new Date().toISOString().split('T')[0]}`;
-    await this.client.rPush(key, JSON.stringify({
-      action,
-      timestamp: Date.now()
-    }));
-    await this.client.expire(key, 86400 * 7); // Keep for 7 days
-  }
-
-  async getUserActivity(userId, date) {
-    const key = `activity:${userId}:${date}`;
-    const activities = await this.client.lRange(key, 0, -1);
-    return activities.map(a => JSON.parse(a));
-  }
-
-  async incrementPageView(pageId) {
-    await this.client.incr(`pageviews:${pageId}`);
-  }
-
-  async getPageViews(pageId) {
-    const views = await this.client.get(`pageviews:${pageId}`);
-    return parseInt(views || '0');
+    await this.client.rPush(key, JSON.stringify({ action, ts: Date.now() }));
+    await this.client.expire(key, 86400 * 7);
   }
 
   async addToLeaderboard(userId, score) {
     await this.client.zAdd('leaderboard', { score, value: userId });
   }
 
-  async getLeaderboard(count = 10) {
-    const results = await this.client.zRangeWithScores('leaderboard', 0, count - 1, {
-      REV: true
-    });
-    return results.map(r => ({ userId: r.value, score: r.score }));
+  async leaderboardTop(count = 10) {
+    const results = await this.client.zRangeWithScores(
+      'leaderboard', 0, count - 1, { REV: true },
+    );
+    return results.map(({ value, score }) => ({ userId: value, score }));
   }
 
   async disconnect() {
-    if (this.subscriber) {
-      await this.subscriber.quit();
-    }
     if (this.client) {
       await this.client.quit();
     }
-    console.log('Disconnected from Redis');
   }
 }
 
-// Usage
 const redis = new RedisManager();
 await redis.connect();
 
-// Cache operations
-await redis.cacheSet('user:1000', { name: 'John', email: '[email protected]' });
-const user = await redis.cacheGet('user:1000');
-console.log(user);
+await redis.cacheSet('user:1000', { name: 'John', email: 'john@example.com' });
+console.log(await redis.cacheGet('user:1000'));
 
-// Track activity
-await redis.trackUserActivity('user:1000', 'login');
-await redis.trackUserActivity('user:1000', 'view_profile');
+await redis.trackActivity('user:1000', 'login');
 
-// Get activity
-const today = new Date().toISOString().split('T')[0];
-const activities = await redis.getUserActivity('user:1000', today);
-console.log(activities);
-
-// Leaderboard
 await redis.addToLeaderboard('user:1000', 500);
 await redis.addToLeaderboard('user:2000', 750);
-await redis.addToLeaderboard('user:3000', 250);
-
-const topUsers = await redis.getLeaderboard(3);
-console.log('Top users:', topUsers);
+console.log(await redis.leaderboardTop(3));
 
 await redis.disconnect();
 ```
+
+## Common Pitfalls
+
+- You must `await client.connect()` before issuing commands; `createClient()` alone doesn't open the socket.
+- You must attach `client.on('error', ...)` before `connect()`; otherwise socket errors crash the process.
+- Pub/sub needs a dedicated connection — use `client.duplicate()` for subscribers.
+- Commands queued in the same tick are pipelined automatically; you don't need `multi()` just to batch.
+- Use `scanIterator` (not `keys`) in production.
+- JSON, Search, and TimeSeries commands depend on Redis Stack or those modules being installed server-side.
+- When upgrading from node-redis v4, watch for renamed command options and the consolidated `socket` configuration.
+
+## Version Notes
+
+- `redis` npm `6.0.0` is the current `latest` dist-tag.
+- v4 maintenance releases are still published under the `maintenance-v4` tag (`4.7.1`).
+- TypeScript types ship with the package; do not install `@types/redis`.
+- npm: https://www.npmjs.com/package/redis.
+- Docs: https://github.com/redis/node-redis.

--- a/content/redis/docs/key-value/python/DOC.md
+++ b/content/redis/docs/key-value/python/DOC.md
@@ -3,2052 +3,835 @@ name: key-value
 description: "Redis Python client (redis-py) for key-value storage, caching, and pub/sub messaging"
 metadata:
   languages: "python"
-  versions: "7.0.1"
-  updated-on: "2026-03-01"
+  versions: "8.0.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "redis,database,cache,key-value,pubsub"
 ---
 
 # Redis Python Client (redis-py) - Complete Integration Guide
 
-## GOLDEN RULE
+## Golden Rule
 
-**ALWAYS use the official `redis` package (redis-py) for Redis integration.**
-
-```bash
-pip install redis
-```
-
-**For enhanced performance, install with hiredis support:**
+Use the official `redis` package (`redis-py`). The current PyPI release is `redis 8.0.0` and it requires Python `>=3.10`. Async support lives at `redis.asyncio`; cluster support lives at `redis.cluster`. Do not pin to deprecated splits like `aioredis` or `redis-py-cluster`.
 
 ```bash
-pip install redis[hiredis]
+pip install "redis==8.0.0"
 ```
 
-**DO NOT use:**
-- `redis-py-cluster` (deprecated, functionality merged into redis-py)
-- `aioredis` (deprecated, async support now in redis-py)
-- `walrus` (third-party wrapper)
-- Any other unofficial Redis clients
-
-The official `redis` package is maintained by Redis and supports both synchronous and asynchronous operations.
-
----
-
-## Installation
-
-### Basic Installation
+With the hiredis parser:
 
 ```bash
-pip install redis
+pip install "redis[hiredis]==8.0.0"
 ```
 
-### Installation with Performance Optimization
+## Install And Environment
 
 ```bash
-pip install redis[hiredis]
+pip install "redis==8.0.0"
+pip install "redis[hiredis]==8.0.0"        # faster parser
+pip install "redis[ocsp]==8.0.0"           # OCSP cert validation
+pip install "redis[otel]==8.0.0"           # OpenTelemetry helpers
 ```
 
-The hiredis library provides a compiled response parser that significantly improves performance.
+If your project is still on Python 3.9, `redis 8.0.0` will not install; downgrade to a 7.x release that supports 3.9.
 
-### Installation with All Optional Dependencies
-
-```bash
-pip install redis[hiredis,cryptography]
-```
-
-### Environment Setup
-
-Create a `.env` file in your project root:
+`.env` for typical apps:
 
 ```env
 REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_PASSWORD=your_password_here
 REDIS_DB=0
-REDIS_URL=redis://username:password@localhost:6379/0
+REDIS_URL=redis://default:your_password_here@localhost:6379/0
 ```
 
-Install python-dotenv to load environment variables:
+## Initialize A Client
 
-```bash
-pip install python-dotenv
-```
-
----
-
-## Initialization
-
-### Basic Connection (Localhost)
+### `redis.Redis(...)` direct constructor
 
 ```python
 import redis
 
-r = redis.Redis(host='localhost', port=6379, decode_responses=True)
-
-# Test connection
-r.ping()  # Returns True
-
-# Use the client...
-
+r = redis.Redis(host="localhost", port=6379, decode_responses=True)
+r.ping()
 r.close()
 ```
 
-### Connection with Environment Variables
+### `redis.from_url(...)` (preferred)
+
+A URL lets local, TLS, ACL, and managed setups share one entry point.
 
 ```python
-import redis
 import os
-from dotenv import load_dotenv
+import redis
 
-load_dotenv()
-
-r = redis.Redis(
-    host=os.getenv('REDIS_HOST', 'localhost'),
-    port=int(os.getenv('REDIS_PORT', 6379)),
-    password=os.getenv('REDIS_PASSWORD'),
-    db=int(os.getenv('REDIS_DB', 0)),
-    decode_responses=True
+r = redis.from_url(
+    os.getenv("REDIS_URL", "redis://localhost:6379/0"),
+    decode_responses=True,
+    health_check_interval=30,
 )
 
 r.ping()
 ```
 
-### Connection Using URL
+Schemes:
 
-```python
-import redis
-import os
-from dotenv import load_dotenv
+- `redis://` plain TCP
+- `rediss://` TLS
+- `unix://` Unix socket
 
-load_dotenv()
-
-redis_url = os.getenv('REDIS_URL', 'redis://localhost:6379/0')
-r = redis.from_url(redis_url, decode_responses=True)
-
-r.ping()
-```
-
-### Connection with Authentication
+### Authentication (ACL)
 
 ```python
 import redis
 
 r = redis.Redis(
-    host='redis.example.com',
+    host="redis.example.com",
     port=6379,
-    username='default',
-    password='your_password',
+    username="default",
+    password="your_password",
     db=0,
-    decode_responses=True
+    decode_responses=True,
 )
 ```
 
-### Connection with TLS/SSL
+### TLS
 
 ```python
-import redis
 import ssl
+import redis
 
 r = redis.Redis(
-    host='redis.example.com',
+    host="redis.example.com",
     port=6380,
-    password='your_password',
+    username="default",
+    password="your_password",
     ssl=True,
-    ssl_certfile='/path/to/client-cert.pem',
-    ssl_keyfile='/path/to/client-key.pem',
-    ssl_ca_certs='/path/to/ca-cert.pem',
     ssl_cert_reqs=ssl.CERT_REQUIRED,
-    decode_responses=True
+    ssl_ca_certs="/etc/ssl/certs/ca-certificates.crt",
+    decode_responses=True,
 )
 ```
 
-### Connection Pool
+### Connection pool
 
 ```python
 import redis
 
-# Create connection pool
 pool = redis.ConnectionPool(
-    host='localhost',
+    host="localhost",
     port=6379,
-    password='your_password',
+    password="your_password",
     db=0,
     max_connections=10,
-    decode_responses=True
+    decode_responses=True,
 )
 
-# Create client from pool
 r = redis.Redis(connection_pool=pool)
-
-# Multiple clients can share the pool
-r2 = redis.Redis(connection_pool=pool)
 ```
 
-### Context Manager (Auto-Close)
+### Context manager
 
 ```python
-import redis
-
-with redis.Redis(host='localhost', port=6379, decode_responses=True) as r:
-    r.set('key', 'value')
-    value = r.get('key')
-    print(value)
-# Connection automatically closed
+with redis.Redis(host="localhost", port=6379, decode_responses=True) as r:
+    r.set("key", "value")
+    print(r.get("key"))
 ```
 
-### Decode Responses
+### `decode_responses`
 
 ```python
-# Without decode_responses (default - returns bytes)
-r = redis.Redis(host='localhost', port=6379)
-value = r.get('key')  # Returns: b'value'
-
-# With decode_responses (returns strings)
-r = redis.Redis(host='localhost', port=6379, decode_responses=True)
-value = r.get('key')  # Returns: 'value'
+r_bytes = redis.Redis()                          # returns bytes
+r_str = redis.Redis(decode_responses=True)       # returns str
 ```
 
----
-
-## Core API Surfaces
-
-## String Operations
-
-### Basic SET and GET
+### RESP3 opt-in
 
 ```python
-# Set a string value
-r.set('key', 'value')
-
-# Get a string value
-value = r.get('key')
-print(value)  # 'value'
+r = redis.Redis(decode_responses=True, protocol=3)
 ```
 
-### SET with Options
+Only use `protocol=3` when both the server and the features you call expect RESP3.
+
+## Strings
 
 ```python
-# Set with expiration (seconds)
-r.set('session:123', 'user_data', ex=3600)  # Expires in 1 hour
+r.set("key", "value")
+value = r.get("key")
 
-# Set with expiration (milliseconds)
-r.set('temp:key', 'value', px=5000)  # Expires in 5 seconds
+r.set("session:123", "user_data", ex=3600)          # EX seconds
+r.set("temp:key", "value", px=5000)                 # PX milliseconds
+r.set("key", "value", nx=True)                      # only if absent
+r.set("key", "new", xx=True)                        # only if present
+old = r.set("key", "new", get=True)                 # SET ... GET
 
-# Set only if key doesn't exist (NX)
-result = r.set('key', 'value', nx=True)  # Returns True if set, None if exists
+r.mset({"k1": "v1", "k2": "v2"})
+values = r.mget(["k1", "k2"])
 
-# Set only if key exists (XX)
-result = r.set('key', 'new_value', xx=True)  # Returns True if set, None if not exists
+r.set("counter", 0)
+r.incr("counter")
+r.incrby("counter", 10)
+r.incrbyfloat("price", 2.5)
+r.decr("counter")
+r.decrby("counter", 5)
 
-# Get old value and set new value
-old_value = r.set('key', 'new_value', get=True)  # Returns old value
-
-# Set with multiple options
-r.set('key', 'value', ex=60, nx=True)
+r.append("message", " World")
+r.getrange("message", 0, 4)
+r.strlen("message")
+r.getdel("temp:key")
+r.getex("key", ex=60)
 ```
 
-### Multiple Keys
+## Hashes
 
 ```python
-# Set multiple keys at once
-r.mset({
-    'key1': 'value1',
-    'key2': 'value2',
-    'key3': 'value3'
+r.hset("user:1000", "name", "John Doe")
+r.hget("user:1000", "name")
+
+r.hset("user:1000", mapping={
+    "name": "John Doe",
+    "email": "john@example.com",
+    "age": 30,
 })
 
-# Get multiple keys at once
-values = r.mget(['key1', 'key2', 'key3'])
-print(values)  # ['value1', 'value2', 'value3']
+user = r.hgetall("user:1000")
 
-# Set multiple only if none exist
-result = r.msetnx({
-    'key4': 'value4',
-    'key5': 'value5'
-})  # Returns True if all set, False if any exist
+r.hexists("user:1000", "email")
+r.hkeys("user:1000")
+r.hvals("user:1000")
+r.hlen("user:1000")
+r.hmget("user:1000", ["name", "email"])
+r.hdel("user:1000", "age")
+r.hincrby("user:1000", "login_count", 1)
+r.hincrbyfloat("user:1000", "balance", 10.50)
+r.hsetnx("user:1000", "created", "2026-01-01")
+
+for field, value in r.hscan_iter("user:1000", count=10):
+    print(field, value)
 ```
 
-### Increment and Decrement
+## Lists
 
 ```python
-# Set initial value
-r.set('counter', 0)
+r.rpush("tasks", "task1")
+r.rpush("tasks", "task2", "task3")
+r.lpush("tasks", "urgent_task")
 
-# Increment by 1
-r.incr('counter')  # Returns 1
+r.llen("tasks")
+r.lrange("tasks", 0, -1)
+r.lindex("tasks", 0)
 
-# Increment by specific amount
-r.incrby('counter', 10)  # Returns 11
+r.rpop("tasks")
+r.lpop("tasks")
+r.lpop("tasks", count=3)
 
-# Increment float
-r.incrbyfloat('price', 2.5)  # Increment by 2.5
+# Blocking pop
+r.blpop("tasks", timeout=10)
+r.brpop(["queue1", "queue2"], timeout=5)
 
-# Decrement by 1
-r.decr('counter')
-
-# Decrement by specific amount
-r.decrby('counter', 5)
+r.lset("tasks", 0, "updated_task")
+r.linsert("tasks", "BEFORE", "task2", "new_task")
+r.lrem("tasks", 0, "task3")             # remove all
+r.ltrim("tasks", 0, 9)
+r.lmove("source", "destination", "LEFT", "RIGHT")
+r.blmove("source", "destination", "RIGHT", "LEFT", timeout=5)
 ```
 
-### String Manipulation
+## Sets
 
 ```python
-# Append to string
-r.set('message', 'Hello')
-r.append('message', ' World')  # 'Hello World'
-
-# Get substring
-substr = r.getrange('message', 0, 4)  # 'Hello'
-
-# Get length
-length = r.strlen('message')  # 11
-
-# Set range
-r.setrange('message', 6, 'Redis')  # 'Hello Redis'
-
-# Get and delete
-value = r.getdel('message')  # Returns value and deletes key
-
-# Get and set expiration
-value = r.getex('key', ex=60)  # Returns value and sets expiration
-```
-
----
-
-## Hash Operations
-
-### Basic Hash Operations
-
-```python
-# Set a single field in a hash
-r.hset('user:1000', 'name', 'John Doe')
-
-# Get a single field from a hash
-name = r.hget('user:1000', 'name')
-print(name)  # 'John Doe'
-
-# Set multiple fields at once
-r.hset('user:1000', mapping={
-    'name': 'John Doe',
-    'email': '[email protected]',
-    'age': 30
-})
-
-# Get all fields and values
-user = r.hgetall('user:1000')
-print(user)
-# {'name': 'John Doe', 'email': '[email protected]', 'age': '30'}
-```
-
-### Advanced Hash Operations
-
-```python
-# Check if field exists
-exists = r.hexists('user:1000', 'email')  # True
-
-# Get all field names
-fields = r.hkeys('user:1000')
-# ['name', 'email', 'age']
-
-# Get all values
-values = r.hvals('user:1000')
-# ['John Doe', '[email protected]', '30']
-
-# Get number of fields
-count = r.hlen('user:1000')  # 3
-
-# Get multiple fields
-user_data = r.hmget('user:1000', ['name', 'email'])
-# ['John Doe', '[email protected]']
-
-# Delete fields
-r.hdel('user:1000', 'age')
-r.hdel('user:1000', 'field1', 'field2', 'field3')  # Multiple fields
-
-# Increment numeric field
-r.hset('user:1000', 'login_count', 0)
-r.hincrby('user:1000', 'login_count', 1)  # 1
-
-# Increment float field
-r.hincrbyfloat('user:1000', 'balance', 10.50)
-
-# Set only if field doesn't exist
-r.hsetnx('user:1000', 'created', '2024-01-01')
-
-# Get random field
-field = r.hrandfield('user:1000')  # Random field name
-fields_and_values = r.hrandfield('user:1000', 2, withvalues=True)
-# [('name', 'John Doe'), ('email', '[email protected]')]
-```
-
-### Scan Hash Fields
-
-```python
-# Scan hash fields (for large hashes)
-cursor = 0
-while True:
-    cursor, fields = r.hscan('user:1000', cursor, count=10)
-    for field, value in fields.items():
-        print(f"{field}: {value}")
-    if cursor == 0:
-        break
-
-# Using hscan_iter (simpler)
-for field, value in r.hscan_iter('user:1000', count=10):
-    print(f"{field}: {value}")
-```
-
----
-
-## List Operations
-
-### Basic List Operations
-
-```python
-# Push elements to the right (end) of list
-r.rpush('tasks', 'task1')
-r.rpush('tasks', 'task2', 'task3')  # Multiple values
-
-# Push elements to the left (beginning) of list
-r.lpush('tasks', 'urgent_task')
-r.lpush('tasks', 'task0', 'task-1')
-
-# Get list length
-length = r.llen('tasks')
-
-# Get range of elements
-tasks = r.lrange('tasks', 0, -1)  # Get all
-first_three = r.lrange('tasks', 0, 2)  # Get first 3
-
-# Get element by index
-task = r.lindex('tasks', 0)
-
-# Pop from right (end)
-last_task = r.rpop('tasks')
-
-# Pop from left (beginning)
-first_task = r.lpop('tasks')
-
-# Pop multiple elements
-tasks = r.lpop('tasks', count=3)  # Pop 3 elements
-```
-
-### Advanced List Operations
-
-```python
-# Blocking pop (wait for element)
-task = r.blpop('tasks', timeout=10)  # Wait up to 10 seconds
-# Returns: ('tasks', 'task1') or None if timeout
-
-task_right = r.brpop('tasks', timeout=10)
-
-# Block on multiple lists
-task = r.blpop(['queue1', 'queue2', 'queue3'], timeout=5)
-
-# Set element at index
-r.lset('tasks', 0, 'updated_task')
-
-# Insert before/after element
-r.linsert('tasks', 'BEFORE', 'task2', 'new_task')
-r.linsert('tasks', 'AFTER', 'task2', 'another_task')
-
-# Remove elements
-r.lrem('tasks', 2, 'task1')  # Remove first 2 occurrences
-r.lrem('tasks', -1, 'task2')  # Remove last occurrence
-r.lrem('tasks', 0, 'task3')  # Remove all occurrences
-
-# Trim list to range
-r.ltrim('tasks', 0, 9)  # Keep only first 10 elements
-
-# Move element between lists
-element = r.rpoplpush('source', 'destination')
-
-# Blocking move
-moved = r.brpoplpush('source', 'destination', timeout=5)
-
-# Move element (new command)
-moved = r.lmove('source', 'destination', 'LEFT', 'RIGHT')
-moved = r.blmove('source', 'destination', 'RIGHT', 'LEFT', timeout=5)
-```
-
----
-
-## Set Operations
-
-### Basic Set Operations
-
-```python
-# Add members to set
-r.sadd('tags', 'javascript')
-r.sadd('tags', 'nodejs', 'redis', 'database')
-
-# Check if member exists
-exists = r.sismember('tags', 'nodejs')  # True
-
-# Get all members
-all_tags = r.smembers('tags')
-# {'javascript', 'nodejs', 'redis', 'database'}
-
-# Get number of members
-count = r.scard('tags')  # 4
-
-# Remove members
-r.srem('tags', 'database')
-r.srem('tags', 'nodejs', 'redis')
-
-# Pop random member
-random_tag = r.spop('tags')
-
-# Pop multiple random members
-random_tags = r.spop('tags', count=2)
-
-# Get random member without removing
-random = r.srandmember('tags')
-random_three = r.srandmember('tags', 3)
-```
-
-### Set Operations Between Multiple Sets
-
-```python
-# Create sets
-r.sadd('set1', 'a', 'b', 'c')
-r.sadd('set2', 'b', 'c', 'd')
-r.sadd('set3', 'c', 'd', 'e')
-
-# Union (combine all unique members)
-union = r.sunion('set1', 'set2')
-# {'a', 'b', 'c', 'd'}
-
-# Store union in new set
-r.sunionstore('result', 'set1', 'set2')
-
-# Intersection (common members)
-inter = r.sinter('set1', 'set2')
-# {'b', 'c'}
-
-# Store intersection
-r.sinterstore('result', 'set1', 'set2')
-
-# Intersection of multiple sets
-inter = r.sinter('set1', 'set2', 'set3')  # {'c'}
-
-# Difference (members in first set but not in others)
-diff = r.sdiff('set1', 'set2')
-# {'a'}
-
-# Store difference
-r.sdiffstore('result', 'set1', 'set2')
-
-# Move member between sets
-r.smove('set1', 'set2', 'a')
-
-# Check multiple members
-result = r.smismember('tags', 'nodejs', 'python', 'redis')
-# [True, False, True]
-```
-
-### Scan Set Members
-
-```python
-# Scan set members (for large sets)
-cursor = 0
-while True:
-    cursor, members = r.sscan('tags', cursor, count=10)
-    for member in members:
-        print(member)
-    if cursor == 0:
-        break
-
-# Using sscan_iter (simpler)
-for member in r.sscan_iter('tags', match='node*', count=10):
+r.sadd("tags", "javascript")
+r.sadd("tags", "nodejs", "redis", "database")
+
+r.sismember("tags", "nodejs")
+r.smembers("tags")
+r.scard("tags")
+r.srem("tags", "database")
+r.spop("tags")
+r.srandmember("tags", 3)
+
+r.sadd("set1", "a", "b", "c")
+r.sadd("set2", "b", "c", "d")
+
+r.sunion("set1", "set2")
+r.sunionstore("result", "set1", "set2")
+r.sinter("set1", "set2")
+r.sinterstore("result", "set1", "set2")
+r.sdiff("set1", "set2")
+r.sdiffstore("result", "set1", "set2")
+r.smove("set1", "set2", "a")
+r.smismember("tags", "nodejs", "python", "redis")
+
+for member in r.sscan_iter("tags", match="node*", count=10):
     print(member)
 ```
 
----
-
-## Sorted Set Operations
-
-### Basic Sorted Set Operations
+## Sorted Sets
 
 ```python
-# Add members with scores
-r.zadd('leaderboard', {'player1': 100})
-r.zadd('leaderboard', {'player2': 200, 'player3': 150})
+r.zadd("leaderboard", {"player1": 100})
+r.zadd("leaderboard", {"player2": 200, "player3": 150})
 
-# Add with options
-r.zadd('leaderboard', {'player4': 175}, nx=True)  # Only if doesn't exist
-r.zadd('leaderboard', {'player1': 120}, xx=True)  # Only if exists
-r.zadd('leaderboard', {'player1': 130}, gt=True)  # Only if new score greater
-r.zadd('leaderboard', {'player1': 110}, lt=True)  # Only if new score less
+r.zadd("leaderboard", {"player4": 175}, nx=True)
+r.zadd("leaderboard", {"player1": 130}, gt=True)
 
-# Get rank (0-based, lowest to highest)
-rank = r.zrank('leaderboard', 'player1')  # 0
+r.zrank("leaderboard", "player1")
+r.zrevrank("leaderboard", "player2")
+r.zscore("leaderboard", "player2")
+r.zcard("leaderboard")
+r.zincrby("leaderboard", 50, "player1")
 
-# Get reverse rank (highest to lowest)
-rev_rank = r.zrevrank('leaderboard', 'player2')  # 0
+r.zrange("leaderboard", 0, 2)
+r.zrange("leaderboard", 0, 2, withscores=True)
+r.zrevrange("leaderboard", 0, 2, withscores=True)
+r.zrangebyscore("leaderboard", 100, 200, withscores=True)
+r.zrangebyscore("leaderboard", 100, "+inf")
 
-# Get score
-score = r.zscore('leaderboard', 'player2')  # 200.0
+r.zcount("leaderboard", 100, 200)
+r.zrem("leaderboard", "player1")
+r.zremrangebyrank("leaderboard", 0, 1)
+r.zremrangebyscore("leaderboard", 0, 100)
+r.zpopmax("leaderboard", count=3)
+r.zpopmin("leaderboard")
+r.bzpopmax(["set1", "set2"], timeout=5)
 
-# Get number of members
-count = r.zcard('leaderboard')  # 3
+r.zunionstore("result", {"set1": 2, "set2": 3}, aggregate="MAX")
+r.zinterstore("result", ["set1", "set2"], aggregate="SUM")
+r.zdiff(["set1", "set2"], withscores=True)
+r.zdiffstore("result", ["set1", "set2"])
 
-# Increment score
-r.zincrby('leaderboard', 50, 'player1')  # 150.0
+for member, score in r.zscan_iter("leaderboard", count=10):
+    print(member, score)
 ```
 
-### Range Queries
+## Key Management
 
 ```python
-# Get range by rank (lowest to highest)
-bottom3 = r.zrange('leaderboard', 0, 2)
-# ['player1', 'player3', 'player2']
+r.exists("mykey")
+r.exists("key1", "key2", "key3")           # count
 
-# Get range with scores
-with_scores = r.zrange('leaderboard', 0, 2, withscores=True)
-# [('player1', 150.0), ('player3', 150.0), ('player2', 200.0)]
+r.delete("mykey")
+r.delete("key1", "key2", "key3")
 
-# Get range by rank (highest to lowest)
-top3 = r.zrevrange('leaderboard', 0, 2)
+r.expire("mykey", 60)
+r.pexpire("mykey", 60_000)
 
-# Get range with scores (descending)
-top3_scores = r.zrevrange('leaderboard', 0, 2, withscores=True)
-
-# Get range by score
-range_result = r.zrangebyscore('leaderboard', 100, 200)
-
-# Get range by score with limit
-limited = r.zrangebyscore('leaderboard', 100, 200, start=0, num=10)
-
-# Get range by score with scores
-range_scores = r.zrangebyscore('leaderboard', 100, 200, withscores=True)
-
-# Get reverse range by score
-rev_range = r.zrevrangebyscore('leaderboard', 200, 100)
-
-# Infinity boundaries
-high_scores = r.zrangebyscore('leaderboard', 150, '+inf')
-low_scores = r.zrangebyscore('leaderboard', '-inf', 150)
-```
-
-### Advanced Sorted Set Operations
-
-```python
-# Count members in score range
-count = r.zcount('leaderboard', 100, 200)
-
-# Count members by lexicographical range
-r.zadd('words', {'apple': 0, 'banana': 0, 'cherry': 0})
-lex_count = r.zlexcount('words', '[a', '[c')
-
-# Get lexicographical range
-lex_range = r.zrangebylex('words', '[a', '[c')
-
-# Remove members
-r.zrem('leaderboard', 'player1')
-r.zrem('leaderboard', 'player2', 'player3')
-
-# Remove by rank range
-r.zremrangebyrank('leaderboard', 0, 1)  # Remove bottom 2
-
-# Remove by score range
-r.zremrangebyscore('leaderboard', 0, 100)
-
-# Remove by lex range
-r.zremrangebylex('words', '[a', '[b')
-
-# Pop highest/lowest scoring member
-highest = r.zpopmax('leaderboard')  # [('player2', 200.0)]
-lowest = r.zpopmin('leaderboard')  # [('player1', 100.0)]
-
-# Pop with count
-top3 = r.zpopmax('leaderboard', count=3)
-
-# Blocking pop
-member = r.bzpopmax('leaderboard', timeout=5)
-# ('leaderboard', 'player2', 200.0)
-min_member = r.bzpopmin('leaderboard', timeout=5)
-
-# Block on multiple sorted sets
-member = r.bzpopmax(['set1', 'set2', 'set3'], timeout=5)
-```
-
-### Sorted Set Operations Between Multiple Sets
-
-```python
-# Union of sorted sets
-r.zunionstore('result', ['set1', 'set2'])
-
-# Union with weights
-r.zunionstore('result', {'set1': 2, 'set2': 3})
-
-# Union with aggregate function
-r.zunionstore('result', ['set1', 'set2'], aggregate='MAX')  # or 'MIN', 'SUM'
-
-# Intersection
-r.zinterstore('result', ['set1', 'set2'])
-
-# Intersection with weights and aggregate
-r.zinterstore('result', {'set1': 1, 'set2': 2}, aggregate='SUM')
-
-# Get union without storing
-union = r.zunion(['set1', 'set2'], withscores=True)
-
-# Get intersection without storing
-inter = r.zinter(['set1', 'set2'], withscores=True)
-
-# Difference between sorted sets
-diff = r.zdiff(['set1', 'set2'])
-diff_scores = r.zdiff(['set1', 'set2'], withscores=True)
-
-# Store difference
-r.zdiffstore('result', ['set1', 'set2'])
-```
-
-### Scan Sorted Set
-
-```python
-# Scan sorted set members
-cursor = 0
-while True:
-    cursor, members = r.zscan('leaderboard', cursor, count=10)
-    for member, score in members:
-        print(f"{member}: {score}")
-    if cursor == 0:
-        break
-
-# Using zscan_iter (simpler)
-for member, score in r.zscan_iter('leaderboard', count=10):
-    print(f"{member}: {score}")
-```
-
----
-
-## Key Management Operations
-
-### Key Operations
-
-```python
-# Check if key exists
-exists = r.exists('mykey')  # 1 if exists, 0 if not
-multi_exists = r.exists('key1', 'key2', 'key3')  # Count
-
-# Delete keys
-r.delete('mykey')
-r.delete('key1', 'key2', 'key3')
-
-# Set expiration in seconds
-r.expire('mykey', 60)  # Expire in 60 seconds
-
-# Set expiration at specific timestamp
 import time
-timestamp = int(time.time()) + 3600
-r.expireat('mykey', timestamp)
+r.expireat("mykey", int(time.time()) + 3600)
+r.pexpireat("mykey", int(time.time() * 1000) + 60_000)
 
-# Set expiration in milliseconds
-r.pexpire('mykey', 60000)  # 60 seconds
+r.ttl("mykey")        # -1 no TTL, -2 missing
+r.pttl("mykey")
+r.persist("mykey")
 
-# Set expiration at timestamp (milliseconds)
-r.pexpireat('mykey', int(time.time() * 1000) + 60000)
-
-# Get time to live in seconds
-ttl = r.ttl('mykey')  # -1 if no expiration, -2 if not exists
-
-# Get time to live in milliseconds
-pttl = r.pttl('mykey')
-
-# Remove expiration
-r.persist('mykey')
-
-# Rename key
-r.rename('oldkey', 'newkey')
-
-# Rename only if new key doesn't exist
-renamed = r.renamenx('oldkey', 'newkey')  # Returns True if renamed
-
-# Get key type
-key_type = r.type('mykey')  # 'string', 'list', 'set', etc.
-
-# Get random key
-random_key = r.randomkey()
-
-# Copy key
-r.copy('source', 'destination')
-r.copy('source', 'destination', replace=True)  # Overwrite if exists
-
-# Touch keys (update last access time)
-r.touch('key1', 'key2', 'key3')
-
-# Get object encoding
-encoding = r.object('encoding', 'mykey')
-
-# Get object idle time
-idle_time = r.object('idletime', 'mykey')
+r.rename("oldkey", "newkey")
+r.renamenx("oldkey", "newkey")
+r.type("mykey")
+r.copy("source", "destination", replace=True)
+r.touch("key1", "key2")
+r.object("encoding", "mykey")
+r.object("idletime", "mykey")
 ```
 
-### Scanning Keys
+### Scanning keys
 
 ```python
-# Scan all keys (use instead of KEYS for production)
-keys = []
-cursor = 0
-while True:
-    cursor, partial_keys = r.scan(cursor, count=100)
-    keys.extend(partial_keys)
-    if cursor == 0:
-        break
-
-# Using scan_iter (simpler)
-for key in r.scan_iter(count=100):
+for key in r.scan_iter(match="user:*", count=100):
     print(key)
 
-# Scan with pattern
-for key in r.scan_iter(match='user:*', count=100):
-    print(key)
-
-# Scan specific key type
-for key in r.scan_iter(_type='string', count=100):
-    print(key)
-
-# Scan with pattern and type
-for key in r.scan_iter(match='session:*', _type='hash', count=100):
+for key in r.scan_iter(match="session:*", _type="hash", count=100):
     print(key)
 ```
 
----
+Use `scan_iter` instead of `KEYS` in production.
 
-## Transactions
+## Pipelines And Transactions
 
-### Basic Transaction (MULTI/EXEC)
+### Pipeline with `MULTI/EXEC`
 
 ```python
-# Execute multiple commands atomically
-r.set('another-key', 'another-value')
-
-pipe = r.pipeline()
-pipe.set('key', 'value')
-pipe.get('another-key')
-pipe.incr('counter')
+pipe = r.pipeline(transaction=True)
+pipe.set("key", "value")
+pipe.get("another-key")
+pipe.incr("counter")
 results = pipe.execute()
-
-print(results)  # [True, 'another-value', 1]
 ```
 
-### Pipeline Without Transaction
+### Pipeline without transaction (batching only)
 
 ```python
-# Execute commands in pipeline without atomicity
 pipe = r.pipeline(transaction=False)
-pipe.set('key1', 'value1')
-pipe.set('key2', 'value2')
-pipe.get('key1')
+pipe.set("key1", "value1")
+pipe.set("key2", "value2")
+pipe.get("key1")
 results = pipe.execute()
 ```
 
-### Transaction with Error Handling
+### `WATCH` optimistic locking
 
 ```python
-try:
-    pipe = r.pipeline()
-    pipe.set('key1', 'value1')
-    pipe.set('key2', 'value2')
-    pipe.get('key1')
-    results = pipe.execute()
-
-    for i, result in enumerate(results):
-        print(f"Command {i} result: {result}")
-except redis.exceptions.ResponseError as e:
-    print(f"Transaction failed: {e}")
-```
-
-### Transaction with WATCH (Optimistic Locking)
-
-```python
-# Watch a key for changes
 with r.pipeline() as pipe:
     while True:
         try:
-            pipe.watch('balance')
-            balance = int(pipe.get('balance') or 0)
+            pipe.watch("balance")
+            balance = int(pipe.get("balance") or 0)
 
-            if balance >= 100:
-                pipe.multi()
-                pipe.decrby('balance', 100)
-                pipe.incrby('purchases', 1)
-                pipe.execute()
-                print('Purchase successful')
-                break
-            else:
+            if balance < 100:
                 pipe.unwatch()
-                print('Insufficient balance')
                 break
+
+            pipe.multi()
+            pipe.decrby("balance", 100)
+            pipe.incrby("purchases", 1)
+            pipe.execute()
+            break
         except redis.WatchError:
-            print('Balance was modified, retrying...')
             continue
 ```
 
-### Complex Transaction Example
+### Chunked pipeline
 
 ```python
-def transfer_money(r, from_account, to_account, amount):
-    """Transfer money between accounts with optimistic locking"""
-    with r.pipeline() as pipe:
-        while True:
-            try:
-                pipe.watch(from_account, to_account)
-
-                from_balance = float(pipe.get(from_account) or 0)
-
-                if from_balance < amount:
-                    pipe.unwatch()
-                    raise ValueError('Insufficient funds')
-
-                pipe.multi()
-                pipe.incrbyfloat(from_account, -amount)
-                pipe.incrbyfloat(to_account, amount)
-                pipe.execute()
-                return True
-            except redis.WatchError:
-                # Another client modified the keys, retry
-                continue
-
-# Usage
-try:
-    transfer_money(r, 'account:1', 'account:2', 50.00)
-    print('Transfer successful')
-except ValueError as e:
-    print(f'Transfer failed: {e}')
-```
-
----
-
-## Pipelining
-
-### Basic Pipelining
-
-```python
-# Execute multiple commands in one round trip
-pipe = r.pipeline(transaction=False)
-pipe.set('key1', 'value1')
-pipe.set('key2', 'value2')
-pipe.get('key1')
-pipe.mget(['key1', 'key2'])
-results = pipe.execute()
-
-print(results)  # [True, True, 'value1', ['value1', 'value2']]
-```
-
-### Large Batch Operations
-
-```python
-def batch_set_keys(r, key_value_pairs):
-    """Set many keys efficiently using pipeline"""
-    pipe = r.pipeline(transaction=False)
-
-    for key, value in key_value_pairs.items():
-        pipe.set(key, value)
-
-    results = pipe.execute()
-    return results
-
-# Usage
-data = {
-    'user:1': 'Alice',
-    'user:2': 'Bob',
-    'user:3': 'Charlie'
-}
-
-batch_set_keys(r, data)
-```
-
-### Chunked Pipeline
-
-```python
-def batch_operation_chunked(r, operations, chunk_size=1000):
-    """Execute operations in chunks to avoid memory issues"""
+def batch_set(client, items, chunk=1000):
+    keys = list(items.items())
     results = []
-
-    for i in range(0, len(operations), chunk_size):
-        chunk = operations[i:i + chunk_size]
-        pipe = r.pipeline(transaction=False)
-
-        for op in chunk:
-            getattr(pipe, op['command'])(*op['args'])
-
+    for i in range(0, len(keys), chunk):
+        pipe = client.pipeline(transaction=False)
+        for k, v in keys[i:i + chunk]:
+            pipe.set(k, v)
         results.extend(pipe.execute())
-
     return results
-
-# Usage
-operations = [
-    {'command': 'set', 'args': [f'key:{i}', f'value:{i}']}
-    for i in range(10000)
-]
-
-batch_operation_chunked(r, operations, chunk_size=1000)
 ```
-
----
 
 ## Pub/Sub
 
-### Basic Subscriber
+### Subscriber
 
 ```python
-import redis
-
-r = redis.Redis(host='localhost', port=6379, decode_responses=True)
-
-# Create PubSub object
 pubsub = r.pubsub()
-
-# Subscribe to channel
-pubsub.subscribe('notifications')
-
-# Listen for messages
-for message in pubsub.listen():
-    if message['type'] == 'message':
-        print(f"Received: {message['data']}")
-```
-
-### Basic Publisher
-
-```python
-import redis
-
-r = redis.Redis(host='localhost', port=6379, decode_responses=True)
-
-# Publish messages
-r.publish('notifications', 'Hello, World!')
-r.publish('notifications', 'System update')
-
-print('Messages published')
-```
-
-### Multiple Channels
-
-```python
-# Subscribe to multiple channels
-pubsub = r.pubsub()
-pubsub.subscribe('channel1', 'channel2', 'channel3')
+pubsub.subscribe("notifications")
 
 for message in pubsub.listen():
-    if message['type'] == 'message':
-        print(f"Channel: {message['channel']}, Message: {message['data']}")
+    if message["type"] == "message":
+        print(message["data"])
 ```
 
-### Pattern-Based Subscription
+### Publisher
 
 ```python
-# Subscribe to channels matching pattern
-pubsub = r.pubsub()
-pubsub.psubscribe('user:*')
+r.publish("notifications", "Hello, World!")
+```
 
+### Multiple channels and patterns
+
+```python
+pubsub.subscribe("channel1", "channel2", "channel3")
+
+pubsub.psubscribe("user:*")
 for message in pubsub.listen():
-    if message['type'] == 'pmessage':
-        print(f"Pattern: {message['pattern']}, Channel: {message['channel']}, Message: {message['data']}")
-
-# Publish to matching channels
-r.publish('user:1000', 'User 1000 logged in')
-r.publish('user:2000', 'User 2000 logged out')
+    if message["type"] == "pmessage":
+        print(message["pattern"], message["channel"], message["data"])
 ```
 
-### Message Handler Functions
+### Handlers running in a thread
 
 ```python
-def message_handler(message):
-    """Handle messages from channel"""
-    print(f"Received: {message['data']}")
+def on_notification(message):
+    print(message["data"])
 
-def error_handler(message):
-    """Handle errors"""
-    print(f"Error: {message}")
-
-# Subscribe with handler
 pubsub = r.pubsub()
-pubsub.subscribe(**{
-    'notifications': message_handler,
-    'errors': error_handler
-})
-
-# Run event loop
+pubsub.subscribe(notifications=on_notification)
 thread = pubsub.run_in_thread(sleep_time=0.01)
 
-# Do other work...
-
-# Stop listening
+# ... later
 thread.stop()
 ```
 
 ### Unsubscribe
 
 ```python
-# Unsubscribe from specific channel
-pubsub.unsubscribe('channel1')
-
-# Unsubscribe from all channels
+pubsub.unsubscribe("channel1")
 pubsub.unsubscribe()
-
-# Unsubscribe from pattern
-pubsub.punsubscribe('user:*')
+pubsub.punsubscribe("user:*")
 ```
 
-### Complete Pub/Sub Example
+## Streams
 
 ```python
-import redis
-import json
-import threading
-import time
+entry_id = r.xadd("events", {"user": "alice", "action": "login"})
+r.xadd("events", {"user": "charlie"}, maxlen=1000, approximate=True)
 
-def subscriber_worker():
-    """Subscriber in separate thread"""
-    r = redis.Redis(host='localhost', port=6379, decode_responses=True)
-    pubsub = r.pubsub()
-    pubsub.subscribe('chat:room1')
-
-    for message in pubsub.listen():
-        if message['type'] == 'message':
-            data = json.loads(message['data'])
-            print(f"{data['user']}: {data['text']}")
-
-def publisher_worker():
-    """Publisher in separate thread"""
-    r = redis.Redis(host='localhost', port=6379, decode_responses=True)
-
-    time.sleep(1)  # Wait for subscriber
-
-    # Publish chat messages
-    r.publish('chat:room1', json.dumps({
-        'user': 'Alice',
-        'text': 'Hello everyone!'
-    }))
-
-    r.publish('chat:room1', json.dumps({
-        'user': 'Bob',
-        'text': 'Hi Alice!'
-    }))
-
-# Start subscriber
-sub_thread = threading.Thread(target=subscriber_worker, daemon=True)
-sub_thread.start()
-
-# Start publisher
-pub_thread = threading.Thread(target=publisher_worker)
-pub_thread.start()
-pub_thread.join()
-
-time.sleep(2)  # Let subscriber process messages
-```
-
----
-
-## Redis Streams
-
-### Add to Stream (XADD)
-
-```python
-# Add entry to stream
-entry_id = r.xadd('events', {
-    'user': 'alice',
-    'action': 'login',
-    'timestamp': time.time()
-})
-
-print(f'Entry ID: {entry_id}')  # '1234567890123-0'
-
-# Add with specific ID
-r.xadd('events', {'user': 'bob', 'action': 'logout'}, id='1234567890123-1')
-
-# Add with maxlen (limit stream size)
-r.xadd('events', {'user': 'charlie', 'action': 'signup'}, maxlen=1000)
-
-# Add with approximate trimming
-r.xadd('events', {'user': 'dave', 'action': 'purchase'}, maxlen=1000, approximate=True)
-
-# Add with minid trimming
-r.xadd('events', {'data': 'value'}, minid='1234567890000-0')
-```
-
-### Read from Stream (XREAD)
-
-```python
-# Read entries from beginning
-messages = r.xread({'events': '0'}, count=10)
-
-for stream, entries in messages:
+for stream, entries in r.xread({"events": "0"}, count=10):
     for entry_id, data in entries:
-        print(f"ID: {entry_id}, Data: {data}")
+        print(entry_id, data)
 
-# Read from multiple streams
-messages = r.xread({'stream1': '0', 'stream2': '0'})
+r.xread({"events": "$"}, block=5000)   # blocking read
 
-# Blocking read (wait for new entries)
-messages = r.xread({'events': '$'}, block=5000)  # Wait up to 5 seconds
+r.xrange("events", "-", "+", count=100)
+r.xrevrange("events", "+", "-", count=10)
+r.xlen("events")
+r.xinfo_stream("events")
 
-# Read only new messages
-messages = r.xread({'events': '$'}, block=0)  # Block indefinitely
-```
-
-### Stream Range Queries
-
-```python
-# Read all entries
-all_entries = r.xrange('events', '-', '+')
-
-# Read range with IDs
-range_entries = r.xrange('events', '1234567890000', '1234567899999')
-
-# Read with limit
-limited = r.xrange('events', '-', '+', count=100)
-
-# Reverse range
-reverse = r.xrevrange('events', '+', '-', count=10)
-
-# Iterate through entries
-for entry_id, data in r.xrange('events', '-', '+'):
-    print(f"{entry_id}: {data}")
-```
-
-### Stream Length and Info
-
-```python
-# Get stream length
-length = r.xlen('events')
-
-# Get stream info
-info = r.xinfo_stream('events')
-print(f"Length: {info['length']}")
-print(f"First entry: {info['first-entry']}")
-print(f"Last entry: {info['last-entry']}")
-```
-
-### Consumer Groups
-
-```python
-# Create consumer group
 try:
-    r.xgroup_create('events', 'processors', '0', mkstream=True)
+    r.xgroup_create("events", "processors", "0", mkstream=True)
 except redis.exceptions.ResponseError:
-    # Group already exists
-    pass
+    pass  # group exists
 
-# Read as consumer group
 messages = r.xreadgroup(
-    'processors',
-    'consumer1',
-    {'events': '>'},  # '>' means undelivered messages
-    count=10,
-    block=5000
+    "processors", "consumer1",
+    {"events": ">"},
+    count=10, block=5000,
 )
-
-# Process messages and acknowledge
 for stream, entries in messages:
     for entry_id, data in entries:
-        # Process message
-        print(f'Processing: {entry_id}, {data}')
+        r.xack("events", "processors", entry_id)
 
-        # Acknowledge message
-        r.xack('events', 'processors', entry_id)
-
-# Get pending messages
-pending = r.xpending('events', 'processors')
-print(f"Pending messages: {pending['pending']}")
-
-# Get detailed pending info
-pending_details = r.xpending_range('events', 'processors', '-', '+', count=10)
-
-# Claim pending messages (take over from another consumer)
-claimed = r.xclaim('events', 'processors', 'consumer2', 3600000, ['1234567890123-0'])
+r.xdel("events", entry_id)
+r.xtrim("events", maxlen=1000, approximate=True)
 ```
 
-### Delete from Stream
+## Lua Scripts
 
 ```python
-# Delete specific entries
-r.xdel('events', '1234567890123-0', '1234567890123-1')
-
-# Trim stream
-r.xtrim('events', maxlen=1000)
-
-# Approximate trim
-r.xtrim('events', maxlen=1000, approximate=True)
-
-# Trim by minid
-r.xtrim('events', minid='1234567890000-0')
-```
-
-### Complete Stream Example
-
-```python
-import redis
-import time
-import json
-
-r = redis.Redis(host='localhost', port=6379, decode_responses=True)
-
-def add_event(event_data):
-    """Add event to stream"""
-    return r.xadd('events', event_data)
-
-def process_events():
-    """Process events using consumer group"""
-    # Create group if not exists
-    try:
-        r.xgroup_create('events', 'workers', '0', mkstream=True)
-    except redis.exceptions.ResponseError:
-        pass
-
-    while True:
-        messages = r.xreadgroup(
-            'workers',
-            'worker1',
-            {'events': '>'},
-            count=10,
-            block=5000
-        )
-
-        if messages:
-            for stream, entries in messages:
-                for entry_id, data in entries:
-                    try:
-                        # Process event
-                        print(f'Processing event: {data}')
-
-                        # Acknowledge
-                        r.xack('events', 'workers', entry_id)
-                    except Exception as e:
-                        print(f'Error processing: {e}')
-
-# Add events
-add_event({'type': 'user_login', 'user': 'alice'})
-add_event({'type': 'user_logout', 'user': 'bob'})
-
-# Process events
-process_events()
-```
-
----
-
-## Scripting with Lua
-
-### Basic Script Execution (EVAL)
-
-```python
-# Execute Lua script
 script = "return redis.call('SET', KEYS[1], ARGV[1])"
-result = r.eval(script, 1, 'mykey', 'myvalue')
-print(result)  # b'OK' or 'OK' with decode_responses=True
-```
+r.eval(script, 1, "mykey", "myvalue")
 
-### Script with Multiple Operations
-
-```python
-script = """
-local current = redis.call('GET', KEYS[1])
-if current == false then
-    current = 0
-end
-local new = tonumber(current) + tonumber(ARGV[1])
-redis.call('SET', KEYS[1], new)
-return new
-"""
-
-new_value = r.eval(script, 1, 'counter', 5)
-print(f'New counter value: {new_value}')
-```
-
-### Register Script (SCRIPT LOAD / EVALSHA)
-
-```python
-# Register script
-script = "return redis.call('GET', KEYS[1])"
-sha = r.script_load(script)
-print(f'Script SHA: {sha}')
-
-# Execute by SHA (more efficient for repeated calls)
-value = r.evalsha(sha, 1, 'mykey')
-
-# Check if script exists
-exists = r.script_exists(sha)
-print(f'Script exists: {exists}')  # [True]
-
-# Flush all scripts
+sha = r.script_load("return redis.call('GET', KEYS[1])")
+r.evalsha(sha, 1, "mykey")
+r.script_exists(sha)
 r.script_flush()
 ```
 
-### Rate Limiting with Lua Script
+Rate limit script:
 
 ```python
-rate_limit_script = """
-local key = KEYS[1]
-local limit = tonumber(ARGV[1])
-local window = tonumber(ARGV[2])
-local current = redis.call('INCR', key)
-if current == 1 then
-    redis.call('EXPIRE', key, window)
-end
-if current > limit then
-    return 0
-else
-    return 1
-end
+rate_limit = """
+local current = redis.call('INCR', KEYS[1])
+if current == 1 then redis.call('EXPIRE', KEYS[1], ARGV[2]) end
+if current > tonumber(ARGV[1]) then return 0 else return 1 end
 """
 
-def check_rate_limit(user_id, limit=10, window=60):
-    """Check if user is within rate limit"""
-    allowed = r.eval(
-        rate_limit_script,
-        1,
-        f'ratelimit:{user_id}',
-        limit,
-        window
-    )
-    return allowed == 1
-
-# Usage
-if check_rate_limit('user:1000', limit=10, window=60):
-    print('Request allowed')
-else:
-    print('Rate limit exceeded')
+def allowed(user_id, limit=10, window=60):
+    return r.eval(rate_limit, 1, f"ratelimit:{user_id}", limit, window) == 1
 ```
 
-### Atomic Get and Delete
+## Geospatial
 
 ```python
-get_and_delete = """
-local value = redis.call('GET', KEYS[1])
-if value then
-    redis.call('DEL', KEYS[1])
-end
-return value
-"""
-
-value = r.eval(get_and_delete, 1, 'temp:key')
-print(f'Retrieved and deleted: {value}')
-```
-
-### Script Class for Reusability
-
-```python
-class RedisScripts:
-    """Reusable Redis Lua scripts"""
-
-    def __init__(self, redis_client):
-        self.r = redis_client
-
-        # Load scripts on initialization
-        self.rate_limit_sha = self.r.script_load("""
-            local key = KEYS[1]
-            local limit = tonumber(ARGV[1])
-            local window = tonumber(ARGV[2])
-            local current = redis.call('INCR', key)
-            if current == 1 then
-                redis.call('EXPIRE', key, window)
-            end
-            return current <= limit and 1 or 0
-        """)
-
-        self.atomic_increment_sha = self.r.script_load("""
-            local current = redis.call('GET', KEYS[1])
-            if not current then
-                current = 0
-            end
-            local new = tonumber(current) + tonumber(ARGV[1])
-            redis.call('SET', KEYS[1], new)
-            return new
-        """)
-
-    def rate_limit(self, key, limit, window):
-        return self.r.evalsha(self.rate_limit_sha, 1, key, limit, window) == 1
-
-    def atomic_increment(self, key, amount):
-        return self.r.evalsha(self.atomic_increment_sha, 1, key, amount)
-
-# Usage
-scripts = RedisScripts(r)
-allowed = scripts.rate_limit('user:1000', 10, 60)
-new_value = scripts.atomic_increment('counter', 5)
-```
-
----
-
-## Geospatial Operations
-
-### Add Geo Points
-
-```python
-# Add location
-r.geoadd('locations', -122.4194, 37.7749, 'San Francisco')
-
-# Add multiple locations
-r.geoadd('locations',
-    -118.2437, 34.0522, 'Los Angeles',
-    -73.9352, 40.7306, 'New York'
-)
-```
-
-### Query Geo Points
-
-```python
-# Get position
-position = r.geopos('locations', 'San Francisco')
-print(position)  # [(-122.4194, 37.7749)]
-
-# Get multiple positions
-positions = r.geopos('locations', 'San Francisco', 'Los Angeles')
-
-# Get distance between points
-distance = r.geodist('locations', 'San Francisco', 'Los Angeles', unit='mi')
-print(f'Distance: {distance} miles')
-
-# Available units: 'm', 'km', 'mi', 'ft'
-
-# Search by radius (from coordinates)
-nearby = r.georadius('locations', -122.4194, 37.7749, 500, unit='mi')
-
-# Search with additional info
-detailed = r.georadius(
-    'locations', -122.4194, 37.7749, 500, unit='mi',
-    withdist=True,
-    withcoord=True,
-    withhash=True,
-    count=10,
-    sort='ASC'
+r.geoadd("locations", -122.4194, 37.7749, "San Francisco")
+r.geoadd(
+    "locations",
+    -118.2437, 34.0522, "Los Angeles",
+    -73.9352, 40.7306, "New York",
 )
 
-# Search by member
-near_sf = r.georadiusbymember('locations', 'San Francisco', 600, unit='mi')
-
-# Search by member with details
-detailed = r.georadiusbymember(
-    'locations', 'San Francisco', 600, unit='mi',
-    withdist=True,
-    withcoord=True
+r.geopos("locations", "San Francisco")
+r.geodist("locations", "San Francisco", "Los Angeles", unit="mi")
+r.georadius("locations", -122.4194, 37.7749, 500, unit="mi")
+r.georadiusbymember(
+    "locations", "San Francisco", 600, unit="mi",
+    withdist=True, withcoord=True,
 )
-
-# Get geohash
-geohash = r.geohash('locations', 'San Francisco')
+r.geohash("locations", "San Francisco")
 ```
 
----
-
-## HyperLogLog (Cardinality Estimation)
+## HyperLogLog And Bitmaps
 
 ```python
-# Add elements
-r.pfadd('unique:visitors', 'user1', 'user2', 'user3')
-r.pfadd('unique:visitors', 'user2', 'user4')  # user2 counted once
+r.pfadd("unique:visitors", "user1", "user2", "user3")
+r.pfcount("unique:visitors")
+r.pfmerge("unique:combined", "unique:day1", "unique:day2")
 
-# Get count
-count = r.pfcount('unique:visitors')  # ~4
-print(f'Unique visitors: {count}')
-
-# Count multiple HyperLogLogs
-total = r.pfcount('unique:day1', 'unique:day2', 'unique:day3')
-
-# Merge multiple HyperLogLogs
-r.pfmerge('unique:combined', 'unique:day1', 'unique:day2')
+r.setbit("login:2026-05-29", 100, 1)
+r.getbit("login:2026-05-29", 100)
+r.bitcount("login:2026-05-29")
+r.bitop("AND", "result", "bitmap1", "bitmap2")
+r.bitpos("login:2026-05-29", 1)
 ```
 
----
-
-## Bitmap Operations
+## Server, Database, And Client Management
 
 ```python
-# Set bit
-r.setbit('login:2024-01-15', 100, 1)  # User 100 logged in
+r.info()
+r.info("memory")
+r.ping()
+r.echo("hi")
+r.time()
 
-# Get bit
-bit = r.getbit('login:2024-01-15', 100)  # 1
-
-# Count set bits
-count = r.bitcount('login:2024-01-15')
-
-# Count bits in range (bytes)
-count = r.bitcount('login:2024-01-15', 0, 10)
-
-# Bitwise operations
-r.bitop('AND', 'result', 'bitmap1', 'bitmap2')
-r.bitop('OR', 'result', 'bitmap1', 'bitmap2')
-r.bitop('XOR', 'result', 'bitmap1', 'bitmap2')
-r.bitop('NOT', 'result', 'bitmap1')
-
-# Find first bit
-pos = r.bitpos('login:2024-01-15', 1)  # First set bit
-pos = r.bitpos('login:2024-01-15', 0)  # First unset bit
-
-# Find bit in range
-pos = r.bitpos('login:2024-01-15', 1, 0, 10)
-```
-
----
-
-## Server and Connection Management
-
-### Server Information
-
-```python
-# Get server info
-info = r.info()
-print(info)
-
-# Get specific section
-stats = r.info('stats')
-memory = r.info('memory')
-replication = r.info('replication')
-
-# Ping server
-pong = r.ping()  # True
-
-# Echo message
-echo = r.echo('Hello Redis')
-
-# Get server time
-server_time = r.time()  # (seconds, microseconds)
-```
-
-### Database Management
-
-```python
-# Select database (0-15 by default)
-r.execute_command('SELECT', 1)
-
-# Get database size
-size = r.dbsize()
-
-# Flush current database
+r.dbsize()
 r.flushdb()
-
-# Flush all databases
 r.flushall()
-
-# Save database to disk
 r.save()
-
-# Background save
 r.bgsave()
-
-# Get last save time
-last_save = r.lastsave()  # Unix timestamp
-
-# Background rewrite AOF
+r.lastsave()
 r.bgrewriteaof()
+
+r.client_list()
+r.client_id()
+r.client_setname("my-app")
+r.client_getname()
+r.client_info()
+
+r.memory_stats()
+r.memory_usage("mykey")
 ```
 
-### Client Management
-
-```python
-# Get client list
-clients = r.client_list()
-
-# Get client ID
-client_id = r.client_id()
-
-# Set client name
-r.client_setname('my-app')
-
-# Get client name
-name = r.client_getname()
-
-# Get client info
-info = r.client_info()
-
-# Kill client
-r.client_kill('127.0.0.1:6379')
-
-# Pause all clients
-r.client_pause(1000)  # Pause for 1000ms
-```
-
-### Memory Management
-
-```python
-# Get memory stats
-memory_stats = r.memory_stats()
-
-# Get memory usage of key
-usage = r.memory_usage('mykey')
-
-# Purge memory
-r.memory_purge()
-```
-
----
-
-## Async/Await Support
-
-### Async Redis Client
+## Async via `redis.asyncio`
 
 ```python
 import asyncio
-import redis.asyncio as aioredis
+import redis.asyncio as redis
 
 async def main():
-    # Create async client
-    r = await aioredis.from_url('redis://localhost:6379', decode_responses=True)
+    r = redis.from_url("redis://localhost:6379/0", decode_responses=True)
+    try:
+        await r.set("key", "value")
+        print(await r.get("key"))
+    finally:
+        await r.aclose()
 
-    # Set value
-    await r.set('key', 'value')
-
-    # Get value
-    value = await r.get('key')
-    print(value)
-
-    # Close connection
-    await r.close()
-
-# Run async code
 asyncio.run(main())
 ```
 
-### Async Pipeline
+Close async clients with `await r.aclose()` so the pool releases its sockets.
+
+### Async pipeline
 
 ```python
-async def async_pipeline():
-    r = await aioredis.from_url('redis://localhost:6379', decode_responses=True)
+import asyncio
+import redis.asyncio as redis
 
+async def pipeline_demo():
+    r = redis.from_url("redis://localhost:6379/0", decode_responses=True)
     async with r.pipeline(transaction=True) as pipe:
-        await pipe.set('key1', 'value1')
-        await pipe.set('key2', 'value2')
-        await pipe.get('key1')
+        await pipe.set("key1", "value1")
+        await pipe.set("key2", "value2")
+        await pipe.get("key1")
         results = await pipe.execute()
-
     print(results)
-    await r.close()
+    await r.aclose()
 
-asyncio.run(async_pipeline())
+asyncio.run(pipeline_demo())
 ```
 
-### Async Pub/Sub
+### Async pub/sub
 
 ```python
-async def reader(channel: aioredis.client.PubSub):
+import asyncio
+import redis.asyncio as redis
+
+async def reader(pubsub):
     while True:
-        message = await channel.get_message(ignore_subscribe_messages=True)
+        message = await pubsub.get_message(ignore_subscribe_messages=True)
         if message is not None:
-            print(f"Received: {message['data']}")
+            print(message["data"])
 
-async def async_pubsub():
-    r = await aioredis.from_url('redis://localhost:6379', decode_responses=True)
-
+async def main():
+    r = redis.from_url("redis://localhost:6379/0", decode_responses=True)
     async with r.pubsub() as pubsub:
-        await pubsub.subscribe('notifications')
-
-        # Create task to read messages
-        future = asyncio.create_task(reader(pubsub))
-
-        # Publish messages
-        await r.publish('notifications', 'Hello Async!')
-
+        await pubsub.subscribe("notifications")
+        task = asyncio.create_task(reader(pubsub))
+        await r.publish("notifications", "Hello Async!")
         await asyncio.sleep(1)
-        future.cancel()
+        task.cancel()
+    await r.aclose()
 
-    await r.close()
-
-asyncio.run(async_pubsub())
+asyncio.run(main())
 ```
-
----
 
 ## Error Handling
 
-### Connection Errors
-
 ```python
-import redis
-from redis.exceptions import ConnectionError, TimeoutError, RedisError
+from redis.exceptions import (
+    ConnectionError, TimeoutError, ResponseError, DataError, RedisError,
+)
+
+r = redis.Redis(
+    host="localhost", port=6379,
+    socket_connect_timeout=5, socket_timeout=5, retry_on_timeout=True,
+)
 
 try:
-    r = redis.Redis(
-        host='localhost',
-        port=6379,
-        socket_connect_timeout=5,
-        socket_timeout=5,
-        retry_on_timeout=True
-    )
     r.ping()
 except ConnectionError as e:
-    print(f'Connection error: {e}')
+    print("Connection error:", e)
 except TimeoutError as e:
-    print(f'Timeout error: {e}')
+    print("Timeout:", e)
 except RedisError as e:
-    print(f'Redis error: {e}')
+    print("Redis error:", e)
 ```
 
-### Command Errors
-
-```python
-from redis.exceptions import ResponseError, DataError
-
-try:
-    r.get('nonexistent')
-except ResponseError as e:
-    print(f'Command error: {e}')
-except DataError as e:
-    print(f'Data error: {e}')
-```
-
-### Pipeline Errors
-
-```python
-pipe = r.pipeline()
-pipe.set('key1', 'value1')
-pipe.incr('not-a-number')  # Will error
-pipe.get('key1')
-
-try:
-    results = pipe.execute()
-except ResponseError as e:
-    print(f'Pipeline error: {e}')
-```
-
-### Retry Logic
+### Retry helper
 
 ```python
 import time
-from redis.exceptions import ConnectionError
 
-def redis_operation_with_retry(operation, max_retries=3):
-    """Execute Redis operation with retry logic"""
-    for attempt in range(max_retries):
+def with_retry(operation, attempts=3):
+    for i in range(attempts):
         try:
             return operation()
         except ConnectionError:
-            if attempt == max_retries - 1:
+            if i == attempts - 1:
                 raise
-            time.sleep(2 ** attempt)  # Exponential backoff
+            time.sleep(2 ** i)
 
-# Usage
-result = redis_operation_with_retry(lambda: r.get('mykey'))
+result = with_retry(lambda: r.get("mykey"))
 ```
-
----
 
 ## Connection Pooling
 
-### Configure Connection Pool
-
 ```python
 pool = redis.ConnectionPool(
-    host='localhost',
+    host="localhost",
     port=6379,
-    password='your_password',
+    password="your_password",
     db=0,
     max_connections=50,
     socket_timeout=5,
     socket_connect_timeout=5,
     socket_keepalive=True,
-    socket_keepalive_options={
-        1: 1,  # TCP_KEEPIDLE
-        2: 1,  # TCP_KEEPINTVL
-        3: 3   # TCP_KEEPCNT
-    },
-    decode_responses=True
+    decode_responses=True,
 )
 
-r = redis.Redis(connection_pool=pool)
+c1 = redis.Redis(connection_pool=pool)
+c2 = redis.Redis(connection_pool=pool)
 ```
 
-### Multiple Clients Sharing Pool
+## Sentinel And Cluster
+
+### Sentinel
 
 ```python
-pool = redis.ConnectionPool(
-    host='localhost',
-    port=6379,
-    max_connections=20,
-    decode_responses=True
+from redis.sentinel import Sentinel
+
+sentinel = Sentinel(
+    [("sentinel-1", 26379), ("sentinel-2", 26379)],
+    socket_timeout=0.5,
+    username="default",
+    password="secret",
 )
 
-# Multiple clients share the pool
-client1 = redis.Redis(connection_pool=pool)
-client2 = redis.Redis(connection_pool=pool)
-client3 = redis.Redis(connection_pool=pool)
+client = sentinel.master_for("mymaster", decode_responses=True)
+client.ping()
 ```
 
----
-
-## Cluster Support
-
-### Connect to Cluster
-
-```python
-from redis.cluster import RedisCluster
-
-# Connect to cluster
-cluster = RedisCluster(
-    host='localhost',
-    port=7000,
-    decode_responses=True
-)
-
-# Use cluster like regular client
-cluster.set('key', 'value')
-value = cluster.get('key')
-
-cluster.close()
-```
-
-### Cluster with Multiple Nodes
+### Cluster
 
 ```python
 from redis.cluster import RedisCluster, ClusterNode
 
-startup_nodes = [
-    ClusterNode('localhost', 7000),
-    ClusterNode('localhost', 7001),
-    ClusterNode('localhost', 7002)
-]
-
 cluster = RedisCluster(
-    startup_nodes=startup_nodes,
-    decode_responses=True
+    startup_nodes=[
+        ClusterNode("localhost", 7000),
+        ClusterNode("localhost", 7001),
+        ClusterNode("localhost", 7002),
+    ],
+    decode_responses=True,
 )
+
+cluster.set("user-profile:{42}", "ready")
+print(cluster.get("user-profile:{42}"))
 ```
 
----
+Use hash tags such as `{42}` when multi-key commands must land on the same slot.
 
 ## Complete Application Example
 
 ```python
-import redis
 import json
-import time
 import os
-from typing import Optional, List, Dict, Any
+import time
+from typing import Any, Optional
+
+import redis
 from dotenv import load_dotenv
 
 load_dotenv()
 
 class RedisManager:
-    """Redis manager with common operations"""
-
     def __init__(self):
         self.pool = redis.ConnectionPool(
-            host=os.getenv('REDIS_HOST', 'localhost'),
-            port=int(os.getenv('REDIS_PORT', 6379)),
-            password=os.getenv('REDIS_PASSWORD'),
-            db=int(os.getenv('REDIS_DB', 0)),
+            host=os.getenv("REDIS_HOST", "localhost"),
+            port=int(os.getenv("REDIS_PORT", "6379")),
+            password=os.getenv("REDIS_PASSWORD"),
+            db=int(os.getenv("REDIS_DB", "0")),
             max_connections=10,
-            decode_responses=True
+            decode_responses=True,
         )
         self.client = redis.Redis(connection_pool=self.pool)
 
     def cache_get(self, key: str) -> Optional[Any]:
-        """Get value from cache"""
-        value = self.client.get(key)
-        return json.loads(value) if value else None
+        raw = self.client.get(key)
+        return json.loads(raw) if raw else None
 
-    def cache_set(self, key: str, value: Any, ttl: int = 3600):
-        """Set value in cache with TTL"""
+    def cache_set(self, key: str, value: Any, ttl: int = 3600) -> None:
         self.client.set(key, json.dumps(value), ex=ttl)
 
-    def invalidate_cache(self, pattern: str):
-        """Invalidate cache keys matching pattern"""
+    def invalidate(self, pattern: str) -> None:
         keys = list(self.client.scan_iter(match=pattern))
         if keys:
             self.client.delete(*keys)
 
-    def track_user_activity(self, user_id: str, action: str):
-        """Track user activity"""
-        today = time.strftime('%Y-%m-%d')
-        key = f'activity:{user_id}:{today}'
+    def track_activity(self, user_id: str, action: str) -> None:
+        key = f"activity:{user_id}:{time.strftime('%Y-%m-%d')}"
+        self.client.rpush(key, json.dumps({"action": action, "ts": time.time()}))
+        self.client.expire(key, 86400 * 7)
 
-        self.client.rpush(key, json.dumps({
-            'action': action,
-            'timestamp': time.time()
-        }))
-        self.client.expire(key, 86400 * 7)  # Keep for 7 days
+    def increment_pageview(self, page_id: str) -> int:
+        return self.client.incr(f"pageviews:{page_id}")
 
-    def get_user_activity(self, user_id: str, date: str) -> List[Dict]:
-        """Get user activity for date"""
-        key = f'activity:{user_id}:{date}'
-        activities = self.client.lrange(key, 0, -1)
-        return [json.loads(a) for a in activities]
+    def leaderboard_add(self, user_id: str, score: float) -> None:
+        self.client.zadd("leaderboard", {user_id: score})
 
-    def increment_page_view(self, page_id: str) -> int:
-        """Increment page view counter"""
-        return self.client.incr(f'pageviews:{page_id}')
-
-    def get_page_views(self, page_id: str) -> int:
-        """Get page view count"""
-        views = self.client.get(f'pageviews:{page_id}')
-        return int(views) if views else 0
-
-    def add_to_leaderboard(self, user_id: str, score: float):
-        """Add or update user score in leaderboard"""
-        self.client.zadd('leaderboard', {user_id: score})
-
-    def get_leaderboard(self, count: int = 10) -> List[Dict]:
-        """Get top users from leaderboard"""
-        results = self.client.zrevrange('leaderboard', 0, count - 1, withscores=True)
-        return [{'user_id': user, 'score': score} for user, score in results]
-
-    def get_user_rank(self, user_id: str) -> Optional[int]:
-        """Get user rank in leaderboard (1-based)"""
-        rank = self.client.zrevrank('leaderboard', user_id)
-        return rank + 1 if rank is not None else None
+    def leaderboard_top(self, count: int = 10):
+        return [
+            {"user_id": user, "score": score}
+            for user, score in self.client.zrevrange(
+                "leaderboard", 0, count - 1, withscores=True,
+            )
+        ]
 
     def rate_limit(self, key: str, limit: int = 10, window: int = 60) -> bool:
-        """Check rate limit"""
-        pipe = self.client.pipeline()
         now = int(time.time())
-        window_start = now - window
-
-        pipe.zremrangebyscore(key, 0, window_start)
+        pipe = self.client.pipeline()
+        pipe.zremrangebyscore(key, 0, now - window)
         pipe.zcard(key)
         pipe.zadd(key, {str(now): now})
         pipe.expire(key, window)
+        _, count, *_ = pipe.execute()
+        return count < limit
 
-        results = pipe.execute()
-        return results[1] < limit
-
-    def close(self):
-        """Close connection"""
+    def close(self) -> None:
         self.client.close()
 
-# Usage example
-if __name__ == '__main__':
-    redis_mgr = RedisManager()
 
-    # Cache operations
-    redis_mgr.cache_set('user:1000', {
-        'name': 'John',
-        'email': '[email protected]'
-    }, ttl=3600)
-
-    user = redis_mgr.cache_get('user:1000')
-    print(f'Cached user: {user}')
-
-    # Track activity
-    redis_mgr.track_user_activity('user:1000', 'login')
-    redis_mgr.track_user_activity('user:1000', 'view_profile')
-
-    # Get activity
-    today = time.strftime('%Y-%m-%d')
-    activities = redis_mgr.get_user_activity('user:1000', today)
-    print(f'Activities: {activities}')
-
-    # Page views
-    views = redis_mgr.increment_page_view('page:home')
-    print(f'Page views: {views}')
-
-    # Leaderboard
-    redis_mgr.add_to_leaderboard('user:1000', 500)
-    redis_mgr.add_to_leaderboard('user:2000', 750)
-    redis_mgr.add_to_leaderboard('user:3000', 250)
-
-    top_users = redis_mgr.get_leaderboard(3)
-    print(f'Top users: {top_users}')
-
-    rank = redis_mgr.get_user_rank('user:1000')
-    print(f'User rank: {rank}')
-
-    # Rate limiting
-    for i in range(12):
-        allowed = redis_mgr.rate_limit('api:user:1000', limit=10, window=60)
-        print(f'Request {i + 1}: {"Allowed" if allowed else "Blocked"}')
-
-    redis_mgr.close()
+if __name__ == "__main__":
+    mgr = RedisManager()
+    mgr.cache_set("user:1000", {"name": "John"}, ttl=3600)
+    print(mgr.cache_get("user:1000"))
+    mgr.increment_pageview("page:home")
+    mgr.leaderboard_add("user:1", 500)
+    mgr.leaderboard_add("user:2", 750)
+    print(mgr.leaderboard_top(3))
+    mgr.close()
 ```
+
+## Common Pitfalls
+
+- Responses are `bytes` by default; set `decode_responses=True` if your app expects `str`.
+- Use `redis.asyncio` for async; the standalone `aioredis` package is deprecated.
+- Use `redis.cluster.RedisCluster` for cluster; the standalone `redis-py-cluster` package is deprecated.
+- `SELECT` is not exposed on the client; choose the DB via URL or constructor.
+- RESP3 is opt-in with `protocol=3`; default clients use RESP2.
+- `scan_iter` is the production-safe alternative to `KEYS`.
+- In cluster mode, multi-key commands require the keys to hash to the same slot; use hash tags.
+- Search, JSON, time series, and vector commands require Redis Stack or server-side modules.
+
+## Version Notes
+
+- `redis 8.0.0` is the current PyPI release.
+- Requires Python `>=3.10`. For Python 3.9, pin to the 7.x line.
+- Docs root: https://redis.readthedocs.io/en/stable/.
+- PyPI: https://pypi.org/project/redis/.

--- a/content/redis/docs/package/python/DOC.md
+++ b/content/redis/docs/package/python/DOC.md
@@ -3,9 +3,9 @@ name: package
 description: "redis-py package guide for Python projects using Redis sync, asyncio, TLS, Sentinel, and cluster clients"
 metadata:
   languages: "python"
-  versions: "7.3.0"
-  revision: 1
-  updated-on: "2026-03-12"
+  versions: "8.0.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "redis,python,cache,key-value,pubsub,asyncio,cluster"
 ---
@@ -14,29 +14,29 @@ metadata:
 
 ## Golden Rule
 
-Use the official `redis` package (`redis-py`) for both synchronous and asynchronous Redis access. As of March 12, 2026, PyPI lists `redis 7.3.0`, requires Python `>=3.10`, and points to `https://redis.readthedocs.io/en/stable/` as the official docs root. The docs URL (`https://redis-py.readthedocs.io/en/stable/`) is stale and should not be used.
+Use the official `redis` package (`redis-py`) for both synchronous and asynchronous Redis access. As of May 29, 2026, PyPI lists `redis 8.0.0`, requires Python `>=3.10`, and points to `https://redis.readthedocs.io/en/stable/` as the official docs root. The older `redis-py.readthedocs.io` URL is stale.
 
 ## Install
 
 Pin the package version your project expects:
 
 ```bash
-python -m pip install "redis==7.3.0"
+python -m pip install "redis==8.0.0"
 ```
 
 Useful extras:
 
 ```bash
-python -m pip install "redis[hiredis]==7.3.0"
-python -m pip install "redis[ocsp]==7.3.0"
-python -m pip install "redis[otel]==7.3.0"
+python -m pip install "redis[hiredis]==8.0.0"
+python -m pip install "redis[ocsp]==8.0.0"
+python -m pip install "redis[otel]==8.0.0"
 ```
 
 - `hiredis`: faster response parser
 - `ocsp`: OCSP validation for TLS connections
 - `otel`: OpenTelemetry instrumentation helpers
 
-If your runtime is still on Python 3.9, `redis 7.3.0` will not install. PyPI notes that `redis 7.0.1` was the last version supporting Python 3.9.
+If your runtime is still on Python 3.9, `redis 8.0.0` will not install. PyPI metadata for `8.0.0` requires Python `>=3.10`; pin to the 7.x line if you need Python 3.9 support.
 
 ## Initialize A Client
 
@@ -291,9 +291,10 @@ Use hash tags like `{42}` when multi-key operations must land in the same slot.
 
 ## Version-Sensitive Notes
 
-- `redis 7.3.0` is the current PyPI release as of March 12, 2026.
+- `redis 8.0.0` is the current PyPI release as of May 29, 2026.
 - The official docs root is `https://redis.readthedocs.io/en/stable/`; the older `redis-py.readthedocs.io` URL is stale.
-- PyPI metadata for `7.3.0` requires Python `>=3.10`. That is the first constraint to check before suggesting an upgrade.
+- PyPI metadata for `8.0.0` requires Python `>=3.10`. That is the first constraint to check before suggesting an upgrade.
+- The 7.x line (most recently `7.3.0`) is the last branch supporting Python 3.9; older releases such as `7.0.1` are also documented as 3.9-compatible if you must stay on the 7.0 line.
 - `redis-py` continues to unify sync, asyncio, Sentinel, and Cluster support in one package, so older package splits from blog posts are usually wrong.
 - If you use RediSearch helpers (`ft()` APIs), check the current query dialect behavior in the upstream docs instead of relying on older examples.
 


### PR DESCRIPTION
docs(redis, mongodb): refresh to redis-py 8.0.0 / node-redis 6.0.0 / mongodb 7.2.0

- redis-py 7.0.1 → 8.0.0 (Python ≥3.10); rewritten for `Redis()`/`from_url`,
  strings/hashes/lists/sets/sorted-sets, key TTL, pipelines/transactions,
  pub/sub, streams, Lua scripts, geospatial, async via `redis.asyncio`,
  Sentinel, Cluster; 7.x downgrade path documented for Python 3.9
- node-redis 5.9.0 → 6.0.0; emphasizes `createClient()` + `await
  client.connect()`, mandatory `client.on('error', ...)`, `client.duplicate()`
  for pub/sub, `multi/exec` pipelines, scan iterators, streams, optional
  Redis Stack modules (JSON, Search, TimeSeries)
- mongodb (Node driver) 6.20.0 → 7.2.0; covers `MongoClient` + SRV URI,
  CRUD, aggregation (`$match`/`$group`/`$lookup`/`$facet`), indexes,
  transactions via `withTransaction`, change streams, bulk writes, and a
  new Atlas Vector Search section (`$vectorSearch`)
- `revision` bumped and `updated-on: 2026-05-29`

Verified versions against PyPI and npm.
