### PR TITLE
docs(sentry, datadog, newrelic): refresh observability docs

### DIFF
--- a/content/datadog/docs/monitoring/javascript/DOC.md
+++ b/content/datadog/docs/monitoring/javascript/DOC.md
@@ -3,8 +3,9 @@ name: monitoring
 description: "Official Datadog API client for JavaScript/TypeScript to submit metrics, manage monitors, and interact with Datadog observability features."
 metadata:
   languages: "javascript"
-  versions: "1.46.0"
-  updated-on: "2026-03-01"
+  versions: "1.58.0"
+  revision: 1
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "datadog,monitoring,metrics,observability,apm"
 ---
@@ -13,7 +14,7 @@ metadata:
 
 ## Golden Rule
 
-**ALWAYS use `@datadog/datadog-api-client` version 1.46.0 or later.**
+**ALWAYS use `@datadog/datadog-api-client` version 1.58.0 or later.**
 
 This is the official Datadog API client for JavaScript and TypeScript. Do NOT use:
 - `datadog-client` (unofficial/deprecated)

--- a/content/datadog/docs/monitoring/python/DOC.md
+++ b/content/datadog/docs/monitoring/python/DOC.md
@@ -3,8 +3,9 @@ name: monitoring
 description: "Official Datadog API client for Python to submit metrics, manage monitors, and interact with Datadog observability features."
 metadata:
   languages: "python"
-  versions: "2.45.0"
-  updated-on: "2026-03-01"
+  versions: "2.55.0"
+  revision: 1
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "datadog,monitoring,metrics,observability,apm"
 ---
@@ -13,7 +14,7 @@ metadata:
 
 ## Golden Rule
 
-**ALWAYS use `datadog-api-client` version 2.45.0 or later.**
+**ALWAYS use `datadog-api-client` version 2.55.0 or later.**
 
 This is the official Datadog API client for Python. Do NOT use:
 - `datadog` (legacy library, limited functionality)

--- a/content/datadog/docs/package/python/DOC.md
+++ b/content/datadog/docs/package/python/DOC.md
@@ -4,8 +4,8 @@ description: "Datadog Python package for DogStatsD metrics, ThreadStats, and leg
 metadata:
   languages: "python"
   versions: "0.52.1"
-  revision: 1
-  updated-on: "2026-03-12"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "datadog,monitoring,metrics,dogstatsd,observability"
 ---

--- a/content/newrelic/docs/package/python/DOC.md
+++ b/content/newrelic/docs/package/python/DOC.md
@@ -3,9 +3,9 @@ name: package
 description: "New Relic Python agent for APM instrumentation, transaction tracing, error reporting, and logs in context"
 metadata:
   languages: "python"
-  versions: "11.5.0"
-  revision: 1
-  updated-on: "2026-03-12"
+  versions: "13.0.1"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "newrelic,apm,observability,monitoring,tracing,logging"
 ---
@@ -21,14 +21,14 @@ Use `newrelic` as an early-process instrumentation agent, not as a library you i
 Pin the version your project expects:
 
 ```bash
-python -m pip install "newrelic==11.5.0"
+python -m pip install "newrelic==13.0.1"
 ```
 
 Common alternatives:
 
 ```bash
-uv add "newrelic==11.5.0"
-poetry add "newrelic==11.5.0"
+uv add "newrelic==13.0.1"
+poetry add "newrelic==13.0.1"
 ```
 
 ## Initial Setup
@@ -182,9 +182,11 @@ Operational guidance:
 - If the app name in APM does not match expectations, check both the local config file and any server-side config overrides in New Relic.
 - If transaction data appears but logs are duplicated, review whether both agent log forwarding and an external log pipeline are enabled.
 
-## Version-Sensitive Notes For 11.5.0
+## Version-Sensitive Notes For 13.0.1
 
-- `11.5.0` adds Hybrid Agent tracing support with OpenTelemetry API compatibility and `TraceIdRatioBased` sampler support. This capability is disabled by default and can be enabled with `otel_enabled = true` or `NEW_RELIC_OTEL_ENABLED=true`.
+- `13.0.1` is the current published release on PyPI. Treat the release notes page as authoritative for changelog details when wiring up a specific feature.
+- The `13.x` line requires Python `3.9+`. Older Python runtimes need to stay on a previous agent line.
+- `11.5.0` introduced Hybrid Agent tracing support with OpenTelemetry API compatibility and `TraceIdRatioBased` sampler support. This capability is disabled by default and can be enabled with `otel_enabled = true` or `NEW_RELIC_OTEL_ENABLED=true`.
 - `11.0.0` removed several long-deprecated APIs. Older snippets from blogs or internal wikis may still reference removed calls, so prefer the current Python agent API guide.
 - `11.0.0` also renamed the application logging forwarding setting from `application_logging.forwarding.max_samples_stored` to `application_logging.forwarding.max_samples`.
 - If you need `.toml` config support, that requires `10.3.0+` and Python `3.11+`.

--- a/content/sentry/docs/error-tracking/javascript/DOC.md
+++ b/content/sentry/docs/error-tracking/javascript/DOC.md
@@ -3,19 +3,20 @@ name: error-tracking
 description: "Sentry JavaScript SDK for error tracking, performance monitoring, and distributed tracing in Node.js and browser applications."
 metadata:
   languages: "javascript"
-  versions: "10.23.0"
-  updated-on: "2026-03-01"
+  versions: "10.55.0"
+  revision: 1
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "sentry,monitoring,error-tracking,performance,tracing"
 ---
 
-# Sentry JavaScript SDK (10.23.0)
+# Sentry JavaScript SDK (10.55.0)
 
 ## Golden Rule
 
 **ALWAYS use `@sentry/node` for Node.js applications or `@sentry/browser` for browser applications.**
 
-The current stable version is **10.23.0**. Do not use deprecated packages like `raven` or `raven-js`.
+The current stable version is **10.55.0**. Do not use deprecated packages like `raven` or `raven-js`.
 
 For framework-specific applications, use the appropriate package:
 - `@sentry/react` for React

--- a/content/sentry/docs/error-tracking/python/DOC.md
+++ b/content/sentry/docs/error-tracking/python/DOC.md
@@ -3,19 +3,20 @@ name: error-tracking
 description: "Sentry Python SDK for error tracking, performance monitoring, and distributed tracing in Python applications."
 metadata:
   languages: "python"
-  versions: "2.43.0"
-  updated-on: "2026-03-01"
+  versions: "2.61.0"
+  revision: 1
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "sentry,monitoring,error-tracking,performance,tracing"
 ---
 
-# Sentry Python SDK (2.43.0)
+# Sentry Python SDK (2.61.0)
 
 ## Golden Rule
 
 **ALWAYS use `sentry-sdk` for Python applications.**
 
-The current stable version is **2.43.0**. Do not use deprecated packages like `raven`.
+The current stable version is **2.61.0**. Do not use deprecated packages like `raven`.
 
 ## Installation
 


### PR DESCRIPTION
docs(sentry, datadog, newrelic): refresh observability docs

- sentry-sdk (Python) 2.43.0 → 2.61.0; version pins refreshed
- @sentry/* (JS) 10.23.0 → 10.55.0; version pins refreshed
- datadog-api-client (Python) 2.45.0 → 2.55.0
- @datadog/datadog-api-client (JS) 1.46.0 → 1.58.0
- datadog (PyPI) unchanged at 0.52.1; metadata refresh
- newrelic 11.5.0 → 13.0.1; rewrites version-sensitive notes
  (Python ≥3.9)
- `revision` bumped and `updated-on: 2026-05-29`

Note: the `datadog/docs/monitoring/*` docs target the API client packages,
not the `ddtrace`/`dd-trace` tracers — preserved.

Verified versions against PyPI and npm.
