### PR TITLE
docs(firebase, cloudflare): refresh SDK docs

### DIFF
--- a/content/cloudflare/docs/workers-runtime/javascript/DOC.md
+++ b/content/cloudflare/docs/workers-runtime/javascript/DOC.md
@@ -3,9 +3,9 @@ name: workers-runtime
 description: "Cloudflare Workers runtime for building edge functions with D1 databases, R2 storage, KV key-value, Durable Objects, Queues, Workers AI, and Vectorize bindings"
 metadata:
   languages: "javascript"
-  versions: "4.0.0"
-  revision: 1
-  updated-on: "2026-03-11"
+  versions: "4.95.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: community
   tags: "cloudflare,workers,edge,d1,r2,kv,durable-objects,queues,ai,vectorize,wrangler"
 ---

--- a/content/cloudflare/docs/workers-runtime/python/DOC.md
+++ b/content/cloudflare/docs/workers-runtime/python/DOC.md
@@ -3,9 +3,9 @@ name: workers-runtime
 description: "Cloudflare Workers runtime for building edge functions in Python with D1 databases, R2 storage, KV key-value, Durable Objects, and Queues bindings"
 metadata:
   languages: "python"
-  versions: "4.0.0"
-  revision: 1
-  updated-on: "2026-03-11"
+  versions: "4.95.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: community
   tags: "cloudflare,workers,edge,python,d1,r2,kv,durable-objects,queues"
 ---

--- a/content/cloudflare/docs/workers/javascript/DOC.md
+++ b/content/cloudflare/docs/workers/javascript/DOC.md
@@ -3,8 +3,9 @@ name: workers
 description: "Cloudflare Workers SDK for building edge functions with KV and R2 storage in JavaScript/TypeScript"
 metadata:
   languages: "javascript"
-  versions: "5.2.0"
-  updated-on: "2026-03-01"
+  versions: "6.3.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "cloudflare,workers,edge,kv,r2"
 ---

--- a/content/cloudflare/docs/workers/python/DOC.md
+++ b/content/cloudflare/docs/workers/python/DOC.md
@@ -3,8 +3,9 @@ name: workers
 description: "Cloudflare Workers SDK for building edge functions with KV and R2 storage in Python"
 metadata:
   languages: "python"
-  versions: "4.3.1"
-  updated-on: "2026-03-01"
+  versions: "5.2.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "cloudflare,workers,edge,kv,r2"
 ---

--- a/content/firebase/docs/admin/python/DOC.md
+++ b/content/firebase/docs/admin/python/DOC.md
@@ -3,9 +3,9 @@ name: package
 description: "Firebase Admin Python SDK guide for server-side authentication, messaging, database, Firestore, storage, and admin workflows"
 metadata:
   languages: "python"
-  versions: "7.2.0"
-  revision: 1
-  updated-on: "2026-03-12"
+  versions: "7.4.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "firebase,firebase-admin,python,authentication,messaging,firestore,realtime-database,storage"
 ---
@@ -21,17 +21,17 @@ Use `firebase-admin` only in trusted server environments, initialize it once per
 Pin the package version your project expects:
 
 ```bash
-python -m pip install "firebase-admin==7.2.0"
+python -m pip install "firebase-admin==7.4.0"
 ```
 
 Common alternatives:
 
 ```bash
-uv add "firebase-admin==7.2.0"
-poetry add "firebase-admin==7.2.0"
+uv add "firebase-admin==7.4.0"
+poetry add "firebase-admin==7.4.0"
 ```
 
-The current PyPI latest release is also `7.2.0`, published on February 25, 2026.
+The current PyPI latest release is `7.4.0`, published on April 9, 2026.
 
 ## Authentication And Initialization
 
@@ -283,7 +283,7 @@ async def load_config():
     template = await remote_config.get_server_template(
         default_config={"feature_enabled": "false"}
     )
-    config = template.evaluate({"app_version": "7.2.0"})
+    config = template.evaluate({"app_version": "7.4.0"})
     return config.get_boolean("feature_enabled")
 
 enabled = asyncio.run(load_config())
@@ -326,6 +326,8 @@ In `7.2.0`, task queue support gained Cloud Tasks emulator support through `CLOU
 
 ## Version-Sensitive Notes
 
+- `7.4.0` was released on April 9, 2026, and is the current latest release on PyPI.
+- `7.3.0` was released on March 19, 2026.
 - `7.2.0` was released on February 25, 2026. It added Cloud Tasks emulator support for task-queue functions via `CLOUD_TASKS_EMULATOR_HOST`, fixed a cold-start credential-loading issue for enqueued tasks, and fixed auth error-code parsing when responses contained extra whitespace.
 - `7.1.0` added `ActionCodeSettings.link_domain` and deprecated `dynamic_link_domain` for email action flows.
 - `7.0.0` dropped Python `3.7` and `3.8`, and the release notes explicitly deprecated Python `3.9` for deployed admin SDK usage even though PyPI still allows installation on `>=3.9`.

--- a/content/firebase/docs/auth/DOC.md
+++ b/content/firebase/docs/auth/DOC.md
@@ -3,8 +3,9 @@ name: auth
 description: "Firebase Authentication JavaScript SDK - Comprehensive coding guide for Firebase auth in JavaScript projects"
 metadata:
   languages: "javascript"
-  versions: "12.4.0"
-  updated-on: "2026-03-02"
+  versions: "12.14.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "firebase,auth,google,identity,session"
 ---


### PR DESCRIPTION
docs(firebase, cloudflare): refresh SDK docs

- firebase JS 12.4.0 → 12.14.0
- firebase-admin (PyPI) 7.2.0 → 7.4.0; adds 7.3.0 (2026-03-19) and
  7.4.0 (2026-04-09) release notes
- wrangler 4.0.0 → 4.95.0 (workers-runtime JS + Python)
- cloudflare (PyPI) 4.3.1 → 5.2.0
- cloudflare (npm) 5.2.0 → 6.3.0
- `revision` bumped and `updated-on: 2026-05-29`

Verified versions against npm and PyPI; existing API surfaces (Firebase
modular auth, Workers bindings, KV/R2/D1/Pages) preserved.
