### PR TITLE
docs(gemini): refresh to google-genai 2.7.0

### DIFF
--- a/content/gemini/docs/deep-research/javascript/DOC.md
+++ b/content/gemini/docs/deep-research/javascript/DOC.md
@@ -3,9 +3,9 @@ name: deep-research
 description: "Gemini Deep Research API via the Interactions endpoint for autonomous multi-step research with structured reports"
 metadata:
   languages: "javascript"
-  versions: "1.33.0"
-  revision: 2
-  updated-on: "2026-03-09"
+  versions: "2.7.0"
+  revision: 3
+  updated-on: "2026-05-29"
   source: community
   tags: "gemini,google,deep-research,research,interactions,agent"
 ---
@@ -26,8 +26,10 @@ interact with Gemini models and agents.
 
 - **Interactions API**: Unified interface for Gemini models and agents, with server-side state management
 - **Asynchronous**: Create a background interaction, then poll for completion (typically 5–15 minutes)
-- **Agent model**: `deep-research-pro-preview-12-2025` (the only available agent as of March 2026)
-- **SDK**: `@google/genai` >= 1.33.0 wraps the Interactions API natively
+- **Agent models** (as of May 2026):
+    - `deep-research-preview-04-2026` — default, balanced quality and speed
+    - `deep-research-max-preview-04-2026` — maximum comprehensiveness (slower, higher cost)
+- **SDK**: `@google/genai` >= 2.7.0 wraps the Interactions API natively
 - **Output**: Markdown report with citations and structured sections
 
 ## Installation
@@ -55,7 +57,7 @@ const client = new GoogleGenAI({});
 
 // Start background research
 const initialInteraction = await client.interactions.create({
-  agent: "deep-research-pro-preview-12-2025",
+  agent: "deep-research-preview-04-2026",
   input: "Research the current state of AI in disaster relief operations.",
   background: true,
 });
@@ -85,7 +87,7 @@ const client = new GoogleGenAI({});
 async function deepResearch(query: string, timeoutMinutes = 60): Promise<string> {
   // Start background research
   const initialInteraction = await client.interactions.create({
-    agent: "deep-research-pro-preview-12-2025",
+    agent: "deep-research-preview-04-2026",
     input: query,
     background: true,
   });
@@ -136,7 +138,7 @@ sending to Deep Research:
 
 ```typescript
 const planInteraction = await client.interactions.create({
-  model: "gemini-2.5-pro",
+  model: "gemini-3.1-pro-preview",
   input: `Create a detailed research plan for: "${topic}". Break it into key areas and questions.`,
 });
 const plan = planInteraction.outputs[planInteraction.outputs.length - 1].text;
@@ -153,7 +155,7 @@ chain interactions using `previousInteractionId`:
 ```typescript
 // First research task
 const interaction1 = await client.interactions.create({
-  agent: "deep-research-pro-preview-12-2025",
+  agent: "deep-research-preview-04-2026",
   input: "Research quantum computing breakthroughs in 2026.",
   background: true,
 });
@@ -161,7 +163,7 @@ const interaction1 = await client.interactions.create({
 
 // Follow-up referencing previous context
 const interaction2 = await client.interactions.create({
-  agent: "deep-research-pro-preview-12-2025",
+  agent: "deep-research-preview-04-2026",
   input: "Now compare these breakthroughs with classical computing limitations.",
   background: true,
   previousInteractionId: interaction1.id,
@@ -173,7 +175,7 @@ const interaction2 = await client.interactions.create({
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `input` | string | Yes | The research query or topic |
-| `agent` | string | Yes | Must be `deep-research-pro-preview-12-2025` |
+| `agent` | string | Yes | One of `deep-research-preview-04-2026` (default) or `deep-research-max-preview-04-2026` (highest depth) |
 | `background` | boolean | Yes | Set to `true` for async execution |
 | `previousInteractionId` | string | No | Chain to a previous interaction for context |
 
@@ -193,7 +195,7 @@ const interaction2 = await client.interactions.create({
 - **Rate limits**: The Interactions API has separate rate limits from `generateContent`. Expect lower throughput.
 - **Report quality**: The agent performs real web searches. More specific queries produce better reports.
 - **Plan first**: For best results, generate a research plan with a standard model first, then pass it to Deep Research.
-- **Agent name**: As of March 2026, the only available agent is `deep-research-pro-preview-12-2025`.
+- **Agent name**: As of May 2026, use `deep-research-preview-04-2026` for typical research, or `deep-research-max-preview-04-2026` for maximum-depth reports (longer wall time and higher cost).
 - **Audio inputs not supported**: The Deep Research agent does not accept audio inputs.
 - **Output is markdown**: Reports come back as structured markdown with headers, bullet points, and citations.
 - **Google Search is built-in**: The agent uses Google Search by default. Grounding restrictions apply to results.

--- a/content/gemini/docs/deep-research/python/DOC.md
+++ b/content/gemini/docs/deep-research/python/DOC.md
@@ -3,9 +3,9 @@ name: deep-research
 description: "Gemini Deep Research API via the Interactions endpoint for autonomous multi-step research with structured reports"
 metadata:
   languages: "python"
-  versions: "1.55.0"
-  revision: 2
-  updated-on: "2026-03-09"
+  versions: "2.7.0"
+  revision: 3
+  updated-on: "2026-05-29"
   source: community
   tags: "gemini,google,deep-research,research,interactions,agent"
 ---
@@ -26,8 +26,10 @@ interact with Gemini models and agents.
 
 - **Interactions API**: Unified interface for Gemini models and agents, with server-side state management
 - **Asynchronous**: Create a background interaction, then poll for completion (typically 5–15 minutes)
-- **Agent model**: `deep-research-pro-preview-12-2025` (the only available agent as of March 2026)
-- **SDK**: `google-genai` >= 1.55.0 wraps the Interactions API natively
+- **Agent models** (as of May 2026):
+    - `deep-research-preview-04-2026` — default, balanced quality and speed
+    - `deep-research-max-preview-04-2026` — maximum comprehensiveness (slower, higher cost)
+- **SDK**: `google-genai` >= 2.7.0 wraps the Interactions API natively
 - **Output**: Markdown report with citations and structured sections
 
 ## Installation
@@ -57,7 +59,7 @@ client = genai.Client()
 
 # Start background research
 interaction = client.interactions.create(
-    agent="deep-research-pro-preview-12-2025",
+    agent="deep-research-preview-04-2026",
     input="Research the current state of AI in disaster relief operations.",
     background=True,
 )
@@ -88,7 +90,7 @@ def deep_research(query: str, timeout_minutes: int = 60) -> str:
     """Run Gemini Deep Research and return the markdown report."""
     # Start background research
     interaction = client.interactions.create(
-        agent="deep-research-pro-preview-12-2025",
+        agent="deep-research-preview-04-2026",
         input=query,
         background=True,
     )
@@ -135,7 +137,7 @@ client = genai.Client()
 
 # Generate plan using a standard model
 plan_interaction = client.interactions.create(
-    model="gemini-2.5-pro",
+    model="gemini-3.1-pro-preview",
     input=f'Create a detailed research plan for: "{topic}". '
           "Break it into key areas and questions. Be concise but comprehensive.",
 )
@@ -153,7 +155,7 @@ chain interactions using `previous_interaction_id`:
 ```python
 # First research task
 interaction1 = client.interactions.create(
-    agent="deep-research-pro-preview-12-2025",
+    agent="deep-research-preview-04-2026",
     input="Research quantum computing breakthroughs in 2026.",
     background=True,
 )
@@ -161,7 +163,7 @@ interaction1 = client.interactions.create(
 
 # Follow-up referencing previous context
 interaction2 = client.interactions.create(
-    agent="deep-research-pro-preview-12-2025",
+    agent="deep-research-preview-04-2026",
     input="Now compare these breakthroughs with classical computing limitations.",
     background=True,
     previous_interaction_id=interaction1.id,
@@ -173,7 +175,7 @@ interaction2 = client.interactions.create(
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `input` | string | Yes | The research query or topic |
-| `agent` | string | Yes | Must be `deep-research-pro-preview-12-2025` |
+| `agent` | string | Yes | One of `deep-research-preview-04-2026` (default) or `deep-research-max-preview-04-2026` (highest depth) |
 | `background` | boolean | Yes | Set to `True` for async execution |
 | `previous_interaction_id` | string | No | Chain to a previous interaction for context |
 
@@ -193,7 +195,7 @@ interaction2 = client.interactions.create(
 - **Rate limits**: The Interactions API has separate rate limits from `generateContent`. Expect lower throughput.
 - **Report quality**: The agent performs real web searches. More specific queries produce better reports.
 - **Plan first**: For best results, generate a research plan with a standard model first, then pass it to Deep Research.
-- **Agent name**: As of March 2026, the only available agent is `deep-research-pro-preview-12-2025`.
+- **Agent name**: As of May 2026, use `deep-research-preview-04-2026` for typical research, or `deep-research-max-preview-04-2026` for maximum-depth reports (longer wall time and higher cost).
 - **Audio inputs not supported**: The Deep Research agent does not accept audio inputs.
 - **Output is markdown**: Reports come back as structured markdown with headers, bullet points, and citations.
 - **Google Search is built-in**: The agent uses Google Search by default. Grounding restrictions apply to results.

--- a/content/gemini/docs/genai/javascript/DOC.md
+++ b/content/gemini/docs/genai/javascript/DOC.md
@@ -3,8 +3,9 @@ name: genai
 description: "Google Gemini GenAI SDK for multimodal LLM interactions, image generation (Nano Banana), and video generation in JavaScript/TypeScript"
 metadata:
   languages: "javascript"
-  versions: "1.43.0"
-  updated-on: "2026-03-01"
+  versions: "2.7.0"
+  revision: 1
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "gemini,google,genai,llm,multimodal,nano banana,imagen,image generation,veo,video generation"
 ---
@@ -84,17 +85,20 @@ const ai = new GoogleGenAI({});
 
 ## Models
 
-- By default, use the following models as of March 2026:
-    - **General Text & Multimodal Tasks:** `gemini-2.5-flash`
-    - **Coding and Complex Reasoning Tasks:** `gemini-2.5-pro`
-    - **Image Generation Tasks:** `imagen-4.0-fast-generate-001`,
-        `imagen-4.0-generate-001` or `imagen-4.0-ultra-generate-001`
-    - **Image Editing Tasks:** `gemini-2.5-flash-image-preview`
-    - **Video Generation Tasks:** `veo-3.0-fast-generate-preview` or
-        `veo-3.0-generate-preview`.
+- By default, use the following models as of May 2026:
+    - **General Text & Multimodal Tasks:** `gemini-3.5-flash` (stable)
+    - **Coding and Complex Reasoning Tasks:** `gemini-3.1-pro-preview`
+    - **Low-latency / Cost-Sensitive Tasks:** `gemini-3.1-flash-lite`
+    - **Image Generation (Nano Banana 2):** `gemini-3.1-flash-image`
+    - **Image Generation (Nano Banana Pro):** `gemini-3-pro-image`
+    - **Image Generation (Imagen 4):** `imagen-4.0-fast-generate-001`,
+        `imagen-4.0-generate-001`, or `imagen-4.0-ultra-generate-001`
+    - **Video Generation Tasks:** `veo-3.1-lite-generate-preview` or
+        `veo-3.1-generate-preview`.
 
-- It is also acceptable to use the following model if explicitly requested by
+- It is also acceptable to use the following models if explicitly requested by
     the user:
+    - **Gemini 2.5 Series**: `gemini-2.5-flash`, `gemini-2.5-pro`
     - **Gemini 2.0 Series**: `gemini-2.0-flash`, `gemini-2.0-pro`
 
 - Do not use the following deprecated models (or their variants like
@@ -114,7 +118,7 @@ const ai = new GoogleGenAI({}); // Assumes GEMINI_API_KEY is set
 
 async function run() {
   const response = await ai.models.generateContent({
-    model: 'gemini-2.5-flash',
+    model: 'gemini-3.5-flash',
     contents: 'why is the sky blue?',
   });
 
@@ -146,7 +150,7 @@ async function run() {
     const imagePart = fileToGenerativePart("path/to/image.jpg", "image/jpeg");
 
     const response = await ai.models.generateContent({
-        model: 'gemini-2.5-flash',
+        model: 'gemini-3.5-flash',
         contents: [imagePart, "explain that image"],
     });
 
@@ -172,7 +176,7 @@ async function run() {
     });
 
     const response = await ai.models.generateContent({
-        model: 'gemini-2.5-flash',
+        model: 'gemini-3.5-flash',
          contents: createUserContent([
           createPartFromUri(f.uri, f.mimeType),
           "Describe this audio clip"
@@ -198,9 +202,15 @@ Below are examples of advanced configurations.
 
 ### Thinking
 
-Gemini 2.5 series models support thinking, which is on by default for
-`gemini-2.5-flash`. It can be adjusted by using `thinking_budget` setting.
-Setting it to zero turns thinking off, and will reduce latency.
+Gemini 2.5 and 3.x series models support thinking. The configuration differs
+between model families:
+
+- **Gemini 3.x** uses `thinkingLevel` with values `"minimal"`, `"low"`,
+    `"medium"`, or `"high"`.
+- **Gemini 2.5** uses `thinkingBudget` (token count). Setting it to zero turns
+    thinking off on `gemini-2.5-flash`, reducing latency.
+
+Gemini 3.x (recommended):
 
 ```javascript
 import { GoogleGenAI } from "@google/genai";
@@ -209,15 +219,12 @@ const ai = new GoogleGenAI({});
 
 async function main() {
   const response = await ai.models.generateContent({
-    model: "gemini-2.5-pro",
+    model: "gemini-3.1-pro-preview",
     contents: "Provide a list of 3 famous physicists and their key contributions",
     config: {
       thinkingConfig: {
-        thinkingBudget: 1024,
-        // Turn off thinking:
-        // thinkingBudget: 0
-        // Turn on dynamic thinking:
-        // thinkingBudget: -1
+        thinkingLevel: "low",        // "minimal", "low", "medium", "high"
+        includeThoughts: true,
       },
     },
   });
@@ -228,14 +235,33 @@ async function main() {
 main();
 ```
 
+Gemini 2.5 (legacy budget API):
+
+```javascript
+await ai.models.generateContent({
+  model: "gemini-2.5-pro",
+  contents: "Explain quantum entanglement in plain English.",
+  config: {
+    thinkingConfig: {
+      thinkingBudget: 1024,
+      // thinkingBudget: 0    // turn off (flash only)
+      // thinkingBudget: -1   // dynamic
+    },
+  },
+});
+```
+
 IMPORTANT NOTES:
 
-- Minimum thinking budget for `gemini-2.5-pro` is `128` and thinking can not
-    be turned off for that model.
-- No models (apart from Gemini 2.5 series) support thinking or thinking
-    budgets APIs. Do not try to adjust thinking budgets other models (such as
-    `gemini-2.0-flash` or `gemini-2.0-pro`) otherwise it will cause syntax
-    errors.
+- Minimum thinking budget for `gemini-2.5-pro` is `128` and thinking cannot be
+    turned off for that model.
+- `gemini-3.1-pro-preview` always thinks; you cannot disable thinking on Pro
+    tier models.
+- Gemini 2.0 and earlier models do not support thinking. Do not pass
+    `thinkingConfig` to them (such as `gemini-2.0-flash` or `gemini-2.0-pro`)
+    otherwise it will cause errors.
+- Do not mix `thinkingLevel` (3.x) and `thinkingBudget` (2.5) on the same
+    request — pick the one matching your model family.
 
 ### System instructions
 
@@ -248,7 +274,7 @@ const ai = new GoogleGenAI({});
 
 async function run() {
     const response = await ai.models.generateContent({
-        model: 'gemini-2.5-flash',
+        model: 'gemini-3.5-flash',
         contents: "Hello.",
         config: {
             systemInstruction: "You are a pirate",
@@ -288,7 +314,7 @@ function fileToGenerativePart(path, mimeType): Part {
 async function run() {
     const img = fileToGenerativePart("/path/to/img.jpg", "image/jpeg");
     const response = await ai.models.generateContent({
-        model: "gemini-2.5-flash",
+        model: "gemini-3.5-flash",
         contents: ['Do these look store-bought or homemade?', img],
         config: {
             safetySettings: [
@@ -314,7 +340,7 @@ const ai = new GoogleGenAI({});
 
 async function run() {
   const responseStream = await ai.models.generateContentStream({
-    model: "gemini-2.5-flash",
+    model: "gemini-3.5-flash",
     contents: ["Explain how AI works"],
   });
 
@@ -337,7 +363,7 @@ import { GoogleGenAI } from '@google/genai';
 const ai = new GoogleGenAI({});
 
 async function run() {
-    const chat = ai.chats.create({model: "gemini-2.5-flash"});
+    const chat = ai.chats.create({model: "gemini-3.5-flash"});
 
     let response = await chat.sendMessage({message:"I have 2 dogs in my house."});
     console.log(response.text);
@@ -354,7 +380,7 @@ run();
 ``` It is also possible to use streaming with Chat:
 
 ```javascript
-    const chat = ai.chats.create({model: "gemini-2.5-flash"});
+    const chat = ai.chats.create({model: "gemini-3.5-flash"});
     const stream = await chat.sendMessageStream({message:"I have 2 dogs in my house."});
     for await (const chunk of stream) {
       console.log(chunk.text);
@@ -417,7 +443,7 @@ import { GoogleGenAI, Type } from "@google/genai";
 
 const ai = new GoogleGenAI({});
 const response = await ai.models.generateContent({
-   model: "gemini-2.5-flash",
+   model: "gemini-3.5-flash",
    contents: "List a few popular cookie recipes, and include the amounts of ingredients.",
    config: {
      responseMimeType: "application/json",
@@ -493,7 +519,7 @@ async function run() {
     };
 
     const response = await ai.models.generateContent({
-        model: 'gemini-2.5-flash',
+        model: 'gemini-3.5-flash',
         contents: 'Dim the lights so the room feels cozy and warm.',
         config: {
             tools: [{functionDeclarations: [controlLightDeclaration]}]
@@ -540,8 +566,9 @@ Note: Do not include negativePrompts in config, it's not supported.
 
 ### Edit Images
 
-Editing images is better done using the Gemini native image generation model.
-Configs are not supported in this model (except modality).
+Editing images is better done using the Gemini native image generation model
+(Nano Banana 2 / Pro). Configs are not supported in this model (except
+modality).
 
 ```javascript
 import { GoogleGenAI } from '@google/genai';
@@ -549,7 +576,7 @@ import { GoogleGenAI } from '@google/genai';
 const ai = new GoogleGenAI({});
 
 const response = await ai.models.generateContent({
-  model: 'gemini-2.5-flash-image-preview',
+  model: 'gemini-3.1-flash-image',  // Nano Banana 2 (use 'gemini-3-pro-image' for Pro tier)
   contents: [imagePart, 'koala eating a nano banana']
 });
 for (const part of response.candidates[0].content.parts) {
@@ -574,7 +601,7 @@ const ai = new GoogleGenAI({});
 
 async function main() {
   let operation = await ai.models.generateVideos({
-    model: "veo-3.0-fast-generate-preview",
+    model: "veo-3.1-lite-generate-preview",
     prompt: "Panning wide shot of a calico kitten sleeping in the sunshine",
     config: {
       personGeneration: "dont_allow",
@@ -611,7 +638,7 @@ const ai = new GoogleGenAI({});
 
 async function run() {
     const response = await ai.models.generateContent({
-       model: "gemini-2.5-flash",
+       model: "gemini-3.5-flash",
        contents: "Who won the latest F1 race?",
        config: {
          tools: [{googleSearch: {}}],
@@ -645,7 +672,7 @@ const ai = new GoogleGenAI({});
 
 async function run() {
     const response = await ai.models.generateContent({
-        model: "gemini-2.5-flash",
+        model: "gemini-3.5-flash",
         contents: "How does AI work?",
     });
     console.log(response.text);
@@ -661,7 +688,7 @@ const ai = new GoogleGenAI({});
 
 async function run() {
     const response = await ai.models.generateContent({
-        model: "gemini-2.5-flash",
+        model: "gemini-3.5-flash",
         contents: [
             { role: "user", parts: [{ text: "How does AI work?" }] },
         ],

--- a/content/gemini/docs/genai/python/DOC.md
+++ b/content/gemini/docs/genai/python/DOC.md
@@ -3,8 +3,9 @@ name: genai
 description: "Google Gemini GenAI SDK for multimodal LLM interactions, image generation (Nano Banana), and video generation in Python"
 metadata:
   languages: "python"
-  versions: "1.56.0"
-  updated-on: "2026-03-01"
+  versions: "2.7.0"
+  revision: 1
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "gemini,google,genai,llm,multimodal,nano banana,imagen,image generation,veo,video generation"
 ---
@@ -72,17 +73,20 @@ The `google-genai` library requires creating a client object for all API calls.
 
 ## Models
 
-- By default, use the following models as of March 2026:
-    - **General Text & Multimodal Tasks:** `gemini-2.5-flash`
-    - **Coding and Complex Reasoning Tasks:** `gemini-2.5-pro`
-    - **Image Generation Tasks:** `imagen-4.0-fast-generate-001`,
-        `imagen-4.0-generate-001` or `imagen-4.0-ultra-generate-001`
-    - **Image Editing Tasks:** `gemini-2.5-flash-image-preview`
-    - **Video Generation Tasks:** `veo-3.0-fast-generate-preview` or
-        `veo-3.0-generate-preview`.
+- By default, use the following models as of May 2026:
+    - **General Text & Multimodal Tasks:** `gemini-3.5-flash` (stable)
+    - **Coding and Complex Reasoning Tasks:** `gemini-3.1-pro-preview`
+    - **Low-latency / Cost-Sensitive Tasks:** `gemini-3.1-flash-lite`
+    - **Image Generation (Nano Banana 2):** `gemini-3.1-flash-image`
+    - **Image Generation (Nano Banana Pro):** `gemini-3-pro-image`
+    - **Image Generation (Imagen 4):** `imagen-4.0-fast-generate-001`,
+        `imagen-4.0-generate-001`, or `imagen-4.0-ultra-generate-001`
+    - **Video Generation Tasks:** `veo-3.1-lite-generate-preview` or
+        `veo-3.1-generate-preview`.
 
-- It is also acceptable to use following models if explicitly requested by the
-    user:
+- It is also acceptable to use the following models if explicitly requested by
+    the user:
+    - **Gemini 2.5 Series**: `gemini-2.5-flash`, `gemini-2.5-pro`
     - **Gemini 2.0 Series**: `gemini-2.0-flash`, `gemini-2.0-pro`
 
 - Do not use the following deprecated models (or their variants like
@@ -101,7 +105,7 @@ from google import genai
 client = genai.Client()
 
 response = client.models.generate_content(
-  model='gemini-2.5-flash',
+  model='gemini-3.5-flash',
   contents='why is the sky blue?',
 )
 
@@ -119,7 +123,7 @@ client = genai.Client()
 image = Image.open(img_path)
 
 response = client.models.generate_content(
-  model='gemini-2.5-flash',
+  model='gemini-3.5-flash',
   contents=[image, "explain that image"],
 )
 
@@ -136,7 +140,7 @@ from google.genai import types
     image_bytes = f.read()
 
   response = client.models.generate_content(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     contents=[
       types.Part.from_bytes(
         data=image_bytes,
@@ -155,7 +159,7 @@ For larger files, use `client.files.upload`:
 f = client.files.upload(file=img_path)
 
 response = client.models.generate_content(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     contents=[f, "can you describe this image?"]
 )
 ```
@@ -173,9 +177,15 @@ Below are examples of advanced configurations.
 
 ### Thinking
 
-Gemini 2.5 series models support thinking, which is on by default for
-`gemini-2.5-flash`. It can be adjusted by using `thinking_budget` setting.
-Setting it to zero turns thinking off, and will reduce latency.
+Gemini 2.5 and 3.x series models support thinking. The configuration differs
+between model families:
+
+- **Gemini 3.x** uses `thinking_level` with values `"minimal"`, `"low"`,
+    `"medium"`, or `"high"`.
+- **Gemini 2.5** uses `thinking_budget` (token count). Setting it to zero turns
+    thinking off and reduces latency on `gemini-2.5-flash`.
+
+Gemini 3.x (recommended):
 
 ```python
 from google import genai
@@ -183,6 +193,20 @@ from google.genai import types
 
 client = genai.Client()
 
+client.models.generate_content(
+  model='gemini-3.5-flash',
+  contents="What is AI?",
+  config=types.GenerateContentConfig(
+    thinking_config=types.ThinkingConfig(
+      thinking_level="low",
+    )
+  )
+)
+```
+
+Gemini 2.5 (legacy budget API):
+
+```python
 client.models.generate_content(
   model='gemini-2.5-flash',
   contents="What is AI?",
@@ -196,12 +220,15 @@ client.models.generate_content(
 
 IMPORTANT NOTES:
 
-- Minimum thinking budget for `gemini-2.5-pro` is `128` and thinking can not
-    be turned off for that model.
-- No models (apart from Gemini 2.5 series) support thinking or thinking
-    budgets APIs. Do not try to adjust thinking budgets other models (such as
-    `gemini-2.0-flash` or `gemini-2.0-pro`) otherwise it will cause syntax
-    errors.
+- Minimum thinking budget for `gemini-2.5-pro` is `128` and thinking cannot be
+    turned off for that model.
+- `gemini-3.1-pro-preview` always thinks; you cannot disable thinking on Pro
+    tier models.
+- Gemini 2.0 and earlier models do not support thinking. Do not pass
+    `thinking_config` to them (such as `gemini-2.0-flash`) otherwise it will
+    cause errors.
+- Do not mix `thinking_level` (3.x) and `thinking_budget` (2.5) on the same
+    request — pick the one matching your model family.
 
 ### System instructions
 
@@ -218,7 +245,7 @@ config = types.GenerateContentConfig(
 )
 
 response = client.models.generate_content(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     contents='Tell me a pirate joke',
     config=config,
 )
@@ -246,7 +273,7 @@ client = genai.Client()
 
 img = Image.open("/path/to/img")
 response = client.models.generate_content(
-    model="gemini-2.0-flash",
+    model="gemini-3.5-flash",
     contents=['Do these look store-bought or homemade?', img],
     config=types.GenerateContentConfig(
       safety_settings=[
@@ -271,7 +298,7 @@ from google import genai
 client = genai.Client()
 
 response = client.models.generate_content_stream(
-    model="gemini-2.5-flash",
+    model="gemini-3.5-flash",
     contents=["Explain how AI works"]
 )
 for chunk in response:
@@ -287,7 +314,7 @@ history.
 from google import genai
 
 client = genai.Client()
-chat = client.chats.create(model="gemini-2.5-flash")
+chat = client.chats.create(model="gemini-3.5-flash")
 
 response = chat.send_message("I have 2 dogs in my house.")
 print(response.text)
@@ -321,7 +348,7 @@ class Recipe(BaseModel):
 
 # Request the model to populate the schema
 response = client.models.generate_content(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     contents="Provide a classic recipe for chocolate chip cookies.",
     config=types.GenerateContentConfig(
         response_mime_type="application/json",
@@ -354,7 +381,7 @@ def get_current_weather(city: str) -> str:
 
 # Make the function available to the model as a tool
 response = client.models.generate_content(
-  model='gemini-2.5-flash',
+  model='gemini-3.5-flash',
   contents="What is the weather like in Boston?",
   config=types.GenerateContentConfig(
       tools=[get_current_weather]
@@ -401,9 +428,9 @@ for generated_image in result.generated_images:
 
 ### Edit images
 
-Editing images is better done using the Gemini native image generation model,
-and it is recommended to use chat mode. Configs are not supported in this model
-(except modality).
+Editing images is better done using the Gemini native image generation model
+(Nano Banana 2 / Pro), and it is recommended to use chat mode. Configs are not
+supported in this model (except modality).
 
 ```python
 from google import genai
@@ -417,8 +444,8 @@ prompt = """
 """
 image = PIL.Image.open('/path/to/image.png')
 
-# Create the chat
-chat = client.chats.create(model="gemini-2.5-flash-image-preview")
+# Create the chat using Nano Banana 2 (use 'gemini-3-pro-image' for Pro tier)
+chat = client.chats.create(model="gemini-3.1-flash-image")
 # Send the image and ask for it to be edited
 response = chat.send_message([prompt, image])
 
@@ -452,7 +479,7 @@ client = genai.Client()
 PIL_image = Image.open("path/to/image.png") # Optional
 
 operation = client.models.generate_videos(
-    model="veo-3.0-fast-generate-preview",
+    model="veo-3.1-lite-generate-preview",
     prompt="Panning wide shot of a calico kitten sleeping in the sunshine",
     image = PIL_image,
     config=types.GenerateVideosConfig(
@@ -486,7 +513,7 @@ from google import genai
 client = genai.Client()
 
 response = client.models.generate_content(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     contents="What was the score of the latest Olympique Lyonnais game?",
     config={"tools": [{"google_search": {}}]},
 )
@@ -517,7 +544,7 @@ from google import genai
 client = genai.Client()
 
 response = client.models.generate_content(
-    model="gemini-2.5-flash",
+    model="gemini-3.5-flash",
     contents="How does AI work?"
 )
 print(response.text)
@@ -532,7 +559,7 @@ from google.genai import types
 client = genai.Client()
 
 response = client.models.generate_content(
-    model="gemini-2.5-flash",
+    model="gemini-3.5-flash",
     contents=[
       types.Content(role="user", parts=[types.Part.from_text(text="How does AI work?")]),
     ]

--- a/content/gemini/docs/live/javascript/DOC.md
+++ b/content/gemini/docs/live/javascript/DOC.md
@@ -3,8 +3,9 @@ name: live
 description: "Google Gemini Live API for real-time bidirectional voice, video, and text streaming over WebSocket in JavaScript/TypeScript"
 metadata:
   languages: "javascript"
-  versions: "1.43.0"
-  updated-on: "2026-03-29"
+  versions: "2.7.0"
+  revision: 1
+  updated-on: "2026-05-29"
   source: community
   tags: "gemini,google,live,realtime,voice,audio,streaming,websocket,vad,speech"
 ---
@@ -30,12 +31,12 @@ Always use the Google Gen AI SDK (`@google/genai`). Do not use legacy libraries.
 
 ## Models
 
-Use these models for the Live API as of March 2026:
+Use these models for the Live API as of May 2026:
 
 | Model | ID | Notes |
 |---|---|---|
-| **Gemini 3.1 Flash Live** (newest) | `gemini-3.1-flash-live-preview` | Recommended default |
-| **Gemini 2.5 Flash Live** | `gemini-2.5-flash-live-preview` | Supports async tools, proactive audio, affective dialog |
+| **Gemini 3.1 Flash Live** (newest) | `gemini-3.1-flash-live-preview` | Recommended default, audio-to-audio |
+| **Gemini 2.5 Flash Live (native audio)** | `gemini-2.5-flash-native-audio-preview-12-2025` | Supports async tools, proactive audio, affective dialog |
 
 **Key differences:**
 

--- a/content/gemini/docs/live/python/DOC.md
+++ b/content/gemini/docs/live/python/DOC.md
@@ -3,8 +3,9 @@ name: live
 description: "Google Gemini Live API for real-time bidirectional voice, video, and text streaming over WebSocket in Python"
 metadata:
   languages: "python"
-  versions: "1.56.0"
-  updated-on: "2026-03-29"
+  versions: "2.7.0"
+  revision: 1
+  updated-on: "2026-05-29"
   source: community
   tags: "gemini,google,live,realtime,voice,audio,streaming,websocket,vad,speech"
 ---
@@ -30,12 +31,12 @@ Always use the Google GenAI SDK (`google-genai`). Do not use legacy libraries.
 
 ## Models
 
-Use these models for the Live API as of March 2026:
+Use these models for the Live API as of May 2026:
 
 | Model | ID | Notes |
 |---|---|---|
-| **Gemini 3.1 Flash Live** (newest) | `gemini-3.1-flash-live-preview` | Recommended default |
-| **Gemini 2.5 Flash Live** | `gemini-2.5-flash-live-preview` | Supports async tools, proactive audio, affective dialog |
+| **Gemini 3.1 Flash Live** (newest) | `gemini-3.1-flash-live-preview` | Recommended default, audio-to-audio |
+| **Gemini 2.5 Flash Live (native audio)** | `gemini-2.5-flash-native-audio-preview-12-2025` | Supports async tools, proactive audio, affective dialog |
 
 **Key differences:**
 


### PR DESCRIPTION
docs(gemini): refresh to google-genai 2.7.0 (Python + JS)

Updates all six gemini DOC.md files (genai, live, deep-research × Py/JS)
to the current SDK and model lineup.

- google-genai (PyPI) and @google/genai (npm) → 2.7.0
- Promotes defaults to current Gemini 3.x family: `gemini-3.5-flash`,
  `gemini-3.1-pro-preview`, `gemini-3.1-flash-image` (Nano Banana 2),
  `veo-3.1-lite-generate-preview`
- Thinking section covers both `thinking_level` (3.x) and `thinking_budget`
  (2.5)
- Live: switched 2.5 Live model from `gemini-2.5-flash-live-preview` to
  `gemini-2.5-flash-native-audio-preview-12-2025`
- Deep research: replaces retired `deep-research-pro-preview-12-2025`
  with the current pair (`deep-research-preview-04-2026` and
  `deep-research-max-preview-04-2026`); planning model →
  `gemini-3.1-pro-preview`
- `revision` bumped and `updated-on: 2026-05-29`

Verified versions against PyPI/npm; model IDs verified against
ai.google.dev/gemini-api/docs (May 2026).
