### PR TITLE
docs(huggingface, replicate, together): refresh

### DIFF
--- a/content/huggingface/docs/hub/python/DOC.md
+++ b/content/huggingface/docs/hub/python/DOC.md
@@ -3,9 +3,9 @@ name: package
 description: "huggingface-hub for Python: authenticate, download files and snapshots, query Hub repos, and upload models, datasets, or Spaces"
 metadata:
   languages: "python"
-  versions: "1.6.0"
-  revision: 1
-  updated-on: "2026-03-12"
+  versions: "1.17.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "huggingface-hub,huggingface,hub,models,datasets,spaces,ml"
 ---
@@ -29,22 +29,22 @@ For Python code, the main imports come from `huggingface_hub`, while the install
 Pin the package version your project expects:
 
 ```bash
-python -m pip install "huggingface-hub==1.6.0"
+python -m pip install "huggingface-hub==1.17.0"
 ```
 
 Common alternatives:
 
 ```bash
-uv add "huggingface-hub==1.6.0"
-poetry add "huggingface-hub==1.6.0"
+uv add "huggingface-hub==1.17.0"
+poetry add "huggingface-hub==1.17.0"
 ```
 
 Useful extras documented by Hugging Face and PyPI metadata:
 
 ```bash
-python -m pip install "huggingface-hub[mcp]==1.6.0"
-python -m pip install "huggingface-hub[torch]==1.6.0"
-python -m pip install "huggingface-hub[hf-xet]==1.6.0"
+python -m pip install "huggingface-hub[mcp]==1.17.0"
+python -m pip install "huggingface-hub[torch]==1.17.0"
+python -m pip install "huggingface-hub[hf-xet]==1.17.0"
 ```
 
 ## Imports At A Glance
@@ -318,14 +318,24 @@ path = hf_hub_download(
 - `HfFileSystem` is convenient but slower than direct `HfApi` calls for simple metadata or file operations.
 - In offline mode, code that expects fresh metadata or remote existence checks will fail unless the artifacts are already cached locally.
 
-## Version-Sensitive Notes For 1.6.0
+## Version-Sensitive Notes For 1.17.0
 
-- PyPI lists `huggingface-hub 1.6.0` released on March 6, 2026.
-- The current docs root publishes `main v1.6.0`, so the primary Hugging Face docs are aligned with the package version for this session.
+- PyPI lists `huggingface-hub 1.17.0` as the current release for this session.
+- The current docs root publishes `main v1.17.0`, so the primary Hugging Face docs are aligned with the package version for this session.
 - The v1.x line requires Python 3.9+.
-- The v1.0 migration notes still matter in `1.6.0`: the library switched to `httpx`, the `Repository` class was removed, `use_auth_token` was removed in favor of `token`, and several cache-constant internals moved or were removed.
+- The v1.0 migration notes still apply in `1.17.0`: the library switched to `httpx`, the `Repository` class was removed, `use_auth_token` was removed in favor of `token`, and several cache-constant internals moved or were removed.
 - If you need code that spans both `0.x` and `1.x`, prefer `huggingface_hub.HfHubHttpError` for shared exception handling because it maps cleanly across the backend switch.
-- The `1.6.0` release adds CLI commands for discussions, webhooks, dataset parquet and SQL export, repo duplication, and bucket support in `HfFileSystem`. These are useful if your automation shells out to `hf` alongside the Python API.
+- Notable additions since `1.6.0` in the `1.x` line worth knowing about:
+  - `CommitOperationCopy` and `copy_files()` support cross-repository copies without re-uploading.
+  - `parse_hf_uri()` and the `HfUri` dataclass centralize `hf://` URI parsing.
+  - `search_spaces()` enables embedding-based semantic search for Spaces.
+  - `fetch_space_logs()` and `get_space_secrets()` give programmatic access to Space build/runtime logs and secret metadata; `hf spaces ssh` opens an SSH session to a Space Dev Mode container.
+  - Jobs gained an independent `JobHardware` enum, plus `update_job_labels()` and `update_scheduled_job_labels()` helpers.
+- Behavior changes worth noting:
+  - URI parsing now requires `namespace/name` format; single-segment IDs are no longer accepted.
+  - `model_name` is deprecated on `list_models()`; use `search=` instead.
+  - The CLI standardized on a `--format [auto|human|agent|json|quiet]` flag and renamed `hf skills upgrade` to `hf skills update`. New CLI subcommands include `hf repos ls`, `hf skills list`, and `hf update`.
+  - Token file permissions are hardened to `0o600` (parent dirs to `0o700`).
 
 ## Official Sources
 
@@ -339,4 +349,4 @@ path = hf_hub_download(
 - `HfFileSystem` reference: `https://huggingface.co/docs/huggingface_hub/en/package_reference/hf_file_system`
 - Migration notes: `https://huggingface.co/docs/huggingface_hub/en/concepts/migration`
 - PyPI: `https://pypi.org/project/huggingface-hub/`
-- GitHub release `v1.6.0`: `https://github.com/huggingface/huggingface_hub/releases/tag/v1.6.0`
+- GitHub releases (latest `v1.17.0`): `https://github.com/huggingface/huggingface_hub/releases`

--- a/content/huggingface/docs/transformers/DOC.md
+++ b/content/huggingface/docs/transformers/DOC.md
@@ -3,8 +3,9 @@ name: transformers
 description: "Transformers.js coding guidelines for running ML models in the browser or Node.js"
 metadata:
   languages: "javascript"
-  versions: "3.7.6"
-  updated-on: "2026-03-02"
+  versions: "4.2.0"
+  revision: 1
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "huggingface,transformers,ml,inference,models"
 ---
@@ -24,12 +25,12 @@ Always use the official Transformers.js package `@huggingface/transformers` for 
 
 - **Library Name:** Transformers.js
 - **NPM Package:** `@huggingface/transformers`
-- **Current Version:** 3.5.2
+- **Current Version:** 4.2.0
 
 **Installation:**
 
 - **Correct:** `npm i @huggingface/transformers`
-- **Browser CDN:** `https://cdn.jsdelivr.net/npm/@huggingface/transformers@3.5.2`
+- **Browser CDN:** `https://cdn.jsdelivr.net/npm/@huggingface/transformers@4.2.0`
 
 **Main APIs and Usage:**
 
@@ -51,7 +52,7 @@ npm i @huggingface/transformers
 **CDN Installation:**
 ```html
 <script type="module">
-    import { pipeline } from 'https://cdn.jsdelivr.net/npm/@huggingface/transformers@3.7.4';
+    import { pipeline } from 'https://cdn.jsdelivr.net/npm/@huggingface/transformers@4.2.0';
 </script>
 ```
 
@@ -445,6 +446,14 @@ To use custom models, convert them to ONNX format:
 
 The conversion script supports quantization:
 
+## Version-Sensitive Notes For 4.2.0
+
+- `@huggingface/transformers` `4.x` introduced a new WebGPU runtime rewritten in C++ while keeping the high-level API (`pipeline`, `AutoModel*`, etc.) backward-compatible with `3.x` code.
+- WebGPU is now usable from Node.js, Bun, and Deno in addition to browsers.
+- New `env` knobs in 4.x include `env.useWasmCache` for offline-capable apps, `env.logLevel` to control logging, and `env.fetch` to plug in a custom fetch (useful for authenticated model access).
+- A `ModelRegistry` API gives explicit visibility into pipeline assets when you need to introspect or pre-cache them.
+- Expanded model coverage in the `4.x` line includes newer architectures such as Gemma family, DeepSeek-v3-class models, Mamba-style state-space models, and MoE variants.
+
 ## Useful Links
 
 - Documentation: https://huggingface.co/docs/transformers.js
@@ -477,7 +486,7 @@ npm i @huggingface/transformers
 Alternatively, you can use it in vanilla JS, without any bundler, by using a CDN or static hosting. For example, using [ES Modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules), you can import the library with:
 ```html
 <script type="module">
-    import { pipeline } from 'https://cdn.jsdelivr.net/npm/@huggingface/transformers@3.5.2';
+    import { pipeline } from 'https://cdn.jsdelivr.net/npm/@huggingface/transformers@4.2.0';
 </script>
 ```
 ```

--- a/content/replicate/docs/model-hosting/DOC.md
+++ b/content/replicate/docs/model-hosting/DOC.md
@@ -3,8 +3,9 @@ name: model-hosting
 description: "Replicate JavaScript SDK coding guide for running ML models via the official Replicate npm package"
 metadata:
   languages: "javascript"
-  versions: "1.3.1"
-  updated-on: "2026-03-02"
+  versions: "1.4.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "replicate,model-hosting,ml,inference,ai"
 ---
@@ -179,6 +180,8 @@ for await (const event of replicate.stream(
   process.stdout.write(event.toString());
 }
 ```
+
+**Note (1.4.0):** When a streamed model emits file outputs, `event.data` defaults to a `FileOutput` instance you can write directly to disk. Pass `useFileOutput: false` in the stream options if you would rather receive plain HTTP URLs or data URLs as in earlier 1.x releases.
 
 **Advanced Streaming with Event Handling:**
 ```javascript

--- a/content/replicate/docs/package/python/DOC.md
+++ b/content/replicate/docs/package/python/DOC.md
@@ -4,8 +4,8 @@ description: "Replicate Python SDK guide for running models, streaming output, a
 metadata:
   languages: "python"
   versions: "1.0.7"
-  revision: 1
-  updated-on: "2026-03-12"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "replicate,python,ml,inference,ai,predictions"
 ---

--- a/content/together/docs/package/python/DOC.md
+++ b/content/together/docs/package/python/DOC.md
@@ -3,9 +3,9 @@ name: package
 description: "Together Python SDK for chat, completions, embeddings, images, rerank, and fine-tuning"
 metadata:
   languages: "python"
-  versions: "2.3.2"
-  revision: 1
-  updated-on: "2026-03-11"
+  versions: "2.16.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "together,python,llm,chat,embeddings,images,rerank,fine-tuning"
 ---
@@ -19,14 +19,14 @@ metadata:
 ## Install
 
 ```bash
-pip install together==2.3.2
+pip install together==2.16.0
 ```
 
 Common project-tool variants:
 
 ```bash
-poetry add together==2.3.2
-uv add together==2.3.2
+poetry add together==2.16.0
+uv add together==2.16.0
 ```
 
 ## Authentication
@@ -255,10 +255,10 @@ Use the current Together fine-tuning docs before copying this flow into producti
 
 ## Version-Sensitive Notes
 
-- This doc is pinned to the version used here `2.3.2`.
-- The PyPI page showed `2.4.0` as the current latest release on 2026-03-11, so some upstream examples may reflect behavior newer than `2.3.2`.
+- This doc is pinned to the version used here `2.16.0`, which PyPI lists as the current latest release for this session.
 - The Together docs are not version-pinned per SDK release. Treat the docs site as current-product guidance and verify any newly documented arguments against the installed package if code fails.
 - The docs site is organized around Together's current v2 platform docs. For package work, prefer the Python SDK page and quickstart over the broader REST reference landing page.
+- Together's catalog changes frequently. Recent quickstart examples have used `openai/gpt-oss-20b` and `meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo`; pull current model IDs from the Together docs or your account's supported-model list rather than hardcoding stale IDs from blog posts.
 
 ## Official Source URLs
 


### PR DESCRIPTION
docs(huggingface, replicate, together): refresh

- transformers.js (`@huggingface/transformers`) 3.7.6 → 4.2.0;
  normalizes CDN references; adds 4.2.0 notes (C++ WebGPU runtime,
  Node/Bun/Deno WebGPU, `ModelRegistry`, new `env` knobs)
- huggingface_hub 1.6.0 → 1.17.0; documents `CommitOperationCopy` /
  `copy_files()`, `parse_hf_uri()`/`HfUri`, `search_spaces()`,
  `fetch_space_logs()`/`get_space_secrets()`/`hf spaces ssh`, independent
  `JobHardware` enum, CLI `--format` standardization, `hf skills update`
  rename, deprecation of `list_models(model_name=...)`, hardened token
  permissions
- replicate JS 1.3.1 → 1.4.0; notes 1.4.0 streamed-file default change
  (`FileOutput` instances; revertible via `useFileOutput: false`)
- replicate Python 1.0.7 unchanged (latest)
- together 2.3.2 → 2.16.0; refreshed model guidance
  (`openai/gpt-oss-20b`, `meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo`)
- `revision` bumped and `updated-on: 2026-05-29`

Verified versions against PyPI and npm.
