### PR TITLE
docs(auth0, clerk, stytch): refresh auth SDK docs

### DIFF
--- a/content/auth0/docs/identity/javascript/DOC.md
+++ b/content/auth0/docs/identity/javascript/DOC.md
@@ -3,8 +3,9 @@ name: identity
 description: "Auth0 JavaScript/Node.js SDK for OAuth, OIDC, and identity management in server-side applications"
 metadata:
   languages: "javascript"
-  versions: "5.0.0"
-  updated-on: "2026-03-01"
+  versions: "5.11.0"
+  revision: 1
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "auth0,identity,oauth,oidc,authentication"
 ---
@@ -22,7 +23,7 @@ Always use the official Auth0 Node.js SDK for server-side authentication and use
 
 - **Library Name:** Auth0 Node.js SDK
 - **NPM Package:** `auth0`
-- **Current Version:** 5.0.0
+- **Current Version:** 5.11.0
 - **Minimum Node.js Version:** 20.19.0+ or 22.12.0+ or 24.0.0+
 
 **Installation:**
@@ -956,6 +957,59 @@ q: 'email:"*@example.com" AND user_metadata.plan:"premium"'
 
 // Search by created date
 q: 'created_at:[2024-01-01 TO 2024-12-31]'
+```
+
+## JWT and Token Verification
+
+The Node.js SDK focuses on Management/Authentication API access. For verifying inbound access tokens (RS256 from Auth0), pair it with `jose` or `jsonwebtoken` plus `jwks-rsa`.
+
+### Verify Access Token with `jose` (Recommended)
+
+```javascript
+import { createRemoteJWKSet, jwtVerify } from 'jose';
+
+const JWKS = createRemoteJWKSet(
+  new URL(`https://${process.env.AUTH0_DOMAIN}/.well-known/jwks.json`)
+);
+
+export async function verifyAccessToken(token) {
+  const { payload } = await jwtVerify(token, JWKS, {
+    issuer: `https://${process.env.AUTH0_DOMAIN}/`,
+    audience: process.env.AUTH0_AUDIENCE,
+  });
+  return payload;
+}
+```
+
+### Express Bearer-Token Middleware
+
+```javascript
+import { verifyAccessToken } from './auth.js';
+
+export async function requireAuth(req, res, next) {
+  const header = req.headers.authorization ?? '';
+  if (!header.startsWith('Bearer ')) {
+    return res.status(401).json({ error: 'missing_token' });
+  }
+  try {
+    req.auth = await verifyAccessToken(header.slice(7));
+    next();
+  } catch (err) {
+    res.status(401).json({ error: 'invalid_token', detail: err.message });
+  }
+}
+```
+
+### Fetch UserInfo from Access Token
+
+```javascript
+import { UserInfoClient } from 'auth0';
+
+const userInfoClient = new UserInfoClient({
+  domain: process.env.AUTH0_DOMAIN,
+});
+
+const profile = await userInfoClient.getUserInfo(accessToken);
 ```
 
 ## Useful Links

--- a/content/auth0/docs/identity/python/DOC.md
+++ b/content/auth0/docs/identity/python/DOC.md
@@ -3,8 +3,9 @@ name: identity
 description: "Auth0 Python SDK for OAuth, OIDC, and identity management in server-side applications"
 metadata:
   languages: "python"
-  versions: "4.7.2"
-  updated-on: "2026-03-01"
+  versions: "5.6.0"
+  revision: 1
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "auth0,identity,oauth,oidc,authentication"
 ---
@@ -22,8 +23,8 @@ Always use the official Auth0 Python SDK for server-side authentication and user
 
 - **Library Name:** Auth0 Python SDK
 - **PyPI Package:** `auth0-python`
-- **Current Version:** 4.13.0
-- **Minimum Python Version:** 3.7+
+- **Current Version:** 5.6.0
+- **Minimum Python Version:** 3.8+
 
 **Installation:**
 
@@ -64,7 +65,7 @@ pip install auth0-python
 For specific versions:
 
 ```bash
-pip install auth0-python==4.13.0
+pip install auth0-python==5.6.0
 ```
 
 ## Initialization
@@ -1187,6 +1188,64 @@ q = '(email:"*@example.com" OR email:"*@test.com") AND user_metadata.active:true
 | 409 | Conflict (e.g., user already exists) |
 | 429 | Too Many Requests (Rate Limited) |
 | 500 | Internal Server Error |
+
+## JWT and Token Verification
+
+The Auth0 Python SDK does not bundle a JWT verifier; use the companion `auth0-python` `authentication` module for `userinfo` lookups and `PyJWT` + `jwks-client` (built into `PyJWT >= 2.0`) for ID/access token validation.
+
+### Validate ID Token via UserInfo
+
+```python
+from auth0.authentication import Users
+
+users_client = Users(domain)
+profile = users_client.userinfo(access_token='Bearer-access-token')
+print(profile['sub'])
+```
+
+### Verify a JWT signature with PyJWT + JWKS
+
+```python
+import jwt
+from jwt import PyJWKClient
+import os
+
+domain = os.getenv('AUTH0_DOMAIN')
+audience = os.getenv('AUTH0_API_AUDIENCE')
+
+jwks_client = PyJWKClient(f'https://{domain}/.well-known/jwks.json')
+
+def verify_access_token(token: str) -> dict:
+    signing_key = jwks_client.get_signing_key_from_jwt(token).key
+    return jwt.decode(
+        token,
+        signing_key,
+        algorithms=['RS256'],
+        audience=audience,
+        issuer=f'https://{domain}/',
+    )
+```
+
+### Flask Bearer-Token Middleware
+
+```python
+from functools import wraps
+from flask import request, jsonify
+
+def require_auth(f):
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        auth_header = request.headers.get('Authorization', '')
+        if not auth_header.startswith('Bearer '):
+            return jsonify({'error': 'missing_token'}), 401
+        token = auth_header.split(' ', 1)[1]
+        try:
+            request.auth = verify_access_token(token)
+        except jwt.PyJWTError as exc:
+            return jsonify({'error': 'invalid_token', 'detail': str(exc)}), 401
+        return f(*args, **kwargs)
+    return wrapper
+```
 
 ## Useful Links
 

--- a/content/clerk/docs/auth/javascript/DOC.md
+++ b/content/clerk/docs/auth/javascript/DOC.md
@@ -3,8 +3,9 @@ name: auth
 description: "Clerk JavaScript SDK for user authentication, session management, and identity workflows"
 metadata:
   languages: "javascript"
-  versions: "5.1.6"
-  updated-on: "2026-03-01"
+  versions: "7.4.2"
+  revision: 1
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "clerk,auth,authentication,user-management,session"
 ---
@@ -32,10 +33,11 @@ This context guide covers both approaches comprehensively.
 
 Always use the appropriate Clerk SDK for your specific framework or environment. Clerk provides specialized packages for different platforms that include framework-specific optimizations and integrations.
 
-**Available Packages:**
-- **Next.js:** `@clerk/nextjs` 
-- **React:** `@clerk/react` 
-- **Vanilla JavaScript:** `@clerk/clerk-js` 
+**Available Packages (current pinned versions):**
+- **Next.js:** `@clerk/nextjs` `7.4.2`
+- **React:** `@clerk/react`
+- **Vanilla JavaScript:** `@clerk/clerk-js`
+- **Backend (Node) SDK:** `@clerk/clerk-sdk-node` `5.1.6` (use `@clerk/backend` for new projects)
 - **Vue:** `@clerk/vue`
 - **Astro:** `@clerk/astro`
 - **Remix:** `@clerk/remix`

--- a/content/clerk/docs/auth/python/DOC.md
+++ b/content/clerk/docs/auth/python/DOC.md
@@ -3,8 +3,9 @@ name: auth
 description: "Clerk Backend API Python SDK for server-side authentication and user management operations"
 metadata:
   languages: "python"
-  versions: "3.3.1"
-  updated-on: "2026-03-01"
+  versions: "5.0.7"
+  revision: 1
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "clerk,auth,authentication,user-management,backend"
 ---
@@ -271,4 +272,74 @@ The SDK includes the following key dependencies:
 
 ## SDK Configuration
 
-The SDK is automatically generated and maintained using Speakeasy configuration. The current version is `2.0.2` and includes comprehensive type hints and documentation.
+The SDK is automatically generated and maintained using Speakeasy configuration. The current version is `5.0.7` and includes comprehensive type hints and documentation.
+
+## Session Token / JWT Verification
+
+For verifying Clerk-issued session JWTs in your own request middleware, use the SDK's `authenticate_request` helper alongside the secret key. The helper validates the token's signature against Clerk's JWKS, checks the issuer, and returns the request state.
+
+### Authenticate a Request
+
+```python
+from clerk_backend_api import Clerk
+from clerk_backend_api.jwks_helpers import AuthenticateRequestOptions
+import httpx
+
+clerk = Clerk(bearer_auth="sk_test_your_secret_key_here")
+
+def verify(request_headers: dict) -> dict | None:
+    httpx_request = httpx.Request(
+        method="GET",
+        url="https://your-app.example.com/api/protected",
+        headers=request_headers,
+    )
+    state = clerk.authenticate_request(
+        httpx_request,
+        AuthenticateRequestOptions(
+            authorized_parties=["https://your-app.example.com"],
+        ),
+    )
+    if not state.is_signed_in:
+        return None
+    return state.payload  # JWT claims (sub, sid, etc.)
+```
+
+### FastAPI Dependency Example
+
+```python
+from fastapi import Depends, FastAPI, HTTPException, Request
+from clerk_backend_api import Clerk
+from clerk_backend_api.jwks_helpers import AuthenticateRequestOptions
+import httpx
+import os
+
+app = FastAPI()
+clerk = Clerk(bearer_auth=os.environ["CLERK_SECRET_KEY"])
+
+async def current_user(request: Request):
+    httpx_req = httpx.Request(
+        method=request.method,
+        url=str(request.url),
+        headers=dict(request.headers),
+    )
+    state = clerk.authenticate_request(
+        httpx_req,
+        AuthenticateRequestOptions(),
+    )
+    if not state.is_signed_in:
+        raise HTTPException(status_code=401, detail=state.reason)
+    return state.payload
+
+@app.get("/me")
+async def me(claims = Depends(current_user)):
+    return {"user_id": claims["sub"], "session_id": claims["sid"]}
+```
+
+### Environment Variables
+
+```
+CLERK_SECRET_KEY=sk_live_your_secret_key
+CLERK_PUBLISHABLE_KEY=pk_live_your_publishable_key
+```
+
+Never check secret keys into source control; load them from environment variables and never expose them to client code.

--- a/content/stytch/docs/auth/javascript/DOC.md
+++ b/content/stytch/docs/auth/javascript/DOC.md
@@ -3,8 +3,9 @@ name: auth
 description: "Stytch Node.js SDK authentication guide for passwordless and OTP-based authentication"
 metadata:
   languages: "javascript"
-  versions: "12.43.0"
-  updated-on: "2026-03-02"
+  versions: "14.0.0"
+  revision: 1
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "stytch,auth,authentication,passwordless,otp"
 ---
@@ -19,7 +20,7 @@ metadata:
 npm install stytch
 ```
 
-**Current version: 12.43.0**
+**Current version: 14.0.0**
 
 **DO NOT use:**
 - Deprecated `@stytch/stytch-js` (deprecated in favor of `@stytch/vanilla-js` for frontend)

--- a/content/stytch/docs/auth/python/DOC.md
+++ b/content/stytch/docs/auth/python/DOC.md
@@ -3,8 +3,9 @@ name: auth
 description: "Stytch Python SDK authentication guide for passwordless and OTP-based authentication"
 metadata:
   languages: "python"
-  versions: "13.28.0"
-  updated-on: "2026-03-02"
+  versions: "15.2.0"
+  revision: 1
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "stytch,auth,authentication,passwordless,otp"
 ---
@@ -19,7 +20,7 @@ metadata:
 pip install stytch
 ```
 
-**Current version: 13.28.0**
+**Current version: 15.2.0**
 
 **DO NOT use:**
 - Any unofficial or outdated Stytch packages


### PR DESCRIPTION
docs(auth0, clerk, stytch): refresh auth SDK docs

- auth0-python 4.7.2/4.13.0 → 5.6.0 (Python ≥3.8); adds JWT/JWKS
  verification with `PyJWT` + Flask Bearer-token middleware
- auth0 (Node) 5.0.0 → 5.11.0; adds JWT verification with `jose` +
  `createRemoteJWKSet`, Express bearer-token middleware
- clerk-backend-api (PyPI) 3.3.1 → 5.0.7; adds `authenticate_request` /
  JWT-claims verification with a FastAPI dependency example
- @clerk/nextjs 5.1.6 → 7.4.2; `@clerk/clerk-sdk-node` pinned 5.1.6
- stytch (PyPI) 13.28.0 → 15.2.0
- stytch (npm) 12.43.0 → 14.0.0
- `revision` bumped and `updated-on: 2026-05-29`

Verified versions against PyPI and npm.
