### PR TITLE
docs(posthog, amplitude): refresh analytics SDK docs

### DIFF
--- a/content/amplitude/docs/analytics/javascript/DOC.md
+++ b/content/amplitude/docs/analytics/javascript/DOC.md
@@ -3,8 +3,9 @@ name: analytics
 description: "Amplitude Analytics JavaScript SDK for browser-based event tracking and product analytics"
 metadata:
   languages: "javascript"
-  versions: "2.30.1"
-  updated-on: "2026-03-02"
+  versions: "2.42.5"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "amplitude,analytics,events,tracking,product"
 ---
@@ -13,7 +14,7 @@ metadata:
 
 ## Golden Rule
 
-**ALWAYS** use `@amplitude/analytics-browser` version 2.30.1 or newer for browser-based JavaScript applications.
+**ALWAYS** use `@amplitude/analytics-browser` version 2.42.5 or newer for browser-based JavaScript applications.
 
 **DO NOT** use the deprecated `amplitude-js` package. It is no longer maintained and lacks modern features.
 

--- a/content/amplitude/docs/analytics/python/DOC.md
+++ b/content/amplitude/docs/analytics/python/DOC.md
@@ -3,8 +3,9 @@ name: analytics
 description: "Amplitude Analytics Python SDK for server-side event tracking and product analytics"
 metadata:
   languages: "python"
-  versions: "1.2.0"
-  updated-on: "2026-03-02"
+  versions: "1.2.3"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "amplitude,analytics,events,tracking,product"
 ---
@@ -13,7 +14,7 @@ metadata:
 
 ## Golden Rule
 
-**ALWAYS** use `amplitude-analytics` version 1.2.0 or newer for Python server-side instrumentation.
+**ALWAYS** use `amplitude-analytics` version 1.2.3 or newer for Python server-side instrumentation.
 
 This is the official Amplitude backend Python SDK maintained by Amplitude Inc.
 
@@ -27,7 +28,7 @@ This is the official Amplitude backend Python SDK maintained by Amplitude Inc.
 pip install amplitude-analytics
 ```
 ```bash
-pip install amplitude-analytics==1.2.0
+pip install amplitude-analytics==1.2.3
 ```
 
 ---

--- a/content/posthog/docs/package/python/DOC.md
+++ b/content/posthog/docs/package/python/DOC.md
@@ -3,9 +3,9 @@ name: package
 description: "PostHog Python SDK for product analytics, feature flags, experiments, and error tracking"
 metadata:
   languages: "python"
-  versions: "7.9.11"
-  revision: 1
-  updated-on: "2026-03-12"
+  versions: "7.16.2"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "posthog,analytics,feature-flags,experiments,error-tracking,python"
 ---
@@ -21,20 +21,20 @@ Use the official `posthog` package, initialize it with your project token and Po
 Pin the package version your project expects:
 
 ```bash
-python -m pip install "posthog==7.9.11"
+python -m pip install "posthog==7.16.2"
 ```
 
 Common alternatives:
 
 ```bash
-uv add "posthog==7.9.11"
-poetry add "posthog==7.9.11"
+uv add "posthog==7.16.2"
+poetry add "posthog==7.16.2"
 ```
 
 Optional extra for LangChain integration:
 
 ```bash
-python -m pip install "posthog[langchain]==7.9.11"
+python -m pip install "posthog[langchain]==7.16.2"
 ```
 
 ## Authentication And Setup
@@ -307,8 +307,8 @@ posthog.disabled = True
 
 - `6.x` introduced the contexts API and breaking changes from `5.x`; do not copy `5.x` patterns blindly into `7.x` projects.
 - `6.3.0+` changed feature-flag capture behavior: `send_feature_flags` is explicit, and dict-based advanced control became available.
-- This guide is pinned to `7.9.11`, but PyPI lists `7.9.12` as the latest release on March 12, 2026. Check release drift before pinning examples for a fresh project.
-- The package metadata currently shown on PyPI for `7.9.12` says `Requires: Python >=3.10`. The PostHog docs page separately says Python `3.9` is no longer supported. Inference: treat current `7.9.x` work as Python `3.10+` unless your exact pinned artifact proves otherwise.
+- This guide is pinned to `7.16.2`, the latest release as of May 29, 2026. Check release drift before pinning examples for a fresh project.
+- The package metadata on PyPI for `7.16.2` says `Requires: Python >=3.10`. The PostHog docs page separately confirms Python `3.9` is no longer supported. Treat current `7.16.x` work as Python `3.10+` unless your exact pinned artifact proves otherwise.
 
 ## Official Sources
 


### PR DESCRIPTION
docs(posthog, amplitude): refresh analytics SDK docs

- posthog (PyPI) 7.9.11 → 7.16.2
- amplitude-analytics (PyPI) 1.2.0 → 1.2.3 (adds missing `revision:`)
- @amplitude/analytics-browser (npm) 2.30.1 → 2.42.5 (adds missing
  `revision:`)
- `revision` bumped and `updated-on: 2026-05-29`

Verified versions against PyPI and npm.
