### PR TITLE
docs(prettier, eslint, esbuild, rollup): refresh JS tooling docs

### DIFF
--- a/content/esbuild/docs/esbuild/javascript/DOC.md
+++ b/content/esbuild/docs/esbuild/javascript/DOC.md
@@ -3,9 +3,9 @@ name: esbuild
 description: "JavaScript bundler and minifier with practical setup for CLI builds, the JavaScript API, watch mode, code splitting, asset loaders, plugins, and bundle analysis."
 metadata:
   languages: "javascript"
-  versions: "0.27.3"
-  revision: 1
-  updated-on: "2026-03-13"
+  versions: "0.28.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "esbuild,build,bundler,minifier,typescript,javascript"
 ---
@@ -18,7 +18,7 @@ This package has no auth flow, no package-specific environment variables, and no
 
 ## Install
 
-`esbuild@0.27.3` requires Node.js 18 or newer.
+`esbuild@0.28.0` requires Node.js 18 or newer.
 
 Install it as a development dependency:
 
@@ -82,11 +82,21 @@ await esbuild.build({
 
 ## CLI builds
 
-### Bundle a browser app
+Frequently used CLI flags:
+
+- `--bundle`: include imports in the output instead of leaving them as external references.
+- `--minify`: minify identifiers, whitespace, and syntax.
+- `--target=<env>`: lowest JavaScript target, for example `es2020`, `node18`, `chrome120`.
+- `--platform=<browser|node|neutral>`: changes resolution and defaults.
+- `--outfile=<path>`: emit one output file.
+- `--outdir=<dir>`: emit multiple files into a directory.
+
+### Bundle and minify a browser app
 
 ```bash
 npx esbuild src/main.ts \
   --bundle \
+  --minify \
   --platform=browser \
   --format=esm \
   --target=es2020 \
@@ -123,6 +133,8 @@ By default, CLI watch mode stops when stdin closes. Use `--watch=forever` if you
 
 ## JavaScript API: basic build
 
+Use `build()` for an async build and `buildSync()` for a blocking synchronous build (avoid `buildSync` in long-running tools, since it blocks the event loop).
+
 ```javascript
 import * as esbuild from "esbuild";
 
@@ -135,6 +147,18 @@ await esbuild.build({
   target: ["es2020"],
   sourcemap: true,
   logLevel: "info",
+});
+```
+
+Synchronous variant:
+
+```javascript
+import * as esbuild from "esbuild";
+
+esbuild.buildSync({
+  entryPoints: ["src/index.ts"],
+  bundle: true,
+  outfile: "dist/app.js",
 });
 ```
 
@@ -196,7 +220,7 @@ await esbuild.build({
 });
 ```
 
-Common loader values include `js`, `jsx`, `ts`, `tsx`, `json`, `css`, `text`, `file`, `dataurl`, and `binary`.
+Common loader values include `js`, `jsx`, `ts`, `tsx`, `json`, `css`, `text`, `file`, `dataurl`, and `binary`. esbuild infers `jsx`/`tsx` from file extensions by default; the `css` loader bundles CSS imports into the output.
 
 ## Code splitting
 
@@ -215,6 +239,14 @@ await esbuild.build({
 ```
 
 Code splitting currently only works with `format: "esm"`.
+
+## Tree-shaking
+
+esbuild tree-shakes ESM imports by default when `bundle: true`. Side effects in modules are preserved unless the consuming package declares `"sideEffects": false` in its `package.json` (or an array of files that do have side effects). To force aggressive elimination of unused code at the top level of an entry point, set `treeShaking: true` on `build()` (defaults to `true` when bundling or minifying). For best results:
+
+- Author and consume ES modules instead of CommonJS, so esbuild can statically analyze imports.
+- Mark library packages as side-effect-free in their `package.json` when appropriate.
+- Avoid wildcard re-exports that pull in modules that are never used.
 
 ## Watch mode and local dev server
 
@@ -254,7 +286,7 @@ Use `ctx.rebuild()` when you want an explicit rebuild, `ctx.cancel()` to stop an
 
 ## Transform source without bundling
 
-Use `transform()` when you have source code in memory and only need transpilation or minification.
+Use `transform()` when you have source code in memory and only need transpilation or minification. A `transformSync()` variant is also available.
 
 ```javascript
 import * as esbuild from "esbuild";

--- a/content/eslint/docs/eslint/javascript/DOC.md
+++ b/content/eslint/docs/eslint/javascript/DOC.md
@@ -3,9 +3,9 @@ name: eslint
 description: "ESLint for JavaScript projects, including flat config setup, CLI usage, autofix, ignore patterns, and the Node.js API."
 metadata:
   languages: "javascript"
-  versions: "10.0.3"
-  revision: 1
-  updated-on: "2026-03-13"
+  versions: "10.4.1"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "eslint,javascript,linting,node,cli,npm"
 ---
@@ -23,19 +23,27 @@ npm install --save-dev eslint
 npx eslint --version
 ```
 
-## Initialization and Config
+## Flat Config (`eslint.config.js`)
 
 The main setup step is creating a flat config file. If your project is not already using ESM, use `eslint.config.mjs`. If your package already sets `"type": "module"`, `eslint.config.js` works too.
 
+A flat config is an array of config objects. Each object can include `files`, `ignores`, `languageOptions`, `plugins`, `rules`, and `extends`.
+
 ```js
+import js from "@eslint/js";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
   {
-    ignores: ["dist/**", "coverage/**"],
+    ignores: ["dist/**", "coverage/**", "**/*.min.js"],
   },
   {
     files: ["**/*.js", "**/*.mjs", "**/*.cjs"],
+    extends: [js.configs.recommended],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+    },
     rules: {
       eqeqeq: "error",
       "no-console": "warn",
@@ -46,7 +54,68 @@ export default defineConfig([
 ]);
 ```
 
+Install the recommended JS config:
+
+```bash
+npm install --save-dev @eslint/js
+```
+
 ESLint reads `eslint.config.*` automatically when you run the CLI from the project root.
+
+### TypeScript setup
+
+For TypeScript, install `typescript-eslint` and its parser, then add a config block for `.ts` and `.tsx` files:
+
+```bash
+npm install --save-dev typescript-eslint
+```
+
+```js
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import { defineConfig } from "eslint/config";
+
+export default defineConfig([
+  {
+    files: ["**/*.js", "**/*.mjs", "**/*.cjs"],
+    extends: [js.configs.recommended],
+  },
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    extends: [...tseslint.configs.recommended],
+  },
+]);
+```
+
+### Plugins
+
+Plugins are registered in the `plugins` map and referenced by name in `rules`. For example, with `eslint-plugin-import`:
+
+```js
+import importPlugin from "eslint-plugin-import";
+
+export default [
+  {
+    plugins: { import: importPlugin },
+    rules: {
+      "import/no-cycle": "error",
+      "import/order": "warn",
+    },
+  },
+];
+```
+
+Common community plugins worth knowing: `typescript-eslint`, `eslint-plugin-import`, `eslint-plugin-react`, `eslint-plugin-react-hooks`, `eslint-plugin-jsx-a11y`, `eslint-plugin-n` (Node), and `eslint-plugin-unicorn`.
+
+### Ignoring files
+
+Put ignore patterns in the flat config rather than a separate `.eslintignore` (no longer supported with flat config). A config object with only `ignores` applies globally:
+
+```js
+export default [
+  { ignores: ["dist/**", "build/**", "coverage/**"] },
+];
+```
 
 ## CLI Workflows
 
@@ -63,6 +132,8 @@ npx eslint . --fix
 # Use an explicit config path
 npx eslint . --config eslint.config.mjs
 ```
+
+`--fix` only rewrites violations whose rule provides a fixer; remaining errors are still reported.
 
 ESLint exits with a non-zero status when it finds errors, so the same command works in local scripts and CI.
 
@@ -124,7 +195,7 @@ Pass `filePath` when you call `lintText()` if your config uses `files` globs. Th
 
 ## Version-Sensitive Notes
 
-- This guide targets `eslint@10.0.3`.
+- This guide targets `eslint@10.4.1`.
 - Current maintainer docs describe the flat config system and the `defineConfig()` helper from `eslint/config` for JavaScript projects.
 - The `ESLint` class is the main programmatic entry point for linting files and strings from Node.js.
 

--- a/content/prettier/docs/prettier/javascript/DOC.md
+++ b/content/prettier/docs/prettier/javascript/DOC.md
@@ -3,9 +3,9 @@ name: prettier
 description: "Prettier 3 guide for JavaScript projects, including CLI usage, config files, ignore rules, and the async Node API."
 metadata:
   languages: "javascript"
-  versions: "3.8.1"
-  revision: 1
-  updated-on: "2026-03-13"
+  versions: "3.8.3"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "javascript,prettier,formatting,code-style,cli"
 ---
@@ -49,10 +49,19 @@ Create `.prettierrc.json` in your project root:
 {
   "semi": true,
   "singleQuote": true,
+  "tabWidth": 2,
   "trailingComma": "all",
   "printWidth": 100
 }
 ```
+
+Common options:
+
+- `semi`: print semicolons at the end of statements (default `true`).
+- `singleQuote`: use `'` instead of `"` for strings (default `false`).
+- `tabWidth`: number of spaces per indent level (default `2`).
+- `trailingComma`: `"all"`, `"es5"`, or `"none"` (default `"all"`).
+- `printWidth`: line length the printer will wrap at (default `80`).
 
 Prettier resolves config from the file path you format. It can also read `.editorconfig` unless you disable that behavior with `--no-editorconfig` in the CLI or `editorconfig: false` in the API.
 
@@ -75,11 +84,15 @@ node_modules
 npx prettier . --write
 ```
 
+`--write` edits matching files in place; use it for local formatting commands and pre-commit hooks.
+
 ### Check formatting in CI
 
 ```bash
 npx prettier . --check
 ```
+
+`--check` does not modify files. It logs files that are not formatted and exits non-zero, which is what you want in CI.
 
 ### List only files that need formatting
 
@@ -195,6 +208,20 @@ async function formatIfSupported(filePath) {
 - The CLI ignores `node_modules` by default. Use `--with-node-modules` only when you explicitly want to format files there.
 - If you are writing an editor or long-running tool that watches config files, call `await prettier.clearConfigCache()` after config changes.
 
+### Using Prettier with ESLint
+
+Install `eslint-config-prettier` and add it to your ESLint config to turn off ESLint rules that conflict with Prettier formatting:
+
+```bash
+npm install -D eslint-config-prettier
+```
+
+Run ESLint for code-quality rules and Prettier for formatting; let `eslint-config-prettier` disable the overlapping ESLint stylistic rules so the two tools do not fight each other.
+
+### Format on save in your editor
+
+Install the Prettier extension for your editor (for example "Prettier - Code formatter" in VS Code), set Prettier as the default formatter, and enable format-on-save. The editor will then run Prettier with the project's `.prettierrc` config every time you save a file.
+
 ## Important Pitfalls
 
 - Do not treat the Node API as synchronous in Prettier 3; the core methods shown here return promises.
@@ -205,7 +232,7 @@ async function formatIfSupported(filePath) {
 
 ## Version Notes
 
-- This guide targets `prettier` `3.8.1`.
+- This guide targets `prettier` `3.8.3`.
 - The API examples here follow the async Prettier 3 API shape documented for the current 3.x line.
 
 ## Official Sources

--- a/content/rollup/docs/rollup/javascript/DOC.md
+++ b/content/rollup/docs/rollup/javascript/DOC.md
@@ -3,9 +3,9 @@ name: rollup
 description: "JavaScript guide for installing Rollup 4, authoring a minimal config, using the CLI and JavaScript API, and handling watch mode and library externals."
 metadata:
   languages: "javascript"
-  versions: "4.59.0"
-  revision: 1
-  updated-on: "2026-03-13"
+  versions: "4.60.4"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "rollup,bundler,build,javascript,cli,node-api"
 ---
@@ -19,7 +19,7 @@ There is no authentication step and no required package-specific environment var
 ## Prerequisites
 
 - Node.js. Use a current Node LTS for modern ESM-based build tooling.
-- `rollup@4.59.0`
+- `rollup@4.60.4`
 - Optional plugins such as TypeScript, CommonJS, or Node resolution plugins when your project needs them
 
 ## Install
@@ -50,7 +50,7 @@ Add scripts in `package.json`:
 }
 ```
 
-Create `rollup.config.mjs`:
+Create `rollup.config.mjs` (or `rollup.config.js` when the package is ESM):
 
 ```javascript
 import { defineConfig } from "rollup";
@@ -66,6 +66,22 @@ export default defineConfig({
   },
 });
 ```
+
+Key config fields:
+
+- `input`: a string, array, or `{ [name]: path }` map of entry points.
+- `output`: a single output object or an array of them. Each output has `file` (single bundle) or `dir` (multi-chunk), plus `format`, `sourcemap`, and optional `name` for browser globals.
+- `external`: package names or a function that returns `true` for imports that must remain external.
+- `plugins`: array of Rollup plugins, applied in order.
+
+### Output formats
+
+`output.format` controls the module system of the generated bundle:
+
+- `es` (also `esm`): standard ES modules.
+- `cjs`: CommonJS for Node.js consumers.
+- `umd`: UMD bundle for browsers and module loaders, requires `output.name`.
+- `iife`: self-executing function for direct `<script>` use, requires `output.name`.
 
 Create a matching entry file:
 
@@ -239,6 +255,74 @@ export default defineConfig({
 
 For UMD and IIFE browser builds that expose exports, set `output.name` or pass `--name` on the CLI.
 
+## Common plugins
+
+Rollup ships only the core bundler. Add plugins for ecosystem features:
+
+```bash
+npm install --save-dev @rollup/plugin-node-resolve @rollup/plugin-commonjs @rollup/plugin-terser @rollup/plugin-typescript
+```
+
+```javascript
+import { defineConfig } from "rollup";
+import resolve from "@rollup/plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
+import terser from "@rollup/plugin-terser";
+import typescript from "@rollup/plugin-typescript";
+
+export default defineConfig({
+  input: "src/index.ts",
+  output: {
+    dir: "dist",
+    format: "es",
+    sourcemap: true,
+  },
+  plugins: [
+    resolve(),
+    commonjs(),
+    typescript(),
+    terser(),
+  ],
+});
+```
+
+- `@rollup/plugin-node-resolve`: locate modules in `node_modules` using Node resolution.
+- `@rollup/plugin-commonjs`: convert CommonJS dependencies into ES modules so Rollup can bundle them.
+- `@rollup/plugin-typescript`: compile TypeScript through the TypeScript compiler.
+- `@rollup/plugin-terser`: minify the output.
+
+## Tree-shaking
+
+Rollup performs tree-shaking by default for ES module input. It can drop exports that are never imported, dead branches, and modules with no side effects. To make tree-shaking effective:
+
+- Author and consume code as ES modules.
+- Set `"sideEffects": false` in `package.json` for library code without runtime side effects, or list the specific files that do.
+- Avoid CommonJS interop on the hot path; if you must include CJS dependencies, isolate them through `@rollup/plugin-commonjs`.
+
+## Code splitting and multiple chunks
+
+When Rollup needs to emit more than one chunk (multiple entry points or dynamic `import()`), use `output.dir` instead of `output.file`.
+
+```javascript
+import { defineConfig } from "rollup";
+
+export default defineConfig({
+  input: {
+    home: "src/home.js",
+    admin: "src/admin.js",
+  },
+  output: {
+    dir: "dist",
+    format: "es",
+    entryFileNames: "[name].js",
+    chunkFileNames: "chunks/[name]-[hash].js",
+    sourcemap: true,
+  },
+});
+```
+
+Dynamic `import("./feature.js")` calls inside any entry point are turned into separate chunks automatically. Use `manualChunks` on `output` for fine-grained control over how shared modules group together.
+
 ## Important pitfalls
 
 - Use `output.file` for a single bundle and `output.dir` when Rollup needs to emit multiple chunks.
@@ -250,6 +334,6 @@ For UMD and IIFE browser builds that expose exports, set `output.name` or pass `
 
 ## Version notes
 
-- This guide targets `rollup@4.59.0`.
+- This guide targets `rollup@4.60.4`.
 - The package exports `defineConfig`, `rollup`, and `watch` from `rollup`.
 - The package also exports `rollup/loadConfigFile`, `rollup/getLogFilter`, and `rollup/parseAst` as subpaths for tooling integrations.


### PR DESCRIPTION
docs(prettier, eslint, esbuild, rollup): refresh JS tooling docs

- prettier 3.8.1 → 3.8.3; expanded `.prettierrc` coverage,
  `--check` vs `--write`, `eslint-config-prettier` integration note,
  format-on-save hint
- eslint 10.0.3 → 10.4.1; restructured flat config section with
  `@eslint/js` recommended extends, TypeScript via `typescript-eslint`,
  plugins example with `eslint-plugin-import`, flat-config-only ignoring,
  `--fix` note
- esbuild 0.27.3 → 0.28.0; CLI flag reference, `--minify` in browser
  example, `buildSync()`/`transformSync()`, jsx/tsx/css loaders,
  tree-shaking section
- rollup 4.59.0 → 4.60.4; input/output/external/plugins breakdown,
  es/cjs/umd/iife formats, common plugins (`@rollup/plugin-node-resolve`,
  `commonjs`, `terser`, `typescript`), tree-shaking, code-splitting with
  multiple inputs and dynamic import
- `revision` bumped and `updated-on: 2026-05-29`

Verified versions against npm `latest`.
