### PR TITLE
docs(sendgrid, resend, twilio): refresh messaging SDK docs

### DIFF
--- a/content/resend/docs/email/DOC.md
+++ b/content/resend/docs/email/DOC.md
@@ -3,8 +3,9 @@ name: email
 description: "Modern email API platform with React Email integration, batch sending, scheduling, webhooks, and domain management"
 metadata:
   languages: "javascript"
-  versions: "6.2.2"
-  updated-on: "2025-10-26"
+  versions: "6.12.4"
+  revision: 1
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "resend,sdk,email,messaging"
 ---
@@ -12,7 +13,7 @@ metadata:
 
 ## Golden Rule
 
-**Always use the official `resend` package from npm.** The current version is 6.2.2.
+**Always use the official `resend` package from npm.** The current version is 6.12.4.
 
 ```bash
 npm install resend

--- a/content/sendgrid/docs/email-api/javascript/DOC.md
+++ b/content/sendgrid/docs/email-api/javascript/DOC.md
@@ -4,7 +4,8 @@ description: "SendGrid Node.js library for sending transactional and marketing e
 metadata:
   languages: "javascript"
   versions: "8.1.6"
-  updated-on: "2026-03-01"
+  revision: 1
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "sendgrid,email,transactional,templates,delivery"
 ---

--- a/content/sendgrid/docs/email-api/python/DOC.md
+++ b/content/sendgrid/docs/email-api/python/DOC.md
@@ -4,7 +4,8 @@ description: "SendGrid Python SDK for sending emails and managing email communic
 metadata:
   languages: "python"
   versions: "6.12.5"
-  updated-on: "2026-03-01"
+  revision: 1
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "sendgrid,email,transactional,templates,delivery"
 ---

--- a/content/sendgrid/docs/package/python/DOC.md
+++ b/content/sendgrid/docs/package/python/DOC.md
@@ -4,8 +4,8 @@ description: "Twilio SendGrid Python SDK for sending email and calling the SendG
 metadata:
   languages: "python"
   versions: "6.12.5"
-  revision: 1
-  updated-on: "2026-03-12"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "sendgrid,twilio,email,transactional-email,templates,delivery"
 ---
@@ -208,7 +208,7 @@ print(response.status_code)  # 200 in sandbox mode
 
 ## Version-Sensitive Notes
 
-- The version used here `6.12.5` matches the current stable PyPI release as of March 12, 2026.
+- The version used here `6.12.5` matches the current stable PyPI release as of May 29, 2026.
 - PyPI also lists `7.0.0rc1` and `7.0.0rc2` as pre-releases. Do not assume 7.x examples apply to the stable package.
 - PyPI's project description says the `6.x` line is a breaking change from `5.x`; do not copy `5.x` tutorials into a `6.12.5` project without checking release notes.
 - The Twilio quickstart page is stale in two places: it still says the SDK supports Python `2.7, 3.5, 3.6, 3.7, and 3.8`, and its sample install output still shows `sendgrid-6.4.6`. PyPI classifiers for `6.12.5` include Python `3.12` and `3.13`, and the upstream changelog says `6.12.0` added Python `3.12` and `3.13` support.

--- a/content/twilio/docs/messaging/python/DOC.md
+++ b/content/twilio/docs/messaging/python/DOC.md
@@ -3,8 +3,9 @@ name: messaging
 description: "Cloud communications platform for SMS, voice, video, and WhatsApp messaging with programmable APIs"
 metadata:
   languages: "python"
-  versions: "9.8.4"
-  updated-on: "2025-09-25"
+  versions: "9.10.9"
+  revision: 1
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "twilio,sdk,sms,voice,communications"
 ---
@@ -23,7 +24,7 @@ Always use the official Twilio Python library to interact with Twilio APIs, whic
 
 - **Library Name:** Twilio Python Helper Library
 - **Python Package:** `twilio`
-- **Current Version:** 9.6.0+
+- **Current Version:** 9.10.9
 
 **Installation:**
 
@@ -47,6 +48,8 @@ The library supports the following Python versions:
 - Python 3.9
 - Python 3.10
 - Python 3.11
+- Python 3.12
+- Python 3.13
 
 ## Installation and Setup
 

--- a/content/twilio/docs/messaging/typescript/DOC.md
+++ b/content/twilio/docs/messaging/typescript/DOC.md
@@ -3,8 +3,9 @@ name: messaging
 description: "Cloud communications platform for SMS, voice, video, and WhatsApp messaging with programmable APIs"
 metadata:
   languages: "typescript"
-  versions: "5.10.3"
-  updated-on: "2025-09-25"
+  versions: "6.0.2"
+  revision: 1
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "twilio,sdk,sms,voice,communications"
 ---
@@ -23,7 +24,7 @@ Always use the official Twilio Node.js library, which is the standard library fo
 
 **Library Name:** Twilio Node.js Helper Library
 **NPM Package:** `twilio`
-**Supported Node.js Versions:** Node.js 18, 20, 22 (LTS)
+**Supported Node.js Versions:** Node.js 20, 22 (LTS) and later (v6.x of the library requires Node.js >= 20)
 
 **Installation:**
 - **Correct:** `npm install twilio` or `yarn add twilio`
@@ -653,13 +654,11 @@ This guide covers the core functionality of the Twilio Node.js library. The libr
 
 # twilio-node
 
-This library supports the following Node.js implementations:
+This library (v6.x) supports the following Node.js implementations:
 
-- Node.js 14
-- Node.js 16
-- Node.js 18
 - Node.js 20
 - Node.js lts(22)
+- Node.js 24
 
 TypeScript is supported for TypeScript version 2.9 and above.
 

--- a/content/twilio/docs/package/python/DOC.md
+++ b/content/twilio/docs/package/python/DOC.md
@@ -3,9 +3,9 @@ name: package
 description: "Twilio Python helper library for REST API access, messaging, voice, and TwiML generation"
 metadata:
   languages: "python"
-  versions: "9.10.3"
-  revision: 1
-  updated-on: "2026-03-12"
+  versions: "9.10.9"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "twilio,communications,sms,voice,twiml,oauth"
 ---
@@ -21,7 +21,7 @@ Use the official `twilio` helper library, import the REST client as `from twilio
 Pin the version your project expects:
 
 ```bash
-python -m pip install "twilio==9.10.3"
+python -m pip install "twilio==9.10.9"
 ```
 
 For a general install without a pin:
@@ -30,7 +30,7 @@ For a general install without a pin:
 python -m pip install twilio
 ```
 
-Twilio's PyPI metadata for `9.10.3` declares support for Python `3.7` through `3.13`.
+Twilio's PyPI metadata for `9.10.9` declares support for Python `3.7` through `3.13`.
 
 ## Authentication And Setup
 
@@ -249,9 +249,9 @@ except TwilioRestException as exc:
 - Region routing is easy to misconfigure. Set both `region` and `edge` together or stay on the default `US1`.
 - OAuth client credentials are still beta and not a universal replacement for account credentials.
 
-## Version-Sensitive Notes For 9.10.3
+## Version-Sensitive Notes For 9.10.9
 
-- PyPI and Twilio's official helper-library docs both list `9.10.3` as the current package version as of March 12, 2026.
+- PyPI and Twilio's official helper-library docs both list `9.10.9` as the current package version as of May 29, 2026.
 - Twilio's `9.0.0` upgrade guide says the helper library moved to OpenAPI-generated code and added JSON request-body support; most high-level resource patterns stayed compatible, but older code that relied on undocumented internals is riskier on `9.x`.
 - Twilio's versioning policy explicitly recommends pinning at least the major version because minor releases can require manual code changes.
-- The published versioning matrix says the current major version supports Python `3.7` through `3.13`. If your runtime is older than `3.7`, `9.10.3` is out of range.
+- The published versioning matrix says the current major version supports Python `3.7` through `3.13`. If your runtime is older than `3.7`, `9.10.9` is out of range.


### PR DESCRIPTION
docs(sendgrid, resend, twilio): refresh messaging SDK docs

- resend (Node) 6.2.2 → 6.12.4
- sendgrid (PyPI) 6.12.5 unchanged (metadata refresh)
- @sendgrid/mail (npm) 8.1.6 unchanged (metadata refresh)
- sendgrid package/python 6.12.5 unchanged (metadata refresh)
- twilio (PyPI) 9.8.4 → 9.10.9; adds Python 3.12 / 3.13 to supported
  runtimes
- twilio (npm) 5.10.3 → 6.0.2 (major bump; Node ≥20)
- twilio package/python 9.10.3 → 9.10.9
- `revision` bumped and `updated-on: 2026-05-29`

Verified versions against PyPI and npm.
