### PR TITLE
docs(django, flask, celery): refresh primary package docs

### DIFF
--- a/content/celery/docs/package/python/DOC.md
+++ b/content/celery/docs/package/python/DOC.md
@@ -3,9 +3,9 @@ name: package
 description: "Celery distributed task queue for Python workers, retries, scheduling, and broker-backed background jobs"
 metadata:
   languages: "python"
-  versions: "5.6.2"
-  revision: 1
-  updated-on: "2026-03-11"
+  versions: "5.6.3"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "celery,python,task-queue,workers,async,redis,rabbitmq,django"
 ---
@@ -25,8 +25,8 @@ Use `celery` when Python code needs broker-backed background jobs, scheduled tas
 
 - Package: `celery`
 - Ecosystem: `pypi`
-- Version: `5.6.2`
-- Release date: `2026-01-04`
+- Version: `5.6.3`
+- Release date: `2026-03-26`
 - Python requirement on PyPI: `>=3.9`
 
 ## Install
@@ -34,20 +34,20 @@ Use `celery` when Python code needs broker-backed background jobs, scheduled tas
 Base install:
 
 ```bash
-pip install celery==5.6.2
+pip install celery==5.6.3
 ```
 
 Common extras from PyPI:
 
 ```bash
 # Redis broker and/or result backend support
-pip install "celery[redis]==5.6.2"
+pip install "celery[redis]==5.6.3"
 
 # Task-side Pydantic validation helpers
-pip install "celery[pydantic]==5.6.2"
+pip install "celery[pydantic]==5.6.3"
 
 # pytest plugin support
-pip install "celery[pytest]==5.6.2"
+pip install "celery[pytest]==5.6.3"
 ```
 
 ## Core Model
@@ -61,9 +61,9 @@ Celery has four moving parts:
 
 Recurring schedules are handled by a separate `beat` process.
 
-## Minimal Setup
+## App Config
 
-Create an importable module such as `tasks.py`:
+Create an importable module such as `tasks.py`. Configure `broker_url` and (optionally) `result_backend` either as constructor arguments or via `app.conf`.
 
 ```python
 import os
@@ -77,13 +77,41 @@ app = Celery(
 )
 
 app.conf.update(
+    broker_url=os.environ.get("CELERY_BROKER_URL", "pyamqp://guest@localhost//"),
+    result_backend=os.environ.get("CELERY_RESULT_BACKEND"),
     task_serializer="json",
     accept_content=["json"],
     result_serializer="json",
     timezone="UTC",
     enable_utc=True,
 )
+```
 
+Common broker URLs:
+
+```text
+pyamqp://guest:guest@localhost//        # RabbitMQ
+redis://localhost:6379/0                 # Redis
+sqs://AWS_ACCESS:AWS_SECRET@/            # Amazon SQS
+```
+
+Common result backends:
+
+```text
+redis://localhost:6379/1
+db+postgresql://user:pass@localhost/celery
+rpc://                                   # short-lived RPC results over the broker
+```
+
+You can also load config from a module:
+
+```python
+app.config_from_object("celeryconfig")
+```
+
+## Defining Tasks With @app.task
+
+```python
 @app.task(
     bind=True,
     autoretry_for=(ConnectionError, TimeoutError),
@@ -96,91 +124,157 @@ def fetch_remote(self, url: str) -> str:
     return f"fetched {url}"
 ```
 
-Start a worker:
-
-```bash
-celery -A tasks worker --loglevel=INFO
-```
-
-Queue a task:
+`@shared_task` is preferred inside reusable apps because it doesn't bind to a specific app instance:
 
 ```python
-from tasks import fetch_remote
+from celery import shared_task
 
-result = fetch_remote.delay("https://example.com/data.json")
-print(result.id)
+
+@shared_task
+def add(x: int, y: int) -> int:
+    return x + y
 ```
 
-## Broker and Backend Choices
+Common `@task` options:
 
-### RabbitMQ
+- `bind=True` injects `self` so you can call `self.retry(...)`, access `self.request.id`, etc.
+- `name="myapp.tasks.add"` fixes the task name across renames.
+- `ignore_result=True` skips storing return values.
+- `acks_late=True` only ack after the task completes (useful with idempotent tasks).
+- `autoretry_for=(...)`, `retry_backoff=`, `retry_backoff_max=`, `retry_jitter=`, `max_retries=`.
+- `pydantic=True` (5.5+) for task-side Pydantic argument/return validation.
 
-- Best default production broker.
-- Stable, durable, and feature-complete in Celery docs.
-- Handles larger messages better than Redis.
-
-Example:
-
-```env
-CELERY_BROKER_URL=pyamqp://guest:guest@localhost//
-```
-
-### Redis
-
-- Stable as both broker and result backend.
-- Good for fast, smaller messages and common local setups.
-- More susceptible to data loss on abrupt termination than RabbitMQ.
-- Large messages can congest Redis when used as a broker.
-
-Example:
-
-```env
-CELERY_BROKER_URL=redis://localhost:6379/0
-CELERY_RESULT_BACKEND=redis://localhost:6379/1
-```
-
-For Redis result backends, install the Redis extra:
-
-```bash
-pip install "celery[redis]==5.6.2"
-```
-
-TLS example for Redis backend:
-
-```env
-CELERY_RESULT_BACKEND=rediss://username:password@redis.example.com:6379/0?ssl_cert_reqs=required
-```
-
-### SQS and Other Brokers
-
-- Amazon SQS is marked stable, but Celery docs note it does not support monitoring or remote control commands.
-- Kafka, Zookeeper, and some other brokers are still marked experimental.
-
-## Calling Tasks
+## Calling Tasks: .delay() and .apply_async()
 
 Use `delay()` for the common case and `apply_async()` when you need execution options:
 
 ```python
 from tasks import fetch_remote
 
+# Equivalent
 fetch_remote.delay("https://example.com/a")
+fetch_remote.apply_async(args=("https://example.com/a",))
 
+# With options
 fetch_remote.apply_async(
     args=("https://example.com/b",),
+    kwargs={},
     countdown=10,
     expires=60,
+    queue="downloads",
+    priority=5,
+    headers={"trace_id": "abc"},
 )
 ```
 
 Useful `apply_async()` options:
 
-- `countdown` or `eta` for delayed execution
-- `expires` to drop stale work
+- `countdown` (seconds) or `eta` (datetime) for delayed execution
+- `expires` (seconds or datetime) to drop stale work
+- `queue` to route to a specific queue
+- `priority` (broker-dependent)
 - `link` and `link_error` for callbacks and errbacks
+- `task_id` to set a deterministic id
 
 Do not use `countdown` or `eta` for large volumes of far-future jobs. Celery keeps those tasks in worker memory until execution time, and Redis brokers can redeliver them when the delay exceeds the broker visibility timeout.
 
-## Results and State
+## Running A Worker
+
+Basic worker:
+
+```bash
+celery -A tasks worker --loglevel=INFO
+```
+
+Named workers with explicit concurrency and routing:
+
+```bash
+celery -A proj worker --loglevel=INFO --concurrency=10 -n worker1@%h
+celery -A proj worker --loglevel=INFO --concurrency=10 -n worker2@%h -Q downloads,default
+```
+
+Useful flags:
+
+- `--concurrency=N` worker process pool size
+- `--pool=prefork|gevent|eventlet|solo|threads`
+- `-Q queue1,queue2` consume only specific queues
+- `-n worker@%h` give each worker a unique node name
+- `--loglevel=INFO|DEBUG|WARNING`
+- `--max-tasks-per-child=N` recycle a worker after N tasks to bound memory growth
+- `--time-limit=` / `--soft-time-limit=` per-task limits
+
+Inspect a running cluster:
+
+```bash
+celery -A tasks inspect active
+celery -A tasks inspect registered
+celery -A tasks inspect scheduled
+celery -A tasks status
+celery -A tasks control shutdown
+```
+
+## Periodic Tasks (Beat)
+
+Run the scheduler separately. Beat sends scheduled tasks to the broker; the workers execute them.
+
+```bash
+celery -A tasks beat -l INFO
+```
+
+Inline schedule:
+
+```python
+from celery.schedules import crontab
+
+app.conf.beat_schedule = {
+    "refresh-every-30-seconds": {
+        "task": "tasks.refresh_cache",
+        "schedule": 30.0,
+    },
+    "billing-nightly": {
+        "task": "tasks.run_billing",
+        "schedule": crontab(hour=2, minute=30),
+        "args": (),
+        "options": {"queue": "billing"},
+    },
+}
+app.conf.timezone = "UTC"
+```
+
+Run only one beat process per cluster, or use a coordinated scheduler like `django-celery-beat` to store schedules in the DB.
+
+## Retries
+
+Two retry styles:
+
+### Declarative
+
+```python
+@app.task(
+    autoretry_for=(ConnectionError, TimeoutError),
+    retry_backoff=True,
+    retry_backoff_max=600,
+    retry_jitter=True,
+    max_retries=7,
+)
+def sync_invoice(invoice_id: str) -> None:
+    ...
+```
+
+### Imperative
+
+```python
+@app.task(bind=True, max_retries=5)
+def push(self, payload):
+    try:
+        do_push(payload)
+    except TransientError as exc:
+        raise self.retry(exc=exc, countdown=10)
+```
+
+`retry_backoff=True` enables exponential backoff. `retry_backoff_max` caps the wait. `retry_jitter=True` randomizes the wait to spread retries.
+
+## Results
 
 Results are off by default. Configure `result_backend` only if you need:
 
@@ -188,21 +282,63 @@ Results are off by default. Configure `result_backend` only if you need:
 - task state inspection
 - chords or workflows that depend on stored results
 
-Example:
-
 ```python
 from tasks import fetch_remote
 
 result = fetch_remote.delay("https://example.com/c")
-value = result.get(timeout=10)
-result.forget()
+print(result.id)
+print(result.state)         # "PENDING" / "STARTED" / "SUCCESS" / "FAILURE" / "RETRY"
+value = result.get(timeout=10, propagate=True)
+result.forget()              # remove stored result from backend
 ```
 
-If you do not need return values, set `ignore_result=True` on the task or use global task result settings to reduce backend load.
+If you do not need return values, set `ignore_result=True` on the task or use `task_ignore_result=True` globally to reduce backend load.
+
+Set `result_expires` (seconds) to clean up stored results automatically.
+
+## Chains, Groups, and Chords
+
+Compose tasks with primitives from `celery`:
+
+```python
+from celery import chain, chord, group
+
+from tasks import add, multiply, summarize
+
+# Chain: run tasks one after another, passing results forward
+chain(add.s(2, 2), multiply.s(4)).apply_async()
+# or with pipe operator
+(add.s(2, 2) | multiply.s(4)).apply_async()
+
+# Group: run tasks in parallel
+group(add.s(i, i) for i in range(5)).apply_async()
+
+# Chord: parallel group then a callback on the collected results
+chord(
+    (add.s(i, i) for i in range(5)),
+    summarize.s(),
+).apply_async()
+```
+
+`task.s(...)` builds a signature (immutable: `task.si(...)`). Chords require a result backend that supports them (Redis and most DB backends do).
+
+## Monitoring Basics
+
+- `celery events` shows a curses TUI of task lifecycle events; workers must be started with `-E` or `worker_send_task_events=True`.
+- `flower` is the most common dashboard:
+
+```bash
+pip install flower
+celery -A tasks flower --port=5555
+```
+
+- `celery -A tasks inspect ...` reports per-worker state.
+- Workers expose Prometheus metrics through third-party exporters.
+- For ad-hoc debugging, run a worker with `--loglevel=DEBUG`.
+
+Note: Amazon SQS does not support monitoring or remote control commands.
 
 ## Production-Oriented Configuration
-
-Common settings worth knowing:
 
 ```python
 app.conf.update(
@@ -216,6 +352,9 @@ app.conf.update(
     worker_prefetch_multiplier=1,
     task_acks_late=True,
     task_reject_on_worker_lost=False,
+    task_time_limit=300,
+    task_soft_time_limit=270,
+    result_expires=24 * 3600,
 )
 ```
 
@@ -239,6 +378,7 @@ Celery also supports:
 ```python
 from celery import shared_task
 
+
 @shared_task(
     autoretry_for=(ConnectionError, TimeoutError),
     retry_backoff=True,
@@ -256,6 +396,7 @@ def sync_invoice(invoice_id: str) -> None:
 ```python
 from celery import shared_task
 
+
 @shared_task(ignore_result=True)
 def send_webhook(payload: dict) -> None:
     ...
@@ -271,11 +412,14 @@ from pydantic import BaseModel
 
 app = Celery("tasks")
 
+
 class JobIn(BaseModel):
     url: str
 
+
 class JobOut(BaseModel):
     status: str
+
 
 @app.task(pydantic=True)
 def run_job(job: JobIn) -> JobOut:
@@ -283,47 +427,6 @@ def run_job(job: JobIn) -> JobOut:
 ```
 
 Important: `pydantic=True` validates on the task side. You still need to serialize task arguments correctly when calling `delay()` or `apply_async()`.
-
-## Workers
-
-Basic worker:
-
-```bash
-celery -A tasks worker -l INFO
-```
-
-Named workers with explicit concurrency:
-
-```bash
-celery -A proj worker --loglevel=INFO --concurrency=10 -n worker1@%h
-celery -A proj worker --loglevel=INFO --concurrency=10 -n worker2@%h
-```
-
-Operational guidance:
-
-- Set explicit timeouts in the I/O your task performs.
-- Use Celery time limits for tasks that can wedge a worker.
-- Prefer multiple smaller workers over one giant process when isolating queues or workloads.
-
-## Periodic Tasks
-
-Run the scheduler separately:
-
-```bash
-celery -A tasks beat -l INFO
-```
-
-Inline schedule example:
-
-```python
-app.conf.beat_schedule = {
-    "refresh-every-30-seconds": {
-        "task": "tasks.refresh_cache",
-        "schedule": 30.0,
-    },
-}
-app.conf.timezone = "UTC"
-```
 
 ## Django Integration
 
@@ -369,14 +472,15 @@ Important testing caveats:
 - Large or distant `countdown` loads: workers hold those messages in memory.
 - Long-running tasks with default prefetch: one worker can reserve too much work early.
 - Triggering Django tasks before transaction commit: the worker may not see the saved rows yet.
+- Running multiple beat processes: schedules will fire more than once.
 
-## Version-Sensitive Notes for 5.6.2
+## Version-Sensitive Notes for 5.6.3
 
-- Stable docs and PyPI both identify the current covered release as `5.6.2`.
+- Stable docs and PyPI both identify the current covered release as `5.6.3` (released 2026-03-26).
 - PyPI project metadata requires Python `>=3.9`.
 - Task-side Pydantic validation via `pydantic=True` is available in Celery `5.5+`.
 - `delay_on_commit()` for Django is available in Celery `5.4+`.
-- The PyPI long description still contains some stale `5.5.x` references, so prefer the stable docs root and PyPI metadata over older prose when checking current support statements.
+- The PyPI long description may still contain some stale `5.5.x` references; prefer the stable docs root and PyPI metadata over older prose when checking current support statements.
 - The project still says Microsoft Windows is unsupported, even though it may work in some environments.
 
 ## Official Sources
@@ -387,7 +491,9 @@ Important testing caveats:
 - Configuration: https://docs.celeryq.dev/en/stable/userguide/configuration.html
 - Tasks: https://docs.celeryq.dev/en/stable/userguide/tasks.html
 - Calling tasks: https://docs.celeryq.dev/en/stable/userguide/calling.html
+- Canvas (chains, groups, chords): https://docs.celeryq.dev/en/stable/userguide/canvas.html
 - Workers: https://docs.celeryq.dev/en/stable/userguide/workers.html
+- Monitoring and management: https://docs.celeryq.dev/en/stable/userguide/monitoring.html
 - Periodic tasks: https://docs.celeryq.dev/en/stable/userguide/periodic-tasks.html
 - Testing: https://docs.celeryq.dev/en/stable/userguide/testing.html
 - Django: https://docs.celeryq.dev/en/stable/django/first-steps-with-django.html

--- a/content/django/docs/package/python/DOC.md
+++ b/content/django/docs/package/python/DOC.md
@@ -3,9 +3,9 @@ name: package
 description: "Django package guide for Python projects using the official Django 6.0 docs"
 metadata:
   languages: "python"
-  versions: "6.0.3"
-  revision: 1
-  updated-on: "2026-03-11"
+  versions: "6.0.5"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "django,python,web,framework,orm,templates,admin"
 ---
@@ -14,7 +14,7 @@ metadata:
 
 ## Golden Rule
 
-Use the Django 6.0 docs for setup and behavior, and stay on the latest 6.0.x patch if your project is pinned to the 6.0 series. As of March 11, 2026, PyPI lists `Django 6.0.3`, while the docs URL pointed to the older Django 5.1 reference.
+Use the Django 6.0 docs for setup and behavior, and stay on the latest 6.0.x patch if your project is pinned to the 6.0 series. As of May 29, 2026, PyPI lists `Django 6.0.5` (released 2026-05-05) as the current 6.0.x patch.
 
 ## Install
 
@@ -24,21 +24,21 @@ Use a virtual environment and pin the version your project expects:
 python -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade pip
-python -m pip install "Django==6.0.3"
+python -m pip install "Django==6.0.5"
 ```
 
 Common alternatives:
 
 ```bash
-uv add "Django==6.0.3"
-poetry add "Django==6.0.3"
+uv add "Django==6.0.5"
+poetry add "Django==6.0.5"
 ```
 
 Optional password hasher extras published on PyPI:
 
 ```bash
-python -m pip install "Django[argon2]==6.0.3"
-python -m pip install "Django[bcrypt]==6.0.3"
+python -m pip install "Django[argon2]==6.0.5"
+python -m pip install "Django[bcrypt]==6.0.5"
 ```
 
 ## Initialize A Project
@@ -60,21 +60,58 @@ The generated project includes these important files:
 - `mysite/asgi.py`: ASGI application entry point
 - `mysite/wsgi.py`: WSGI application entry point
 
-## Core Workflow
+## Project And App Structure
 
-### Create an app
+A Django project is a Python package that contains one or more apps. Each app should be a focused unit of functionality (auth, billing, polls, etc.) that can theoretically be reused across projects.
+
+```text
+mysite/
+  manage.py
+  mysite/
+    __init__.py
+    settings.py
+    urls.py
+    asgi.py
+    wsgi.py
+  polls/
+    __init__.py
+    admin.py
+    apps.py
+    models.py
+    views.py
+    urls.py
+    migrations/
+    templates/polls/
+    static/polls/
+```
+
+Create an app and register it:
 
 ```bash
 python manage.py startapp polls
 ```
 
-Add the app to `INSTALLED_APPS` in `settings.py` before expecting models, templates, or admin registration to work.
+```python
+# mysite/settings.py
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "polls.apps.PollsConfig",
+]
+```
 
-### Define a model and create migrations
+## Models And Migrations
+
+Models are plain Python classes that subclass `django.db.models.Model`. Each model maps to one DB table.
 
 ```python
 # polls/models.py
 from django.db import models
+
 
 class Question(models.Model):
     question_text = models.CharField(max_length=200)
@@ -82,7 +119,15 @@ class Question(models.Model):
 
     def __str__(self) -> str:
         return self.question_text
+
+
+class Choice(models.Model):
+    question = models.ForeignKey(Question, on_delete=models.CASCADE, related_name="choices")
+    choice_text = models.CharField(max_length=200)
+    votes = models.IntegerField(default=0)
 ```
+
+Generate and apply migrations:
 
 ```bash
 python manage.py makemigrations polls
@@ -93,18 +138,57 @@ Useful inspection commands:
 
 ```bash
 python manage.py sqlmigrate polls 0001
+python manage.py showmigrations
 python manage.py shell
 ```
 
-### Add views and routes
+`makemigrations` writes migration files; `migrate` runs them. You need both.
+
+## Views
+
+### Function-based views
 
 ```python
 # polls/views.py
 from django.http import HttpResponse
+from django.shortcuts import get_object_or_404, render
+
+from .models import Question
+
 
 def index(request):
-    return HttpResponse("Hello from polls")
+    latest = Question.objects.order_by("-pub_date")[:5]
+    return render(request, "polls/index.html", {"latest_question_list": latest})
+
+
+def detail(request, question_id: int):
+    question = get_object_or_404(Question, pk=question_id)
+    return render(request, "polls/detail.html", {"question": question})
 ```
+
+### Class-based views
+
+```python
+# polls/views.py
+from django.views.generic import DetailView, ListView
+
+from .models import Question
+
+
+class IndexView(ListView):
+    template_name = "polls/index.html"
+    context_object_name = "latest_question_list"
+
+    def get_queryset(self):
+        return Question.objects.order_by("-pub_date")[:5]
+
+
+class DetailView(DetailView):
+    model = Question
+    template_name = "polls/detail.html"
+```
+
+## URL Routing
 
 ```python
 # polls/urls.py
@@ -112,8 +196,10 @@ from django.urls import path
 
 from . import views
 
+app_name = "polls"
 urlpatterns = [
     path("", views.index, name="index"),
+    path("<int:question_id>/", views.detail, name="detail"),
 ]
 ```
 
@@ -128,7 +214,15 @@ urlpatterns = [
 ]
 ```
 
-### Render templates instead of hard-coded responses
+Reverse URLs with `reverse()` or `{% url %}` to avoid hard-coding paths:
+
+```python
+from django.urls import reverse
+
+reverse("polls:detail", kwargs={"question_id": 3})
+```
+
+## Templates
 
 Keep app templates namespaced under the app name to avoid collisions:
 
@@ -137,26 +231,102 @@ polls/
   templates/
     polls/
       index.html
+      detail.html
+```
+
+```html
+{# polls/templates/polls/index.html #}
+{% if latest_question_list %}
+  <ul>
+  {% for q in latest_question_list %}
+    <li><a href="{% url 'polls:detail' q.id %}">{{ q.question_text }}</a></li>
+  {% endfor %}
+  </ul>
+{% else %}
+  <p>No polls available.</p>
+{% endif %}
+```
+
+Configure template engines in `settings.py`:
+
+```python
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [BASE_DIR / "templates"],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+        },
+    },
+]
+```
+
+Django 6.0 also ships template partials (`{% partialdef %}` / `{% partial %}`) for reusable template fragments.
+
+## Forms
+
+```python
+# polls/forms.py
+from django import forms
+
+from .models import Question
+
+
+class QuestionForm(forms.ModelForm):
+    class Meta:
+        model = Question
+        fields = ["question_text", "pub_date"]
+
+
+class SearchForm(forms.Form):
+    q = forms.CharField(max_length=200, required=False)
 ```
 
 ```python
 # polls/views.py
-from django.shortcuts import render
+from django.shortcuts import redirect, render
 
-def index(request):
-    context = {"latest_question_list": []}
-    return render(request, "polls/index.html", context)
+from .forms import QuestionForm
+
+
+def new_question(request):
+    if request.method == "POST":
+        form = QuestionForm(request.POST)
+        if form.is_valid():
+            form.save()
+            return redirect("polls:index")
+    else:
+        form = QuestionForm()
+    return render(request, "polls/new.html", {"form": form})
 ```
 
-### Register models in the admin
+Always include `{% csrf_token %}` inside `<form method="post">` blocks.
+
+## Admin
 
 ```python
 # polls/admin.py
 from django.contrib import admin
 
-from .models import Question
+from .models import Choice, Question
 
-admin.site.register(Question)
+
+class ChoiceInline(admin.TabularInline):
+    model = Choice
+    extra = 2
+
+
+@admin.register(Question)
+class QuestionAdmin(admin.ModelAdmin):
+    list_display = ("question_text", "pub_date")
+    list_filter = ("pub_date",)
+    search_fields = ("question_text",)
+    inlines = [ChoiceInline]
 ```
 
 Create an admin user:
@@ -165,7 +335,61 @@ Create an admin user:
 python manage.py createsuperuser
 ```
 
-## Settings And Environment
+## ORM And QuerySets
+
+QuerySets are lazy. They do not hit the database until iterated, sliced (without a step), or coerced.
+
+```python
+from django.db.models import Count, F, Q
+
+# Filtering
+Question.objects.filter(pub_date__year=2026)
+Question.objects.exclude(question_text__icontains="test")
+Question.objects.filter(Q(pub_date__year=2026) | Q(question_text__startswith="Hi"))
+
+# Ordering, slicing
+Question.objects.order_by("-pub_date")[:10]
+
+# Aggregation and annotation
+Question.objects.annotate(num_choices=Count("choices")).filter(num_choices__gt=0)
+
+# Updates without loading rows
+Question.objects.filter(pk=1).update(question_text=F("question_text"))
+
+# Related lookups
+Question.objects.filter(choices__votes__gt=10).distinct()
+Question.objects.select_related("author").prefetch_related("choices")
+
+# Single object
+Question.objects.get(pk=1)            # raises DoesNotExist / MultipleObjectsReturned
+Question.objects.filter(pk=1).first() # returns None if missing
+
+# Create / update
+q, created = Question.objects.get_or_create(question_text="Hi", defaults={"pub_date": now()})
+Question.objects.update_or_create(pk=1, defaults={"question_text": "Updated"})
+```
+
+Use `select_related()` for one-to-one and many-to-one joins, `prefetch_related()` for many-to-many and reverse relations to avoid N+1 queries.
+
+### Async ORM
+
+Django supports async ORM methods alongside sync ones:
+
+```python
+async def latest_questions():
+    qs = Question.objects.order_by("-pub_date")
+    async for q in qs:
+        print(q.question_text)
+
+    first = await qs.afirst()
+    count = await qs.acount()
+    obj = await Question.objects.aget(pk=1)
+    await Question.objects.acreate(question_text="async", pub_date=now())
+```
+
+Most sync ORM methods have an `a`-prefixed async variant (`aget`, `acreate`, `asave`, `adelete`, `afilter` not needed since `filter` is lazy, `aiterator`, etc.). Iterating querysets with `async for` works directly.
+
+## Settings Essentials
 
 Django loads settings from the module pointed to by `DJANGO_SETTINGS_MODULE`. The default `manage.py`, `asgi.py`, and `wsgi.py` created by `startproject` set this for you.
 
@@ -177,13 +401,18 @@ Minimum production settings to review explicitly:
 - `ALLOWED_HOSTS = ["your-domain.example"]`
 - `CSRF_TRUSTED_ORIGINS = ["https://your-domain.example"]` when needed behind HTTPS proxies or cross-origin admin flows
 - `SECRET_KEY` from an environment variable
+- `SECRET_KEY_FALLBACKS` when rotating keys
 - `DATABASES` from environment-specific config
 - `STATIC_ROOT` and static file serving strategy
+- `SECURE_PROXY_SSL_HEADER` and `SECURE_SSL_REDIRECT` when terminating TLS at a proxy
 
 Example environment-driven settings:
 
 ```python
 import os
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
 
 DEBUG = os.getenv("DJANGO_DEBUG", "").lower() == "true"
 SECRET_KEY = os.environ["DJANGO_SECRET_KEY"]
@@ -191,7 +420,97 @@ ALLOWED_HOSTS = os.getenv("DJANGO_ALLOWED_HOSTS", "localhost,127.0.0.1").split("
 CSRF_TRUSTED_ORIGINS = [
     origin for origin in os.getenv("DJANGO_CSRF_TRUSTED_ORIGINS", "").split(",") if origin
 ]
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": os.environ["DB_NAME"],
+        "USER": os.environ["DB_USER"],
+        "PASSWORD": os.environ["DB_PASSWORD"],
+        "HOST": os.environ["DB_HOST"],
+        "PORT": os.getenv("DB_PORT", "5432"),
+    }
+}
 ```
+
+## Middleware
+
+Middleware are classes that wrap every request/response. They run top-to-bottom on request and bottom-to-top on response.
+
+```python
+# settings.py
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+]
+```
+
+Custom middleware:
+
+```python
+class RequestTimingMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        response["X-Server"] = "django"
+        return response
+```
+
+Django 6.0 also added built-in Content Security Policy middleware; configure via `SECURE_CSP` and `SECURE_CSP_REPORT_ONLY` and include `django.middleware.csp.ContentSecurityPolicyMiddleware`.
+
+## Authentication Basics
+
+The `django.contrib.auth` app provides `User`, password hashing, sessions, login views, and permissions out of the box.
+
+```python
+from django.contrib.auth import authenticate, login, logout
+from django.contrib.auth.decorators import login_required, permission_required
+from django.shortcuts import redirect, render
+
+
+def sign_in(request):
+    if request.method == "POST":
+        user = authenticate(
+            request,
+            username=request.POST["username"],
+            password=request.POST["password"],
+        )
+        if user is not None:
+            login(request, user)
+            return redirect("polls:index")
+    return render(request, "registration/login.html")
+
+
+@login_required
+def my_polls(request):
+    return render(request, "polls/mine.html", {"polls": request.user.polls.all()})
+
+
+@permission_required("polls.change_question")
+def edit(request, pk):
+    ...
+```
+
+Class-based equivalents:
+
+```python
+from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
+from django.views.generic import ListView
+
+
+class MyPolls(LoginRequiredMixin, ListView):
+    model = Question
+    template_name = "polls/mine.html"
+```
+
+Hook custom user models via `AUTH_USER_MODEL = "accounts.User"` early in a project's life. Migrating after data exists is painful.
 
 ## ASGI vs WSGI
 
@@ -235,15 +554,17 @@ python manage.py check --deploy
 - New apps must be added to `INSTALLED_APPS` before model discovery, app configs, admin registration, and template loading behave as expected.
 - Keep templates under `templates/<app_name>/...`; flat template names collide quickly in larger projects.
 - Set `ALLOWED_HOSTS` before turning `DEBUG` off or you will get `DisallowedHost` errors.
-- Keep `SECRET_KEY` out of the repo. If rotating keys, Django 6.0 still supports `SECRET_KEY_FALLBACKS` for staged rotation.
+- Keep `SECRET_KEY` out of the repo. Django 6.0 supports `SECRET_KEY_FALLBACKS` for staged rotation.
 - The deployment checklist is not optional. Run `python manage.py check --deploy` against production settings before release.
 - Async Django is not the same as "everything is non-blocking". Avoid calling blocking libraries directly from async views.
+- N+1 queries are easy to hit with related objects in templates; reach for `select_related`/`prefetch_related`.
 
 ## Version-Sensitive Notes For Django 6.0
 
 - Django 6.0 requires Python 3.12 or later.
-- The Django 6.0 release adds built-in Content Security Policy support, template partials, and a task framework. These are new enough that many third-party blog posts will not cover them correctly.
-- Django 6.0.3 is a patch release in the 6.0 line; check the 6.0.3 release notes before copying examples from early 6.0 articles, especially around security fixes and bugfixes.
+- Django 6.0.5 (2026-05-05) is the current 6.0.x patch on PyPI.
+- The Django 6.0 release adds built-in Content Security Policy support, template partials, and a task framework. Many third-party blog posts will not cover them correctly yet.
+- Check the 6.0.x release notes before copying examples from early 6.0 articles, especially around security fixes and bugfixes.
 - If a project still targets Python 3.10 or 3.11, it cannot move to Django 6.0 without a Python upgrade.
 
 ## Official Sources
@@ -252,10 +573,14 @@ python manage.py check --deploy
 - Installation guide: https://docs.djangoproject.com/en/6.0/intro/install/
 - Tutorial part 1: https://docs.djangoproject.com/en/6.0/intro/tutorial01/
 - Tutorial part 2: https://docs.djangoproject.com/en/6.0/intro/tutorial02/
+- Models and databases: https://docs.djangoproject.com/en/6.0/topics/db/
+- Async support: https://docs.djangoproject.com/en/6.0/topics/async/
 - Settings topic guide: https://docs.djangoproject.com/en/6.0/topics/settings/
+- Middleware: https://docs.djangoproject.com/en/6.0/topics/http/middleware/
+- Authentication: https://docs.djangoproject.com/en/6.0/topics/auth/
 - Deployment checklist: https://docs.djangoproject.com/en/6.0/howto/deployment/checklist/
 - ASGI deployment: https://docs.djangoproject.com/en/6.0/howto/deployment/asgi/
 - WSGI deployment: https://docs.djangoproject.com/en/6.0/howto/deployment/wsgi/
 - Django 6.0 release notes: https://docs.djangoproject.com/en/6.0/releases/6.0/
-- Django 6.0.3 release notes: https://docs.djangoproject.com/en/6.0/releases/6.0.3/
+- Django 6.0.5 release notes: https://docs.djangoproject.com/en/6.0/releases/6.0.5/
 - PyPI package page: https://pypi.org/project/django/

--- a/content/flask/docs/package/python/DOC.md
+++ b/content/flask/docs/package/python/DOC.md
@@ -4,8 +4,8 @@ description: "Flask 3.1.3 package guide for building and testing Python web appl
 metadata:
   languages: "python"
   versions: "3.1.3"
-  revision: 1
-  updated-on: "2026-03-11"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "flask,python,web,wsgi,jinja,werkzeug"
 ---
@@ -14,7 +14,7 @@ metadata:
 
 ## Install
 
-Flask 3.1.3 requires Python 3.9+.
+Flask 3.1.3 requires Python 3.9+. Released 2026-02-19, it is still the current release on PyPI as of 2026-05-29.
 
 ```bash
 python -m venv .venv
@@ -57,7 +57,7 @@ Important:
 - Use `--debug` at startup rather than trying to flip `DEBUG` later in code.
 - The built-in server is for development only, not production.
 
-## Recommended App Factory Layout
+## App Factory And Blueprints
 
 For any non-trivial project, prefer an application factory and blueprints. This makes testing easier and avoids binding extension state too early.
 
@@ -65,6 +65,9 @@ For any non-trivial project, prefer an application factory and blueprints. This 
 
 ```python
 from flask import Flask
+
+from .extensions import db, login_manager
+
 
 def create_app(test_config: dict | None = None) -> Flask:
     app = Flask(__name__, instance_relative_config=True)
@@ -79,10 +82,25 @@ def create_app(test_config: dict | None = None) -> Flask:
     else:
         app.config.from_prefixed_env()
 
-    from .views import bp
-    app.register_blueprint(bp)
+    db.init_app(app)
+    login_manager.init_app(app)
+
+    from .views import bp as main_bp
+    from .api import bp as api_bp
+    app.register_blueprint(main_bp)
+    app.register_blueprint(api_bp, url_prefix="/api")
 
     return app
+```
+
+`myapp/extensions.py`
+
+```python
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import LoginManager
+
+db = SQLAlchemy()
+login_manager = LoginManager()
 ```
 
 `myapp/views.py`
@@ -92,12 +110,32 @@ from flask import Blueprint, current_app, jsonify
 
 bp = Blueprint("main", __name__)
 
+
 @bp.get("/")
 def index():
     return jsonify(
         app_name=current_app.name,
         debug=current_app.debug,
     )
+```
+
+`myapp/api.py`
+
+```python
+from flask import Blueprint, jsonify, request
+
+bp = Blueprint("api", __name__)
+
+
+@bp.get("/items")
+def list_items():
+    return jsonify(items=[])
+
+
+@bp.post("/items")
+def create_item():
+    payload = request.get_json()
+    return jsonify(id=1, **payload), 201
 ```
 
 Run a factory app:
@@ -108,14 +146,17 @@ flask --app myapp:create_app run --debug
 
 Flask will auto-detect a factory named `create_app` or `make_app`.
 
-## Core Request and Response Patterns
+## Routes, Request, And Response
 
 ### Route methods and path params
+
+Flask 3.x prefers method-specific decorators (`@app.get`, `@app.post`, ...) over `methods=[...]`.
 
 ```python
 from flask import Flask, abort, jsonify, request
 
 app = Flask(__name__)
+
 
 @app.get("/users/<int:user_id>")
 def get_user(user_id: int):
@@ -130,6 +171,7 @@ def get_user(user_id: int):
 
     return jsonify(user)
 
+
 @app.post("/users")
 def create_user():
     payload = request.get_json(force=False, silent=False)
@@ -137,34 +179,88 @@ def create_user():
         abort(400)
 
     return jsonify(id=123, name=payload["name"]), 201
+
+
+@app.route("/legacy", methods=["GET", "POST"])
+def legacy():
+    if request.method == "POST":
+        ...
+    return "ok"
 ```
 
-Use:
+Converters supported in URL rules: `string` (default), `int`, `float`, `path`, `uuid`, `any`.
+
+### Reading request data
 
 - `request.args` for query parameters
 - `request.form` for HTML form fields
 - `request.files` for uploads
 - `request.get_json()` for JSON request bodies
-- `jsonify(...)` or dict return values for JSON responses
+- `request.headers`, `request.cookies`, `request.remote_addr`
 - `abort(status_code)` for simple HTTP errors
 
-### Templates and static assets
+### Building responses
+
+```python
+from flask import Response, jsonify, make_response, redirect, url_for
+
+
+@app.get("/redirect")
+def go():
+    return redirect(url_for("get_user", user_id=1))
+
+
+@app.get("/raw")
+def raw():
+    response = make_response("hello")
+    response.status_code = 202
+    response.headers["X-Server"] = "flask"
+    return response
+
+
+@app.get("/csv")
+def csv():
+    return Response("a,b\n1,2\n", mimetype="text/csv")
+```
+
+Dict or list return values are auto-JSON-serialized.
+
+## Jinja2 Templates
 
 ```python
 from flask import Flask, render_template
 
 app = Flask(__name__)
 
+
 @app.get("/hello/<name>")
 def hello(name: str):
-    return render_template("hello.html", name=name)
+    return render_template("hello.html", name=name, items=["a", "b"])
+```
+
+`templates/hello.html`
+
+```html
+<!doctype html>
+<title>{{ name }}</title>
+<h1>Hi {{ name|title }}</h1>
+<ul>
+  {% for item in items %}
+    <li>{{ item }}</li>
+  {% else %}
+    <li>none</li>
+  {% endfor %}
+</ul>
+{{ url_for('static', filename='app.css') }}
 ```
 
 - Templates live under `templates/`
 - Static files live under `static/`
 - `__name__` on the `Flask(...)` app tells Flask where to find those resources
+- Jinja auto-escapes HTML; use `|safe` deliberately, not by default
+- Use `{% extends "base.html" %}` and `{% block %}` for layout inheritance
 
-### Sessions
+## Sessions
 
 ```python
 from flask import Flask, redirect, session, url_for
@@ -172,15 +268,23 @@ from flask import Flask, redirect, session, url_for
 app = Flask(__name__)
 app.config["SECRET_KEY"] = "replace-in-production"
 
+
 @app.post("/login")
 def login():
     session["user_id"] = 42
     session.permanent = True
     return redirect(url_for("me"))
 
+
 @app.get("/me")
 def me():
     return {"user_id": session.get("user_id")}
+
+
+@app.post("/logout")
+def logout():
+    session.clear()
+    return redirect(url_for("me"))
 ```
 
 Flask's built-in session uses a signed cookie, not a server-side session store. Keep session payloads small and non-sensitive.
@@ -200,13 +304,13 @@ app.config.update(
 )
 ```
 
-Prefer loading environment-driven config in the factory:
+Loading patterns:
 
 ```python
-def create_app():
-    app = Flask(__name__)
-    app.config.from_prefixed_env()
-    return app
+app.config.from_pyfile("config.py")            # /instance/config.py
+app.config.from_object("myapp.settings")        # importable module or class
+app.config.from_envvar("MYAPP_SETTINGS")        # path read from env var
+app.config.from_prefixed_env()                  # FLASK_FOO -> app.config["FOO"]
 ```
 
 With the default `FLASK_` prefix:
@@ -220,19 +324,131 @@ flask --app myapp:create_app run --debug
 Key config to know in 3.1.x:
 
 - `SECRET_KEY`: required for sessions, flash messages, and many extensions.
-- `SECRET_KEY_FALLBACKS`: lets you rotate signing keys without immediately invalidating active sessions.
-- `TRUSTED_HOSTS`: validates the incoming host header during routing. Use this instead of assuming `SERVER_NAME` will restrict hosts.
+- `SECRET_KEY_FALLBACKS`: rotate signing keys without immediately invalidating active sessions.
+- `TRUSTED_HOSTS`: validates the incoming host header during routing.
 - `MAX_CONTENT_LENGTH`: caps request body size.
-- `MAX_FORM_MEMORY_SIZE` and `MAX_FORM_PARTS`: new in 3.1 for multipart form limits.
-- `SESSION_COOKIE_SECURE`: send cookies only over HTTPS.
-- `SESSION_COOKIE_SAMESITE`: usually `"Lax"` unless cross-site behavior is required.
-- `SESSION_COOKIE_PARTITIONED`: new in 3.1 for embedded third-party cookie scenarios; enabling it also requires secure cookies.
+- `MAX_FORM_MEMORY_SIZE` and `MAX_FORM_PARTS`: 3.1 multipart form limits.
+- `SESSION_COOKIE_SECURE`, `SESSION_COOKIE_SAMESITE`, `SESSION_COOKIE_PARTITIONED`.
 - `TESTING`: enable in tests so exceptions propagate and extensions switch into test-friendly behavior.
 
-Auth note:
+## Error Handlers
 
-- Flask does not ship with a full authentication system.
-- Store auth provider secrets in config or environment, not inline in code.
+```python
+from flask import jsonify
+from werkzeug.exceptions import HTTPException
+
+
+@app.errorhandler(404)
+def not_found(err):
+    return jsonify(error="not_found"), 404
+
+
+@app.errorhandler(HTTPException)
+def http_error(err):
+    return jsonify(error=err.name, code=err.code), err.code
+
+
+@app.errorhandler(Exception)
+def server_error(err):
+    app.logger.exception("unhandled error")
+    return jsonify(error="server_error"), 500
+```
+
+Error handlers can also be registered on blueprints with `@bp.errorhandler(...)` and apply only to routes under that blueprint.
+
+## App Context vs Request Context
+
+Flask uses two stacks of contexts. Both are pushed automatically while handling a request.
+
+- **App context**: `current_app`, `g`. Active whenever any Flask code runs against an app (CLI commands, background jobs you bind manually, request handlers).
+- **Request context**: `request`, `session`. Active only while handling an HTTP request.
+
+When working outside a request (CLI tasks, scripts, background workers), push contexts manually:
+
+```python
+with app.app_context():
+    # current_app, g available; request/session not
+    do_offline_work()
+
+with app.test_request_context("/?x=1"):
+    # request, session also available
+    assert request.args["x"] == "1"
+```
+
+`g` is a per-request scratchpad. It is reset on every request; do not use it for cross-request state.
+
+## Async Views
+
+Flask 3.1.3 supports async views and async request hooks if installed with the `async` extra.
+
+```python
+from flask import Flask, jsonify
+
+app = Flask(__name__)
+
+
+@app.get("/aggregate")
+async def aggregate():
+    result = await fetch_remote_data()
+    return jsonify(result)
+
+
+@app.before_request
+async def before():
+    ...
+```
+
+Important limitations:
+
+- Flask remains a WSGI framework. Each async view runs on a worker thread's event loop.
+- One worker still handles one request/response cycle.
+- Async helps with concurrent IO inside a view, not with serving more requests per worker.
+- Do not spawn background tasks with `asyncio.create_task()` from a view; unfinished tasks are cancelled when the async view completes.
+
+If most of your stack is async-first, or you need websockets and long-lived async workloads, an ASGI-native framework may be a better fit.
+
+## Extension Hooks
+
+Most extensions follow `Extension(app=None)` + `extension.init_app(app)` so they cooperate with the factory pattern.
+
+```python
+# myapp/extensions.py
+from flask_sqlalchemy import SQLAlchemy
+
+db = SQLAlchemy()
+```
+
+```python
+# myapp/__init__.py
+from .extensions import db
+
+
+def create_app():
+    app = Flask(__name__)
+    app.config.from_prefixed_env()
+    db.init_app(app)
+    return app
+```
+
+App-level lifecycle hooks for custom logic:
+
+```python
+@app.before_request
+def open_db():
+    g.db = connect()
+
+
+@app.teardown_request
+def close_db(exc):
+    db_conn = g.pop("db", None)
+    if db_conn is not None:
+        db_conn.close()
+
+
+@app.context_processor
+def inject_globals():
+    return {"site_name": "Acme"}
+```
 
 ## Testing
 
@@ -245,14 +461,17 @@ import pytest
 
 from myapp import create_app
 
+
 @pytest.fixture()
 def app():
     app = create_app({"TESTING": True, "SECRET_KEY": "test-secret"})
     yield app
 
+
 @pytest.fixture()
 def client(app):
     return app.test_client()
+
 
 @pytest.fixture()
 def runner(app):
@@ -264,14 +483,17 @@ def runner(app):
 ```python
 from flask import session
 
+
 def test_index(client):
     response = client.get("/")
     assert response.status_code == 200
+
 
 def test_redirect_chain(client):
     response = client.get("/logout", follow_redirects=True)
     assert response.status_code == 200
     assert response.history
+
 
 def test_modify_session(client):
     with client.session_transaction() as sess:
@@ -280,49 +502,16 @@ def test_modify_session(client):
     response = client.get("/me")
     assert response.json["user_id"] == 1
 
+
 def test_context_access(client):
     with client:
         client.post("/login")
         assert session["user_id"] == 42
 ```
 
-Useful testing primitives:
-
-- `app.test_client()` for HTTP requests without a live server
-- `follow_redirects=True` to assert on final redirected responses
-- `client.session_transaction()` to seed or inspect session state
-- `app.test_cli_runner()` for `@app.cli.command(...)` tests
-- `with app.app_context():` when testing code that needs `current_app`, database bindings, or extension state
-
-## Async Support
-
-Flask 3.1.3 supports async views and async request hooks if installed with the `async` extra.
-
-```python
-from flask import Flask, jsonify
-
-app = Flask(__name__)
-
-@app.get("/aggregate")
-async def aggregate():
-    result = await fetch_remote_data()
-    return jsonify(result)
-```
-
-Important limitations:
-
-- Flask remains a WSGI framework.
-- One worker still handles one request/response cycle.
-- Async helps with concurrent IO inside a view, not with serving more requests per worker.
-- Do not spawn background tasks with `asyncio.create_task()` from a view; unfinished tasks are cancelled when the async view completes.
-
-If most of your stack is async-first, or you need websockets and long-lived async workloads, an ASGI-native framework may be a better fit.
-
 ## Deployment
 
-Do not deploy the development server.
-
-Use a production WSGI server or managed platform, for example:
+Do not deploy the development server. Use a production WSGI server or managed platform, for example:
 
 - Gunicorn
 - Waitress
@@ -336,7 +525,7 @@ Common production concerns:
 - set `TRUSTED_HOSTS`
 - set secure cookie flags
 - configure body/form limits
-- if behind a proxy, configure proxy handling correctly before trusting forwarded headers
+- if behind a proxy, wrap with `werkzeug.middleware.proxy_fix.ProxyFix` before trusting forwarded headers
 
 ## Common Pitfalls
 
@@ -349,25 +538,30 @@ Common production concerns:
 - Binding extensions directly inside module import paths: prefer `extension = Extension()` and `extension.init_app(app)` in the factory.
 - Copying old blog posts that use `FLASK_ENV` or `app.env`: those were removed in Flask 2.3.
 - Relying on `flask.__version__`: deprecated since 3.0. Use `importlib.metadata.version("flask")`.
+- Using `g` to store cross-request state: it is reset every request.
 
 ## Version-Sensitive Notes for 3.1.3
 
-- `3.1.3` is the current PyPI release as of 2026-03-11.
+- `3.1.3` is the current PyPI release as of 2026-05-29 (released 2026-02-19).
 - `3.1.3` is a security-fix release and should not otherwise change behavior relative to the latest feature release.
-- `3.1.2` fixed async `stream_with_context` behavior and corrected session state when using `follow_redirects` in tests.
-- `3.1.1` fixed signing key selection order when `SECRET_KEY_FALLBACKS` is enabled.
-- `3.1.0` added `SECRET_KEY_FALLBACKS`, `TRUSTED_HOSTS`, `MAX_FORM_MEMORY_SIZE`, `MAX_FORM_PARTS`, and `SESSION_COOKIE_PARTITIONED`.
+- `3.1.2` (2025-08-19) fixed async `stream_with_context` behavior and corrected session state when using `follow_redirects` in tests.
+- `3.1.1` (2025-05-13) fixed signing key selection order when `SECRET_KEY_FALLBACKS` is enabled.
+- `3.1.0` (2024-11-13) added `SECRET_KEY_FALLBACKS`, `TRUSTED_HOSTS`, `MAX_FORM_MEMORY_SIZE`, `MAX_FORM_PARTS`, and `SESSION_COOKIE_PARTITIONED`.
 - `3.1.0` also changed `SERVER_NAME` behavior so it no longer restricts incoming requests to that domain.
 
 ## Official Sources
 
-- Flask installation: `https://flask.palletsprojects.com/en/stable/installation/`
-- Flask quickstart: `https://flask.palletsprojects.com/en/stable/quickstart/`
-- Flask configuration: `https://flask.palletsprojects.com/en/stable/config/`
-- Flask testing: `https://flask.palletsprojects.com/en/stable/testing/`
-- Flask async support: `https://flask.palletsprojects.com/en/stable/async-await/`
-- Flask application factories: `https://flask.palletsprojects.com/en/stable/patterns/appfactories/`
-- Flask deployment: `https://flask.palletsprojects.com/en/stable/deploying/`
-- Flask changelog: `https://flask.palletsprojects.com/en/stable/changes/`
-- Flask release page: `https://github.com/pallets/flask/releases/tag/3.1.3`
-- PyPI package: `https://pypi.org/project/Flask/`
+- Flask installation: https://flask.palletsprojects.com/en/stable/installation/
+- Flask quickstart: https://flask.palletsprojects.com/en/stable/quickstart/
+- Flask configuration: https://flask.palletsprojects.com/en/stable/config/
+- Flask testing: https://flask.palletsprojects.com/en/stable/testing/
+- Flask async support: https://flask.palletsprojects.com/en/stable/async-await/
+- Flask application factories: https://flask.palletsprojects.com/en/stable/patterns/appfactories/
+- Flask blueprints: https://flask.palletsprojects.com/en/stable/blueprints/
+- Flask app context: https://flask.palletsprojects.com/en/stable/appcontext/
+- Flask request context: https://flask.palletsprojects.com/en/stable/reqcontext/
+- Flask error handling: https://flask.palletsprojects.com/en/stable/errorhandling/
+- Flask deployment: https://flask.palletsprojects.com/en/stable/deploying/
+- Flask changelog: https://flask.palletsprojects.com/en/stable/changes/
+- Flask release page: https://github.com/pallets/flask/releases/tag/3.1.3
+- PyPI package: https://pypi.org/project/Flask/


### PR DESCRIPTION
docs(django, flask, celery): refresh primary package docs

- Django 6.0.3 → 6.0.5; expanded coverage of project/app structure,
  models + migrations, function/CBV views, URL routing, templates
  (incl. 6.0 partials), forms, admin (inlines + decorator registration),
  ORM querysets + async ORM (`afirst`/`aget`/`acreate`), settings,
  middleware (incl. 6.0 CSP), auth basics
- Flask 3.1.3 unchanged (latest on PyPI); expanded app factory +
  blueprints, routes/request/response, Jinja2, sessions, config loaders,
  error handlers, app vs request context, async views, extension hook
  patterns
- Celery 5.6.2 → 5.6.3; reorganized into app config, `@app.task`/
  `@shared_task`, `.delay()`/`.apply_async()`, worker flags, beat
  schedules with `crontab`, retries, results/state, chains/groups/chords,
  monitoring (events, Flower, inspect)
- `revision` bumped and `updated-on: 2026-05-29`

Verified versions against PyPI.
