### PR TITLE
docs(pytest, poetry, uv, ruff): refresh Python tooling docs

### DIFF
--- a/content/poetry/docs/package/python/DOC.md
+++ b/content/poetry/docs/package/python/DOC.md
@@ -3,9 +3,9 @@ name: package
 description: "Poetry package guide for Python dependency management, virtual environments, packaging, and publishing"
 metadata:
   languages: "python"
-  versions: "2.3.2"
-  revision: 1
-  updated-on: "2026-03-12"
+  versions: "2.4.1"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "poetry,python,packaging,dependencies,virtualenv,pyproject,publishing"
 ---
@@ -14,7 +14,7 @@ metadata:
 
 ## Golden Rule
 
-Use Poetry as the project tool that owns `pyproject.toml`, the lock file, and the virtual environment workflow. For Poetry `2.3.2`, prefer the modern `[project]` section for your main package metadata and runtime dependencies, use `poetry sync` when you need the environment to exactly match `poetry.lock`, and keep Poetry-specific settings under `[tool.poetry]`.
+Use Poetry as the project tool that owns `pyproject.toml`, the lock file, and the virtual environment workflow. For Poetry `2.4.1`, prefer the modern `[project]` section for your main package metadata and runtime dependencies, use `poetry sync` when you need the environment to exactly match `poetry.lock`, and keep Poetry-specific settings under `[tool.poetry]`.
 
 Do not add `poetry` as an application dependency with `poetry add poetry`. Install the CLI separately, then use it to manage your project.
 
@@ -23,14 +23,14 @@ Do not add `poetry` as an application dependency with `poetry add poetry`. Insta
 The most practical installation for local development is `pipx` so Poetry stays isolated from the project it manages:
 
 ```bash
-pipx install "poetry==2.3.2"
+pipx install "poetry==2.4.1"
 poetry --version
 ```
 
 Official installer alternative:
 
 ```bash
-curl -sSL https://install.python-poetry.org | POETRY_VERSION=2.3.2 python3 -
+curl -sSL https://install.python-poetry.org | POETRY_VERSION=2.4.1 python3 -
 poetry --version
 ```
 
@@ -267,18 +267,23 @@ poetry publish --build --repository internal-pub
 - `poetry env activate` prints shell-specific activation code. For scripts, CI, and agents, `poetry run ...` is usually more reliable.
 - `poetry check` should be part of the edit loop whenever an agent writes `pyproject.toml`.
 
-## Version-Sensitive Notes For 2.3.2
+## Version-Sensitive Notes For 2.4.1
 
-- PyPI lists `2.3.2` as the current Poetry release. The version used here matches live upstream as of March 12, 2026.
-- Poetry `2.3.x` requires Python `>=3.10,<4.0`. Some older docs snippets still mention Python 3.9, but the `2.3.0` release history and PyPI metadata are the authoritative signals for this series.
+- PyPI lists `2.4.1` as the current Poetry release. The version used here matches live upstream as of May 29, 2026.
+- Poetry `2.4.x` requires Python `>=3.10,<4.0`. Some older docs snippets still mention Python 3.9, but the `2.4.0` release history and PyPI metadata are the authoritative signals for this series.
 - Poetry 2.x prefers `[project]` metadata and runtime dependencies. Older blog posts often use only `[tool.poetry.dependencies]`; that is no longer the best default for new work.
-- The CLI docs mark `export` as provided by the Export Poetry Plugin, and the `2.3.0` release history notes that Poetry no longer depends on `poetry-plugin-export` by default. If `poetry export` is missing, install the plugin explicitly:
+- The CLI docs mark `export` as provided by the Export Poetry Plugin, and Poetry no longer depends on `poetry-plugin-export` by default. If `poetry export` is missing, install the plugin explicitly:
 
 ```bash
 poetry self add poetry-plugin-export
 ```
 
-- The `2.3.0` release history also notes the installer default `installer.re-resolve = false` behavior. If you compare behavior with much older Poetry examples, dependency resolution details may not match exactly.
+- Poetry `2.4.0` made `installer.re-resolve = false` the default. If you compare behavior with much older Poetry examples, dependency resolution details may not match exactly.
+- Poetry `2.4.0` added a `solver.min-release-age` setting, which lets the solver filter out package releases that are newer than the configured age during resolution. Per-package and per-index exclusions are supported, which is useful when you want to avoid brand-new releases without fully pinning versions.
+- Poetry `2.4.0` made `poetry update <package>` raise an error when the argument is not a declared dependency, instead of silently ignoring it. `poetry update <package>` can also operate on transitive dependencies; `2.4.1` fixed a regression in that path. If you previously relied on the silent no-op, expect a hard error now.
+- Poetry `2.4.0` normalizes dependency group names. If you used inconsistent casing, the normalized form is what now appears in resolution and lock output.
+- Poetry `2.4.0` added support for build constraints on dependencies, dynamic version determination via the build-backend for published artifacts, and editable installs of project plugins. PEP 735 dependency groups now contribute to the lock file hash.
+- Poetry `2.4.1` is a bug-fix release: it resolves a performance regression in the wheel installer and relaxes the `installer` lower bound so `installer==0.7.0` is acceptable again.
 
 ## Official Source URLs
 

--- a/content/pytest/docs/package/python/DOC.md
+++ b/content/pytest/docs/package/python/DOC.md
@@ -3,9 +3,9 @@ name: package
 description: "pytest package guide for Python with practical setup, fixtures, parametrization, plugin, and 9.0.x notes"
 metadata:
   languages: "python"
-  versions: "9.0.2"
-  revision: 1
-  updated-on: "2026-03-12"
+  versions: "9.0.3"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "pytest,testing,python,fixtures,assertions,plugins"
 ---
@@ -29,14 +29,14 @@ Use it when a Python project needs:
 Install `pytest` into the project environment and pin it if the test suite depends on 9.0 behavior:
 
 ```bash
-python -m pip install "pytest==9.0.2"
+python -m pip install "pytest==9.0.3"
 ```
 
 Common alternatives:
 
 ```bash
-uv add --dev "pytest==9.0.2"
-poetry add --group dev "pytest==9.0.2"
+uv add --dev "pytest==9.0.3"
+poetry add --group dev "pytest==9.0.3"
 ```
 
 If you are authoring a package, also install your package in editable mode so tests exercise the local code cleanly:
@@ -294,8 +294,9 @@ Async tests are version-sensitive:
 - `pytest 9.0` added native TOML configuration with `[tool.pytest]`, plus `pytest.toml` / `.pytest.toml`.
 - `pytest 9.0` added `strict = true` as a bundled strict-mode switch.
 - `strict_xfail` is the 9.0 name; `xfail_strict` is still accepted as an alias.
-- `pytest 9.0.2` is the latest PyPI release as of March 12, 2026.
+- `pytest 9.0.3` is the latest PyPI release as of May 29, 2026.
 - `pytest 9.0.2` changed the terminal progress plugin defaults on non-Windows platforms. If your local output changed after upgrading, check terminal progress settings and related plugins before assuming collection is broken.
+- `pytest 9.0.3` is a bug-fix release. Notable changes: `pytest.approx()` now respects `Mapping` key order during comparisons, attempting to disable a `conftest.py` with `-p no:` now raises a clear error rather than failing internally, exception groups raised in tests with `__tracebackhide__ = True` no longer crash the reporter, non-string messages from `unittest.TestCase.subTest()` are now displayed, and an insecure temporary directory issue (CVE-2025-71176) was fixed.
 
 ## Official Sources
 

--- a/content/ruff/docs/package/python/DOC.md
+++ b/content/ruff/docs/package/python/DOC.md
@@ -3,9 +3,9 @@ name: package
 description: "Ruff package guide for Python projects using the official Ruff docs"
 metadata:
   languages: "python"
-  versions: "0.15.5"
-  revision: 1
-  updated-on: "2026-03-12"
+  versions: "0.15.15"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "ruff,python,linter,formatter,quality,pre-commit"
 ---
@@ -21,21 +21,21 @@ Use `ruff` as a project tool, not as a runtime library. Put configuration in `py
 Pin the version your project expects:
 
 ```bash
-python -m pip install "ruff==0.15.5"
+python -m pip install "ruff==0.15.15"
 ```
 
 Common alternatives:
 
 ```bash
-uv add --dev "ruff==0.15.5"
-poetry add --group dev "ruff==0.15.5"
+uv add --dev "ruff==0.15.15"
+poetry add --group dev "ruff==0.15.15"
 ```
 
 Tool-only install:
 
 ```bash
-uv tool install "ruff==0.15.5"
-pipx install "ruff==0.15.5"
+uv tool install "ruff==0.15.15"
+pipx install "ruff==0.15.15"
 ```
 
 Confirm the binary:
@@ -134,7 +134,7 @@ Use the official `ruff-pre-commit` hooks:
 ```yaml
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.5
+    rev: v0.15.15
     hooks:
       - id: ruff-check
         args: [--fix]
@@ -161,11 +161,16 @@ Keep the hook revision aligned with the package version you expect in CI and loc
 - If a subdirectory has its own config file, Ruff uses that nearest config instead of the repo-root config. This surprises agents in monorepos.
 - Unsafe fixes can change behavior. Treat `--unsafe-fixes` as a deliberate review step, not the default path.
 
-## Version-Sensitive Notes For 0.15.5
+## Version-Sensitive Notes For 0.15.15
 
-- Ruff uses a documented custom versioning scheme rather than strict SemVer. Minor releases can include breaking changes, so moving from `0.15.x` to `0.16.x` should be reviewed like a meaningful upgrade.
+- Ruff uses a documented custom versioning scheme rather than strict SemVer. Minor releases can include breaking changes, so moving from `0.15.x` to `0.16.x` should be reviewed like a meaningful upgrade. Patch-level upgrades within `0.15.x` still occasionally add or extend rules.
 - The built-in language server is the current path; older `ruff-lsp` guidance is stale for modern setups.
 - If you copy snippets from older blog posts, verify section names against the current config reference. Modern Ruff config is split across `[tool.ruff]`, `[tool.ruff.lint]`, and `[tool.ruff.format]`.
+- Several preview rules have been added across the `0.15.x` patch line, including `RUF050` (unnecessary-if), `RUF072` (useless-finally), `RUF073` (f-string-percent-format), `RUF074` (incorrect-decorator-order), `RUF075` (fallible-context-manager), Airflow rules `AIR201`, `AIR202`, and `AIR004`, and the pylint rule `W0717` (too-many-try-statements). These are preview-gated; enabling `preview = true` is required to see them.
+- `F811` now reports duplicate imports inside `TYPE_CHECKING` blocks, and `F821` handling of bare annotations follows PEP 526 more closely. Suites that previously suppressed these will see new diagnostics.
+- The formatter gained a `nested-string-quote-style` option and improved handling of lambdas and nested f-strings on supported Python versions.
+- Logical-line suppression comments `#ruff:file-ignore` and `#ruff:ignore` are now supported alongside the existing `# noqa` syntax.
+- The maximum allowed `line-length` value has been increased, which only matters for projects that were previously hitting the cap.
 
 ## Official Sources
 

--- a/content/uv/docs/package/python/DOC.md
+++ b/content/uv/docs/package/python/DOC.md
@@ -3,9 +3,9 @@ name: package
 description: "uv package guide for Python projects using Astral's package, project, tool, and Python management workflows"
 metadata:
   languages: "python"
-  versions: "0.10.9"
-  revision: 1
-  updated-on: "2026-03-12"
+  versions: "0.11.17"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "uv,python,packaging,virtualenv,dependency-management,cli"
 ---
@@ -25,7 +25,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
 ```bash
-python -m pip install "uv==0.10.9"
+python -m pip install "uv==0.11.17"
 ```
 
 Common alternatives:
@@ -173,11 +173,21 @@ When using private indexes, verify both pieces separately:
 - `managed = false` disables uv's project environment management for that project. Use it only when another workflow is intentionally responsible for the environment.
 - Private package indexes need both index configuration and credentials. One without the other leads to misleading resolution failures.
 
-## Version-Sensitive Notes For 0.10.9
+## Version-Sensitive Notes For 0.11.17
 
-- `uv` follows a release policy that is not strict Semantic Versioning. Minor releases may still include breaking changes, so read the changelog and migration notes before assuming any `0.x` upgrade is trivial.
+- `uv` follows a release policy that is not strict Semantic Versioning. Minor releases may still include breaking changes, so read the changelog and migration notes before assuming any `0.x` upgrade is trivial. The jump from the `0.10.x` line to `0.11.x` falls into this category.
 - Preview functionality is opt-in. If a workflow depends on features such as `native-auth`, make the preview requirement explicit in automation and onboarding docs.
-- As of March 12, 2026, PyPI and the maintainer docs agree on `uv 0.10.9`.
+- As of May 29, 2026, PyPI and the maintainer docs agree on `uv 0.11.17`.
+- The `0.11.x` line tightened entry-point validation: scripts can no longer use names like `python3`, and entry points cannot escape the configured scripts directory. If a tool install used to install a shim named `python3`, it will now fail.
+- Git references embedded in URLs must now be percent-encoded. If you previously fed raw branch or tag names with special characters into `uv add` or `uv pip install` for a Git dependency, those URLs now need to be encoded.
+- `uv add` and `uv pip install` gained `--no-editable` and `--no-editable-package` flags to suppress editable installs even when a project or workspace member would otherwise be installed as editable.
+- `uv python pin` accepts `--python-downloads-json-url` for using a custom Python version index instead of the default Astral-hosted manifest.
+- `uv sync` and related commands now treat `--no-dev` as overriding `UV_DEV=1` instead of the other way around. Configurations that intentionally set `UV_DEV=1` and then add `--no-dev` to a single command will now see the flag win.
+- `uv lock` skips direct-URL freshness checks when running offline, which makes `--offline` more usable for re-syncing existing lockfiles.
+- Python discovery picks up versioned executables when `requires-python` pins a specific version, which improves first-run behavior on systems where only `python3.12` (not `python`) is on `PATH`.
+- New environment variables include `UV_NO_SYSTEM_CONFIG`, `UV_PYTHON_NO_REGISTRY`, `UV_NO_PROJECT`, and `UV_PYTHON_SEARCH_PATH`. These help when you need to opt out of system-wide configuration or registry lookups in CI.
+- A preview `uv audit` command emits structured JSON for security vulnerabilities, intended for CI integration.
+- `uv workspace list` is now visible in `--help` and `uv workspace metadata` reports module owners.
 
 ## Official Sources
 


### PR DESCRIPTION
docs(pytest, poetry, uv, ruff): refresh Python tooling docs

- pytest 9.0.2 → 9.0.3; expanded 9.0.x notes (Mapping-aware
  `pytest.approx()`, clearer `-p no:conftest` errors, ExceptionGroup
  `__tracebackhide__` fix, subTest non-string messages, CVE-2025-71176)
- poetry 2.3.2 → 2.4.1; updates install snippets and version-sensitive
  notes covering 2.4.0 additions (`solver.min-release-age`, build
  constraints, dynamic versioning, editable plugins, PEP 735 lock hashing,
  normalized group names, stricter `poetry update <package>` errors) and
  2.4.1 fixes
- uv 0.10.9 → 0.11.17 (0.10 → 0.11 line jump); rewrites version notes
  for entry-point validation tightening, Git ref percent-encoding,
  `--no-editable` / `--python-downloads-json-url`, `--no-dev` precedence
  over `UV_DEV`, offline lock behavior, versioned executable discovery,
  new `UV_*` env vars, preview `uv audit` JSON, `uv workspace list` /
  `metadata` updates
- ruff 0.15.5 → 0.15.15; bumps pre-commit `rev: v0.15.15` and extends
  version notes for new preview rules (RUF050/072–075, AIR201/202/004,
  PLW0717), `F811`/`F821` behavior changes,
  `nested-string-quote-style`, `#ruff:file-ignore` /
  `#ruff:ignore` suppressions, increased `line-length` cap
- `revision` bumped and `updated-on: 2026-05-29`

Verified versions against PyPI.
