### PR TITLE
docs(elevenlabs, deepgram, assemblyai): refresh speech SDK docs

### DIFF
--- a/content/assemblyai/docs/transcription/DOC.md
+++ b/content/assemblyai/docs/transcription/DOC.md
@@ -3,8 +3,9 @@ name: transcription
 description: "AssemblyAI JavaScript SDK coding guide for speech-to-text transcription"
 metadata:
   languages: "javascript"
-  versions: "4.18.4"
-  updated-on: "2026-03-02"
+  versions: "4.33.3"
+  revision: 1
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "assemblyai,transcription,speech-to-text,audio,ai"
 ---
@@ -22,7 +23,10 @@ To check the latest version, run:
 npm view assemblyai version
 ```
 
-**Never use deprecated, unofficial, or direct HTTP clients.** The official `assemblyai` package is the only supported JavaScript/TypeScript SDK maintained by AssemblyAI. It provides type-safe interfaces, automatic polling, streaming support, and simplified error handling.
+**Never use deprecated, unofficial, or direct HTTP clients.** The official
+`assemblyai` package is the only supported JavaScript/TypeScript SDK maintained
+by AssemblyAI. It provides type-safe interfaces, automatic polling, streaming
+support, and simplified error handling.
 
 ## 2. Installation
 
@@ -48,7 +52,8 @@ ASSEMBLYAI_API_KEY=your_api_key_here
 
 **Get your API key:**
 
-Sign up at https://www.assemblyai.com, navigate to the AssemblyAI Dashboard, and copy your API key from the "Your API Key" section.
+Sign up at https://www.assemblyai.com, navigate to the AssemblyAI Dashboard, and
+copy your API key.
 
 ## 3. Initialization
 
@@ -65,24 +70,27 @@ const client = new AssemblyAI({
 ```javascript
 const client = new AssemblyAI({
   apiKey: process.env.ASSEMBLYAI_API_KEY,
-  // Optional: Custom base URL (for testing or proxy)
+  // Optional: custom base URL (for testing or proxy)
   baseUrl: "https://api.assemblyai.com",
 });
 ```
 
 **Authentication Best Practice:**
-The SDK reads from the `ASSEMBLYAI_API_KEY` environment variable by default. Always store API keys in environment variables, never hardcode them in source code.
+Always store API keys in environment variables, never hardcode them in source
+code.
 
 ## 4. Core API Surfaces
 
 ### 4.1 Async Transcription
 
-Async transcription processes pre-recorded audio files. The SDK automatically polls the transcription status until completion.
+Async transcription processes pre-recorded audio files. `transcribe()`
+automatically polls the transcription status until completion.
 
 **Minimal Example (Transcribe from URL):**
 ```javascript
 const transcript = await client.transcripts.transcribe({
   audio: "https://example.com/audio.mp3",
+  speech_models: ["universal-3-pro", "universal-2"],
 });
 
 console.log(transcript.text);
@@ -92,15 +100,27 @@ console.log(transcript.text);
 ```javascript
 const transcript = await client.transcripts.transcribe({
   audio: "./path/to/local/audio.mp3",
+  speech_models: ["universal-3-pro", "universal-2"],
 });
 
 console.log(transcript.text);
 ```
 
+**Speech Model Selection:**
+
+AssemblyAI lets you pass an ordered list of preferred models via
+`speech_models`. The first available model that supports the audio's language
+will be used. Recommended defaults:
+
+- `universal-3-pro` - highest accuracy general-purpose model
+- `universal-2` - reliable fallback with broad language coverage
+
 **Advanced Example with Audio Intelligence:**
 ```javascript
 const transcript = await client.transcripts.transcribe({
   audio: "https://example.com/meeting.mp3",
+  speech_models: ["universal-3-pro", "universal-2"],
+
   // Speaker identification
   speaker_labels: true,
   speakers_expected: 2,
@@ -112,9 +132,8 @@ const transcript = await client.transcripts.transcribe({
   content_safety: true,
   iab_categories: true,
 
-  // Language detection and translation
-  language_code: "en",
-  language_detection: false,
+  // Language detection
+  language_detection: true,
 
   // Formatting options
   format_text: true,
@@ -126,25 +145,25 @@ const transcript = await client.transcripts.transcribe({
   boost_param: "high",
 });
 
-// Access results
 console.log(transcript.text);
 console.log(transcript.sentiment_analysis_results);
 console.log(transcript.entities);
 console.log(transcript.auto_highlights_result);
 ```
 
-**Transcribe Without Waiting (Webhook or Manual Polling):**
+**Transcribe Without Waiting (Submit + Manual Retrieve):**
 ```javascript
 // Submit transcription without waiting
-const transcript = await client.transcripts.submit({
+const submitted = await client.transcripts.submit({
   audio: "https://example.com/audio.mp3",
+  speech_models: ["universal-3-pro", "universal-2"],
   webhook_url: "https://your-domain.com/webhook",
 });
 
-console.log(transcript.id); // Use this ID to check status later
+console.log(submitted.id); // Use this ID to check status later
 
 // Later, retrieve the transcript
-const result = await client.transcripts.get(transcript.id);
+const result = await client.transcripts.get(submitted.id);
 if (result.status === "completed") {
   console.log(result.text);
 } else if (result.status === "error") {
@@ -152,31 +171,44 @@ if (result.status === "completed") {
 }
 ```
 
+**Polling Helper:**
+```javascript
+const submitted = await client.transcripts.submit({
+  audio: "https://example.com/audio.mp3",
+});
+
+// Wait until the transcript is ready (polls automatically)
+const transcript = await client.transcripts.waitUntilReady(submitted.id, {
+  pollingInterval: 1000,
+});
+console.log(transcript.text);
+```
+
 ### 4.2 Real-Time Streaming Transcription
 
-Real-time transcription provides live speech-to-text with low latency (300ms P50 on final transcripts).
+Real-time transcription is exposed through `client.streaming.transcriber(...)`.
+It provides live speech-to-text with low latency.
 
 **Minimal Example:**
 ```javascript
-import { RealtimeTranscriber } from "assemblyai";
+import { AssemblyAI } from "assemblyai";
 
-const transcriber = new RealtimeTranscriber({
+const client = new AssemblyAI({
   apiKey: process.env.ASSEMBLYAI_API_KEY,
+});
+
+const transcriber = client.streaming.transcriber({
+  speechModel: "u3-rt-pro",
   sampleRate: 16000,
+  formatTurns: true,
 });
 
-transcriber.on("open", ({ sessionId }) => {
-  console.log("Session opened:", sessionId);
+transcriber.on("open", ({ id }) => {
+  console.log("Session opened:", id);
 });
 
-transcriber.on("transcript", (transcript) => {
-  if (!transcript.text) return;
-
-  if (transcript.message_type === "FinalTranscript") {
-    console.log("Final:", transcript.text);
-  } else {
-    console.log("Partial:", transcript.text);
-  }
+transcriber.on("turn", ({ transcript }) => {
+  if (transcript) console.log("Transcript:", transcript);
 });
 
 transcriber.on("error", (error) => {
@@ -190,87 +222,52 @@ transcriber.on("close", (code, reason) => {
 // Connect to the streaming service
 await transcriber.connect();
 
-// Send audio data (16-bit PCM audio)
+// Send audio data (16-bit PCM)
 transcriber.sendAudio(audioChunk);
 
 // Close when done
 await transcriber.close();
 ```
 
-**Advanced Example with Audio Intelligence:**
+**Streaming from a Microphone Stream:**
 ```javascript
-const transcriber = new RealtimeTranscriber({
-  apiKey: process.env.ASSEMBLYAI_API_KEY,
+const transcriber = client.streaming.transcriber({
+  speechModel: "u3-rt-pro",
   sampleRate: 16000,
-  encoding: "pcm_s16le",
-
-  // Enable word-level timestamps
-  word_boost: ["AssemblyAI", "JavaScript"],
-
-  // Disable automatic punctuation
-  disable_partial_transcripts: false,
-
-  // End utterance silence threshold
-  end_utterance_silence_threshold: 500,
-});
-
-transcriber.on("transcript", (transcript) => {
-  if (transcript.message_type === "FinalTranscript") {
-    console.log("Final transcript:", transcript.text);
-    console.log("Confidence:", transcript.confidence);
-    console.log("Words:", transcript.words);
-  } else if (transcript.message_type === "PartialTranscript") {
-    console.log("Partial:", transcript.text);
-  }
+  formatTurns: true,
 });
 
 await transcriber.connect();
 
-// Stream from microphone or file
 const stream = getMicrophoneStream(); // Your audio source
 stream.on("data", (chunk) => {
   transcriber.sendAudio(chunk);
 });
 ```
 
-**Streaming with Temporary Token (Client-Side Security):**
+**Streaming with a Temporary Token (Client-Side Security):**
 ```javascript
-// Server-side: Generate temporary token
-const token = await client.realtime.createTemporaryToken({
-  expires_in: 3600, // 1 hour
+// Server-side: mint a short-lived token
+const { token } = await client.streaming.createTemporaryToken({
+  expires_in_seconds: 3600,
 });
-// Send token to client
 
-// Client-side: Use token instead of API key
-import { RealtimeTranscriber } from "assemblyai";
-
-const transcriber = new RealtimeTranscriber({
-  token: temporaryToken, // Use token instead of apiKey
+// Client-side: use the token instead of your API key
+const transcriber = client.streaming.transcriber({
+  token,
+  speechModel: "u3-rt-pro",
   sampleRate: 16000,
 });
 ```
 
 ### 4.3 PII Redaction
 
-Automatically detect and redact 23 categories of Personally Identifiable Information (PII).
+Automatically detect and redact categories of Personally Identifiable
+Information (PII).
 
-**Minimal Example:**
 ```javascript
 const transcript = await client.transcripts.transcribe({
   audio: "https://example.com/audio.mp3",
-  redact_pii: true,
-  redact_pii_policies: ["us_social_security_number", "credit_card_number"],
-});
-
-console.log(transcript.text); // PII replaced with [REDACTED]
-```
-
-**Advanced Example with Audio Redaction:**
-```javascript
-const transcript = await client.transcripts.transcribe({
-  audio: "https://example.com/sensitive-call.mp3",
-
-  // Text redaction
   redact_pii: true,
   redact_pii_policies: [
     "us_social_security_number",
@@ -284,88 +281,40 @@ const transcript = await client.transcripts.transcribe({
     "medication",
     "person_name",
   ],
-  redact_pii_sub: "hash", // Options: "hash" or "entity_name"
+  redact_pii_sub: "hash", // "hash" or "entity_name"
 
-  // Audio redaction
+  // Optionally also produce a redacted audio file
   redact_pii_audio: true,
-  redact_pii_audio_quality: "mp3", // Options: "mp3" or "wav"
+  redact_pii_audio_quality: "mp3", // "mp3" or "wav"
 });
 
-console.log(transcript.text); // Text with PII redacted
-console.log(transcript.redacted_audio_url); // URL to redacted audio file
-
-// Download redacted audio
-if (transcript.redacted_audio_url) {
-  const redactedAudio = await fetch(transcript.redacted_audio_url);
-  // Process redacted audio
-}
+console.log(transcript.text);
+console.log(transcript.redacted_audio_url);
 ```
 
-**Available PII Categories:**
-
-To see the complete list of 23+ available PII categories, check the TypeScript types or run:
-```bash
-npm info assemblyai | grep -A 50 "redact_pii_policies"
-```
-
-Or view the official documentation at https://www.assemblyai.com/docs/audio-intelligence/pii-redaction for the most up-to-date list of supported PII categories including SSN, credit cards, medical information, and more.
+See the official documentation for the full list of supported PII policies:
+https://www.assemblyai.com/docs/audio-intelligence/pii-redaction
 
 ### 4.4 Speaker Diarization
 
-Identify and label different speakers in audio (up to 10 speakers).
+Identify and label different speakers in audio.
 
-**Minimal Example:**
 ```javascript
 const transcript = await client.transcripts.transcribe({
   audio: "https://example.com/meeting.mp3",
   speaker_labels: true,
+  speakers_expected: 4, // optional hint
 });
 
-// Access speaker-labeled words
 for (const utterance of transcript.utterances) {
   console.log(`Speaker ${utterance.speaker}: ${utterance.text}`);
 }
 ```
 
-**Advanced Example:**
-```javascript
-const transcript = await client.transcripts.transcribe({
-  audio: "https://example.com/conference-call.mp3",
-  speaker_labels: true,
-  speakers_expected: 4, // Hint for better accuracy
-
-  // Combine with other features
-  sentiment_analysis: true,
-  entity_detection: true,
-});
-
-// Analyze per-speaker sentiment
-const speakerSentiments = {};
-for (const result of transcript.sentiment_analysis_results) {
-  const speaker = result.speaker;
-  if (!speakerSentiments[speaker]) {
-    speakerSentiments[speaker] = [];
-  }
-  speakerSentiments[speaker].push(result.sentiment);
-}
-
-console.log("Speaker sentiments:", speakerSentiments);
-
-// Get full utterances with timestamps
-for (const utterance of transcript.utterances) {
-  console.log({
-    speaker: utterance.speaker,
-    text: utterance.text,
-    start: utterance.start,
-    end: utterance.end,
-    confidence: utterance.confidence,
-  });
-}
-```
-
 ### 4.5 LeMUR - Apply LLMs to Audio
 
-LeMUR (Leveraging Large Language Models to Understand Recordings) applies powerful LLMs to transcribed speech for summarization, Q&A, action items, and custom tasks.
+LeMUR (Leveraging Large Language Models to Understand Recordings) applies LLMs
+to transcribed speech for summarization, Q&A, action items, and custom tasks.
 
 **Question & Answer:**
 ```javascript
@@ -376,13 +325,8 @@ const transcript = await client.transcripts.transcribe({
 const { response } = await client.lemur.question({
   transcript_ids: [transcript.id],
   questions: [
-    {
-      question: "What were the main action items discussed?",
-      answer_format: "bullet points",
-    },
-    {
-      question: "Who was assigned to work on the new feature?",
-    },
+    { question: "What were the main action items discussed?", answer_format: "bullet points" },
+    { question: "Who was assigned to work on the new feature?" },
   ],
 });
 
@@ -396,8 +340,6 @@ const { response } = await client.lemur.summary({
   answer_format: "one sentence",
   context: "This is a sales call between a sales rep and a potential customer",
 });
-
-console.log("Summary:", response);
 ```
 
 **Action Items:**
@@ -405,112 +347,33 @@ console.log("Summary:", response);
 const { response } = await client.lemur.actionItems({
   transcript_ids: [transcript.id],
 });
-
-console.log("Action items:", response);
 ```
 
 **Custom Task:**
 ```javascript
 const { response } = await client.lemur.task({
   transcript_ids: [transcript.id],
-  prompt: "Identify the key risks discussed in this meeting and categorize them as technical, financial, or operational. Return as JSON with structure: {technical: [], financial: [], operational: []}",
+  prompt: "Identify the key risks discussed and categorize them as technical, financial, or operational.",
   final_model: "anthropic/claude-3-5-sonnet",
 });
-
-console.log(response);
 ```
-
-**Advanced LeMUR with Multiple Transcripts:**
-```javascript
-// Transcribe multiple files
-const transcript1 = await client.transcripts.transcribe({
-  audio: "https://example.com/day1.mp3",
-});
-const transcript2 = await client.transcripts.transcribe({
-  audio: "https://example.com/day2.mp3",
-});
-
-// Analyze all transcripts together
-const { response } = await client.lemur.task({
-  transcript_ids: [transcript1.id, transcript2.id],
-  prompt: `Analyze these two conference sessions and:
-    1. Identify common themes
-    2. List key speakers and their main points
-    3. Suggest follow-up topics for the next conference
-
-    Return as structured markdown.`,
-  final_model: "anthropic/claude-3-5-sonnet",
-  max_output_size: 4000,
-  temperature: 0.3,
-});
-
-console.log(response);
-```
-
-**Available LeMUR Models:**
-
-To see the current list of supported LLM models, check the official documentation at https://www.assemblyai.com/docs/api-reference/lemur or inspect the TypeScript types. As of 2025, Claude 3.5 Sonnet is recommended for most tasks.
 
 ### 4.6 Content Moderation
 
-Detect sensitive or inappropriate content across multiple categories.
-
-**Minimal Example:**
 ```javascript
 const transcript = await client.transcripts.transcribe({
   audio: "https://example.com/content.mp3",
   content_safety: true,
-});
-
-for (const result of transcript.content_safety_labels.results) {
-  console.log(`${result.text}: ${result.labels.map(l => l.label).join(", ")}`);
-}
-```
-
-**Advanced Example:**
-```javascript
-const transcript = await client.transcripts.transcribe({
-  audio: "https://example.com/user-generated-content.mp3",
-  content_safety: true,
-
-  // Set confidence threshold
   content_safety_confidence: 75,
 });
 
-// Filter high-severity content
-const severityThreshold = 0.8;
-const flaggedContent = transcript.content_safety_labels.results.filter(
-  (result) => result.labels.some(label => label.confidence > severityThreshold)
-);
-
-if (flaggedContent.length > 0) {
-  console.log("Flagged content detected:");
-  for (const item of flaggedContent) {
-    console.log({
-      text: item.text,
-      timestamp: `${item.timestamp.start}ms - ${item.timestamp.end}ms`,
-      labels: item.labels.map(l => ({
-        category: l.label,
-        confidence: l.confidence,
-        severity: l.severity,
-      })),
-    });
-  }
+for (const result of transcript.content_safety_labels.results) {
+  console.log(`${result.text}: ${result.labels.map((l) => l.label).join(", ")}`);
 }
-
-// Summary of content safety
-console.log("Summary:", transcript.content_safety_labels.summary);
 ```
-
-**Content Safety Categories:**
-
-To see the complete list of content moderation categories, check the official documentation at https://www.assemblyai.com/docs/audio-intelligence/content-moderation or inspect the SDK TypeScript types for `ContentSafetyLabel`. Categories include violence, profanity, NSFW, hate speech, and more.
 
 ### 4.7 Topic Detection (IAB Classification)
 
-Automatically classify content using IAB (Interactive Advertising Bureau) taxonomy.
-
-**Minimal Example:**
 ```javascript
 const transcript = await client.transcripts.transcribe({
   audio: "https://example.com/podcast.mp3",
@@ -520,41 +383,8 @@ const transcript = await client.transcripts.transcribe({
 console.log("Detected topics:", transcript.iab_categories_result.summary);
 ```
 
-**Advanced Example:**
-```javascript
-const transcript = await client.transcripts.transcribe({
-  audio: "https://example.com/podcast.mp3",
-  iab_categories: true,
-});
-
-// Get overall summary
-const topTopics = Object.entries(transcript.iab_categories_result.summary)
-  .sort((a, b) => b[1] - a[1])
-  .slice(0, 5);
-
-console.log("Top 5 topics:");
-for (const [topic, relevance] of topTopics) {
-  console.log(`${topic}: ${(relevance * 100).toFixed(1)}%`);
-}
-
-// Get segment-level topics
-for (const result of transcript.iab_categories_result.results) {
-  console.log({
-    text: result.text,
-    timestamp: `${result.timestamp.start}ms - ${result.timestamp.end}ms`,
-    topics: result.labels.map(l => ({
-      category: l.label,
-      relevance: l.relevance,
-    })),
-  });
-}
-```
-
 ### 4.8 Sentiment Analysis
 
-Analyze emotional tone throughout the audio.
-
-**Minimal Example:**
 ```javascript
 const transcript = await client.transcripts.transcribe({
   audio: "https://example.com/customer-call.mp3",
@@ -566,45 +396,8 @@ for (const result of transcript.sentiment_analysis_results) {
 }
 ```
 
-**Advanced Example:**
-```javascript
-const transcript = await client.transcripts.transcribe({
-  audio: "https://example.com/customer-call.mp3",
-  sentiment_analysis: true,
-  speaker_labels: true,
-});
-
-// Calculate sentiment distribution
-const sentimentCounts = { POSITIVE: 0, NEUTRAL: 0, NEGATIVE: 0 };
-for (const result of transcript.sentiment_analysis_results) {
-  sentimentCounts[result.sentiment]++;
-}
-
-const total = transcript.sentiment_analysis_results.length;
-console.log("Sentiment distribution:");
-console.log(`Positive: ${(sentimentCounts.POSITIVE / total * 100).toFixed(1)}%`);
-console.log(`Neutral: ${(sentimentCounts.NEUTRAL / total * 100).toFixed(1)}%`);
-console.log(`Negative: ${(sentimentCounts.NEGATIVE / total * 100).toFixed(1)}%`);
-
-// Analyze sentiment by speaker
-const speakerSentiments = {};
-for (const result of transcript.sentiment_analysis_results) {
-  if (!result.speaker) continue;
-
-  if (!speakerSentiments[result.speaker]) {
-    speakerSentiments[result.speaker] = { POSITIVE: 0, NEUTRAL: 0, NEGATIVE: 0 };
-  }
-  speakerSentiments[result.speaker][result.sentiment]++;
-}
-
-console.log("\nSentiment by speaker:", speakerSentiments);
-```
-
 ### 4.9 Entity Detection
 
-Extract and classify named entities from transcripts.
-
-**Minimal Example:**
 ```javascript
 const transcript = await client.transcripts.transcribe({
   audio: "https://example.com/news.mp3",
@@ -616,43 +409,8 @@ for (const entity of transcript.entities) {
 }
 ```
 
-**Advanced Example:**
-```javascript
-const transcript = await client.transcripts.transcribe({
-  audio: "https://example.com/business-meeting.mp3",
-  entity_detection: true,
-});
-
-// Group entities by type
-const entitiesByType = {};
-for (const entity of transcript.entities) {
-  if (!entitiesByType[entity.entity_type]) {
-    entitiesByType[entity.entity_type] = [];
-  }
-  entitiesByType[entity.entity_type].push({
-    text: entity.text,
-    start: entity.start,
-    end: entity.end,
-  });
-}
-
-console.log("Entities by type:");
-for (const [type, entities] of Object.entries(entitiesByType)) {
-  console.log(`\n${type}:`);
-  const uniqueEntities = [...new Set(entities.map(e => e.text))];
-  console.log(uniqueEntities.join(", "));
-}
-```
-
-**Entity Types:**
-
-To see the complete list of detectable entity types, check the official documentation at https://www.assemblyai.com/docs/audio-intelligence/entity-detection or inspect the SDK TypeScript types for `EntityType`. Supported types include person names, locations, organizations, dates, medical terms, and more.
-
 ### 4.10 Auto Highlights
 
-Automatically identify and extract key phrases and important moments.
-
-**Minimal Example:**
 ```javascript
 const transcript = await client.transcripts.transcribe({
   audio: "https://example.com/meeting.mp3",
@@ -664,102 +422,36 @@ for (const highlight of transcript.auto_highlights_result.results) {
 }
 ```
 
-**Advanced Example:**
-```javascript
-const transcript = await client.transcripts.transcribe({
-  audio: "https://example.com/podcast.mp3",
-  auto_highlights: true,
-});
+### 4.11 Export Subtitles (SRT / VTT)
 
-// Get top highlights
-const topHighlights = transcript.auto_highlights_result.results
-  .sort((a, b) => b.rank - a.rank)
-  .slice(0, 10);
-
-console.log("Top 10 highlights:");
-for (const highlight of topHighlights) {
-  console.log({
-    text: highlight.text,
-    rank: highlight.rank,
-    count: highlight.count,
-    timestamps: highlight.timestamps.map(t => ({
-      start: t.start,
-      end: t.end,
-    })),
-  });
-}
-```
-
-### 4.11 Export Subtitles (SRT/VTT)
-
-Export completed transcripts as subtitle files for video.
-
-**Export as SRT:**
 ```javascript
 const transcript = await client.transcripts.transcribe({
   audio: "https://example.com/video-audio.mp3",
 });
 
 const srt = await client.transcripts.subtitles(transcript.id, "srt");
-console.log(srt);
-
-// Or with custom chars per caption
-const srtCustom = await client.transcripts.subtitles(
-  transcript.id,
-  "srt",
-  40 // chars_per_caption
-);
-```
-
-**Export as VTT:**
-```javascript
 const vtt = await client.transcripts.subtitles(transcript.id, "vtt");
-console.log(vtt);
 
-// Save to file
-import fs from "fs";
-fs.writeFileSync("subtitles.vtt", vtt);
+// Optional chars-per-caption argument
+const srtCustom = await client.transcripts.subtitles(transcript.id, "srt", 40);
 ```
 
 ### 4.12 Paragraphs and Sentences
 
-Retrieve transcripts automatically segmented into paragraphs or sentences.
-
-**Get Paragraphs:**
 ```javascript
-const transcript = await client.transcripts.transcribe({
-  audio: "https://example.com/lecture.mp3",
-});
-
 const paragraphs = await client.transcripts.paragraphs(transcript.id);
-
 for (const para of paragraphs.paragraphs) {
-  console.log(`[${para.start}ms - ${para.end}ms]`);
-  console.log(para.text);
-  console.log("---");
+  console.log(`[${para.start}ms - ${para.end}ms] ${para.text}`);
 }
-```
 
-**Get Sentences:**
-```javascript
 const sentences = await client.transcripts.sentences(transcript.id);
-
-for (const sentence of sentences.sentences) {
-  console.log({
-    text: sentence.text,
-    start: sentence.start,
-    end: sentence.end,
-    confidence: sentence.confidence,
-    speaker: sentence.speaker,
-  });
+for (const s of sentences.sentences) {
+  console.log({ text: s.text, start: s.start, end: s.end });
 }
 ```
 
 ### 4.13 Word-Level Timestamps
 
-Access precise word-level timing information.
-
-**Example:**
 ```javascript
 const transcript = await client.transcripts.transcribe({
   audio: "https://example.com/speech.mp3",
@@ -771,19 +463,8 @@ for (const word of transcript.words) {
     start: word.start, // milliseconds
     end: word.end,
     confidence: word.confidence,
-    speaker: word.speaker, // if speaker_labels enabled
+    speaker: word.speaker,
   });
-}
-
-// Find specific words
-const targetWord = "important";
-const occurrences = transcript.words.filter(w =>
-  w.text.toLowerCase() === targetWord.toLowerCase()
-);
-
-console.log(`"${targetWord}" appears ${occurrences.length} times at:`);
-for (const word of occurrences) {
-  console.log(`  ${word.start}ms - ${word.end}ms`);
 }
 ```
 
@@ -801,70 +482,32 @@ const transcript = await client.transcripts.transcribe({
 console.log("Detected language:", transcript.language_code);
 ```
 
-**Specify Language:**
+**Specify a Language:**
 ```javascript
 const transcript = await client.transcripts.transcribe({
   audio: "https://example.com/spanish-audio.mp3",
-  language_code: "es", // Spanish
+  language_code: "es",
 });
 ```
 
-**Supported Languages:**
-
-AssemblyAI supports 100+ languages. To see the complete list of supported language codes, check the official documentation at https://www.assemblyai.com/docs/concepts/supported-languages or run:
-```bash
-npm info assemblyai | grep -A 20 "language_code"
-```
-
-Common language codes include `en` (English), `es` (Spanish), `fr` (French), `de` (German), `zh` (Chinese), `ja` (Japanese), and many more.
-
-**Multilingual Streaming (Beta):**
-```javascript
-const transcriber = new RealtimeTranscriber({
-  apiKey: process.env.ASSEMBLYAI_API_KEY,
-  sampleRate: 16000,
-  // Auto-detect between supported languages
-  language_code: "multi",
-});
-```
+AssemblyAI supports 100+ languages. See the official documentation for the full
+list of supported language codes:
+https://www.assemblyai.com/docs/concepts/supported-languages
 
 ### 5.2 Custom Vocabulary and Word Boost
 
-Improve accuracy for domain-specific terms.
-
-**Word Boost:**
 ```javascript
 const transcript = await client.transcripts.transcribe({
   audio: "https://example.com/tech-talk.mp3",
-  word_boost: [
-    "AssemblyAI",
-    "Kubernetes",
-    "GraphQL",
-    "TypeScript",
-    "microservices",
-  ],
-  boost_param: "high", // Options: "low", "default", "high"
+  word_boost: ["AssemblyAI", "Kubernetes", "GraphQL", "TypeScript"],
+  boost_param: "high", // "low", "default", or "high"
 });
 ```
 
-### 5.3 Audio Format Support
+### 5.3 Webhook Configuration
 
-AssemblyAI automatically detects and processes various audio formats.
-
-**Supported Formats:**
-
-AssemblyAI automatically detects and supports most common audio/video formats including MP3, MP4, WAV, FLAC, AAC, and more. For the complete list of supported formats, see https://www.assemblyai.com/docs/concepts/audio-formats
-
-**Optimal Settings:**
-For best transcription quality, use audio with 16kHz+ sample rate, mono or stereo channels, and 16-bit+ depth.
-
-### 5.4 Webhook Configuration
-
-Receive notifications when transcription completes.
-
-**Setup Webhook:**
 ```javascript
-const transcript = await client.transcripts.submit({
+const submitted = await client.transcripts.submit({
   audio: "https://example.com/audio.mp3",
   webhook_url: "https://your-domain.com/webhook/assemblyai",
   webhook_auth_header_name: "X-Webhook-Secret",
@@ -879,8 +522,7 @@ import express from "express";
 const app = express();
 app.use(express.json());
 
-app.post("/webhook/assemblyai", (req, res) => {
-  // Verify webhook secret
+app.post("/webhook/assemblyai", async (req, res) => {
   if (req.headers["x-webhook-secret"] !== process.env.WEBHOOK_SECRET) {
     return res.status(401).send("Unauthorized");
   }
@@ -888,11 +530,8 @@ app.post("/webhook/assemblyai", (req, res) => {
   const { transcript_id, status } = req.body;
 
   if (status === "completed") {
-    console.log("Transcription completed:", transcript_id);
-    // Retrieve full transcript
-    client.transcripts.get(transcript_id).then(transcript => {
-      console.log(transcript.text);
-    });
+    const transcript = await client.transcripts.get(transcript_id);
+    console.log(transcript.text);
   } else if (status === "error") {
     console.error("Transcription failed:", req.body.error);
   }
@@ -901,45 +540,13 @@ app.post("/webhook/assemblyai", (req, res) => {
 });
 ```
 
-### 5.5 Polling Status Manually
+### 5.4 Delete Transcripts
 
 ```javascript
-const transcript = await client.transcripts.submit({
-  audio: "https://example.com/audio.mp3",
-});
-
-// Poll every 3 seconds
-const checkStatus = async () => {
-  const result = await client.transcripts.get(transcript.id);
-
-  if (result.status === "completed") {
-    console.log("Done:", result.text);
-    return result;
-  } else if (result.status === "error") {
-    throw new Error(result.error);
-  } else {
-    console.log("Status:", result.status);
-    await new Promise(resolve => setTimeout(resolve, 3000));
-    return checkStatus();
-  }
-};
-
-const finalTranscript = await checkStatus();
-```
-
-### 5.6 Delete Transcripts
-
-Permanently delete transcripts from AssemblyAI servers.
-
-```javascript
-// Delete a specific transcript
 await client.transcripts.delete(transcript.id);
-console.log("Transcript deleted");
 ```
 
-### 5.7 List Transcripts
-
-Retrieve a list of previously submitted transcripts.
+### 5.5 List Transcripts
 
 ```javascript
 const page = await client.transcripts.list({
@@ -947,48 +554,29 @@ const page = await client.transcripts.list({
   status: "completed",
 });
 
-for (const transcript of page.transcripts) {
-  console.log({
-    id: transcript.id,
-    status: transcript.status,
-    created: transcript.created,
-    audio_duration: transcript.audio_duration,
-  });
-}
-
-// Handle pagination
-if (page.page_details.next_url) {
-  const nextPage = await client.transcripts.list({
-    limit: 10,
-    before_id: page.transcripts[page.transcripts.length - 1].id,
-  });
+for (const t of page.transcripts) {
+  console.log({ id: t.id, status: t.status, audio_duration: t.audio_duration });
 }
 ```
 
 ## 6. TypeScript Usage
 
-The AssemblyAI SDK is written in TypeScript and provides comprehensive type definitions.
+The AssemblyAI SDK is written in TypeScript and provides comprehensive type
+definitions.
 
-### Import Types
 ```typescript
 import {
   AssemblyAI,
   TranscribeParams,
   Transcript,
-  RealtimeTranscript,
-  TranscriptStatus,
   SentimentAnalysisResult,
   Entity,
-  ContentSafetyLabel,
   LemurTaskParams,
-  LemurResponse,
 } from "assemblyai";
-```
 
-### Type-Safe Transcription
-```typescript
 const params: TranscribeParams = {
   audio: "https://example.com/audio.mp3",
+  speech_models: ["universal-3-pro", "universal-2"],
   speaker_labels: true,
   sentiment_analysis: true,
   entity_detection: true,
@@ -996,7 +584,6 @@ const params: TranscribeParams = {
 
 const transcript: Transcript = await client.transcripts.transcribe(params);
 
-// TypeScript knows the available properties
 if (transcript.status === "completed") {
   const text: string = transcript.text;
   const sentiments: SentimentAnalysisResult[] | undefined =
@@ -1005,39 +592,15 @@ if (transcript.status === "completed") {
 }
 ```
 
-### Type-Safe LeMUR
+**Type-Safe Streaming:**
 ```typescript
-import type { LemurQuestionAnswerParams } from "assemblyai";
+const transcriber = client.streaming.transcriber({
+  speechModel: "u3-rt-pro",
+  sampleRate: 16000,
+  formatTurns: true,
+});
 
-const params: LemurQuestionAnswerParams = {
-  transcript_ids: [transcript.id],
-  questions: [
-    {
-      question: "What were the key takeaways?",
-      answer_format: "bullet points",
-    },
-  ],
-  final_model: "anthropic/claude-3-5-sonnet",
-};
-
-const result = await client.lemur.question(params);
-```
-
-### Type Guards for Real-Time Transcripts
-```typescript
-import { RealtimeTranscript } from "assemblyai";
-
-transcriber.on("transcript", (transcript: RealtimeTranscript) => {
-  if (transcript.message_type === "FinalTranscript") {
-    // TypeScript knows this is a final transcript
-    const text: string = transcript.text;
-    const confidence: number = transcript.confidence;
-    const words: Array<{ text: string; start: number; end: number }> =
-      transcript.words;
-  } else if (transcript.message_type === "PartialTranscript") {
-    // Partial transcript
-    const partialText: string = transcript.text;
-  }
+transcriber.on("turn", ({ transcript, end_of_turn }) => {
+  console.log({ transcript, end_of_turn });
 });
 ```
-

--- a/content/deepgram/docs/speech/javascript/DOC.md
+++ b/content/deepgram/docs/speech/javascript/DOC.md
@@ -3,8 +3,9 @@ name: speech
 description: "Deepgram JavaScript SDK coding guidelines for speech recognition, text-to-speech, and audio intelligence"
 metadata:
   languages: "javascript"
-  versions: "4.11.2"
-  updated-on: "2026-03-02"
+  versions: "5.3.0"
+  revision: 1
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "deepgram,speech,transcription,tts,audio"
 ---
@@ -28,26 +29,31 @@ Always use the official Deepgram JavaScript SDK, which is the standard library f
 
 **Installation:**
 
-- **Correct:** `npm install @deepgram/sdk` 
+```bash
+npm install @deepgram/sdk
+```
 
 **APIs and Usage:**
 
-- **Correct:** `import { createClient } from "@deepgram/sdk"`
-- **Correct:** `const deepgram = createClient(DEEPGRAM_API_KEY)`
-- **Incorrect:** Using any other import patterns or client creation methods
+- **Correct (v5):** `import { DeepgramClient } from "@deepgram/sdk"`
+- **Correct (v5):** `const client = new DeepgramClient({ apiKey: DEEPGRAM_API_KEY })`
 
 ## Initialization and API Key
 
-The `@deepgram/sdk` library requires creating a client instance for all API calls.
+The `@deepgram/sdk` library requires creating a `DeepgramClient` instance for all API calls.
 
-- Always use `createClient()` to create an instance
-- Set your Deepgram API key as the first parameter
+- Always construct with `new DeepgramClient(...)`
+- Pass your Deepgram API key in the constructor, or set the `DEEPGRAM_API_KEY` environment variable
 - Get your free API key from: https://console.deepgram.com/signup?jump=keys
 
 ```javascript
-import { createClient } from "@deepgram/sdk";
+import { DeepgramClient } from "@deepgram/sdk";
 
-const deepgram = createClient("your-deepgram-api-key");
+// Reads DEEPGRAM_API_KEY from env if no options are passed
+const client = new DeepgramClient();
+
+// Or pass the API key explicitly
+const explicit = new DeepgramClient({ apiKey: "YOUR_API_KEY" });
 ```
 
 ## Models
@@ -58,10 +64,8 @@ By default, use the following models for speech recognition:
 
 - **General Purpose (Recommended):** `nova-3` or `nova-3-general`
 - **Medical Applications:** `nova-3-medical` or `nova-2-medical`
-- **Meeting Transcription:** `nova-2-meeting` or `enhanced-meeting`
-- **Phone Call Audio:** `nova-2-phonecall` or `enhanced-phonecall`
-- **Cost-Effective Option:** `nova` or `enhanced`
-- **Highest Accuracy:** `nova-3` (latest generation)
+- **Phone Call Audio:** `nova-2-phonecall`
+- **Highest Accuracy / Latest:** `nova-3`
 
 ### Text-to-Speech Models
 
@@ -69,60 +73,87 @@ For text-to-speech, use the Aura model series:
 
 - **Recommended Default:** `aura-2-thalia-en`
 - **Available Voices:** All `aura-2-*` models for various voice characteristics
-- **Legacy Support:** `aura-*` models (first generation)
 
-## Basic Speech Recognition (Transcription)
+## Speech Recognition (Transcription)
 
-### Synchronous Transcription - Remote Files
+### Prerecorded - Transcribe from URL
 
 ```javascript
-import { createClient } from "@deepgram/sdk";
+import { DeepgramClient } from "@deepgram/sdk";
 
-const deepgram = createClient("your-api-key");
+const client = new DeepgramClient();
 
-const { result, error } = await deepgram.listen.prerecorded.transcribeUrl(
+const response = await client.listen.v1.media.transcribeUrl(
   { url: "https://example.com/audio.wav" },
-  { model: "nova-3" }
+  { model: "nova-3", smartFormat: true, language: "en" }
 );
 
-if (error) {
-  console.error("Transcription error:", error);
-} else {
-  console.log("Transcript:", result);
-}
+console.log(response.results.channels[0].alternatives[0].transcript);
 ```
 
-### Synchronous Transcription - Local Files
+### Prerecorded - Transcribe from File / Buffer
 
 ```javascript
-import fs from "fs";
+import { createReadStream, readFileSync } from "fs";
+import { DeepgramClient } from "@deepgram/sdk";
 
-// Using file stream
-const { result, error } = await deepgram.listen.prerecorded.transcribeFile(
-  fs.createReadStream("./audio.wav"),
+const client = new DeepgramClient();
+
+// From a readable stream
+const fromStream = await client.listen.v1.media.transcribeFile(
+  createReadStream("./audio.wav"),
+  { model: "nova-3", smartFormat: true, diarize: true, utterances: true }
+);
+
+// From a buffer
+const fromBuffer = await client.listen.v1.media.transcribeFile(
+  readFileSync("./audio.wav"),
   { model: "nova-3" }
 );
 
-// Using file buffer
-const { result, error } = await deepgram.listen.prerecorded.transcribeFile(
-  fs.readFileSync("./audio.wav"),
-  { model: "nova-3" }
-);
+console.log(fromStream.results.channels[0].alternatives[0].transcript);
 ```
 
-### Live Streaming Transcription
+### Common Transcription Options
+
+- `model`: Speech recognition model to use
+- `language`: Language code (e.g., `"en"`, `"es"`, `"fr"`) or `"multi"`
+- `punctuate`: Add punctuation
+- `diarize`: Speaker identification
+- `smartFormat`: Automatic punctuation, numerals, dates, etc.
+- `utterances`: Group transcripts into utterances
+- `keyterm`: Keyword detection (Nova 3 only)
+
+### Live Streaming Transcription (WebSocket)
 
 ```javascript
-const dgConnection = deepgram.listen.live({ model: "nova-3" });
+import { DeepgramClient } from "@deepgram/sdk";
 
-dgConnection.on(LiveTranscriptionEvents.Open, () => {
-  dgConnection.on(LiveTranscriptionEvents.Transcript, (data) => {
-    console.log(data);
-  });
+const client = new DeepgramClient();
 
-  // Send audio data
-  dgConnection.send(audioData);
+const connection = await client.listen.v1.connect({
+  model: "nova-3",
+  language: "en",
+  smartFormat: true,
+  interimResults: true,
 });
+
+connection.on("open", () => console.log("Connection opened"));
+
+connection.on("message", (data) => {
+  if (data.type === "Results") {
+    console.log(data.channel.alternatives[0].transcript);
+  }
+});
+
+connection.on("error", (error) => console.error("Error:", error));
+connection.on("close", () => console.log("Connection closed"));
+
+connection.connect();
+await connection.waitForOpen();
+
+// Send raw 16-bit PCM audio frames
+connection.socket.send(audioData);
 ```
 
 ## Text-to-Speech
@@ -130,171 +161,150 @@ dgConnection.on(LiveTranscriptionEvents.Open, () => {
 ### REST API (One-off requests)
 
 ```javascript
-const { result, error } = await deepgram.speak.request(
-  { text: "Hello, how are you today?" }, 
-  { model: "aura-2-thalia-en" }
-);
+import { DeepgramClient } from "@deepgram/sdk";
+import { createWriteStream } from "fs";
+
+const client = new DeepgramClient();
+
+const response = await client.speak.v1.audio.generate({
+  text: "Hello, how are you today?",
+  model: "aura-2-thalia-en",
+  encoding: "linear16",
+  container: "wav",
+});
+
+// Pipe the audio stream to a file
+const audioStream = response.stream();
+audioStream.pipe(createWriteStream("output.wav"));
 ```
 
-### WebSocket (Streaming)
+### WebSocket (Streaming TTS)
 
 ```javascript
-const dgConnection = deepgram.speak.live({ model: "aura-2-thalia-en" });
-
-dgConnection.on(LiveTTSEvents.Open, () => {
-  dgConnection.sendText("Hello world");
-  dgConnection.flush(); // Important: flush after sending text
+const connection = await client.speak.v1.connect({
+  model: "aura-2-thalia-en",
+  encoding: "linear16",
+  sampleRate: 24000,
 });
+
+connection.on("open", () => {
+  connection.sendText("Hello world from Deepgram streaming TTS.");
+  // Important: flush after sending text so the server begins synthesis
+  connection.flush();
+});
+
+connection.on("message", (audioChunk) => {
+  // audioChunk contains raw audio bytes
+});
+
+connection.connect();
 ```
 
 ## Voice Agent
 
 ```javascript
-const agent = deepgram.agent();
+import { DeepgramClient } from "@deepgram/sdk";
 
-agent.on(AgentEvents.Open, () => {
+const client = new DeepgramClient();
+const agent = client.agent.v1.connect();
+
+agent.on("open", () => {
   agent.configure({
     audio: {
-      input: { encoding: "linear16", sample_rate: 16000 },
-      output: { encoding: "linear16", container: "wav", sample_rate: 24000 }
+      input: { encoding: "linear16", sampleRate: 16000 },
+      output: { encoding: "linear16", container: "wav", sampleRate: 24000 },
     },
     agent: {
-      listen: { model: "nova-3" },
-      speak: { model: "aura-2-thalia-en" },
+      listen: { provider: { type: "deepgram", model: "nova-3" } },
+      speak: { provider: { type: "deepgram", model: "aura-2-thalia-en" } },
       think: {
-        provider: { type: "anthropic" },
-        model: "claude-3-haiku-20240307",
-        instructions: "You are a helpful AI assistant."
-      }
-    }
+        provider: { type: "anthropic", model: "claude-3-haiku-20240307" },
+        prompt: "You are a helpful AI assistant.",
+      },
+    },
   });
 });
 
-agent.on(AgentEvents.Audio, (audio) => {
-  // Handle audio response
+agent.on("audio", (audio) => {
+  // Handle audio bytes from the agent
 });
+
+agent.on("conversationText", (message) => {
+  console.log(`${message.role} said: ${message.content}`);
+});
+
+agent.connect();
 ```
 
 ## Error Handling
 
-The SDK uses a consistent error handling pattern with `DeepgramResponse`:
-
-**Error Types:**
-
-- `DeepgramError`: Base error class
-- `DeepgramApiError`: API-related errors with HTTP status codes
-- `DeepgramUnknownError`: Unexpected errors
-- `DeepgramVersionError`: SDK version compatibility errors
+The v5 SDK throws on error rather than returning `{ result, error }`. Wrap calls
+in `try/catch`.
 
 ```javascript
-const { result, error } = await deepgram.listen.prerecorded.transcribeUrl(
-  { url: "invalid-url" },
-  { model: "nova-3" }
-);
-
-if (error) {
-  if (error instanceof DeepgramApiError) {
-    console.error(`API Error (${error.status}): ${error.message}`);
-  } else {
-    console.error("Unexpected error:", error.message);
-  }
-  return;
+try {
+  const response = await client.listen.v1.media.transcribeUrl(
+    { url: "https://example.com/audio.wav" },
+    { model: "nova-3" }
+  );
+  console.log(response.results.channels[0].alternatives[0].transcript);
+} catch (error) {
+  console.error("Deepgram error:", error);
 }
-
-// Process successful result
-console.log(result);
 ```
 
-## Configuration and Advanced Features
-
-### Scoped Configuration
-
-The SDK supports namespace-specific configurations:
+## Text Intelligence
 
 ```javascript
-// Global configuration
-const deepgram = createClient("api-key", {
-  global: { 
-    fetch: { options: { url: "https://api.beta.deepgram.com" } } 
-  }
-});
-
-// Transcription-specific configuration
-const deepgram = createClient("api-key", {
-  listen: { 
-    fetch: { options: { url: "http://localhost:8080" } } 
-  }
-});
-```
-
-### Important Transcription Options
-
-- `model`: Speech recognition model to use
-- `language`: Language code (e.g., "en", "es", "fr")
-- `punctuate`: Add punctuation to transcript
-- `diarize`: Speaker identification
-- `smart_format`: Automatic formatting improvements
-- `keyterm`: Keyword detection (Nova 3 only)
-
-### Keyterm Detection (Nova 3 Only)
-
-```javascript
-const { result, error } = await deepgram.listen.prerecorded.transcribeUrl(
-  { url: "audio.wav" },
-  { 
-    model: "nova-3",
-    keyterm: ["urgent", "deadline", "meeting"]
-  }
+const response = await client.read.v1.text.analyze(
+  { text: "Your text content here" },
+  { language: "en", topics: true, sentiment: true }
 );
 ```
+
+## Captions Generation
+
+```javascript
+import { webvtt, srt } from "@deepgram/captions";
+
+// After a prerecorded transcription
+const vttOutput = webvtt(response);
+const srtOutput = srt(response);
+```
+
+## Migration Notes (v4 → v5)
+
+- Client construction: use `new DeepgramClient(...)` instead of `createClient(...)`.
+- Prerecorded transcription moved under `client.listen.v1.media.transcribeUrl`
+  and `client.listen.v1.media.transcribeFile`.
+- Live transcription uses `client.listen.v1.connect(options)` and emits
+  `"open" | "message" | "error" | "close"` events. Use `connection.connect()`
+  and `connection.waitForOpen()` before sending audio.
+- TTS REST moved to `client.speak.v1.audio.generate(...)`. The response exposes
+  a `stream()` method returning a readable stream of audio bytes.
+- TTS streaming uses `client.speak.v1.connect(options)` with `sendText()` /
+  `flush()`.
+- Responses are returned directly (or throw) rather than wrapped in
+  `{ result, error }`.
 
 ## Common Mistakes to Avoid
 
-- **Don't** use deprecated models like older versions without explicit need
-- **Don't** forget to handle both `result` and `error` in responses
-- **Don't** use keyterm detection with non-Nova-3 models
-- **Don't** forget to call `flush()` when using live text-to-speech
-- **Don't** hardcode API keys in your source code - use environment variables
-- **Always** check for errors before processing results
+- Don't use deprecated v4 APIs like `deepgram.listen.prerecorded.transcribeUrl`
+- Don't forget to call `flush()` when using live text-to-speech
+- Don't use keyterm detection with non-Nova-3 models
+- Don't hardcode API keys in your source code - use environment variables
+- Always handle errors with try/catch on every async API call
 
 ## Browser Support
 
 The SDK works in browsers with UMD and ESM support:
 
 ```html
-<!-- UMD -->
-<script src="https://cdn.jsdelivr.net/npm/@deepgram/sdk"></script>
-<script>
-  const { createClient } = deepgram;
-  const client = createClient("api-key");
-</script>
-
 <!-- ESM -->
 <script type="module">
-  import { createClient } from "https://cdn.jsdelivr.net/npm/@deepgram/sdk/+esm";
-  const client = createClient("api-key");
+  import { DeepgramClient } from "https://cdn.jsdelivr.net/npm/@deepgram/sdk/+esm";
+  const client = new DeepgramClient({ apiKey: "your-api-key" });
 </script>
-```
-
-## Additional Features
-
-### Text Intelligence
-
-```javascript
-const { result, error } = await deepgram.read.analyzeText(
-  { text: "Your text content here" },
-  { language: "en", topics: true, sentiment: true }
-);
-```
-
-### Captions Generation
-
-```javascript
-import { webvtt, srt } from "@deepgram/captions";
-
-// After getting transcription result
-const vttOutput = webvtt(result);
-const srtOutput = srt(result);
 ```
 
 ## Useful Links
@@ -307,579 +317,6 @@ const srtOutput = srt(result);
 ## Notes
 
 - The SDK strictly follows semantic versioning
-- Always use documented interfaces to ensure compatibility
 - The SDK supports both Node.js (18+) and browser environments
 - For production applications, implement proper error handling and logging
 - Consider using environment variables for API key management
-
-### Citations
-
-```json
-  "name": "@deepgram/sdk",
-  "engines": {
-    "node": ">=18.0.0"
-  },
-npm install @deepgram/sdk
-```
-
-
-### UMD
-
-You can now use plain `<script>`s to import deepgram from CDNs, like:
-
-<script src="https://cdn.jsdelivr.net/npm/@deepgram/sdk"></script>
-
-
-or even:
-
-```html
-<script src="https://unpkg.com/@deepgram/sdk"></script>
-```
-
-Then you can use it from a global deepgram variable:
-
-```html
-<script>
-  const { createClient } = deepgram;
-  const _deepgram = createClient("deepgram-api-key");
-
-  console.log("Deepgram Instance: ", _deepgram);
-  // ...
-</script>
-```
-
-### ESM
-
-You can now use type="module" `<script>`s to import deepgram from CDNs, like:
-
-```html
-<script type="module">
-  import { createClient } from "https://cdn.jsdelivr.net/npm/@deepgram/sdk/+esm";
-  const deepgram = createClient("deepgram-api-key");
-
-  console.log("Deepgram Instance: ", deepgram);
-  // ...
-</script>
-```
-
-```typescript
-import { createClient } from "@deepgram/sdk";
-// - or -
-const { createClient } = require("@deepgram/sdk");
-```
-
-```typescript
-const deepgram = createClient(DEEPGRAM_API_KEY);
-```
-
- To access the Deepgram API you will need a [free Deepgram API Key](https://console.deepgram.com/signup?jump=keys).
-
-
-The SDK supports scoped configuration. You'll be able to configure various aspects of each namespace of the SDK from the initialization. Below outlines a flexible and customizable configuration system for the Deepgram SDK. Here's how the namespace configuration works:
-
-### 1. Global Defaults
-
-- The `global` namespace serves as the foundational configuration applicable across all other namespaces unless overridden.
-- Includes general settings like URL and headers applicable for all API calls.
-- If no specific configurations are provided for other namespaces, the `global` defaults are used.
-
-### 2. Namespace-specific Configurations
-
-- Each namespace (`listen`, `manage`, `onprem`, `read`, `speak`) can have its specific configurations which override the `global` settings within their respective scopes.
-- Allows for detailed control over different parts of the application interacting with various Deepgram API endpoints.
-
-### 3. Transport Options
-
-- Configurations for both `fetch` and `websocket` can be specified under each namespace, allowing different transport mechanisms for different operations.
-- For example, the `fetch` configuration can have its own URL and proxy settings distinct from the `websocket`.
-- The generic interfaces define a structure for transport options which include a client (like a `fetch` or `WebSocket` instance) and associated options (like headers, URL, proxy settings).
-
-This configuration system enables robust customization where defaults provide a foundation, but every aspect of the client's interaction with the API can be finely controlled and tailored to specific needs through namespace-specific settings. This enhances the maintainability and scalability of the application by localizing configurations to their relevant contexts.
-
-
-
-
-```js
-const { result, error } = await deepgram.listen.prerecorded.transcribeUrl(
-  {
-    url: "https://dpgr.am/spacewalk.wav",
-  },
-  {
-    model: "nova",
-  }
-);
-
-const { result, error } = await deepgram.listen.prerecorded.transcribeFile(
-  fs.createReadStream("./examples/spacewalk.wav"),
-  {
-    model: "nova",
-  }
-);
-```
-
-or
-
-```js
-const { result, error } = await deepgram.listen.prerecorded.transcribeFile(
-  fs.readFileSync("./examples/spacewalk.wav"),
-  {
-    model: "nova",
-  }
-);
-
-const dgConnection = deepgram.listen.live({ model: "nova" });
-
-dgConnection.on(LiveTranscriptionEvents.Open, () => {
-  dgConnection.on(LiveTranscriptionEvents.Transcript, (data) => {
-    console.log(data);
-  });
-
-  source.addListener("got-some-audio", async (event) => {
-    dgConnection.send(event.raw_audio_data);
-  });
-});
-
-```
-```js
-import { webvtt /* , srt */ } from "@deepgram/captions";
-
-const { result, error } = await deepgram.listen.prerecorded.transcribeUrl(
-  {
-    url: "https://dpgr.am/spacewalk.wav",
-  },
-  {
-    model: "nova",
-  }
-);
-
-const vttOutput = webvtt(result);
-// const srtOutput = srt(result);
-
-```
-```js
-import { createClient } from "@deepgram/sdk";
-import { AgentEvents } from "@deepgram/sdk";
-
-const deepgram = createClient(DEEPGRAM_API_KEY);
-
-// Create an agent connection
-const agent = deepgram.agent();
-
-// Set up event handlers
-agent.on(AgentEvents.Open, () => {
-  console.log("Connection opened");
-
-  // Configure the agent once connection is established
-  agent.configure({
-    audio: {
-      input: {
-        encoding: "linear16",
-        sampleRate: 16000,
-      },
-      output: {
-        encoding: "linear16",
-        container: "wav",
-        sampleRate: 24000,
-      },
-    },
-    agent: {
-      listen: {
-        model: "nova-3",
-      },
-      speak: {
-        model: "aura-2-thalia-en",
-      },
-      think: {
-        provider: {
-          type: "anthropic",
-        },
-        model: "claude-3-haiku-20240307",
-        instructions: "You are a helpful AI assistant. Keep responses brief and friendly.",
-      },
-    },
-  });
-});
-
-// Handle agent responses
-agent.on(AgentEvents.AgentStartedSpeaking, (data) => {
-  console.log("Agent started speaking:", data["total_latency"]);
-});
-
-agent.on(AgentEvents.ConversationText, (message) => {
-  console.log(`${message.role} said: ${message.content}`);
-});
-
-agent.on(AgentEvents.Audio, (audio) => {
-  // Handle audio data from the agent
-  playAudio(audio); // Your audio playback implementation
-});
-
-agent.on(AgentEvents.Error, (error) => {
-  console.error("Error:", error);
-});
-
-agent.on(AgentEvents.Close, () => {
-  console.log("Connection closed");
-});
-
-// Send audio data
-function sendAudioData(audioData) {
-  agent.send(audioData);
-}
-
-// Keep the connection alive
-setInterval(() => {
-  agent.keepAlive();
-}, 8000);
-
-
-const { result } = await deepgram.speak.request({ text }, { model: "aura-2-thalia-en" });
-
-
-
-const dgConnection = deepgram.speak.live({ model: "aura-2-thalia-en" });
-
-dgConnection.on(LiveTTSEvents.Open, () => {
-  console.log("Connection opened");
-
-  // Send text data for TTS synthesis
-  dgConnection.sendText(text);
-
-  // Send Flush message to the server after sending the text
-  dgConnection.flush();
-
-  dgConnection.on(LiveTTSEvents.Close, () => {
-    console.log("Connection closed");
-  });
-});
-
-
-
-const { result, error } = await deepgram.read.analyzeText(
-  { text },
-  { language: "en", topics: true, sentiment: true }
-);
-```
-
-
-
-Older SDK versions will receive Priority 1 (P1) bug support only. Security issues, both in our code and dependencies, are promptly addressed. Significant bugs without clear workarounds are also given priority attention.
-
-We strictly follow semver, and will not introduce breaking changes to the publicly documented interfaces of the SDK. **Use internal and undocumented interfaces without pinning your version, at your own risk.**
-
-
-
-```typescript
-type ListenModel =
-  | "nova-3"
-  | "nova-3-general"
-  | "nova-3-medical"
-  | "nova-2"
-  | "nova-2-meeting"
-  | "nova-2-phonecall"
-  | "nova-2-voicemail"
-  | "nova-2-finance"
-  | "nova-2-conversational"
-  | "nova-2-video"
-  | "nova-2-medical"
-  | "nova-2-drivethru"
-  | "nova-2-automotive"
-  | "nova-2-atc"
-  | "nova"
-  | "nova-phonecall"
-  | "enhanced"
-  | "enhanced-meeting"
-  | "enhanced-phonecall"
-  | "enhanced-finance"
-  | "base"
-  | "base-meeting"
-  | "base-phonecall"
-  | "base-voicemail"
-  | "base-finance"
-  | "base-conversational"
-  | "base-video"
-  | "whisper-tiny"
-  | "whisper"
-  | "whisper-small"
-  | "whisper-medium"
-  | "whisper-large"
-  | string;
-```
-
-```typescript
-type SpeakModel =
-  | "aura-asteria-en"
-  | "aura-luna-en"
-  | "aura-stella-en"
-  | "aura-athena-en"
-  | "aura-hera-en"
-  | "aura-orion-en"
-  | "aura-arcas-en"
-  | "aura-perseus-en"
-  | "aura-angus-en"
-  | "aura-orpheus-en"
-  | "aura-helios-en"
-  | "aura-zeus-en"
-  | "aura-2-amalthea-en"
-  | "aura-2-andromeda-en"
-  | "aura-2-apollo-en"
-  | "aura-2-arcas-en"
-  | "aura-2-aries-en"
-  | "aura-2-asteria-en"
-  | "aura-2-athena-en"
-  | "aura-2-atlas-en"
-  | "aura-2-aurora-en"
-  | "aura-2-callista-en"
-  | "aura-2-cordelia-en"
-  | "aura-2-cora-en"
-  | "aura-2-cressida-en"
-  | "aura-2-delia-en"
-  | "aura-2-draco-en"
-  | "aura-2-electra-en"
-  | "aura-2-harmonia-en"
-  | "aura-2-helena-en"
-  | "aura-2-hera-en"
-  | "aura-2-hermes-en"
-  | "aura-2-hyperion-en"
-  | "aura-2-iris-en"
-  | "aura-2-janus-en"
-  | "aura-2-juno-en"
-  | "aura-2-jupiter-en"
-  | "aura-2-luna-en"
-  | "aura-2-mars-en"
-  | "aura-2-minerva-en"
-  | "aura-2-neptune-en"
-  | "aura-2-odysseus-en"
-  | "aura-2-ophelia-en"
-  | "aura-2-orion-en"
-  | "aura-2-orpheus-en"
-  | "aura-2-pandora-en"
-  | "aura-2-phoebe-en"
-  | "aura-2-pluto-en"
-  | "aura-2-saturn-en"
-  | "aura-2-selene-en"
-  | "aura-2-thalia-en"
-  | "aura-2-theia-en"
-  | "aura-2-vesta-en"
-  | "aura-2-zeus-en"
-  | string;
-        /**
-         * Only available for Nova 3.
-         * @see https://developers.deepgram.com/docs/keyterm
-         */
-        keyterms?: string[];
-      };
-```
-
-```typescript
-export type DeepgramResponse<T> = SuccessResponse<T> | ErrorResponse;
-
-interface SuccessResponse<T> {
-  result: T;
-  error: null;
-}
-
-interface ErrorResponse {
-  result: null;
-  error: DeepgramError;
-}
-```
-
-```typescript
-export class DeepgramError extends Error {
-  protected __dgError = true;
-
-  constructor(message: string) {
-    super(message);
-    this.name = "DeepgramError";
-  }
-}
-
-export function isDeepgramError(error: unknown): error is DeepgramError {
-  return typeof error === "object" && error !== null && "__dgError" in error;
-}
-
-export class DeepgramApiError extends DeepgramError {
-  status: number;
-
-  constructor(message: string, status: number) {
-    super(message);
-    this.name = "DeepgramApiError";
-    this.status = status;
-  }
-
-  toJSON() {
-    return {
-      name: this.name,
-      message: this.message,
-      status: this.status,
-    };
-  }
-}
-
-export class DeepgramUnknownError extends DeepgramError {
-  originalError: unknown;
-
-  constructor(message: string, originalError: unknown) {
-    super(message);
-    this.name = "DeepgramUnknownError";
-    this.originalError = originalError;
-  }
-}
-
-export class DeepgramVersionError extends DeepgramError {
-  constructor() {
-    super(
-      `You are attempting to use an old format for a newer SDK version. Read more here: https://dpgr.am/js-v3`
-    );
-
-    this.name = "DeepgramVersionError";
-  }
-}
-```
-
-```typescript
-interface TranscriptionSchema extends Record<string, unknown> {
-  /**
-   * @see https://developers.deepgram.com/docs/model
-   */
-  model?: string;
-
-  /**
-   * @deprecated
-   * @see https://developers.deepgram.com/docs/tier
-   */
-  tier?: string;
-
-  /**
-   * @see https://developers.deepgram.com/docs/version
-   */
-  version?: string;
-
-  /**
-   * @see https://developers.deepgram.com/docs/language
-   */
-  language?: string;
-
-  /**
-   * @see https://developers.deepgram.com/docs/punctuation
-   */
-  punctuate?: boolean;
-
-  /**
-   * @see https://developers.deepgram.com/docs/profanity-filter
-   */
-  profanity_filter?: boolean;
-
-  /**
-   * @see https://developers.deepgram.com/docs/redaction
-   */
-  redact?: string[] | string | boolean;
-
-  /**
-   * @see https://developers.deepgram.com/docs/diarization
-   */
-  diarize?: boolean;
-
-  /**
-   * @see https://developers.deepgram.com/docs/diarization
-   */
-  diarize_version?: string;
-
-  /**
-   * @see https://developers.deepgram.com/docs/smart-format
-   */
-  smart_format?: boolean;
-
-  /**
-   * @see https://developers.deepgram.com/docs/filler-words
-   */
-  filler_words?: boolean;
-
-  /**
-   * @see https://developers.deepgram.com/docs/multichannel
-   */
-  multichannel?: boolean;
-
-  /**
-   * @see https://developers.deepgram.com/docs/numerals
-   * @deprecated
-   */
-  numerals?: boolean;
-
-  /**
-   * @see https://developers.deepgram.com/docs/search
-   */
-  search?: string[] | string;
-
-  /**
-   * @see https://developers.deepgram.com/docs/find-and-replace
-   */
-  replace?: string[] | string;
-
-  /**
-   * @see https://developers.deepgram.com/docs/callback
-   */
-  callback?: string;
-
-  /**
-   * @see https://developers.deepgram.com/docs/callback#results
-   */
-  callback_method?: "put" | "post";
-
-  /**
-   * @see https://developers.deepgram.com/docs/keywords
-   */
-  keywords?: string[] | string;
-
-  /**
-   * @see https://developers.deepgram.com/docs/keyterm
-   */
-  keyterm?: string[] | string;
-
-  /**
-   * @see https://developers.deepgram.com/docs/tagging
-   */
-  tag?: string[];
-
-  /**
-   * As yet unreleased.
-   */
-  sentiment?: boolean;
-
-  /**
-   * As yet unreleased.
-   */
-  intents?: boolean;
-
-  /**
-   * As yet unreleased.
-   */
-  custom_intent?: string[] | string;
-
-  /**
-   * As yet unreleased.
-   */
-  custom_intent_mode?: "strict" | "extended";
-
-  /**
-   * As yet unreleased.
-   */
-  topics?: boolean;
-
-  /**
-   * As yet unreleased.
-   */
-  custom_topic?: string[] | string;
-
-  /**
-   * As yet unreleased.
-   */
-  custom_topic_mode?: "strict" | "extended";
-
-  /**
-   * @see https://developers.deepgram.com/docs/extra-metadata
-   */
-  extra?: string[] | string;
-}
-```

--- a/content/deepgram/docs/speech/python/DOC.md
+++ b/content/deepgram/docs/speech/python/DOC.md
@@ -3,8 +3,9 @@ name: speech
 description: "Deepgram Python SDK coding guidelines for speech recognition, text-to-speech, and audio intelligence"
 metadata:
   languages: "python"
-  versions: "5.1.0"
-  updated-on: "2026-03-02"
+  versions: "7.2.0"
+  revision: 1
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "deepgram,speech,transcription,tts,audio"
 ---
@@ -20,7 +21,7 @@ https://developers.deepgram.com/docs
 
 ## Golden Rule: Use the Correct and Current SDK
 
-Always use the official Deepgram Python SDK for all Deepgram API interactions. <cite/>
+Always use the official Deepgram Python SDK for all Deepgram API interactions.
 
 - **Library Name:** Deepgram Python SDK
 - **Python Package:** `deepgram-sdk`
@@ -30,15 +31,18 @@ Always use the official Deepgram Python SDK for all Deepgram API interactions. <
 
 - **Correct:** `pip install deepgram-sdk`
 
+**Requirements:**
+
+- Python 3.10 or higher
+
 **APIs and Usage:**
 
 - **Correct:** `from deepgram import DeepgramClient`
-- **Correct:** `from deepgram import SpeakOptions, PrerecordedOptions, LiveOptions`
-- **Correct:** `from deepgram import ReadOptions, SettingsOptions`
+- **Correct:** `from deepgram.core.events import EventType`
 
 ## Initialization and API Key
 
-The `deepgram-sdk` library requires creating a client object for all API calls. <cite/>
+The `deepgram-sdk` library requires creating a client object for all API calls.
 
 - Always use `client = DeepgramClient()` to create a client object
 - Set `DEEPGRAM_API_KEY` environment variable, which will be picked up automatically
@@ -82,307 +86,210 @@ client = DeepgramClient()  # Auto-detects from environment
 
 ## Models
 
-By default, use the following models when using the Deepgram SDK: <cite/>
+By default, use the following models when using the Deepgram SDK:
 
-- **Speech-to-Text Tasks:** `nova-3` (latest general model)
+- **Speech-to-Text (general, prerecorded):** `nova-3` (latest general model)
+- **Speech-to-Text (real-time, low latency):** `flux-general-en`
 - **Text-to-Speech Tasks:** `aura-2-thalia-en` (default TTS model)
 - **Text Intelligence Tasks:** `nova-3`
 
 ## Speech-to-Text (Transcription)
 
-### Pre-Recorded Audio (Synchronous)
-
-For transcribing pre-recorded audio files:
+### Pre-Recorded Audio from URL
 
 ```python
-from deepgram import DeepgramClient, PrerecordedOptions, FileSource
+from deepgram import DeepgramClient
 
-# Create client
 client = DeepgramClient()
 
-# Configure options
-options = PrerecordedOptions(
+response = client.listen.v1.media.transcribe_url(
+    request={"url": "https://example.com/audio.wav"},
     model="nova-3",
     smart_format=True,
-    language="en"
+    language="en",
 )
-
-# From URL
-url_source = {"url": "https://example.com/audio.wav"}
-response = client.listen.rest.v("1").transcribe_url(url_source, options)
-
-# From local file
-with open("audio.wav", "rb") as file:
-    buffer_data = file.read()
-    
-payload = {"buffer": buffer_data}
-response = client.listen.rest.v("1").transcribe_file(payload, options)
 
 print(response.results.channels[0].alternatives[0].transcript)
 ```
 
-### Pre-Recorded Audio (Asynchronous)
-
-For asynchronous transcription with callbacks:
+### Pre-Recorded Audio from File / Buffer
 
 ```python
-import asyncio
-from deepgram import DeepgramClient, PrerecordedOptions
+from deepgram import DeepgramClient
 
-async def main():
-    client = DeepgramClient()
-    
-    options = PrerecordedOptions(
-        model="nova-3",
-        smart_format=True
-    )
-    
-    url_source = {"url": "https://example.com/audio.wav"}
-    response = await client.listen.asyncrest.v("1").transcribe_url(url_source, options)
-    
-    print(response.results.channels[0].alternatives[0].transcript)
-
-asyncio.run(main())
-```
-
-### Streaming Audio (Real-time)
-
-For real-time audio transcription:
-
-```python
-from deepgram import DeepgramClient, LiveTranscriptionEvents, LiveOptions
-
-# Create client
 client = DeepgramClient()
 
-# Create connection
-dg_connection = client.listen.websocket.v("1")
+with open("audio.wav", "rb") as audio_file:
+    response = client.listen.v1.media.transcribe_file(
+        request=audio_file.read(),
+        model="nova-3",
+        smart_format=True,
+        diarize=True,
+        utterances=True,
+        language="en",
+    )
 
-def on_message(self, result, **kwargs):
-    sentence = result.channel.alternatives[0].transcript
-    if len(sentence) == 0:
-        return
-    print(f"Transcript: {sentence}")
-
-def on_error(self, error, **kwargs):
-    print(f"Error: {error}")
-
-# Register event handlers
-dg_connection.on(LiveTranscriptionEvents.Transcript, on_message)
-dg_connection.on(LiveTranscriptionEvents.Error, on_error)
-
-# Configure options
-options = LiveOptions(
-    model="nova-3",
-    language="en",
-    smart_format=True
-)
-
-# Start connection
-if dg_connection.start(options) is False:
-    print("Failed to start connection")
-    exit()
-
-# Send audio data (example with microphone)
-# dg_connection.send(audio_data)
-
-# Close connection when done
-dg_connection.finish()
+print(response.results.channels[0].alternatives[0].transcript)
 ```
+
+### Common Transcription Options
+
+- `model`: `nova-3`, `nova-3-general`, `nova-3-medical`, `nova-2`, etc.
+- `language`: BCP-47 language code (e.g., `"en"`, `"es"`, `"fr"`) or `"multi"` for multilingual
+- `smart_format`: Automatic punctuation, numerals, dates, and more
+- `diarize`: Speaker identification
+- `utterances`: Group transcript into utterances
+- `punctuate`: Add punctuation
+- `keyterm`: Keyword detection (Nova 3 only)
+
+### Streaming Audio (Real-time WebSocket)
+
+For real-time audio transcription, the v7 SDK uses a context-managed WebSocket
+connection with event handlers registered via `EventType`.
+
+```python
+from deepgram import DeepgramClient
+from deepgram.core.events import EventType
+
+client = DeepgramClient()
+
+with client.listen.v2.connect(
+    model="flux-general-en",
+    encoding="linear16",
+    sample_rate=16000,
+) as connection:
+    def on_message(message):
+        # Inspect message.type to determine the kind of event
+        print(f"Received {message.type} event")
+
+    connection.on(EventType.OPEN, lambda _: print("Connection opened"))
+    connection.on(EventType.MESSAGE, on_message)
+    connection.on(EventType.CLOSE, lambda _: print("Connection closed"))
+    connection.on(EventType.ERROR, lambda error: print(f"Error: {error}"))
+
+    connection.start_listening()
+
+    # Send raw audio bytes
+    # connection.send_media(audio_chunk)
+
+    # Send control messages when needed
+    # connection.send_keep_alive()
+    # connection.send_finalize()
+```
+
+Use `send_media(audio_bytes)` to transmit audio frames. Control messages have
+dedicated methods such as `send_keep_alive()`, `send_finalize()`, and
+`send_flush()` rather than the v5 `send_control()` API.
 
 ## Text-to-Speech
 
 ### REST API (Batch Conversion)
 
-For converting text to speech in batch mode:
-
 ```python
-from deepgram import DeepgramClient, SpeakOptions
-
-# Create client
-client = DeepgramClient()
-
-# Configure TTS options
-options = SpeakOptions(
-    model="aura-2-thalia-en",
-    encoding="linear16",
-    sample_rate=24000
-)
-
-# Input text
-input_text = {"text": "Hello, world."}
-
-# Convert text to speech and store in memory
-response = client.speak.rest.v("1").stream_memory(input_text, options)
-
-# Access the audio data
-audio_data = response.stream_memory.getbuffer()
-
-# Save to a file
-with open("output.wav", "wb") as file:
-    file.write(audio_data)
-```
-
-### REST API (Save to File)
-
-```python
-from deepgram import DeepgramClient, SpeakOptions
+from deepgram import DeepgramClient
 
 client = DeepgramClient()
 
-options = SpeakOptions(
+response = client.speak.v1.audio.generate(
+    text="Hello, world.",
     model="aura-2-thalia-en",
     encoding="linear16",
-    sample_rate=24000
+    container="wav",
+    sample_rate=24000,
 )
 
-input_text = {"text": "Hello, world."}
-
-# Convert text to speech and save directly to file
-response = client.speak.rest.v("1").save("output.wav", input_text, options)
-```
-
-### Asynchronous Text-to-Speech
-
-```python
-import asyncio
-from deepgram import DeepgramClient, SpeakOptions
-
-async def main():
-    client = DeepgramClient()
-    
-    options = SpeakOptions(
-        model="aura-2-thalia-en",
-        encoding="linear16",
-        sample_rate=24000
-    )
-    
-    input_text = {"text": "Hello, world."}
-    
-    response = await client.speak.asyncrest.v("1").stream_memory(input_text, options)
-    
-    audio_data = response.stream_memory.getbuffer()
-    
-    with open("output.wav", "wb") as file:
-        file.write(audio_data)
-
-asyncio.run(main())
+# Stream the audio bytes to a file
+with open("output.wav", "wb") as f:
+    for chunk in response:
+        f.write(chunk)
 ```
 
 ### WebSocket API (Streaming TTS)
 
-For real-time streaming text-to-speech:
-
 ```python
-from deepgram import DeepgramClient, SpeakWebSocketEvents, SpeakWSOptions
+from deepgram import DeepgramClient
+from deepgram.core.events import EventType
 
-# Create client
 client = DeepgramClient()
 
-# Create websocket connection
-dg_connection = client.speak.websocket.v("1")
-
-def on_open(self, open, **kwargs):
-    print(f"Connection opened: {open}")
-
-def on_binary_data(self, data, **kwargs):
-    print("Received audio data")
-    # Process audio data here
-    with open("output.wav", "ab") as f:
-        f.write(data)
-
-def on_close(self, close, **kwargs):
-    print(f"Connection closed: {close}")
-
-# Register event handlers
-dg_connection.on(SpeakWebSocketEvents.Open, on_open)
-dg_connection.on(SpeakWebSocketEvents.AudioData, on_binary_data)
-dg_connection.on(SpeakWebSocketEvents.Close, on_close)
-
-# Configure TTS options
-options = SpeakWSOptions(
+with client.speak.v1.connect(
     model="aura-2-thalia-en",
     encoding="linear16",
-    sample_rate=16000
-)
+    sample_rate=16000,
+) as connection:
+    def on_audio(data):
+        with open("output.wav", "ab") as f:
+            f.write(data)
 
-# Start the connection
-if dg_connection.start(options) is False:
-    print("Failed to start connection")
-    exit()
+    connection.on(EventType.OPEN, lambda _: print("Connection opened"))
+    connection.on(EventType.MESSAGE, on_audio)
+    connection.on(EventType.CLOSE, lambda _: print("Connection closed"))
 
-# Send text to be converted to speech
-dg_connection.send_text("Hello, this is a text to speech example using Deepgram.")
+    connection.start_listening()
 
-# Flush the connection
-dg_connection.flush()
+    # Send text to be synthesized
+    connection.send_text("Hello, this is a text to speech example using Deepgram.")
 
-# Wait for processing to complete
-dg_connection.wait_for_complete()
+    # Flush to force generation of any buffered text
+    connection.send_flush()
+```
 
-# Close the connection
-dg_connection.finish()
+## Voice Agent
+
+Configure a Voice Agent for conversational AI. In v7 the agent uses domain
+types under `deepgram.agent.v1.types`.
+
+```python
+from deepgram import DeepgramClient
+from deepgram.core.events import EventType
+
+client = DeepgramClient()
+
+with client.agent.v1.connect() as connection:
+    connection.on(EventType.OPEN, lambda _: print("Agent connected"))
+    connection.on(EventType.MESSAGE, lambda msg: print(msg))
+    connection.on(EventType.CLOSE, lambda _: print("Agent closed"))
+
+    # Send a Settings message to configure the agent
+    connection.send_settings({
+        "language": "en",
+        "agent": {
+            "listen": {"provider": {"type": "deepgram", "model": "nova-3"}},
+            "think": {
+                "provider": {"type": "open_ai", "model": "gpt-4o-mini"},
+                "prompt": "You are a helpful AI assistant.",
+            },
+            "speak": {"provider": {"type": "deepgram", "model": "aura-2-thalia-en"}},
+        },
+        "greeting": "Hello, I'm your AI assistant.",
+    })
+
+    connection.start_listening()
 ```
 
 ## Text Intelligence
 
-Analyze text for insights and intelligence:
+Analyze text for insights using the Read API.
 
 ```python
-from deepgram import DeepgramClient, ReadOptions
+from deepgram import DeepgramClient
 
 client = DeepgramClient()
 
-# Configure read options
-options = ReadOptions(
-    model="nova-3",
-    language="en"
-)
-
-# Process text for intelligence
-response = client.read.rest.v("1").process(
-    text="The quick brown fox jumps over the lazy dog.",
-    options=options
+response = client.read.v1.text.analyze(
+    request={"text": "The quick brown fox jumps over the lazy dog."},
+    language="en",
+    sentiment=True,
+    topics=True,
 )
 
 print(response.results)
 ```
 
-## Voice Agent
-
-Configure a Voice Agent for conversational AI:
-
-```python
-from deepgram import DeepgramClient, SettingsOptions
-
-client = DeepgramClient()
-
-# Create websocket connection
-connection = client.agent.websocket.v("1")
-
-# Configure agent settings
-options = SettingsOptions()
-options.language = "en"
-options.agent.think.provider.type = "open_ai"
-options.agent.think.provider.model = "gpt-4o-mini"
-options.agent.think.prompt = "You are a helpful AI assistant."
-options.agent.listen.provider.type = "deepgram"
-options.agent.listen.provider.model = "nova-3"
-options.agent.speak.provider.type = "deepgram"
-options.agent.speak.provider.model = "aura-2-thalia-en"
-
-options.greeting = "Hello, I'm your AI assistant."
-
-# Start the connection
-connection.start(options)
-
-# Close the connection
-connection.finish()
-```
-
 ## Captions Generation
 
-Convert transcription results to captions:
+Convert transcription results to caption formats using the companion
+`deepgram-captions` package.
 
 ### WebVTT
 ```python
@@ -408,9 +315,13 @@ Always implement proper error handling:
 from deepgram import DeepgramClient
 from deepgram.errors import DeepgramError
 
+client = DeepgramClient()
+
 try:
-    client = DeepgramClient()
-    response = client.listen.rest.v("1").transcribe_url(url_source, options)
+    response = client.listen.v1.media.transcribe_url(
+        request={"url": "https://example.com/audio.wav"},
+        model="nova-3",
+    )
     print(response.results.channels[0].alternatives[0].transcript)
 except DeepgramError as e:
     print(f"Deepgram Error: {e}")
@@ -418,74 +329,33 @@ except Exception as e:
     print(f"Unexpected error: {e}")
 ```
 
-## Advanced Configuration
+## Type System (v7)
 
-### Client Options
+Version 7 reorganizes types under domain-specific namespaces:
 
-Configure advanced client settings:
+- `deepgram.listen.v1.types` and `deepgram.listen.v2.types` for speech-to-text
+- `deepgram.speak.v1.types` for text-to-speech
+- `deepgram.agent.v1.types` for Voice Agent
 
-```python
-from deepgram import DeepgramClient, DeepgramClientOptions
-from deepgram.utils import verboselogs
+Prefer importing types from these domain namespaces rather than from the legacy
+shared modules.
 
-config = DeepgramClientOptions(
-    options={
-        "auto_flush_speak_delta": "500",  # Auto-flush after 500ms
-        "speaker_playback": "true"        # Auto-play audio
-    },
-    verbose=verboselogs.DEBUG
-)
+## Migration Notes (v5 → v7)
 
-client = DeepgramClient("", config)
-```
+If you are upgrading from v5:
 
-### Integration Example
-
-Combine Speech-to-Text and Text-to-Speech:
-
-```python
-from deepgram import DeepgramClient, SpeakOptions, PrerecordedOptions
-
-client = DeepgramClient()
-
-# Text to convert to speech
-text = "Hello, world."
-
-# Configure TTS options
-tts_options = SpeakOptions(
-    model="aura-2-thalia-en", 
-    encoding="linear16", 
-    sample_rate=24000
-)
-
-# Convert text to speech
-tts_response = client.speak.rest.v("1").stream_memory({"text": text}, tts_options)
-
-# Save the audio to a buffer
-audio_buffer = tts_response.stream_memory.getbuffer()
-
-# Configure STT options
-stt_options = PrerecordedOptions(
-    model="nova-3",
-    smart_format=True
-)
-
-# Transcribe the generated audio
-stt_response = client.listen.rest.v("1").transcribe_file(
-    {"buffer": audio_buffer}, 
-    stt_options
-)
-
-# Verify the transcription matches the original text
-transcript = stt_response.results.channels[0].alternatives[0].transcript
-print(f"Original: {text}")
-print(f"Transcribed: {transcript}")
-```
-
-## Requirements
-
-- Python 3.10 or higher
-- `deepgram-sdk` package
+- WebSocket connections are now opened via `client.listen.v2.connect(...)` and
+  `client.speak.v1.connect(...)` and used as context managers.
+- Event handling uses `from deepgram.core.events import EventType` with
+  `EventType.OPEN`, `EventType.MESSAGE`, `EventType.CLOSE`, `EventType.ERROR`.
+- Send raw audio with `send_media(bytes)`; use dedicated control methods
+  (`send_keep_alive`, `send_finalize`, `send_flush`) instead of the v5 generic
+  `send_control()`.
+- REST prerecorded transcription moved to `client.listen.v1.media.transcribe_url`
+  and `client.listen.v1.media.transcribe_file`.
+- REST TTS moved to `client.speak.v1.audio.generate(...)`.
+- Agent settings types were renamed (e.g., `AgentV1SettingsMessage` →
+  `AgentV1Settings`).
 
 ## Useful Links
 
@@ -496,190 +366,8 @@ print(f"Transcribed: {transcript}")
 
 ## Notes
 
-This SDK provides comprehensive support for all Deepgram APIs including Speech-to-Text (both pre-recorded and streaming), Text-to-Speech (both REST and WebSocket), Text Intelligence, and Voice Agent functionality. <cite/> The SDK follows semantic versioning and maintains backward compatibility within major versions. For development and testing, the repository includes both daily tests (against real API endpoints) and unit tests (against mock endpoints).
-
-Wiki pages you might want to explore:
-- [Text-to-Speech API (deepgram/deepgram-python-sdk)](/wiki/deepgram/deepgram-python-sdk#3)
-
-### Citations
-
-## Requirements
-
-[Python](https://www.python.org/downloads/) (version ^3.10)
-
-```python
-from deepgram_captions import DeepgramConverter, webvtt
-
-transcription = DeepgramConverter(dg_response)
-captions = webvtt(transcription)
-```
-
-### SRT
-
-```python
-from deepgram_captions import DeepgramConverter, srt
-
-transcription = DeepgramConverter(dg_response)
-captions = srt(transcription)
-```
-
-[See our stand alone captions library for more information.](https://github.com/deepgram/deepgram-python-captions).
-```
-
-```python
-from deepgram import (
-    SettingsOptions
-)
-
-# Create websocket connection
-connection = deepgram.agent.websocket.v("1")
-
-# Configure agent settings
-options = SettingsOptions()
-options.language = "en"
-options.agent.think.provider.type = "open_ai"
-options.agent.think.provider.model = "gpt-4o-mini"
-options.agent.think.prompt = "You are a helpful AI assistant."
-options.agent.listen.provider.type = "deepgram"
-options.agent.listen.provider.model = "nova-3"
-options.agent.speak.provider.type = "deepgram"
-options.agent.speak.provider.model ="aura-2-thalia-en"
-
-options.greeting = "Hello, I'm your AI assistant."
-
-# Start the connection
-connection.start(options)
-
-# Close the connection
-connection.finish()
-```
-```
-
-```python
-from deepgram import ReadOptions
-
-# Configure read options
-options = ReadOptions(
-    model="nova-3",
-    language="en"
-)
-
-# Process text for intelligence
-response = deepgram.read.rest.v("1").process(
-    text="The quick brown fox jumps over the lazy dog.",
-    options=options
-)
-```
-```
-
-The Deepgram Python SDK supports multiple authentication methods to provide flexibility and enhanced security for your applications.
-
-### Authentication Methods
-
-#### API Key Authentication (Traditional)
-
-The traditional method using your Deepgram API key:
-
-```python
-from deepgram import DeepgramClient
-
-# Direct API key
-client = DeepgramClient(api_key="YOUR_API_KEY")
-
-# Or using environment variable DEEPGRAM_API_KEY
-client = DeepgramClient()  # Auto-detects from environment
-```
-
-#### Bearer Token Authentication (OAuth 2.0)
-
-Use short-lived access tokens for enhanced security:
-
-```python
-from deepgram import DeepgramClient
-
-# Direct access token
-client = DeepgramClient(access_token="YOUR_ACCESS_TOKEN")
-
-# Or using environment variable DEEPGRAM_ACCESS_TOKEN
-client = DeepgramClient()  # Auto-detects from environment
-```
-```
-
-If you are looking to use, run, contribute or modify to the daily/unit tests, then you need to install the following dependencies:
-
-```bash
-pip install -r requirements-dev.txt
-```
-
-### Daily Tests
-
-The daily tests invoke a series of checks against the actual/real API endpoint and save the results in the `tests/response_data` folder. This response data is updated nightly to reflect the latest response from the server. Running the daily tests does require a `DEEPGRAM_API_KEY` set in your environment variables.
-
-To run the Daily Tests:
-
-```bash
-make daily-test
-```
-
-#### Unit Tests
-
-The unit tests invoke a series of checks against mock endpoints using the responses saved in `tests/response_data` from the daily tests. These tests are meant to simulate running against the endpoint without actually reaching out to the endpoint; running the unit tests does require a `DEEPGRAM_API_KEY` set in your environment variables, but you will not actually reach out to the server.
-
-```bash
-make unit-test
-```
-```
-
-## Backwards Compatibility
-
-We follow semantic versioning (semver) to ensure a smooth upgrade experience. Within a major version (like `4.*`), we will maintain backward compatibility so your code will continue to work without breaking changes. When we release a new major version (like moving from `3.*` to `4.*`), we may introduce breaking changes to improve the SDK. We'll always document these changes clearly in our release notes to help you upgrade smoothly.
-
-Older SDK versions will receive Priority 1 (P1) bug support only. Security issues, both in our code and dependencies, are promptly addressed. Significant bugs without clear workarounds are also given priority attention.
-```
-
-```python
-from deepgram import DeepgramClient, SpeakOptions, PrerecordedOptions, FileSource
-
-from tests.utils import save_metadata_string
-
-TTS_MODEL = "aura-2-thalia-en"
-STT_MODEL = "general-nova-3"
-
-# response constants
-TEXT1 = "Hello, world."
-
-# Create a list of tuples to store the key-value pairs
-input_output = [
-    (
-        TEXT1,
-        SpeakOptions(model=TTS_MODEL, encoding="linear16", sample_rate=24000),
-        PrerecordedOptions(model="nova-3", smart_format=True),
-        {"results.channels.0.alternatives.0.transcript": [TEXT1]},
-    ),
-]
-```
-
-```python
-from deepgram import DeepgramClient, SpeakOptions, PrerecordedOptions, FileSource
-
-from tests.utils import read_metadata_string, save_metadata_string
-
-MODEL = "aura-2-thalia-en"
-
-# response constants
-TEXT1 = "Hello, world."
-
-# Create a list of tuples to store the key-value pairs
-input_output = [
-    (
-        TEXT1,
-        SpeakOptions(model=MODEL, encoding="linear16", sample_rate=24000),
-        {
-            "content_type": ["audio/wav"],
-            "model_name": ["aura-2-thalia-en"],
-            "characters": ["13"],
-        },
-    ),
-]
-```
-cture 
+This SDK provides comprehensive support for all Deepgram APIs including
+Speech-to-Text (both pre-recorded and streaming), Text-to-Speech (both REST and
+WebSocket), Text Intelligence, and Voice Agent functionality. The SDK follows
+semantic versioning; v7 introduced a fully generated WebSocket client and a
+restructured type system relative to v5.

--- a/content/elevenlabs/docs/text-to-speech/javascript/DOC.md
+++ b/content/elevenlabs/docs/text-to-speech/javascript/DOC.md
@@ -3,8 +3,9 @@ name: text-to-speech
 description: "ElevenLabs JS library coding guidelines for text-to-speech, TTS, and audio voice generation"
 metadata:
   languages: "javascript"
-  versions: "1.59.0"
-  updated-on: "2026-03-02"
+  versions: "2.49.1"
+  revision: 1
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "elevenlabs,text-to-speech,tts,audio,voice"
 ---
@@ -111,6 +112,48 @@ const voices = await elevenlabs.voices.search();
 
 // Get specific voice details
 const voice = await elevenlabs.voices.get("VOICE_ID");
+```
+
+## Voice Cloning (Instant Voice Clone)
+
+Clone a voice from audio sample files. In Node.js you can pass `Blob`s or
+`fs.ReadStream` instances as files.
+
+```javascript
+import * as fs from "fs";
+import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
+
+const elevenlabs = new ElevenLabsClient();
+
+const voice = await elevenlabs.voices.ivc.create({
+    name: "Alex",
+    description: "An old American male voice with a slight hoarseness in his throat.",
+    files: [
+        new Blob([fs.readFileSync("./sample_0.mp3")], { type: "audio/mp3" }),
+        new Blob([fs.readFileSync("./sample_1.mp3")], { type: "audio/mp3" }),
+    ],
+});
+
+console.log("New voice id:", voice.voiceId);
+```
+
+## Saving Audio to Disk
+
+`textToSpeech.convert` returns a `ReadableStream` of audio bytes. Pipe it to a
+file or collect it into a `Buffer`.
+
+```javascript
+import * as fs from "fs";
+import { Readable } from "stream";
+
+const audio = await elevenlabs.textToSpeech.convert("VOICE_ID", {
+    text: "Save me to disk.",
+    modelId: "eleven_multilingual_v2",
+    outputFormat: "mp3_44100_128",
+});
+
+// Pipe a Web ReadableStream to a Node writable stream
+Readable.fromWeb(audio).pipe(fs.createWriteStream("output.mp3"));
 ```
 
 ## Streaming Audio

--- a/content/elevenlabs/docs/text-to-speech/python/DOC.md
+++ b/content/elevenlabs/docs/text-to-speech/python/DOC.md
@@ -3,8 +3,9 @@ name: text-to-speech
 description: "ElevenLabs Python SDK for text-to-speech synthesis, voice cloning, audio generation, and real-time streaming"
 metadata:
   languages: "python"
-  versions: "2.18.0"
-  updated-on: "2026-03-02"
+  versions: "2.50.0"
+  revision: 1
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "elevenlabs,text-to-speech,tts,audio,voice"
 ---
@@ -42,6 +43,16 @@ The `elevenlabs` library requires creating a client object for all API calls.
 - Always use `client = ElevenLabs()` to create a client object.
 - Set `ELEVENLABS_API_KEY` environment variable, which will be picked up automatically.
 - Alternatively, pass the API key directly: `client = ElevenLabs(api_key="YOUR_API_KEY")`
+
+```python
+from elevenlabs.client import ElevenLabs
+
+# Reads ELEVENLABS_API_KEY from the environment
+client = ElevenLabs()
+
+# Or pass the API key explicitly
+client = ElevenLabs(api_key="YOUR_API_KEY")
+```
 
 ## Main Models
 
@@ -89,7 +100,7 @@ The SDK supports various audio formats specified as `codec_sample_rate_bitrate`:
 
 - **MP3 formats:** `mp3_22050_32`, `mp3_44100_32`, `mp3_44100_64`, `mp3_44100_96`, `mp3_44100_128`, `mp3_44100_192`
 - **PCM formats:** `pcm_8000`, `pcm_16000`, `pcm_22050`, `pcm_24000`, `pcm_44100`, `pcm_48000`
-- **Other formats:** `ulaw_8000`, `alaw_8000`, `opus_48000_32`, `opus_48000_64`, etc.
+- **Other formats:** `ulaw_8000`, `alaw_8000`, `opus_48000_32`, `opus_48000_64`, `opus_48000_96`, `opus_48000_128`, `opus_48000_192`
 
 **Note:** MP3 with 192kbps bitrate requires Creator tier or above. PCM with 44.1kHz sample rate requires Pro tier or above.
 
@@ -104,10 +115,10 @@ from elevenlabs import play
 # Play audio directly
 play(audio)
 
-# Play in Jupyter notebook
+# Play in a Jupyter notebook
 play(audio, notebook=True)
 
-# Use alternative audio backend
+# Use the alternative audio backend (no ffmpeg)
 play(audio, use_ffmpeg=False)
 ```
 
@@ -118,34 +129,39 @@ from elevenlabs import save
 save(audio, "output.mp3")
 ```
 
+`save` accepts either raw `bytes` or an `Iterator[bytes]` and writes the
+concatenated audio to disk.
+
 ### Stream Audio
 ```python
 from elevenlabs import stream
 
-# For streamed audio
 stream(audio_stream)
 ```
+
+`stream` requires `mpv` to be installed on the host system.
 
 ## Voice Management
 
 ### List Available Voices
+
 ```python
+from elevenlabs.client import ElevenLabs
+
 client = ElevenLabs(api_key="YOUR_API_KEY")
 
-# Get all voices
-response = client.voices.get_all()
-print(response.voices)
-
-# Search voices with pagination
+# Search voices with pagination (recommended)
 response = client.voices.search()
 print(response.voices)
 ```
 
 ## Voice Cloning
 
-Clone a voice using audio samples:
+Clone a voice using audio samples via the Instant Voice Clone (IVC) API:
 
 ```python
+from elevenlabs.client import ElevenLabs
+
 client = ElevenLabs(api_key="YOUR_API_KEY")
 
 voice = client.voices.ivc.create(
@@ -153,9 +169,12 @@ voice = client.voices.ivc.create(
     description="An old American male voice with a slight hoarseness in his throat. Perfect for news",
     files=["./sample_0.mp3", "./sample_1.mp3", "./sample_2.mp3"],
 )
+
+print(voice.voice_id)
 ```
 
-The `create` method accepts multiple audio file paths and optional parameters like `remove_background_noise` and `description`.
+The `create` method accepts a list of audio file paths and optional parameters
+including `remove_background_noise`, `description`, and `labels`.
 
 ## Streaming Audio
 
@@ -170,19 +189,29 @@ client = ElevenLabs()
 audio_stream = client.text_to_speech.stream(
     text="This is a test",
     voice_id="JBFqnCBsd6RMkjVDRZzb",
-    model_id="eleven_multilingual_v2"
+    model_id="eleven_multilingual_v2",
 )
 
-# Option 1: Play the streamed audio locally
+# Option 1: play the streamed audio locally
 stream(audio_stream)
 
-# Option 2: Process the audio bytes manually
+# Option 2: process the audio bytes manually
 for chunk in audio_stream:
     if isinstance(chunk, bytes):
-        print(chunk)
+        print(len(chunk))
 ```
 
 The `stream` method returns an iterator of bytes for real-time audio processing.
+
+### Latency Optimization
+
+Control streaming latency with `optimize_streaming_latency` (0-4):
+
+- 0 - default (no optimizations)
+- 1 - normal optimizations (~50% of max improvement)
+- 2 - strong optimizations (~75% of max improvement)
+- 3 - max optimizations
+- 4 - max optimizations with text normalizer disabled (can mispronounce numbers/dates)
 
 ## Async Client
 
@@ -198,7 +227,7 @@ async def generate_speech():
     audio = await client.text_to_speech.convert(
         text="Hello, world!",
         voice_id="JBFqnCBsd6RMkjVDRZzb",
-        model_id="eleven_multilingual_v2"
+        model_id="eleven_multilingual_v2",
     )
     return audio
 
@@ -208,22 +237,37 @@ asyncio.run(generate_speech())
 ## Advanced Features
 
 ### Text-to-Speech with Timestamps
+
 ```python
 response = client.text_to_speech.convert_with_timestamps(
     voice_id="21m00Tcm4TlvDq8ikWAM",
     text="This is a test for the API of ElevenLabs.",
 )
+
+# response contains audio plus character-level alignment data
 ```
 
 ### Voice Settings Customization
-You can override voice settings for individual requests by passing a `VoiceSettings` object:
 
-### Latency Optimization
-Control streaming latency with the `optimize_streaming_latency` parameter (0-4, where 4 is maximum optimization):
+Override voice settings on a per-request basis by passing a `VoiceSettings`
+object via the `voice_settings` parameter to `convert` or `stream`.
 
 ## Error Handling
 
-The SDK provides specific error types for different API responses:
+The SDK exposes specific error types under `elevenlabs.errors`:
+
+```python
+from elevenlabs.errors import (
+    BadRequestError,
+    ForbiddenError,
+    NotFoundError,
+    TooEarlyError,
+    UnprocessableEntityError,
+)
+```
+
+Wrap API calls in `try/except` and handle these errors as appropriate for your
+application.
 
 ## Useful Links
 
@@ -238,315 +282,39 @@ The SDK provides specific error types for different API responses:
 - Voice cloning requires an API key and appropriate subscription tier
 - Some output formats and features require specific subscription tiers
 - The SDK supports both synchronous and asynchronous operations
-- Audio files are returned as byte iterators for efficient memory usage
+- Audio is returned as byte iterators for efficient memory usage; collect with `b"".join(audio)` or pass to `save()` / `stream()` / `play()`
 
-### Citations
+## API Reference Quick Notes
 
-```bash
-pip install elevenlabs
+**`client.text_to_speech.convert(voice_id, *, text, model_id=..., output_format=..., voice_settings=..., language_code=..., seed=..., ...) -> Iterator[bytes]`**
+
+Returns an iterator of audio bytes. Accepts any standard
+`TextToSpeechConvertRequestOutputFormat` value (e.g. `"mp3_44100_128"`,
+`"pcm_24000"`, `"ulaw_8000"`).
+
+**`client.text_to_speech.stream(voice_id, *, text, model_id=..., output_format=..., optimize_streaming_latency=..., ...) -> Iterator[bytes]`**
+
+Same shape as `convert` but streams chunks as the server produces them.
+
+**`client.text_to_speech.convert_with_timestamps(voice_id, *, text, ...) -> AudioWithTimestampsResponse`**
+
+Returns audio plus character-level timing alignment.
+
+**`client.voices.search() -> GetVoicesResponse`**
+
+Paginated list of available voices.
+
+**`client.voices.ivc.create(*, name, files, description=None, remove_background_noise=None, labels=None) -> AddVoiceIvcResponseModel`**
+
+Instant Voice Clone from one or more audio sample files.
+
+**Utility helpers:**
+
+```python
+def play(audio: Union[bytes, Iterator[bytes]], notebook: bool = False, use_ffmpeg: bool = True) -> None: ...
+def save(audio: Union[bytes, Iterator[bytes]], filename: str) -> None: ...
+def stream(audio_stream: Iterator[bytes]) -> bytes: ...
 ```
 
-1. **Eleven Multilingual v2** (`eleven_multilingual_v2`)
-
-    - Excels in stability, language diversity, and accent accuracy
-    - Supports 29 languages
-    - Recommended for most use cases
-
-2. **Eleven Flash v2.5** (`eleven_flash_v2_5`)
-
-    - Ultra-low latency
-    - Supports 32 languages
-    - Faster model, 50% lower price per character
-
-2. **Eleven Turbo v2.5** (`eleven_turbo_v2_5`)
-
-    - Good balance of quality and latency
-    - Ideal for developer use cases where speed is crucial
-    - Supports 32 languages
-
-
-```python
-from dotenv import load_dotenv
-from elevenlabs.client import ElevenLabs
-from elevenlabs import play
-
-load_dotenv()
-
-client = ElevenLabs()
-
-audio = client.text_to_speech.convert(
-    text="The first move is what sets everything in motion.",
-    voice_id="JBFqnCBsd6RMkjVDRZzb",
-    model_id="eleven_multilingual_v2",
-    output_format="mp3_44100_128",
-)
-
-play(audio)
-
-
-```python
-from elevenlabs.client import ElevenLabs
-
-client = ElevenLabs(
-  api_key="YOUR_API_KEY",
-)
-
-response = client.voices.search()
-print(response.voices)
-
-```python
-from elevenlabs.client import ElevenLabs
-from elevenlabs import play
-
-client = ElevenLabs(
-  api_key="YOUR_API_KEY",
-)
-
-voice = client.voices.ivc.create(
-    name="Alex",
-    description="An old American male voice with a slight hoarseness in his throat. Perfect for news", # Optional
-    files=["./sample_0.mp3", "./sample_1.mp3", "./sample_2.mp3"],
-)
-```
-
-```python
-from elevenlabs import stream
-from elevenlabs.client import ElevenLabs
-
-client = ElevenLabs()
-
-audio_stream = client.text_to_speech.stream(
-    text="This is a test",
-    voice_id="JBFqnCBsd6RMkjVDRZzb",
-    model_id="eleven_multilingual_v2"
-)
-
-# option 1: play the streamed audio locally
-stream(audio_stream)
-
-# option 2: process the audio bytes manually
-for chunk in audio_stream:
-    if isinstance(chunk, bytes):
-        print(chunk)
-
-```
-
-```python
-import asyncio
-
-from elevenlabs.client import AsyncElevenLabs
-
-eleven = AsyncElevenLabs(
-  api_key="MY_API_KEY"
-)
-
-async def print_models() -> None:
-    models = await eleven.models.list()
-    print(models)
-
-asyncio.run(print_models())
-```
-
-```python
-from .errors import BadRequestError, ForbiddenError, NotFoundError, TooEarlyError, UnprocessableEntityError
-```
-
-```python
-from .client import AsyncElevenLabs, ElevenLabs
-from .environment import ElevenLabsEnvironment
-from .history import HistoryListRequestSource
-from .play import play, save, stream
-```
-
-```python
-    def __init__(
-        self,
-        *,
-        base_url: typing.Optional[str] = None,
-        environment: ElevenLabsEnvironment = ElevenLabsEnvironment.PRODUCTION,
-        api_key: typing.Optional[str] = os.getenv("ELEVENLABS_API_KEY"),
-        timeout: typing.Optional[float] = 60,
-        httpx_client: typing.Optional[httpx.Client] = None
-```
-
-```python
-    def convert(
-        self,
-        voice_id: str,
-        *,
-        text: str,
-        enable_logging: typing.Optional[bool] = None,
-        optimize_streaming_latency: typing.Optional[int] = None,
-        output_format: typing.Optional[TextToSpeechConvertRequestOutputFormat] = None,
-        model_id: typing.Optional[str] = OMIT,
-        language_code: typing.Optional[str] = OMIT,
-        voice_settings: typing.Optional[VoiceSettings] = OMIT,
-        pronunciation_dictionary_locators: typing.Optional[
-            typing.Sequence[PronunciationDictionaryVersionLocator]
-        ] = OMIT,
-        seed: typing.Optional[int] = OMIT,
-        previous_text: typing.Optional[str] = OMIT,
-        next_text: typing.Optional[str] = OMIT,
-        previous_request_ids: typing.Optional[typing.Sequence[str]] = OMIT,
-        next_request_ids: typing.Optional[typing.Sequence[str]] = OMIT,
-        use_pvc_as_ivc: typing.Optional[bool] = OMIT,
-        apply_text_normalization: typing.Optional[
-            BodyTextToSpeechV1TextToSpeechVoiceIdPostApplyTextNormalization
-        ] = OMIT,
-        apply_language_text_normalization: typing.Optional[bool] = OMIT,
-        request_options: typing.Optional[RequestOptions] = None,
-    ) -> typing.Iterator[bytes]:
-```
-
-```python
-        optimize_streaming_latency : typing.Optional[int]
-            You can turn on latency optimizations at some cost of quality. The best possible final latency varies by model. Possible values:
-            0 - default mode (no latency optimizations)
-            1 - normal latency optimizations (about 50% of possible latency improvement of option 3)
-            2 - strong latency optimizations (about 75% of possible latency improvement of option 3)
-            3 - max latency optimizations
-            4 - max latency optimizations, but also with text normalizer turned off for even more latency savings (best latency, but can mispronounce eg numbers and dates).
-
-            Defaults to None.
-```
-
-```python
-        output_format : typing.Optional[TextToSpeechConvertRequestOutputFormat]
-            Output format of the generated audio. Formatted as codec_sample_rate_bitrate. So an mp3 with 22.05kHz sample rate at 32kbs is represented as mp3_22050_32. MP3 with 192kbps bitrate requires you to be subscribed to Creator tier or above. PCM with 44.1kHz sample rate requires you to be subscribed to Pro tier or above. Note that the μ-law format (sometimes written mu-law, often approximated as u-law) is commonly used for Twilio audio inputs.
-
-```
-
-```python
-        voice_settings : typing.Optional[VoiceSettings]
-            Voice settings overriding stored settings for the given voice. They are applied only on the given request.
-```
-
-```python
-    def convert_with_timestamps(
-        self,
-        voice_id: str,
-        *,
-        text: str,
-        enable_logging: typing.Optional[bool] = None,
-        optimize_streaming_latency: typing.Optional[int] = None,
-        output_format: typing.Optional[TextToSpeechConvertWithTimestampsRequestOutputFormat] = None,
-        model_id: typing.Optional[str] = OMIT,
-        language_code: typing.Optional[str] = OMIT,
-        voice_settings: typing.Optional[VoiceSettings] = OMIT,
-        pronunciation_dictionary_locators: typing.Optional[
-            typing.Sequence[PronunciationDictionaryVersionLocator]
-        ] = OMIT,
-        seed: typing.Optional[int] = OMIT,
-        previous_text: typing.Optional[str] = OMIT,
-        next_text: typing.Optional[str] = OMIT,
-        previous_request_ids: typing.Optional[typing.Sequence[str]] = OMIT,
-        next_request_ids: typing.Optional[typing.Sequence[str]] = OMIT,
-        use_pvc_as_ivc: typing.Optional[bool] = OMIT,
-        apply_text_normalization: typing.Optional[
-            BodyTextToSpeechWithTimestampsV1TextToSpeechVoiceIdWithTimestampsPostApplyTextNormalization
-        ] = OMIT,
-        apply_language_text_normalization: typing.Optional[bool] = OMIT,
-        request_options: typing.Optional[RequestOptions] = None,
-    ) -> AudioWithTimestampsResponse:
-        """
-        Generate speech from text with precise character-level timing information for audio-text synchronization.
-
-        Parameters
-```
-
-```python
-    def stream(
-        self,
-        voice_id: str,
-        *,
-        text: str,
-        enable_logging: typing.Optional[bool] = None,
-        optimize_streaming_latency: typing.Optional[int] = None,
-        output_format: typing.Optional[TextToSpeechStreamRequestOutputFormat] = None,
-        model_id: typing.Optional[str] = OMIT,
-        language_code: typing.Optional[str] = OMIT,
-        voice_settings: typing.Optional[VoiceSettings] = OMIT,
-        pronunciation_dictionary_locators: typing.Optional[
-            typing.Sequence[PronunciationDictionaryVersionLocator]
-        ] = OMIT,
-        seed: typing.Optional[int] = OMIT,
-        previous_text: typing.Optional[str] = OMIT,
-        next_text: typing.Optional[str] = OMIT,
-        previous_request_ids: typing.Optional[typing.Sequence[str]] = OMIT,
-        next_request_ids: typing.Optional[typing.Sequence[str]] = OMIT,
-        use_pvc_as_ivc: typing.Optional[bool] = OMIT,
-        apply_text_normalization: typing.Optional[
-            BodyTextToSpeechStreamingV1TextToSpeechVoiceIdStreamPostApplyTextNormalization
-        ] = OMIT,
-        apply_language_text_normalization: typing.Optional[bool] = OMIT,
-        request_options: typing.Optional[RequestOptions] = None,
-    ) -> typing.Iterator[bytes]:
-```
-
-```python
-TextToSpeechStreamRequestOutputFormat = typing.Union[
-    typing.Literal[
-        "mp3_22050_32",
-        "mp3_44100_32",
-        "mp3_44100_64",
-        "mp3_44100_96",
-        "mp3_44100_128",
-        "mp3_44100_192",
-        "pcm_8000",
-        "pcm_16000",
-        "pcm_22050",
-        "pcm_24000",
-        "pcm_44100",
-        "pcm_48000",
-        "ulaw_8000",
-        "alaw_8000",
-        "opus_48000_32",
-        "opus_48000_64",
-        "opus_48000_96",
-        "opus_48000_128",
-        "opus_48000_192",
-    ],
-    typing.Any,
-]
-```
-
-```python
-def play(
-    audio: Union[bytes, Iterator[bytes]], 
-    notebook: bool = False, 
-    use_ffmpeg: bool = True
-) -> None:
-```
-
-```python
-def save(audio: Union[bytes, Iterator[bytes]], filename: str) -> None:
-    if isinstance(audio, Iterator):
-        audio = b"".join(audio)
-    with open(filename, "wb") as f:
-        f.write(audio)
-```
-
-```python
-def stream(audio_stream: Iterator[bytes]) -> bytes:
-    if not is_installed("mpv"):
-        message = (
-            "mpv not found, necessary to stream audio. "
-            "On mac you can install it with 'brew install mpv'. "
-            "On linux and windows you can install it from https://mpv.io/"
-        )
-        raise ValueError(message)
-```
-
- src/elevenlabs/voices/ivc/client.py
-```python
-    def create(
-        self,
-        *,
-        name: str,
-        files: typing.List[core.File],
-        remove_background_noise: typing.Optional[bool] = OMIT,
-        description: typing.Optional[str] = OMIT,
-        labels: typing.Optional[str] = OMIT,
-        request_options: typing.Optional[RequestOptions] = None,
-    ) -> AddVoiceIvcResponseModel:
-```
+`play` and `stream` require `mpv` (and optionally `ffmpeg`) to be installed on
+the host machine.


### PR DESCRIPTION
docs(elevenlabs, deepgram, assemblyai): refresh speech SDK docs

- elevenlabs Python 2.18.0 → 2.50.0; trims duplicated appendix; covers
  `text_to_speech.convert`/`stream`/`convert_with_timestamps`,
  `voices.search`, `voices.ivc.create`, `play`/`save`/`stream` helpers
- `@elevenlabs/elevenlabs-js` 1.59.0 → 2.49.1 (major bump); adds Voice
  Cloning (`voices.ivc.create`), Saving Audio to Disk
- deepgram Python 5.1.0 → 7.2.0 (two major bumps); rewrites for v7
  generated WebSocket API (`client.listen.v2.connect`,
  `client.speak.v1.connect`, `EventType`,
  `send_media`/`send_keep_alive`/`send_finalize`/`send_flush`) and new
  REST surfaces (`client.listen.v1.media.transcribe_url`/`transcribe_file`,
  `client.speak.v1.audio.generate`, `client.read.v1.text.analyze`); adds
  v5→v7 migration notes
- `@deepgram/sdk` 4.11.2 → 5.3.0; v5 API (`new DeepgramClient(...)`,
  `listen.v1.media.transcribeUrl`/`transcribeFile`, `listen.v1.connect`,
  `speak.v1.audio.generate`, `speak.v1.connect`, `read.v1.text.analyze`);
  switches error pattern from `{result, error}` to try/catch; adds
  v4→v5 migration notes
- assemblyai 4.18.4 → 4.33.3; replaces deprecated `RealtimeTranscriber`
  with `client.streaming.transcriber` and the new `"turn"` event model;
  adds `speech_models` preference list, `waitUntilReady`,
  `client.streaming.createTemporaryToken`
- `revision` bumped and `updated-on: 2026-05-29`

Verified versions against PyPI and npm.
