### PR TITLE
docs(jest, vitest, playwright): refresh testing-tool docs

### DIFF
--- a/content/jest/docs/jest/javascript/DOC.md
+++ b/content/jest/docs/jest/javascript/DOC.md
@@ -3,9 +3,9 @@ name: jest
 description: "Jest test runner for JavaScript projects, including configuration, async tests, mocks, snapshots, and CLI usage"
 metadata:
   languages: "javascript"
-  versions: "30.3.0"
-  revision: 1
-  updated-on: "2026-03-13"
+  versions: "30.4.2"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "jest,testing,javascript,unit-testing,mocking,snapshots"
 ---
@@ -14,7 +14,7 @@ metadata:
 
 Jest runs JavaScript tests, provides `expect` assertions, includes mock helpers such as `jest.fn()` and `jest.spyOn()`, and supports snapshots and watch mode from the CLI.
 
-This guide covers the common Node.js setup for `jest@30.3.0` and the extra step required for browser-like DOM tests.
+This guide covers the common Node.js setup for `jest@30.4.2` and the extra step required for browser-like DOM tests.
 
 ## Requirements
 
@@ -68,6 +68,27 @@ test('adds two numbers', () => {
   expect(sum(1, 2)).toBe(3);
 });
 ```
+
+Group tests with `describe` and write assertions with `expect` matchers:
+
+```javascript
+const { sum } = require('./sum');
+
+describe('sum', () => {
+  it('returns the sum of two integers', () => {
+    expect(sum(1, 2)).toBe(3);
+    expect(sum(1, 2)).toEqual(3);
+    expect(sum(0, 0)).not.toBeNaN();
+  });
+
+  it('handles negative numbers', () => {
+    expect(sum(-2, 5)).toBeGreaterThan(0);
+    expect(sum(-2, 5)).toBeLessThanOrEqual(3);
+  });
+});
+```
+
+Common matchers include `toBe`, `toEqual`, `toStrictEqual`, `toContain`, `toHaveLength`, `toMatch`, `toThrow`, `toBeNull`, `toBeUndefined`, `toBeTruthy`, `toHaveBeenCalledWith`, and `toHaveBeenCalledTimes`.
 
 Run all tests:
 
@@ -160,6 +181,16 @@ test('handles failures', async () => {
 Use `jest.fn()` for stand-alone mocks and `jest.spyOn()` when you want to replace an existing method temporarily.
 
 ```javascript
+test('records calls on a mock function', () => {
+  const onClick = jest.fn();
+
+  onClick('first');
+  onClick('second');
+
+  expect(onClick).toHaveBeenCalledTimes(2);
+  expect(onClick).toHaveBeenNthCalledWith(2, 'second');
+});
+
 test('spies on Date.now', () => {
   const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1700000000000);
 
@@ -170,6 +201,50 @@ test('spies on Date.now', () => {
 ```
 
 If you use `jest.spyOn()`, restore the original implementation in the test itself or from a shared `afterEach` hook.
+
+Use `jest.mock()` to replace an entire module. The call is hoisted to the top of the file by Jest's Babel transform:
+
+```javascript
+jest.mock('./api');
+
+const { fetchUser } = require('./api');
+const { loadUser } = require('./user-service');
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+test('uses the mocked module', async () => {
+  fetchUser.mockResolvedValue({ id: 'u_1', name: 'Ada' });
+
+  await expect(loadUser('u_1')).resolves.toEqual({ id: 'u_1', name: 'Ada' });
+  expect(fetchUser).toHaveBeenCalledWith('u_1');
+});
+```
+
+## Setup and teardown
+
+Use `beforeAll`, `beforeEach`, `afterEach`, and `afterAll` for shared setup. They can be scoped to a file or to a `describe` block.
+
+```javascript
+let server;
+
+beforeAll(async () => {
+  server = await startTestServer();
+});
+
+afterAll(async () => {
+  await server.close();
+});
+
+beforeEach(() => {
+  server.reset();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+```
 
 ## Snapshot tests
 
@@ -192,6 +267,35 @@ npm test -- -u
 ```
 
 In CI mode, Jest does not write snapshot files unless you explicitly pass `-u` or `--updateSnapshot`.
+
+## ESM notes
+
+Jest's classic transform runs CommonJS by default. To run native ESM tests without a transpiler:
+
+- Use `.mjs` test files or set `"type": "module"` in `package.json`.
+- Run Jest with experimental VM modules:
+
+```bash
+node --experimental-vm-modules node_modules/jest/bin/jest.js
+```
+
+- ESM hoisting of `jest.mock()` does not work the same way. Use `jest.unstable_mockModule()` plus dynamic `import()`:
+
+```javascript
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('./api.js', () => ({
+  fetchUser: jest.fn().mockResolvedValue({ id: 'u_1' }),
+}));
+
+const { loadUser } = await import('./user-service.js');
+
+test('uses the ESM mocked module', async () => {
+  await expect(loadUser('u_1')).resolves.toEqual({ id: 'u_1' });
+});
+```
+
+- Import `jest`, `expect`, `describe`, `test`, and hooks from `@jest/globals` in ESM files; the globals are not injected automatically.
 
 ## DOM tests with jsdom
 
@@ -245,6 +349,24 @@ Run all tests and collect coverage:
 ```bash
 npx jest --coverage
 ```
+
+Configure coverage in `jest.config.cjs`:
+
+```javascript
+/** @type {import('jest').Config} */
+module.exports = {
+  collectCoverage: true,
+  coverageProvider: 'v8',
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'lcov', 'html'],
+  collectCoverageFrom: ['src/**/*.{js,ts}', '!src/**/*.d.ts'],
+  coverageThreshold: {
+    global: { branches: 80, functions: 80, lines: 80, statements: 80 },
+  },
+};
+```
+
+Jest 30 ships two providers: `babel` (default, instrumented through Babel) and `v8` (uses Node's built-in V8 coverage).
 
 Run tests serially in one process:
 

--- a/content/playwright/docs/package/python/DOC.md
+++ b/content/playwright/docs/package/python/DOC.md
@@ -3,9 +3,9 @@ name: package
 description: "Playwright Python package guide for browser automation, end-to-end testing, and authenticated browser flows"
 metadata:
   languages: "python"
-  versions: "1.58.0"
-  revision: 1
-  updated-on: "2026-03-12"
+  versions: "1.60.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "playwright,python,browser,testing,e2e,automation"
 ---
@@ -21,7 +21,7 @@ Use the official `playwright` Python package, install the browser binaries after
 Pin the package version your project expects:
 
 ```bash
-python -m pip install "playwright==1.58.0"
+python -m pip install "playwright==1.60.0"
 ```
 
 Install browser binaries after the package install:
@@ -36,8 +36,8 @@ Common variants:
 python -m playwright install chromium
 python -m playwright install chromium firefox webkit
 python -m playwright install --with-deps chromium
-uv add "playwright==1.58.0"
-poetry add "playwright==1.58.0"
+uv add "playwright==1.60.0"
+poetry add "playwright==1.60.0"
 ```
 
 Notes:
@@ -118,9 +118,51 @@ Playwright's locator API auto-waits for actionability. Prefer:
 - `page.get_by_role(...)`
 - `page.get_by_label(...)`
 - `page.get_by_text(...)`
+- `page.get_by_placeholder(...)`
 - `page.get_by_test_id(...)`
+- `page.locator(...)` for CSS or chained queries when no semantic locator fits
+
+```python
+page.get_by_role("button", name="Sign in").click()
+page.get_by_label("Email").fill("user@example.com")
+page.get_by_test_id("user-menu").click()
+page.locator("main").get_by_role("listitem").first.click()
+```
 
 Avoid writing code that depends on `time.sleep(...)` or fragile selectors when a semantic locator exists.
+
+### Web-first assertions with `expect`
+
+Playwright ships an `expect` helper that auto-retries until the assertion passes or the timeout elapses. Import it from the matching API module:
+
+```python
+from playwright.sync_api import expect, sync_playwright
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    page = browser.new_page()
+    page.goto("https://playwright.dev/")
+
+    docs_link = page.get_by_role("link", name="Docs")
+    expect(docs_link).to_be_visible()
+    expect(docs_link).to_have_attribute("href", "/docs/intro")
+    expect(page).to_have_title("Fast and reliable end-to-end testing for modern web apps | Playwright")
+    expect(page).to_have_url("https://playwright.dev/")
+```
+
+Common assertions: `to_be_visible`, `to_be_hidden`, `to_be_enabled`, `to_be_checked`, `to_have_text`, `to_contain_text`, `to_have_value`, `to_have_count`, `to_have_attribute`, `to_have_url`, `to_have_title`.
+
+For the async API, import `expect` from `playwright.async_api` and `await` each call:
+
+```python
+from playwright.async_api import expect, async_playwright
+
+async with async_playwright() as p:
+    browser = await p.chromium.launch()
+    page = await browser.new_page()
+    await page.goto("https://playwright.dev/")
+    await expect(page.get_by_role("link", name="Docs")).to_be_visible()
+```
 
 ### Bootstrap selectors with codegen when needed
 
@@ -138,12 +180,31 @@ Install the plugin separately:
 python -m pip install pytest-playwright
 ```
 
+The plugin provides ready-made fixtures: `browser`, `context`, `page`, `browser_name`, `browser_type`, `browser_channel`, `playwright`, plus `browser_context_args` and `browser_type_launch_args` for project-level overrides.
+
 Minimal pytest usage:
 
 ```python
-def test_homepage(page):
+from playwright.sync_api import Page, expect
+
+def test_homepage(page: Page):
     page.goto("https://playwright.dev/")
-    assert page.get_by_role("link", name="Docs").is_visible()
+    expect(page.get_by_role("link", name="Docs")).to_be_visible()
+```
+
+Override context defaults at the project level in `conftest.py`:
+
+```python
+import pytest
+
+@pytest.fixture(scope="session")
+def browser_context_args(browser_context_args):
+    return {
+        **browser_context_args,
+        "base_url": "https://example.com",
+        "locale": "en-US",
+        "viewport": {"width": 1440, "height": 900},
+    }
 ```
 
 Common CLI flags:
@@ -152,6 +213,11 @@ Common CLI flags:
 pytest --browser chromium
 pytest --browser firefox --headed
 pytest --device "iPhone 13"
+pytest --tracing retain-on-failure
+pytest --screenshot only-on-failure
+pytest --video retain-on-failure
+pytest --output test-results
+pytest --slowmo 250
 ```
 
 Important plugin behavior:
@@ -246,11 +312,11 @@ Do not call sync Playwright APIs inside an `asyncio` event loop, and do not forg
 
 ### 3. Using brittle selectors
 
-In `1.58`, the deprecated React and Vue locator engines (`_react=`, `_vue=`) and the `:light` CSS extension were removed. Prefer accessibility-first locators and test IDs.
+The deprecated React and Vue locator engines (`_react=`, `_vue=`) and the `:light` CSS extension were removed in `1.58` and remain gone in `1.60`. Prefer accessibility-first locators and test IDs.
 
 ### 4. Assuming old launch options still exist
 
-The `devtools` launch option was removed in `1.58`. Pass Chromium args directly when you need equivalent behavior.
+The `devtools` launch option was removed in `1.58` and is not coming back. Pass Chromium args directly when you need equivalent behavior.
 
 ### 5. Leaking state between tests
 
@@ -260,12 +326,13 @@ A `browser` can host many contexts. Reusing one context across unrelated tests u
 
 Storage-state files and screenshots can contain secrets, account data, or internal URLs. Keep them out of version control unless they are sanitized fixtures created for testing only.
 
-## Version-Sensitive Notes For 1.58.0
+## Version-Sensitive Notes For 1.60.0
 
-- `1.58.0` removed `_react`, `_vue`, `:light`, and the `devtools` launch option.
-- The same release dropped macOS 13 support for WebKit.
+- The `1.58` removals of `_react`, `_vue`, `:light`, and the `devtools` launch option still apply through `1.60`.
+- macOS 13 is no longer a supported target for WebKit.
 - If you are copying older community snippets, expect selector and launch-option drift around these removed features.
-- Auth-state reuse got more robust in recent Playwright releases because `storage_state(indexed_db=True)` can now capture IndexedDB-backed auth state; use it when cookie-only snapshots are not enough.
+- `storage_state(indexed_db=True)` captures IndexedDB-backed auth state; use it when cookie-only snapshots are not enough.
+- Re-run `python -m playwright install` after upgrading to `1.60.0`; the bundled browser binaries change between minor releases.
 
 ## Official Source URLs
 

--- a/content/playwright/docs/playwright/javascript/DOC.md
+++ b/content/playwright/docs/playwright/javascript/DOC.md
@@ -3,9 +3,9 @@ name: playwright
 description: "Playwright for JavaScript and Node.js: browser automation, locators, auth state reuse, and browser installation"
 metadata:
   languages: "javascript"
-  versions: "1.58.2"
-  revision: 1
-  updated-on: "2026-03-13"
+  versions: "1.60.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "playwright,javascript,nodejs,browser,testing,e2e,automation"
 ---
@@ -279,42 +279,216 @@ npm install -D @playwright/test
 npx playwright install
 ```
 
-Minimal `playwright.config.ts`:
+### Configure projects and parallelism
+
+`playwright.config.ts` ties together test discovery, parallel workers, browser projects, traces, and reporters.
 
 ```typescript
 import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: [['list'], ['html', { open: 'never' }]],
   use: {
     baseURL: process.env.E2E_BASE_URL ?? 'http://127.0.0.1:3000',
     trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
   },
   projects: [
-    {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
-    },
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'firefox',  use: { ...devices['Desktop Firefox'] } },
+    { name: 'webkit',   use: { ...devices['Desktop Safari'] } },
+    { name: 'mobile-chrome', use: { ...devices['Pixel 7'] } },
   ],
 });
 ```
 
-Minimal test:
+`fullyParallel: true` runs tests inside a file in parallel; `workers` controls how many processes execute test files concurrently.
+
+### Write tests with `test()` and `expect()`
+
+`test()` defines a test case and receives Playwright's built-in fixtures (`page`, `context`, `browser`, `request`, and friends). `expect()` provides locator-aware web-first assertions that auto-retry until they pass or hit the timeout.
 
 ```typescript
 import { test, expect } from '@playwright/test';
 
 test('homepage shows docs link', async ({ page }) => {
   await page.goto('/');
-  await expect(page.getByRole('link', { name: 'Docs' })).toBeVisible();
+
+  const docsLink = page.getByRole('link', { name: 'Docs' });
+
+  await expect(docsLink).toBeVisible();
+  await expect(docsLink).toHaveAttribute('href', /\/docs/);
 });
 ```
 
-Run it:
+Group related tests with `test.describe()`, share setup with `test.beforeEach()` / `test.afterEach()`, and skip or mark conditionally with `test.skip()`, `test.fixme()`, `test.fail()`, and `test.slow()`:
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('checkout', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/cart');
+  });
+
+  test('renders the cart total', async ({ page }) => {
+    await expect(page.getByTestId('cart-total')).toHaveText(/\$\d+/);
+  });
+
+  test.skip('legacy promo banner', async ({ page }) => {
+    // covered by visual tests instead
+  });
+});
+```
+
+### Locators and web-first assertions
+
+Prefer accessibility-first locators that the runner can auto-wait on:
+
+```typescript
+page.getByRole('button', { name: 'Sign in' });
+page.getByRole('heading', { level: 1, name: 'Dashboard' });
+page.getByLabel('Email');
+page.getByPlaceholder('you@example.com');
+page.getByText('Welcome back');
+page.getByTestId('user-menu');
+page.locator('main').getByRole('list').getByRole('listitem').first();
+```
+
+Common assertions on locators:
+
+```typescript
+await expect(locator).toBeVisible();
+await expect(locator).toBeHidden();
+await expect(locator).toBeEnabled();
+await expect(locator).toBeChecked();
+await expect(locator).toHaveText('Welcome');
+await expect(locator).toContainText('Welcome');
+await expect(locator).toHaveValue('hello');
+await expect(locator).toHaveCount(3);
+await expect(locator).toHaveAttribute('href', /\/docs/);
+await expect(page).toHaveURL(/\/dashboard$/);
+await expect(page).toHaveTitle(/Playwright/);
+```
+
+### Page Object Model
+
+Wrap repeated locator chains and flows in a class to keep tests readable.
+
+`tests/pages/login.page.ts`
+
+```typescript
+import type { Page } from '@playwright/test';
+
+export class LoginPage {
+  constructor(private readonly page: Page) {}
+
+  readonly email = this.page.getByLabel('Email');
+  readonly password = this.page.getByLabel('Password');
+  readonly submit = this.page.getByRole('button', { name: 'Sign in' });
+
+  async goto() {
+    await this.page.goto('/login');
+  }
+
+  async signIn(email: string, password: string) {
+    await this.email.fill(email);
+    await this.password.fill(password);
+    await this.submit.click();
+  }
+}
+```
+
+`tests/login.spec.ts`
+
+```typescript
+import { test, expect } from '@playwright/test';
+import { LoginPage } from './pages/login.page';
+
+test('user can sign in', async ({ page }) => {
+  const login = new LoginPage(page);
+  await login.goto();
+  await login.signIn('user@example.com', 'correct-horse-battery-staple');
+
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+});
+```
+
+### Custom fixtures
+
+Extend `test` with project-specific fixtures so each test gets a ready-to-use object instead of repeating setup.
+
+```typescript
+import { test as base, expect } from '@playwright/test';
+import { LoginPage } from './pages/login.page';
+
+type Fixtures = {
+  loginPage: LoginPage;
+};
+
+export const test = base.extend<Fixtures>({
+  loginPage: async ({ page }, use) => {
+    const loginPage = new LoginPage(page);
+    await loginPage.goto();
+    await use(loginPage);
+  },
+});
+
+export { expect };
+
+test('uses the loginPage fixture', async ({ loginPage, page }) => {
+  await loginPage.signIn('user@example.com', 'correct-horse-battery-staple');
+  await expect(page).toHaveURL(/\/dashboard/);
+});
+```
+
+### Traces, screenshots, and video
+
+Enable artifacts in `use`, and they appear in the HTML report on failure:
+
+```typescript
+use: {
+  trace: 'on-first-retry',     // 'on' | 'off' | 'retain-on-failure' | 'on-first-retry'
+  screenshot: 'only-on-failure', // 'on' | 'off' | 'only-on-failure'
+  video: 'retain-on-failure',
+}
+```
+
+Open the trace viewer for a specific run:
+
+```bash
+npx playwright show-trace test-results/.../trace.zip
+npx playwright show-report
+```
+
+### Codegen
+
+Bootstrap selectors and flows interactively:
+
+```bash
+npx playwright codegen https://example.com
+npx playwright codegen --target=javascript --output=tests/example.spec.ts https://example.com
+```
+
+Simplify generated locators into role/label/test-id forms before committing.
+
+### Running tests
 
 ```bash
 npx playwright test
+npx playwright test tests/login.spec.ts
+npx playwright test -g "sign in"
 npx playwright test --project=chromium --headed
+npx playwright test --workers=4
+npx playwright test --repeat-each=3
+npx playwright test --ui          # interactive UI mode
+npx playwright test --debug       # step through with Playwright Inspector
 ```
 
 ## Common Pitfalls
@@ -351,12 +525,13 @@ A browser can host many contexts. Reusing one context across unrelated tests ten
 
 Storage-state files, screenshots, videos, and traces can contain secrets, account data, and internal URLs. Keep them out of version control unless they are sanitized fixtures created for testing.
 
-## Version-Sensitive Notes For 1.58.2
+## Version-Sensitive Notes For 1.60.0
 
-- Playwright `1.58.x` includes the `1.58.0` breaking removals of `_react`, `_vue`, `:light`, and the Chromium `devtools` launch option.
+- The `1.58.0` breaking removals of `_react`, `_vue`, `:light`, and the Chromium `devtools` launch option still apply through `1.60.x`.
 - If you are copying older snippets, rewrite selector logic around role, label, text, or test-id locators instead of removed selector engines.
 - If you relied on the old `devtools` launch flag, switch to Chromium launch arguments or Playwright Inspector-based debugging.
-- Playwright `1.58` also dropped macOS 13 support for WebKit.
+- macOS 13 is no longer supported for WebKit.
+- Re-run `npx playwright install` after upgrading to `1.60.0`; the browser binaries shipped with this release require a fresh download.
 
 ## Official Source URLs
 

--- a/content/vitest/docs/vitest/javascript/DOC.md
+++ b/content/vitest/docs/vitest/javascript/DOC.md
@@ -3,16 +3,16 @@ name: vitest
 description: "Vitest 4 for JavaScript projects: install it, configure test environments, write tests, mock modules, and run coverage from the CLI"
 metadata:
   languages: "javascript"
-  versions: "4.0.18"
-  revision: 1
-  updated-on: "2026-03-13"
+  versions: "4.1.7"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "vitest,testing,unit-test,mocking,vite"
 ---
 
 # Vitest for JavaScript
 
-Vitest is a test runner for JavaScript and TypeScript projects. In `4.0.18`, the package requires Node.js `^20.0.0 || ^22.0.0 || >=24.0.0`.
+Vitest is a test runner for JavaScript and TypeScript projects. In `4.1.7`, the package requires Node.js `^20.0.0 || ^22.0.0 || >=24.0.0`.
 
 ## Install
 
@@ -132,9 +132,37 @@ npx vitest list
 - `related` runs tests related to changed source files.
 - `list` is useful when Vitest is not picking up the files you expected.
 
-## Setup files
+## Setup and teardown
 
-Use `setupFiles` for test-wide initialization.
+Vitest exposes `beforeAll`, `beforeEach`, `afterEach`, and `afterAll` for shared setup. They scope to the surrounding `describe` block or to the whole file.
+
+```js
+import { afterAll, afterEach, beforeAll, beforeEach, describe, it } from 'vitest'
+
+describe('checkout', () => {
+  let server
+
+  beforeAll(async () => {
+    server = await startTestServer()
+  })
+
+  afterAll(async () => {
+    await server.close()
+  })
+
+  beforeEach(() => {
+    server.reset()
+  })
+
+  afterEach(() => {
+    // per-test cleanup
+  })
+
+  it('runs', () => {})
+})
+```
+
+Use `setupFiles` for project-wide initialization that should apply to every test file.
 
 Example `test/setup.js`:
 
@@ -267,6 +295,55 @@ npm install -D happy-dom
 npx vitest --dom
 ```
 
+## In-source testing
+
+Vitest can run tests that live alongside production code, behind an `import.meta.vitest` guard, so the test bundle is stripped from production builds.
+
+`src/math.js`
+
+```js
+export function add(a, b) {
+  return a + b
+}
+
+if (import.meta.vitest) {
+  const { describe, expect, it } = import.meta.vitest
+  describe('add', () => {
+    it('adds two numbers', () => {
+      expect(add(1, 2)).toBe(3)
+    })
+  })
+}
+```
+
+Enable in `vitest.config.js`:
+
+```js
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    includeSource: ['src/**/*.{js,ts}'],
+  },
+  define: {
+    'import.meta.vitest': 'undefined',
+  },
+})
+```
+
+## Watch mode and UI mode
+
+By default, `vitest` (no `run`) starts in watch mode: it re-runs only the tests affected by file changes, and the CLI accepts interactive commands such as `a` (run all), `f` (only failed), `t` (filter by name), and `q` (quit).
+
+```bash
+npx vitest                  # watch mode (default in TTY)
+npx vitest run              # one-shot, no watch
+npx vitest --ui             # open the @vitest/ui dashboard in the browser
+npx vitest run --reporter=verbose
+```
+
+The UI requires `@vitest/ui` installed as a dev dependency.
+
 ## Snapshots and coverage
 
 Snapshot example:
@@ -299,11 +376,64 @@ npx vitest run --coverage.reporter=text --coverage.reporter=html
 npx vitest run --coverage.thresholds.lines=90
 ```
 
-In `4.0.18`, the built-in coverage defaults are:
+In `4.1.7`, the built-in coverage defaults are:
 
 - `provider: 'v8'`
 - `reportsDirectory: './coverage'`
 - reporters: `text`, `html`, `clover`, and `json`
+
+Vitest supports two coverage providers:
+
+- `v8` (default): uses Node's built-in V8 coverage. Fast, no source transform, but coverage maps back to source via source maps and can show slightly different branch coverage than instrumented runs.
+- `istanbul`: instruments source through Babel. Slower, but matches the long-standing Istanbul reports and works well when you need precise branch coverage.
+
+Install the matching package for the provider you choose:
+
+```bash
+npm install -D @vitest/coverage-v8
+npm install -D @vitest/coverage-istanbul
+```
+
+```js
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: 'istanbul',
+      reporter: ['text', 'html', 'lcov'],
+      include: ['src/**/*.{js,ts}'],
+      thresholds: { lines: 90, functions: 90, branches: 80, statements: 90 },
+    },
+  },
+})
+```
+
+## Browser mode
+
+Vitest can run the same tests inside a real browser (Chromium, Firefox, WebKit) via Playwright or WebDriverIO. Install `@vitest/browser` plus the matching provider, then configure:
+
+```bash
+npm install -D @vitest/browser playwright
+```
+
+```js
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    browser: {
+      enabled: true,
+      provider: 'playwright',
+      instances: [
+        { browser: 'chromium' },
+      ],
+    },
+  },
+})
+```
+
+Run it with `npx vitest --browser` or `npx vitest run --browser`. Browser mode is useful when DOM-only emulation via `jsdom` or `happy-dom` is not faithful enough.
 
 ## Typecheck and UI workflows
 
@@ -328,7 +458,7 @@ npx vitest --ui
 
 ## High-value pitfalls
 
-- Vitest `4.0.18` does not support Node 18; use Node 20, 22, or 24+.
+- Vitest `4.1.7` does not support Node 18; use Node 20, 22, or 24+.
 - If your test files are not discovered, either match the default glob `**/*.{test,spec}.?(c|m)[jt]s?(x)` or set `test.include` explicitly.
 - If `describe`, `it`, or `expect` are undefined, either import them from `vitest` or enable `test.globals`.
 - If DOM globals like `document` are missing, install `jsdom` or `happy-dom` and set the environment.


### PR DESCRIPTION
docs(jest, vitest, playwright): refresh testing-tool docs

- jest 30.3.0 → 30.4.2; expands describe/it/expect matchers,
  `jest.mock`, setup/teardown, native-ESM testing with
  `jest.unstable_mockModule()` + `@jest/globals`, v8/babel coverage config
- vitest 4.0.18 → 4.1.7; adds explicit setup/teardown hooks, in-source
  testing via `import.meta.vitest`, watch + `--ui`, v8-vs-istanbul
  coverage comparison, brief `@vitest/browser` browser-mode section
- @playwright/test 1.58.2 → 1.60.0; rewrites runner section with
  projects/parallel config, web-first locator assertions, Page Object
  Model example, custom fixtures via `test.extend`, tracing/screenshots/
  video, `--ui` and `--debug`
- playwright Python 1.58.0 → 1.60.0; adds web-first `expect` (sync +
  async), broader locator examples, expanded pytest-playwright section
- `revision` bumped and `updated-on: 2026-05-29`

Verified versions against npm and PyPI.
