### PR TITLE
docs(livekit, slack, slack-sdk, discord): refresh realtime/social SDK docs

### DIFF
--- a/content/discord/docs/bot/javascript/DOC.md
+++ b/content/discord/docs/bot/javascript/DOC.md
@@ -3,8 +3,9 @@ name: bot
 description: "Discord.js SDK for building Discord bots with slash commands and gateway events in JavaScript/TypeScript"
 metadata:
   languages: "javascript"
-  versions: "14.24.0"
-  updated-on: "2026-03-01"
+  versions: "14.26.4"
+  revision: 1
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "discord,bot,slash-commands,gateway,sdk"
 ---
@@ -14,7 +15,7 @@ metadata:
 You are a Discord.js coding expert. Help me with writing code using the Discord API calling the official libraries and SDKs.
 
 You can find the official SDK documentation and code samples here:
-https://discord.js.org/docs/packages/discord.js/14.24.0
+https://discord.js.org/docs/packages/discord.js/14.26.4
 
 ## Golden Rule: Use the Correct and Current SDK
 
@@ -22,7 +23,7 @@ Always use the discord.js library to interact with the Discord API, which is the
 
 - **Library Name:** discord.js
 - **NPM Package:** `discord.js`
-- **Current Version:** 14.24.0 (v14)
+- **Current Version:** 14.26.4 (v14)
 - **Legacy Libraries:** discord.js v12, discord.js v13 are outdated and not recommended
 
 **Installation:**
@@ -1083,7 +1084,7 @@ const connection = joinVoiceChannel({
 
 ## Useful Links
 
-- Documentation: https://discord.js.org/docs/packages/discord.js/14.24.0
+- Documentation: https://discord.js.org/docs/packages/discord.js/14.26.4
 - Guide: https://discordjs.guide/
 - Discord API Docs: https://discord.com/developers/docs
 - Developer Portal: https://discord.com/developers/applications

--- a/content/discord/docs/bot/python/DOC.md
+++ b/content/discord/docs/bot/python/DOC.md
@@ -3,8 +3,9 @@ name: bot
 description: "Discord.py SDK for building Discord bots with slash commands and gateway events in Python"
 metadata:
   languages: "python"
-  versions: "2.6.4"
-  updated-on: "2026-03-01"
+  versions: "2.7.1"
+  revision: 1
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "discord,bot,slash-commands,gateway,sdk"
 ---
@@ -22,7 +23,7 @@ Always use the discord.py library to interact with the Discord API, which is the
 
 - **Library Name:** discord.py
 - **PyPI Package:** `discord.py`
-- **Current Version:** 2.6.4
+- **Current Version:** 2.7.1
 - **Legacy Libraries:** discord.py v1.x is outdated and not recommended
 
 **Installation:**

--- a/content/livekit/docs/realtime/javascript/DOC.md
+++ b/content/livekit/docs/realtime/javascript/DOC.md
@@ -3,8 +3,9 @@ name: realtime
 description: "LiveKit Client SDK for JavaScript/TypeScript enabling real-time video, audio, and data communication via WebRTC."
 metadata:
   languages: "javascript"
-  versions: "2.15.13"
-  updated-on: "2026-03-01"
+  versions: "2.19.1"
+  revision: 1
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "livekit,realtime,webrtc,video,audio"
 ---
@@ -19,7 +20,7 @@ Always use the official LiveKit Client SDK for JavaScript/TypeScript, which is t
 
 - **Library Name:** LiveKit Client SDK
 - **Package Name:** `livekit-client`
-- **Current Version:** 2.11.3 
+- **Current Version:** 2.19.1
 
 **Installation:**
 - **Correct:** `npm install livekit-client`

--- a/content/livekit/docs/realtime/python/DOC.md
+++ b/content/livekit/docs/realtime/python/DOC.md
@@ -3,8 +3,9 @@ name: realtime
 description: "LiveKit Python SDK for real-time video, audio, and data communication including room management and recording."
 metadata:
   languages: "python"
-  versions: "1.0.17"
-  updated-on: "2026-03-01"
+  versions: "1.1.9,1.1.0"
+  revision: 1
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "livekit,realtime,webrtc,video,audio"
 ---

--- a/content/slack-sdk/docs/package/python/DOC.md
+++ b/content/slack-sdk/docs/package/python/DOC.md
@@ -3,9 +3,9 @@ name: package
 description: "Slack Python SDK for Web API calls, webhooks, OAuth installs, Socket Mode, and request verification"
 metadata:
   languages: "python"
-  versions: "3.40.1,3.41.0"
-  revision: 1
-  updated-on: "2026-03-12"
+  versions: "3.42.0"
+  revision: 2
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "slack,slack-sdk,python,chat,web-api,oauth,webhooks,socket-mode"
 ---
@@ -28,27 +28,21 @@ Do not start from the deprecated `slack` / `slackclient` package. The current pa
 Pin the version your project expects:
 
 ```bash
-python -m pip install "slack-sdk==3.40.1"
-```
-
-If you want the latest current patch validated during this session:
-
-```bash
-python -m pip install "slack-sdk==3.41.0"
+python -m pip install "slack-sdk==3.42.0"
 ```
 
 If you use async clients, install `aiohttp` explicitly:
 
 ```bash
-python -m pip install "slack-sdk==3.40.1" aiohttp
+python -m pip install "slack-sdk==3.42.0" aiohttp
 ```
 
 For Socket Mode with alternate transports, add the corresponding library yourself:
 
 ```bash
-python -m pip install "slack-sdk==3.40.1" websocket-client
-python -m pip install "slack-sdk==3.40.1" aiohttp
-python -m pip install "slack-sdk==3.40.1" websockets
+python -m pip install "slack-sdk==3.42.0" websocket-client
+python -m pip install "slack-sdk==3.42.0" aiohttp
+python -m pip install "slack-sdk==3.42.0" websockets
 ```
 
 ## Authentication And Setup
@@ -284,7 +278,7 @@ client.retry_handlers.append(RateLimitErrorRetryHandler(max_retry_count=1))
 
 ## Version-Sensitive Notes
 
-- As of Thursday, March 12, 2026, PyPI lists `3.41.0` as the latest release, while the initial package metadata was `3.40.1` from Tuesday, February 18, 2026.
+- As of Friday, May 29, 2026, PyPI lists `3.42.0` as the latest release of `slack-sdk`.
 - The current Slack docs still describe Python `3.7+` support and the same client surface used here.
 - Since SDK v3, the project name is `slack_sdk` / `slack-sdk`, not `slackclient`, and async-related dependencies are no longer installed automatically.
 - Current docs and PyPI examples use `files_upload_v2`; prefer that over older file-upload examples.

--- a/content/slack/docs/workspace/javascript/DOC.md
+++ b/content/slack/docs/workspace/javascript/DOC.md
@@ -3,8 +3,9 @@ name: workspace
 description: "Slack Node SDK for building bots, handling workspace events, and messaging integrations"
 metadata:
   languages: "javascript"
-  versions: "7.12.0"
-  updated-on: "2026-03-01"
+  versions: "7.16.0"
+  revision: 1
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "slack,bot,workspace,messaging,events-api"
 ---

--- a/content/slack/docs/workspace/python/DOC.md
+++ b/content/slack/docs/workspace/python/DOC.md
@@ -3,8 +3,9 @@ name: workspace
 description: "Slack Python SDK for building Slack apps, bots, and workspace integrations"
 metadata:
   languages: "python"
-  versions: "3.37.0"
-  updated-on: "2026-03-01"
+  versions: "3.42.0"
+  revision: 1
+  updated-on: "2026-05-29"
   source: maintainer
   tags: "slack,bot,workspace,messaging,events-api"
 ---


### PR DESCRIPTION
docs(livekit, slack, slack-sdk, discord): refresh realtime/social SDK docs

- slack-sdk (PyPI) → 3.42.0 (slack and slack-sdk docs)
- @slack/web-api → 7.16.0
- livekit + livekit-api (PyPI) → 1.1.9 / 1.1.0
- livekit-client (npm) → 2.19.1
- discord.py → 2.7.1
- discord.js → 14.26.4
- `revision` bumped and `updated-on: 2026-05-29`

Verified versions against PyPI and npm. Existing API surfaces (WebClient,
SocketModeClient, Room/connect, commands.Bot, v14 builders) preserved.
