### PR TITLE
docs(cohere, mistralai, groq): refresh LLM SDK docs

### DIFF
--- a/content/cohere/docs/llm/DOC.md
+++ b/content/cohere/docs/llm/DOC.md
@@ -3,8 +3,9 @@ name: llm
 description: "Cohere API JavaScript/TypeScript SDK coding guide for LLM, embeddings, and rerank"
 metadata:
   languages: "javascript"
-  versions: "7.19.0"
-  updated-on: "2026-03-02"
+  versions: "8.0.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "cohere,llm,ai,embeddings,rerank"
 ---
@@ -819,7 +820,7 @@ async function chatWithBackoff(messages, retries = 3, delay = 1000) {
 
 ### Model Selection
 
-**Current Production Models (as of 2025):** `command-a-03-2025` (latest Command A model with 256K context, 111B parameters, highest throughput - 150% faster than Command R+), `command-r-plus-08-2024` (Command R+ with strong reasoning capabilities), `embed-english-v3.0` (English embeddings with 1024 dimensions), `embed-multilingual-v3.0` (multilingual embeddings supporting 100+ languages), `rerank-english-v3.0` (English reranking model), and `rerank-multilingual-v3.0` (multilingual reranking).
+**Current Production Models (verified May 2026):** `command-a-03-2025` (latest Command A model with 256K context, 111B parameters, highest throughput - 150% faster than Command R+), `command-r-plus-08-2024` (Command R+ with strong reasoning capabilities), `embed-english-v3.0` (English embeddings with 1024 dimensions), `embed-multilingual-v3.0` (multilingual embeddings supporting 100+ languages), `rerank-english-v3.0` (English reranking model), and `rerank-multilingual-v3.0` (multilingual reranking). Verify current model IDs in the Cohere docs before deploying — model availability evolves independently of the SDK version.
 
 **Choosing the right model:**
 
@@ -1017,12 +1018,13 @@ class EmbeddingCache {
 // package.json - Pin exact SDK version
 {
   "dependencies": {
-    "cohere-ai": "7.14.0"
+    "cohere-ai": "8.0.0"
   }
 }
 ```
 
 - Pin exact SDK version in `package.json`
+- `cohere-ai` 8.x requires Node.js 18 or higher
 - Review changelog before upgrading
 - Test thoroughly in staging before production deployment
 - Monitor Cohere's release notes for breaking changes

--- a/content/cohere/docs/package/python/DOC.md
+++ b/content/cohere/docs/package/python/DOC.md
@@ -3,9 +3,9 @@ name: package
 description: "Cohere Python SDK guide for chat, embeddings, rerank, classification, and async usage"
 metadata:
   languages: "python"
-  versions: "5.20.7"
-  revision: 1
-  updated-on: "2026-03-12"
+  versions: "7.0.2"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "cohere,python,llm,chat,embeddings,rerank"
 ---
@@ -19,7 +19,7 @@ Use the official `cohere` PyPI package when a Python project needs Cohere-hosted
 - Ecosystem: `pypi`
 - Package: `cohere`
 - Import: `import cohere`
-- Version covered here: `5.20.7`
+- Version covered here: `7.0.2`
 - Official docs root: `https://docs.cohere.com/`
 - Reference landing page: `https://docs.cohere.com/reference/about`
 
@@ -28,7 +28,7 @@ Use the official `cohere` PyPI package when a Python project needs Cohere-hosted
 Install the package directly:
 
 ```bash
-pip install cohere==5.20.7
+pip install cohere==7.0.2
 ```
 
 If the project does not need an exact pin, `pip install cohere` is the normal install path.
@@ -106,6 +106,67 @@ async def main() -> None:
 
 asyncio.run(main())
 ```
+
+### Streaming Chat
+
+Use `chat_stream` to consume tokens as they arrive. Events are typed; check the `type` field before reading deltas.
+
+```python
+import os
+import cohere
+
+co = cohere.ClientV2(api_key=os.environ["CO_API_KEY"])
+
+stream = co.chat_stream(
+    model="command-a-03-2025",
+    messages=[{"role": "user", "content": "Count from 1 to 5."}],
+)
+
+for event in stream:
+    if event.type == "content-delta":
+        text = event.delta.message.content.text
+        if text:
+            print(text, end="", flush=True)
+print()
+```
+
+### Tool / Function Calling
+
+Pass JSON-schema tool definitions and inspect `tool_calls` on the returned message.
+
+```python
+import os
+import cohere
+
+co = cohere.ClientV2(api_key=os.environ["CO_API_KEY"])
+
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the current weather for a city.",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    }
+]
+
+response = co.chat(
+    model="command-a-03-2025",
+    messages=[{"role": "user", "content": "What is the weather in Berkeley?"}],
+    tools=tools,
+)
+
+if response.message.tool_calls:
+    for call in response.message.tool_calls:
+        print(call.function.name, call.function.arguments)
+```
+
+The `arguments` value is a JSON string. To finish a tool round trip, append a `{"role": "tool", "tool_call_id": call.id, "content": ...}` message and call `co.chat(...)` again with the same `tools` list.
 
 ### Embeddings
 
@@ -198,10 +259,11 @@ print(response.classifications[0].prediction)
 - Assuming the embed response is always a plain list. In v2, embeddings are typed, for example `response.embeddings.float_`.
 - Catching broad exceptions only. Use `cohere.core.api_error.ApiError` for request failures you expect from the SDK.
 
-## Version-Sensitive Notes For `5.20.7`
+## Version-Sensitive Notes For `7.0.2`
 
-- This doc is pinned to `cohere` `5.20.7`, but the official docs site is organized around the current v2 API docs rather than versioned per package release.
-- The official `cohere-python` repository includes a v4-to-v5 migration guide. If a codebase still uses pre-v5 snippets, check that guide before rewriting imports or error handling.
+- This doc is pinned to `cohere` `7.0.2`, but the official docs site is organized around the current v2 API docs rather than versioned per package release.
+- `cohere` 7.x continues to expose `ClientV2` and `AsyncClientV2` as the default entry points; legacy `cohere.Client` (v1) snippets should be migrated.
+- The official `cohere-python` repository includes a v4-to-v5 migration guide. If a codebase still uses pre-v5 snippets, check that guide before rewriting imports or error handling. The 6.x and 7.x lines have been incremental on top of the v5 surface.
 - The docs URL points to the API reference landing page. For implementation work, the most useful current pages are under `https://docs.cohere.com/v2/docs/`.
 
 ## Official Sources

--- a/content/groq/docs/package/python/DOC.md
+++ b/content/groq/docs/package/python/DOC.md
@@ -3,9 +3,9 @@ name: package
 description: "Groq Python SDK for chat completions, streaming, async clients, and audio transcription"
 metadata:
   languages: "python"
-  versions: "1.1.1"
-  revision: 1
-  updated-on: "2026-03-12"
+  versions: "1.4.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "groq,llm,inference,chat,streaming,audio"
 ---
@@ -16,14 +16,14 @@ metadata:
 
 Use `groq` when you want the official Groq Python SDK for server-side text generation, streaming chat completions, async calls, and speech-to-text requests.
 
-This entry is pinned to package version `1.1.1`.
+This entry is pinned to package version `1.4.0`.
 
 ## Install
 
 Install the pinned version when you need this exact SDK surface:
 
 ```bash
-pip install groq==1.1.1
+pip install groq==1.4.0
 ```
 
 If you are not pinning strictly, install the latest compatible release for the project and then confirm the API surface against the installed version:
@@ -64,7 +64,7 @@ That implicit style depends on `GROQ_API_KEY` already being set in the environme
 
 ### Chat Completions
 
-`groq` `1.1.1` uses the `client.chat.completions.create(...)` pattern.
+`groq` `1.4.0` uses the `client.chat.completions.create(...)` pattern.
 
 ```python
 from groq import Groq
@@ -72,7 +72,7 @@ from groq import Groq
 client = Groq()
 
 completion = client.chat.completions.create(
-    model="your-model-id",
+    model="llama-3.3-70b-versatile",
     messages=[
         {"role": "system", "content": "You are a concise assistant."},
         {"role": "user", "content": "Summarize the benefits of HTTP keep-alive."},
@@ -81,6 +81,8 @@ completion = client.chat.completions.create(
 
 print(completion.choices[0].message.content)
 ```
+
+Current production models (verified May 2026) include `llama-3.3-70b-versatile`, `llama-3.1-8b-instant`, `openai/gpt-oss-120b`, and `openai/gpt-oss-20b`. Confirm available model IDs in the Groq Console before deploying — the model catalog changes faster than the SDK does.
 
 Response objects are typed models rather than plain dictionaries. Access fields with attributes such as `completion.choices[0].message.content`. If you need plain data for logging or serialization, use the model helpers shown in the upstream README, such as `to_json()` and `to_dict()`.
 
@@ -94,7 +96,7 @@ from groq import Groq
 client = Groq()
 
 stream = client.chat.completions.create(
-    model="your-model-id",
+    model="llama-3.3-70b-versatile",
     messages=[
         {"role": "user", "content": "Count from 1 to 5."},
     ],
@@ -121,7 +123,7 @@ client = AsyncGroq()
 
 async def main() -> None:
     completion = await client.chat.completions.create(
-        model="your-model-id",
+        model="llama-3.3-70b-versatile",
         messages=[
             {"role": "user", "content": "Give me three commit message tips."},
         ],
@@ -132,6 +134,47 @@ asyncio.run(main())
 ```
 
 Do not `await` the synchronous `Groq` client, and do not call `AsyncGroq` from sync code without an event loop.
+
+### Tool / Function Calling
+
+Pass OpenAI-compatible tool definitions and inspect `tool_calls` on the response message:
+
+```python
+from groq import Groq
+
+client = Groq()
+
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the current weather for a city.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string"},
+                },
+                "required": ["city"],
+            },
+        },
+    }
+]
+
+completion = client.chat.completions.create(
+    model="llama-3.3-70b-versatile",
+    messages=[{"role": "user", "content": "What is the weather in Berkeley?"}],
+    tools=tools,
+    tool_choice="auto",
+)
+
+message = completion.choices[0].message
+if message.tool_calls:
+    for call in message.tool_calls:
+        print(call.function.name, call.function.arguments)
+```
+
+The arguments field is a JSON string; parse it with `json.loads(...)` before calling your function. Append a `{"role": "tool", "tool_call_id": ..., "content": ...}` message and re-call `chat.completions.create` to complete the round trip.
 
 ### Audio Transcription
 
@@ -182,7 +225,7 @@ client = Groq()
 
 try:
     client.chat.completions.create(
-        model="your-model-id",
+        model="llama-3.3-70b-versatile",
         messages=[{"role": "user", "content": "Ping"}],
     )
 except APIConnectionError as exc:
@@ -197,18 +240,18 @@ The SDK README also documents specific subclasses such as `RateLimitError`.
 
 - `groq` is the package name and the import namespace. Use `from groq import Groq`, not `import groq as client`.
 - The SDK version and the available hosted models are separate concerns. Verify current model IDs in Groq Console docs before hard-coding them.
-- Some Groq docs pages still show older setup text. For package `1.1.1`, rely on package metadata and the SDK repo for Python compatibility: `>=3.8`.
+- Some Groq docs pages still show older setup text. For package `1.4.0`, rely on package metadata and the SDK repo for Python compatibility: `>=3.10`.
 - Responses are typed objects, not raw dictionaries. Attribute access is the default path.
 - Streaming chunks can contain empty deltas. Guard against `None` or empty strings before concatenating output.
 - If you rely on implicit environment loading, missing `GROQ_API_KEY` failures can be delayed until runtime. In deployed code, `os.environ["GROQ_API_KEY"]` is usually the safer setup.
 - Default retries can mask whether a failure was transient. For debugging or idempotency-sensitive workflows, set `max_retries=0`.
 
-## Version-Sensitive Notes For `1.1.1`
+## Version-Sensitive Notes For `1.4.0`
 
-- This doc is intentionally pinned to version used here `1.1.1`.
-- The package surface verified from official sources includes sync and async clients, chat completions, streaming, audio transcriptions, translations, typed responses, retries, and timeout configuration.
+- This doc is intentionally pinned to version used here `1.4.0`.
+- The package surface verified from official sources includes sync and async clients, chat completions, streaming, tool/function calling, audio transcriptions, translations, typed responses, retries, and timeout configuration.
 - Groq Console docs describe the live platform and can drift ahead of a pinned SDK release. If an example from the console does not match installed code, confirm the local SDK version first.
-- The docs landing page currently contains older Python-version wording in places. The maintained SDK metadata and README indicate Python `3.8+` for this package line.
+- The current `1.x` line targets Python `>=3.10`. Codebases on 3.9 should pin an older `groq` release or upgrade the runtime before adopting `1.4.0`.
 
 ## Official Sources Used
 

--- a/content/mistralai/docs/package/python/DOC.md
+++ b/content/mistralai/docs/package/python/DOC.md
@@ -3,9 +3,9 @@ name: package
 description: "Mistral AI Python SDK for chat completions, embeddings, files, OCR, and related platform APIs"
 metadata:
   languages: "python"
-  versions: "2.0.0"
-  revision: 1
-  updated-on: "2026-03-12"
+  versions: "2.4.8"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "mistral,mistralai,llm,chat,embeddings,ocr,agents"
 ---
@@ -14,7 +14,7 @@ metadata:
 
 ## Golden Rule
 
-For `mistralai==2.0.0`, use the current official v2 SDK patterns and check the migration guide before copying older code.
+For `mistralai==2.4.8`, use the current official v2 SDK patterns and check the migration guide before copying older code.
 
 - New code can follow the official README import style: `from mistralai import Mistral`
 - If you are migrating v1 code, replace `MistralClient` with `Mistral`
@@ -23,15 +23,15 @@ For `mistralai==2.0.0`, use the current official v2 SDK patterns and check the m
 ## Installation
 
 ```bash
-pip install mistralai==2.0.0
+pip install mistralai==2.4.8
 ```
 
 ```bash
-uv add mistralai==2.0.0
+uv add mistralai==2.4.8
 ```
 
 ```bash
-poetry add mistralai==2.0.0
+poetry add mistralai==2.4.8
 ```
 
 Optional extras exposed by the package metadata:
@@ -135,6 +135,47 @@ print(len(vectors), len(vectors[0]))
 
 The response is model-backed data, so use attribute access like `response.data` and `item.embedding`.
 
+### Tool / Function Calling
+
+Pass JSON-schema tool definitions and inspect `tool_calls` on the assistant message.
+
+```python
+import os
+
+from mistralai import Mistral
+
+client = Mistral(api_key=os.environ["MISTRAL_API_KEY"])
+
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the current weather for a city.",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    }
+]
+
+response = client.chat.complete(
+    model="mistral-small-latest",
+    messages=[{"role": "user", "content": "What is the weather in Berkeley?"}],
+    tools=tools,
+    tool_choice="auto",
+)
+
+message = response.choices[0].message
+if message.tool_calls:
+    for call in message.tool_calls:
+        print(call.function.name, call.function.arguments)
+```
+
+The `arguments` field is a JSON string; parse it before invoking your function. To complete a tool round trip, append a `{"role": "tool", "tool_call_id": call.id, "name": ..., "content": ...}` message and call `chat.complete` again.
+
 ### File Upload And OCR
 
 OCR requires an upload step first.
@@ -208,14 +249,14 @@ If your project uses a non-default provider, check the migration guide before ad
 ## Common Pitfalls
 
 - Mixing v1 and v2 examples. `MistralClient`, `ChatMessage`, and dict-style response handling are migration clues that you are looking at older code.
-- Assuming the SDK version pins a model version. SDK version `2.0.0` and model aliases like `mistral-small-latest` are separate concerns.
+- Assuming the SDK version pins a model version. SDK version `2.4.8` and model aliases like `mistral-small-latest` are separate concerns.
 - Treating streamed events like final responses. Build the output from deltas.
 - Forgetting the file upload step for OCR and other file-based workflows.
 - Copying third-party snippets that use unofficial import paths or outdated async helpers.
 
 ## Recommended Agent Workflow
 
-1. Install `mistralai==2.0.0` and confirm Python `>=3.9`.
+1. Install `mistralai==2.4.8` and confirm Python `>=3.10` (current SDK line dropped 3.9 support).
 2. Set `MISTRAL_API_KEY` and create a single shared `Mistral` client.
 3. Start with `chat.complete` or `chat.stream` for normal LLM calls.
 4. Add `embeddings.create`, `files.upload`, or `ocr.process` only when the task actually needs them.


### PR DESCRIPTION
docs(cohere, mistralai, groq): refresh LLM SDK docs

- cohere-ai (npm) 7.19.0 → 8.0.0; Node ≥18 required; "as of 2025" model
  note refreshed to "verified May 2026"
- cohere (PyPI) 5.20.7 → 7.0.2; adds Streaming Chat (`chat_stream`) and
  Tool/Function Calling sections
- mistralai 2.0.0 → 2.4.8; adds Tool/Function Calling section using
  `client.chat.complete` with `tools=`/`tool_choice`; Python floor
  raised to ≥3.10
- groq 1.1.1 → 1.4.0; replaces placeholders with current production model
  `llama-3.3-70b-versatile`; adds Tool/Function Calling section; Python
  floor raised to ≥3.10
- `revision` bumped and `updated-on: 2026-05-29`

Verified versions against npm and PyPI.
