### PR TITLE
Add Firecrawl docs + best-practices skill

### DIFF
--- a/content/firecrawl/docs/sdk/javascript/DOC.md
+++ b/content/firecrawl/docs/sdk/javascript/DOC.md
@@ -1,0 +1,197 @@
+---
+name: sdk
+description: "Firecrawl JavaScript/TypeScript SDK: scrape, crawl, map, search, and extract web content as clean, LLM-ready data"
+metadata:
+  languages: "javascript"
+  versions: "4.28.2"
+  revision: 1
+  updated-on: "2026-06-21"
+  source: maintainer
+  tags: "firecrawl,scrape,crawl,map,search,extract,ai,agents,rag,web-scraping,web-search,javascript"
+---
+# Firecrawl JavaScript SDK
+
+Turn any website into clean, LLM-ready data — markdown, structured JSON,
+screenshots, or links — through one SDK. Provides scrape, crawl, map, search, and
+extract. The client is async by default.
+
+**Package:** `firecrawl` on npm
+**Docs:** https://docs.firecrawl.dev/sdks/node
+
+## Installation
+
+```bash
+npm install firecrawl
+```
+
+## Initialization
+
+Set `FIRECRAWL_API_KEY` in your environment, or pass it directly.
+
+```javascript
+import { Firecrawl } from 'firecrawl';
+
+const firecrawl = new Firecrawl({ apiKey: 'fc-YOUR_API_KEY' });
+```
+
+## Scrape
+
+Get clean content from a single URL. Firecrawl renders JavaScript and strips
+boilerplate.
+
+```javascript
+const doc = await firecrawl.scrape('https://firecrawl.dev', {
+  formats: ['markdown', 'html'],
+});
+console.log(doc.markdown);
+console.log(doc.metadata.title);
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `url` **(required)** | `string` | — | Page to scrape |
+| `formats` | `array` | `['markdown']` | `markdown`, `html`, `rawHtml`, `links`, `screenshot`, `summary`, `json` |
+| `onlyMainContent` | `boolean` | — | Strip nav/footer; keep the main body |
+| `includeTags` | `string[]` | — | Only keep these tags/selectors |
+| `excludeTags` | `string[]` | — | Drop these tags/selectors |
+| `waitFor` | `number` | — | Milliseconds to wait for JS to render |
+| `actions` | `array` | — | Browser interactions before scraping |
+| `maxAge` | `number` | — | Accept cached content up to this many ms old |
+| `timeout` | `number` | — | Request timeout in milliseconds |
+
+### Structured JSON
+
+```javascript
+const doc = await firecrawl.scrape('https://firecrawl.dev', {
+  formats: [{
+    type: 'json',
+    prompt: 'Extract the company mission statement',
+  }],
+});
+console.log(doc.json);
+```
+
+## Crawl
+
+Traverse a whole site and scrape every discovered page.
+
+```javascript
+const job = await firecrawl.crawl('https://docs.firecrawl.dev', {
+  limit: 100,
+  scrapeOptions: { formats: ['markdown'] },
+});
+for (const page of job.data) {
+  console.log(page.metadata.sourceURL);
+}
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `url` **(required)** | `string` | — | Starting URL |
+| `limit` | `number` | — | Max pages to crawl |
+| `maxDiscoveryDepth` | `number` | — | Link levels deep to follow |
+| `includePaths` | `string[]` | — | Only crawl matching paths |
+| `excludePaths` | `string[]` | — | Skip matching paths |
+| `scrapeOptions` | `object` | — | Per-page scrape options |
+
+### Async crawl jobs
+
+```javascript
+const started = await firecrawl.startCrawl('https://docs.firecrawl.dev', { limit: 500 });
+let status = await firecrawl.getCrawlStatus(started.id);
+while (!['completed', 'failed'].includes(status.status)) {
+  status = await firecrawl.getCrawlStatus(started.id);
+}
+```
+
+## Map
+
+Discover a site's URLs without scraping content.
+
+```javascript
+const res = await firecrawl.map('https://docs.firecrawl.dev', { limit: 100 });
+for (const link of res.links) {
+  console.log(link.url);
+}
+```
+
+Key parameters: `url`, `search` (filter URLs by keyword), `limit`.
+
+## Search
+
+Search the web by query, optionally scraping results in the same call.
+
+```javascript
+const res = await firecrawl.search('best open source web scrapers', {
+  limit: 5,
+  sources: ['web'],
+  scrapeOptions: { formats: ['markdown'] },
+});
+for (const item of res.web ?? []) {
+  console.log(item.title, item.url);
+}
+```
+
+Key parameters: `query`, `limit`, `sources` (`web`/`news`/`images`), `tbs`
+(time filter), `location`, `scrapeOptions`.
+
+## Extract
+
+Pull structured data from one or many URLs (wildcards allowed) using an LLM.
+
+```javascript
+const schema = {
+  type: 'object',
+  properties: { mission: { type: 'string' } },
+  required: ['mission'],
+};
+
+const res = await firecrawl.extract({
+  urls: ['https://firecrawl.dev'],
+  prompt: 'Extract the company mission',
+  schema,
+});
+console.log(res.data);
+```
+
+Key parameters: `urls` (wildcards like `example.com/*`), `prompt`, `schema`,
+`enableWebSearch`.
+
+## Batch Scrape
+
+Scrape many known URLs efficiently.
+
+```javascript
+const started = await firecrawl.startBatchScrape(['https://a.com', 'https://b.com'], {
+  options: { formats: ['markdown'] },
+});
+const status = await firecrawl.getBatchScrapeStatus(started.id);
+```
+
+## Concurrency
+
+The client is async by default — run independent calls in parallel:
+
+```javascript
+const urls = ['https://a.com', 'https://b.com'];
+const results = await Promise.allSettled(
+  urls.map((u) => firecrawl.scrape(u, { formats: ['markdown'] }))
+);
+```
+
+## Error Handling
+
+```javascript
+try {
+  const doc = await firecrawl.scrape('https://example.com', { formats: ['markdown'] });
+} catch (err) {
+  console.error('Scrape failed:', err.message);
+}
+```
+
+For the canonical, always-current reference, see the
+[Firecrawl Node SDK docs](https://docs.firecrawl.dev/sdks/node).

--- a/content/firecrawl/docs/sdk/javascript/DOC.md
+++ b/content/firecrawl/docs/sdk/javascript/DOC.md
@@ -143,6 +143,10 @@ Key parameters: `query`, `limit`, `sources` (`web`/`news`/`images`), `tbs`
 
 Pull structured data from one or many URLs (wildcards allowed) using an LLM.
 
+> **Note:** The standalone `extract` endpoint is in maintenance mode in v4. For a
+> single known page, prefer `scrape` with the `json` format. Reach for `extract`
+> when you need structured data across many URLs or wildcard patterns.
+
 ```javascript
 const schema = {
   type: 'object',

--- a/content/firecrawl/docs/sdk/python/DOC.md
+++ b/content/firecrawl/docs/sdk/python/DOC.md
@@ -163,6 +163,10 @@ Key parameters: `query`, `limit`, `sources` (`web`/`news`/`images`), `tbs`
 
 Pull structured data from one or many URLs (wildcards allowed) using an LLM.
 
+> **Note:** The standalone `extract` endpoint is in maintenance mode in v4. For a
+> single known page, prefer `scrape` with the `json` format. Reach for `extract`
+> when you need structured data across many URLs or wildcard patterns.
+
 ```python
 schema = {
     "type": "object",

--- a/content/firecrawl/docs/sdk/python/DOC.md
+++ b/content/firecrawl/docs/sdk/python/DOC.md
@@ -1,0 +1,225 @@
+---
+name: sdk
+description: "Firecrawl Python SDK: scrape, crawl, map, search, and extract web content as clean, LLM-ready data"
+metadata:
+  languages: "python"
+  versions: "4.30.2"
+  revision: 1
+  updated-on: "2026-06-21"
+  source: maintainer
+  tags: "firecrawl,scrape,crawl,map,search,extract,ai,agents,rag,web-scraping,web-search,python"
+---
+# Firecrawl Python SDK
+
+Turn any website into clean, LLM-ready data — markdown, structured JSON,
+screenshots, or links — through one SDK. Provides scrape, crawl, map, search, and
+extract.
+
+**Package:** `firecrawl-py` on PyPI
+**Docs:** https://docs.firecrawl.dev/sdks/python
+
+## Installation
+
+```bash
+pip install firecrawl-py
+```
+
+With `uv`:
+
+```bash
+uv add firecrawl-py
+```
+
+## Initialization
+
+Set `FIRECRAWL_API_KEY` in your environment, or pass it directly.
+
+### Synchronous Client
+
+```python
+from firecrawl import Firecrawl
+
+firecrawl = Firecrawl(api_key="fc-YOUR_API_KEY")
+```
+
+### Asynchronous Client
+
+```python
+from firecrawl import AsyncFirecrawl
+
+firecrawl = AsyncFirecrawl(api_key="fc-YOUR_API_KEY")
+```
+
+All async methods share the same names and signatures as the sync client and are
+awaitable.
+
+## Scrape
+
+Get clean content from a single URL. Firecrawl renders JavaScript and strips
+boilerplate.
+
+```python
+doc = firecrawl.scrape("https://firecrawl.dev", formats=["markdown", "html"])
+print(doc.markdown)
+print(doc.metadata.title)
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `url` **(required)** | `str` | — | Page to scrape |
+| `formats` | `list` | `["markdown"]` | `markdown`, `html`, `rawHtml`, `links`, `screenshot`, `summary`, `json` |
+| `only_main_content` | `bool` | — | Strip nav/footer; keep the main body |
+| `include_tags` | `list[str]` | — | Only keep these tags/selectors |
+| `exclude_tags` | `list[str]` | — | Drop these tags/selectors |
+| `wait_for` | `int` | — | Milliseconds to wait for JS to render |
+| `actions` | `list` | — | Browser interactions before scraping |
+| `max_age` | `int` | — | Accept cached content up to this many ms old |
+| `timeout` | `int` | — | Request timeout in milliseconds |
+
+### Structured JSON
+
+```python
+from pydantic import BaseModel
+
+class CompanyInfo(BaseModel):
+    mission: str
+    is_open_source: bool
+
+doc = firecrawl.scrape(
+    "https://firecrawl.dev",
+    formats=[{"type": "json", "schema": CompanyInfo.model_json_schema()}],
+)
+print(doc.json)
+```
+
+## Crawl
+
+Traverse a whole site and scrape every discovered page.
+
+```python
+job = firecrawl.crawl(
+    "https://docs.firecrawl.dev",
+    limit=100,
+    scrape_options={"formats": ["markdown"]},
+)
+for page in job.data:
+    print(page.metadata.source_url)
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `url` **(required)** | `str` | — | Starting URL |
+| `limit` | `int` | — | Max pages to crawl |
+| `max_discovery_depth` | `int` | — | Link levels deep to follow |
+| `include_paths` | `list[str]` | — | Only crawl matching paths |
+| `exclude_paths` | `list[str]` | — | Skip matching paths |
+| `scrape_options` | `dict` | — | Per-page scrape options |
+
+### Async crawl jobs
+
+```python
+started = firecrawl.start_crawl("https://docs.firecrawl.dev", limit=500)
+status = firecrawl.get_crawl_status(started.id)
+while status.status not in ("completed", "failed"):
+    status = firecrawl.get_crawl_status(started.id)
+firecrawl.cancel_crawl(started.id)  # optional
+```
+
+## Map
+
+Discover a site's URLs without scraping content.
+
+```python
+res = firecrawl.map("https://docs.firecrawl.dev", limit=100)
+for link in res.links:
+    print(link.url)
+```
+
+Key parameters: `url`, `search` (filter URLs by keyword), `limit`.
+
+## Search
+
+Search the web by query, optionally scraping results in the same call.
+
+```python
+res = firecrawl.search(
+    "best open source web scrapers",
+    limit=5,
+    sources=["web"],
+    scrape_options={"formats": ["markdown"]},
+)
+for item in res.web or []:
+    print(item.title, item.url)
+```
+
+Key parameters: `query`, `limit`, `sources` (`web`/`news`/`images`), `tbs`
+(time filter), `location`, `scrape_options`.
+
+## Extract
+
+Pull structured data from one or many URLs (wildcards allowed) using an LLM.
+
+```python
+schema = {
+    "type": "object",
+    "properties": {"mission": {"type": "string"}},
+    "required": ["mission"],
+}
+res = firecrawl.extract(
+    urls=["https://firecrawl.dev"],
+    prompt="Extract the company mission",
+    schema=schema,
+)
+print(res.data["mission"])
+```
+
+Key parameters: `urls` (wildcards like `example.com/*`), `prompt`, `schema`,
+`enable_web_search`.
+
+## Batch Scrape
+
+Scrape many known URLs efficiently.
+
+```python
+docs = firecrawl.batch_scrape(
+    ["https://a.com", "https://b.com"],
+    formats=["markdown"],
+)
+```
+
+Non-blocking variant: `start_batch_scrape(urls)` returns a job id; poll with
+`get_batch_scrape_status(job_id)`.
+
+## Async Usage
+
+```python
+import asyncio
+from firecrawl import AsyncFirecrawl
+
+firecrawl = AsyncFirecrawl(api_key="fc-YOUR_API_KEY")
+
+async def scrape_many(urls):
+    results = await asyncio.gather(
+        *(firecrawl.scrape(u, formats=["markdown"]) for u in urls),
+        return_exceptions=True,
+    )
+    return [r for r in results if not isinstance(r, Exception)]
+
+asyncio.run(scrape_many(["https://a.com", "https://b.com"]))
+```
+
+## Error Handling
+
+```python
+try:
+    doc = firecrawl.scrape("https://example.com", formats=["markdown"])
+except Exception as e:
+    print(f"Scrape failed: {e}")
+```
+
+For the canonical, always-current reference, see the
+[Firecrawl Python SDK docs](https://docs.firecrawl.dev/sdks/python).

--- a/content/firecrawl/skills/firecrawl-best-practices/SKILL.md
+++ b/content/firecrawl/skills/firecrawl-best-practices/SKILL.md
@@ -2,10 +2,10 @@
 name: firecrawl-best-practices
 description: "Build production web-data pipelines with Firecrawl: scrape single pages, crawl whole sites, map URLs, search the web, and extract structured data for LLMs, RAG, and agents"
 metadata:
-  revision: 1
+  revision: 2
   updated-on: "2026-06-21"
   source: maintainer
-  tags: "firecrawl,scrape,crawl,map,search,extract,web-scraping,web-search,ai,agents,rag,best-practices"
+  tags: "firecrawl,scrape,crawl,map,search,extract,mcp,integrations,langchain,llamaindex,web-scraping,web-search,ai,agents,rag,best-practices"
 ---
 
 # Firecrawl
@@ -137,3 +137,5 @@ See **[references/extract.md](references/extract.md)**.
 - **[references/search.md](references/search.md)** — sources, time/domain filters, search-then-scrape in one call
 - **[references/extract.md](references/extract.md)** — prompt vs schema, multi-URL and wildcard extraction, web-search-augmented extraction
 - **[references/sdk.md](references/sdk.md)** — Python & JS clients, async patterns, status polling, error handling
+- **[references/mcp.md](references/mcp.md)** — use Firecrawl via the Model Context Protocol (hosted or local), tool list, client setup, keyless free tier
+- **[references/integrations.md](references/integrations.md)** — native Firecrawl components for LangChain, LlamaIndex, CrewAI, Dify, Flowise, Langflow, and more

--- a/content/firecrawl/skills/firecrawl-best-practices/SKILL.md
+++ b/content/firecrawl/skills/firecrawl-best-practices/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: firecrawl-best-practices
+description: "Build production web-data pipelines with Firecrawl: scrape single pages, crawl whole sites, map URLs, search the web, and extract structured data for LLMs, RAG, and agents"
+metadata:
+  revision: 1
+  updated-on: "2026-06-21"
+  source: maintainer
+  tags: "firecrawl,scrape,crawl,map,search,extract,web-scraping,web-search,ai,agents,rag,best-practices"
+---
+
+# Firecrawl
+
+Firecrawl turns websites into clean, LLM-ready data. Give it a URL and get back
+markdown, structured JSON, screenshots, or links — without writing per-site
+parsers, rotating proxies, or rendering JavaScript yourself.
+
+## Installation
+
+**Python:**
+```bash
+pip install firecrawl-py
+```
+
+**JavaScript / TypeScript:**
+```bash
+npm install firecrawl
+```
+
+See **[references/sdk.md](references/sdk.md)** for the complete SDK reference (client
+classes, async usage, status polling).
+
+## Client Initialization
+
+```python
+from firecrawl import Firecrawl
+
+# Reads FIRECRAWL_API_KEY from the environment if api_key is omitted
+firecrawl = Firecrawl(api_key="fc-YOUR_API_KEY")
+
+# Async client for concurrent requests
+from firecrawl import AsyncFirecrawl
+async_firecrawl = AsyncFirecrawl(api_key="fc-YOUR_API_KEY")
+```
+
+```javascript
+import { Firecrawl } from 'firecrawl';
+
+const firecrawl = new Firecrawl({ apiKey: 'fc-YOUR_API_KEY' });
+```
+
+## Choosing the Right Method
+
+| Need | Method |
+|------|--------|
+| Clean content from one known URL | `scrape()` |
+| Content from an entire site / docs section | `crawl()` |
+| Discover every URL on a site (no content) | `map()` |
+| Find pages across the web by query | `search()` |
+| Structured fields from one or many pages (LLM) | `extract()` |
+| Many known URLs at once | `batch_scrape()` |
+
+Rules of thumb:
+
+- **Know the URL?** Use `scrape`. **Know the data shape?** Add a `json` format or use `extract`.
+- **Want a whole site?** `map` first to see the structure, then `crawl` or `scrape` the URLs you actually need.
+- **Don't know the URL?** Use `search`, optionally with `scrapeOptions` to get content in the same call.
+
+## Quick Reference
+
+### scrape() — Single Page
+
+```python
+doc = firecrawl.scrape("https://firecrawl.dev", formats=["markdown", "html"])
+print(doc.markdown)
+print(doc.metadata.title)
+```
+Key parameters: `url`, `formats` (`markdown`, `html`, `rawHtml`, `links`, `screenshot`, `summary`, `json`), `only_main_content`, `wait_for`, `actions`, `max_age` (cache).
+
+See **[references/scrape.md](references/scrape.md)**.
+
+### crawl() — Whole Site
+
+```python
+job = firecrawl.crawl("https://docs.firecrawl.dev", limit=100,
+                      scrape_options={"formats": ["markdown"]})
+for page in job.data:
+    print(page.metadata.source_url)
+```
+Key parameters: `url`, `limit`, `max_discovery_depth`, `include_paths`, `exclude_paths`, `scrape_options`. Blocking `crawl()` waits; `start_crawl()` returns a job id to poll.
+
+See **[references/crawl.md](references/crawl.md)**.
+
+### map() — URL Discovery
+
+```python
+res = firecrawl.map("https://docs.firecrawl.dev", limit=100)
+for link in res.links:
+    print(link.url)
+```
+Key parameters: `url`, `search` (filter URLs by keyword), `limit`.
+
+See **[references/map.md](references/map.md)**.
+
+### search() — Web Search
+
+```python
+res = firecrawl.search("best open source web scrapers", limit=5,
+                       scrape_options={"formats": ["markdown"]})
+for item in res.web or []:
+    print(item.url, item.title)
+```
+Key parameters: `query`, `limit`, `sources` (`web`, `news`, `images`), `tbs` (time filter), `location`, `scrape_options`.
+
+See **[references/search.md](references/search.md)**.
+
+### extract() — Structured Data
+
+```python
+schema = {
+    "type": "object",
+    "properties": {"mission": {"type": "string"}},
+    "required": ["mission"],
+}
+res = firecrawl.extract(urls=["https://firecrawl.dev"],
+                        prompt="Extract the company mission", schema=schema)
+print(res.data["mission"])
+```
+Key parameters: `urls` (wildcards like `example.com/*` allowed), `prompt`, `schema`, `enable_web_search`. For a single page, prefer `scrape` with the `json` format — the standalone `extract` endpoint is in maintenance mode in v4.
+
+See **[references/extract.md](references/extract.md)**.
+
+## Detailed Guides
+
+- **[references/scrape.md](references/scrape.md)** — formats, JSON extraction, actions for interactive pages, caching with `max_age`
+- **[references/crawl.md](references/crawl.md)** — path filters, depth, async jobs, status polling, crawl vs map
+- **[references/map.md](references/map.md)** — fast URL discovery, the map-then-scrape pattern
+- **[references/search.md](references/search.md)** — sources, time/domain filters, search-then-scrape in one call
+- **[references/extract.md](references/extract.md)** — prompt vs schema, multi-URL and wildcard extraction, web-search-augmented extraction
+- **[references/sdk.md](references/sdk.md)** — Python & JS clients, async patterns, status polling, error handling

--- a/content/firecrawl/skills/firecrawl-best-practices/references/crawl.md
+++ b/content/firecrawl/skills/firecrawl-best-practices/references/crawl.md
@@ -1,0 +1,159 @@
+# Crawl API Reference
+
+Crawl traverses a site starting from a URL, discovers its pages, and scrapes each
+one. Use it to ingest whole documentation sites, blogs, or product sections into
+a RAG pipeline.
+
+## Table of Contents
+
+- [Crawl vs Map vs Scrape](#crawl-vs-map-vs-scrape)
+- [Basic Usage](#basic-usage)
+- [Key Parameters](#key-parameters)
+- [Path Filtering](#path-filtering)
+- [Async Jobs and Status Polling](#async-jobs-and-status-polling)
+- [Best Practices](#best-practices)
+- [Response Fields](#response-fields)
+
+---
+
+## Crawl vs Map vs Scrape
+
+| Method | Returns | Use when |
+|--------|---------|----------|
+| `scrape` | One page's content | You have the exact URL |
+| `map` | A list of URLs (no content) | You want to discover structure fast |
+| `crawl` | Content for many discovered pages | You want a whole site/section ingested |
+
+A common, efficient pattern is **map first** to inspect the URL list, then
+`crawl` (or batch `scrape`) only the paths you actually need.
+
+---
+
+## Basic Usage
+
+Blocking crawl — waits for completion and returns all pages:
+
+```python
+from firecrawl import Firecrawl
+
+firecrawl = Firecrawl(api_key="fc-YOUR_API_KEY")
+
+job = firecrawl.crawl(
+    "https://docs.firecrawl.dev",
+    limit=100,
+    scrape_options={"formats": ["markdown"]},
+)
+
+for page in job.data:
+    print(page.metadata.source_url, len(page.markdown))
+```
+
+```javascript
+const job = await firecrawl.crawl('https://docs.firecrawl.dev', {
+  limit: 100,
+  scrapeOptions: { formats: ['markdown'] },
+});
+
+for (const page of job.data) {
+  console.log(page.metadata.sourceURL);
+}
+```
+
+---
+
+## Key Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `url` **(required)** | `str` | Starting URL |
+| `limit` | `int` | Max number of pages to crawl |
+| `max_discovery_depth` | `int` | How many link levels deep to follow |
+| `include_paths` | `list[str]` | Only crawl URLs matching these path patterns |
+| `exclude_paths` | `list[str]` | Skip URLs matching these path patterns |
+| `scrape_options` | `dict` | Per-page scrape options (`formats`, `only_main_content`, etc.) |
+
+In the JS SDK: `maxDiscoveryDepth`, `includePaths`, `excludePaths`, `scrapeOptions`.
+
+---
+
+## Path Filtering
+
+Focus the crawl on the sections you care about. Always pair `limit` with path
+filters to avoid runaway crawls.
+
+```python
+job = firecrawl.crawl(
+    "https://docs.firecrawl.dev",
+    limit=200,
+    include_paths=["/features/.*", "/sdks/.*"],
+    exclude_paths=["/changelog/.*"],
+    scrape_options={"formats": ["markdown"]},
+)
+```
+
+---
+
+## Async Jobs and Status Polling
+
+For large sites, start the crawl without blocking and poll for status. This lets
+you stream results and survive long-running jobs.
+
+```python
+started = firecrawl.start_crawl("https://docs.firecrawl.dev", limit=500)
+crawl_id = started.id
+
+status = firecrawl.get_crawl_status(crawl_id)
+while status.status not in ("completed", "failed"):
+    status = firecrawl.get_crawl_status(crawl_id)
+
+print(status.status, len(status.data))
+
+# Cancel a running crawl if needed
+firecrawl.cancel_crawl(crawl_id)
+```
+
+```javascript
+const started = await firecrawl.startCrawl('https://docs.firecrawl.dev', { limit: 500 });
+let status = await firecrawl.getCrawlStatus(started.id);
+while (!['completed', 'failed'].includes(status.status)) {
+  status = await firecrawl.getCrawlStatus(started.id);
+}
+```
+
+The status object reports `status`, the accumulated `data` (pages scraped so
+far), and pagination info for large result sets.
+
+---
+
+## Best Practices
+
+1. **Always set a `limit`** — crawls can otherwise expand unexpectedly.
+2. **Start with path filters** (`include_paths` / `exclude_paths`) to stay on-topic.
+3. **Map before you crawl** when you're unsure of a site's structure.
+4. **Use `start_crawl` + polling** for large sites instead of a blocking call.
+5. **Set `only_main_content` in `scrape_options`** to drop nav/footer boilerplate.
+6. **Pick minimal `formats`** (usually just `markdown`) to keep tokens and cost down.
+
+---
+
+## Response Fields
+
+A completed crawl returns a list of page documents, each with the same shape as a
+single [`scrape`](scrape.md) result:
+
+```json
+{
+  "status": "completed",
+  "total": 100,
+  "completed": 100,
+  "data": [
+    {
+      "markdown": "...",
+      "metadata": { "title": "...", "sourceURL": "...", "statusCode": 200 }
+    }
+  ]
+}
+```
+
+For the canonical, always-current parameter list see the
+[Firecrawl crawl docs](https://docs.firecrawl.dev/features/crawl).

--- a/content/firecrawl/skills/firecrawl-best-practices/references/crawl.md
+++ b/content/firecrawl/skills/firecrawl-best-practices/references/crawl.md
@@ -21,7 +21,7 @@ a RAG pipeline.
 | Method | Returns | Use when |
 |--------|---------|----------|
 | `scrape` | One page's content | You have the exact URL |
-| `map` | A list of URLs (no content) | You want to discover structure fast |
+| `map` | A list of URLs (no content) | You want to quickly understand the site's URL structure |
 | `crawl` | Content for many discovered pages | You want a whole site/section ingested |
 
 A common, efficient pattern is **map first** to inspect the URL list, then

--- a/content/firecrawl/skills/firecrawl-best-practices/references/extract.md
+++ b/content/firecrawl/skills/firecrawl-best-practices/references/extract.md
@@ -1,0 +1,168 @@
+# Extract API Reference
+
+Extract pulls structured data from one or many URLs using an LLM. Give it URLs (or
+wildcard patterns) plus a prompt and/or JSON schema, and it returns typed fields —
+no per-site parsing.
+
+> **Note:** As of the v4 SDK the standalone `extract` endpoint is in maintenance
+> mode. For a single page, prefer `scrape` with the `json` format (see
+> [scrape.md](scrape.md)). `extract` remains the path for multi-URL and
+> whole-domain wildcard extraction.
+
+## Table of Contents
+
+- [Extract vs scrape json](#extract-vs-scrape-json)
+- [Basic Usage](#basic-usage)
+- [Key Parameters](#key-parameters)
+- [Prompt vs Schema](#prompt-vs-schema)
+- [Wildcards and Multiple URLs](#wildcards-and-multiple-urls)
+- [Web-Search-Augmented Extraction](#web-search-augmented-extraction)
+- [Response Fields](#response-fields)
+
+---
+
+## Extract vs scrape json
+
+| Need | Use |
+|------|-----|
+| Structured fields from **one** known page | `scrape` with the `json` format |
+| Structured fields across **many** pages or a **wildcard** | `extract` |
+
+Both use an LLM and accept a schema or prompt; `extract` is built for breadth
+(multiple URLs, whole-domain wildcards) while `scrape`'s `json` format is the
+single-page path. See [scrape.md](scrape.md) for the single-page case.
+
+---
+
+## Basic Usage
+
+```python
+from firecrawl import Firecrawl
+
+firecrawl = Firecrawl(api_key="fc-YOUR_API_KEY")
+
+schema = {
+    "type": "object",
+    "properties": {"description": {"type": "string"}},
+    "required": ["description"],
+}
+
+res = firecrawl.extract(
+    urls=["https://docs.firecrawl.dev"],
+    prompt="Extract the page description",
+    schema=schema,
+)
+print(res.data["description"])
+```
+
+```javascript
+import { Firecrawl } from 'firecrawl';
+
+const firecrawl = new Firecrawl({ apiKey: 'fc-YOUR_API_KEY' });
+
+const schema = {
+  type: 'object',
+  properties: { title: { type: 'string' } },
+  required: ['title'],
+};
+
+const res = await firecrawl.extract({
+  urls: ['https://docs.firecrawl.dev'],
+  prompt: 'Extract the page title',
+  schema,
+});
+
+console.log(res.data);
+```
+
+---
+
+## Key Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `urls` **(required)** | `list[str]` | URLs to extract from; wildcards allowed (`example.com/*`) |
+| `prompt` | `str` | Natural-language description of the data you want |
+| `schema` | `dict` | JSON schema (or Pydantic/Zod model) defining the output shape |
+| `enable_web_search` | `bool` | Let extraction follow links beyond the given pages for more context |
+
+In the JS SDK: `enableWebSearch`. You can pass a `prompt`, a `schema`, or both.
+
+---
+
+## Prompt vs Schema
+
+- **Schema** — when you know the exact fields and types you want. Most reliable
+  for pipelines; the output conforms to your structure.
+- **Prompt** — when the shape is fuzzy or exploratory. Firecrawl infers a
+  structure from your description.
+- **Both** — a schema for structure plus a prompt to guide interpretation.
+
+```python
+# Schema-driven (recommended for pipelines)
+schema = {
+    "type": "object",
+    "properties": {
+        "company_mission": {"type": "string"},
+        "is_open_source": {"type": "boolean"},
+    },
+    "required": ["company_mission"],
+}
+res = firecrawl.extract(urls=["https://firecrawl.dev"], schema=schema)
+```
+
+---
+
+## Wildcards and Multiple URLs
+
+Pass several URLs, or use a wildcard to extract the same shape across a whole
+section of a site:
+
+```python
+res = firecrawl.extract(
+    urls=["https://docs.firecrawl.dev/features/*"],
+    prompt="For each page, extract its title and a one-sentence summary",
+    schema={
+        "type": "object",
+        "properties": {
+            "title": {"type": "string"},
+            "summary": {"type": "string"},
+        },
+        "required": ["title", "summary"],
+    },
+)
+```
+
+---
+
+## Web-Search-Augmented Extraction
+
+Set `enable_web_search=True` to let Firecrawl pull in supporting context from
+linked or related pages when the answer isn't fully present on the given URLs.
+
+```python
+res = firecrawl.extract(
+    urls=["https://firecrawl.dev"],
+    prompt="What pricing tiers are offered and what does each include?",
+    enable_web_search=True,
+)
+```
+
+---
+
+## Response Fields
+
+```json
+{
+  "success": true,
+  "data": {
+    "company_mission": "...",
+    "is_open_source": true
+  }
+}
+```
+
+In the SDKs the extracted object is available as `res.data`.
+
+For the canonical, always-current parameter list see the
+[Firecrawl extract docs](https://docs.firecrawl.dev/features/extract).

--- a/content/firecrawl/skills/firecrawl-best-practices/references/integrations.md
+++ b/content/firecrawl/skills/firecrawl-best-practices/references/integrations.md
@@ -1,0 +1,52 @@
+# Firecrawl Integrations
+
+Firecrawl is the web-data layer underneath most agent and RAG frameworks — you
+rarely need to call the API by hand. If you are already building on one of these
+stacks, use its native Firecrawl component instead of reinventing the plumbing.
+
+## Agent & LLM frameworks
+
+| Framework | Firecrawl component | Use it for |
+|-----------|--------------------|-----------|
+| **LangChain** | `FireCrawlLoader` (Document Loader) | Load scraped/crawled pages as LangChain `Document`s for RAG |
+| **LlamaIndex** | `FireCrawlReader` | Ingest web pages/sites as LlamaIndex documents |
+| **CrewAI** | Firecrawl tools | Give crews of agents scrape/crawl/search capabilities |
+| **Camel AI** | Firecrawl toolkit | Web data for multi-agent workflows |
+
+Docs: [LangChain](https://docs.firecrawl.dev/integrations/langchain) ·
+[LlamaIndex](https://docs.firecrawl.dev/integrations/llamaindex) ·
+[CrewAI](https://docs.firecrawl.dev/integrations/crewai) ·
+[Camel AI](https://docs.firecrawl.dev/integrations/camelai)
+
+## Visual / low-code builders
+
+| Tool | Use it for |
+|------|-----------|
+| **Dify** | Extract structured data from web pages inside Dify apps |
+| **Flowise** | Sync data directly from websites in a Flowise flow |
+| **Langflow** | Design visual web-data pipelines |
+| **SourceSync.ai** | Build RAG applications backed by web data |
+
+Docs: [Dify](https://docs.firecrawl.dev/integrations/dify) ·
+[Flowise](https://docs.firecrawl.dev/integrations/flowise) ·
+[Langflow](https://docs.firecrawl.dev/integrations/langflow) ·
+[SourceSync.ai](https://docs.firecrawl.dev/integrations/sourcesyncai)
+
+## Platform
+
+- **Vercel Marketplace** — add Firecrawl to a Vercel project with automatic API
+  key setup. See [Vercel Marketplace](https://docs.firecrawl.dev/quickstarts/vercel-marketplace).
+- **MCP** — any MCP-capable client (Claude Code, Cursor, Windsurf, n8n, …) can use
+  Firecrawl with no SDK code. See [mcp.md](mcp.md).
+
+## Picking an integration path
+
+- **Building a RAG pipeline?** Use the LangChain `FireCrawlLoader` or LlamaIndex
+  `FireCrawlReader` — they hand you framework-native documents directly.
+- **Orchestrating agents?** Use the CrewAI / Camel AI tools, or [MCP](mcp.md) if
+  your host speaks it.
+- **Low-code / visual?** Dify, Flowise, or Langflow expose Firecrawl as a node.
+- **Rolling your own service?** Call the [SDK](sdk.md) directly.
+
+For the current, authoritative list see
+[docs.firecrawl.dev/integrations](https://docs.firecrawl.dev/integrations).

--- a/content/firecrawl/skills/firecrawl-best-practices/references/map.md
+++ b/content/firecrawl/skills/firecrawl-best-practices/references/map.md
@@ -1,0 +1,98 @@
+# Map API Reference
+
+Map returns a list of URLs for a site without scraping their content. It is the
+fastest way to discover a site's structure and decide what to scrape or crawl.
+
+## Table of Contents
+
+- [When to Use Map](#when-to-use-map)
+- [Basic Usage](#basic-usage)
+- [Key Parameters](#key-parameters)
+- [Map-then-Scrape Pattern](#map-then-scrape-pattern)
+- [Response Fields](#response-fields)
+
+---
+
+## When to Use Map
+
+| Goal | Method |
+|------|--------|
+| See every URL on a site, fast | `map` |
+| Get the content of those pages | `crawl` or `scrape` |
+
+Use `map` to plan: inspect the URL list, filter to the paths you want, then scrape
+only those. This is cheaper and faster than crawling everything.
+
+---
+
+## Basic Usage
+
+```python
+from firecrawl import Firecrawl
+
+firecrawl = Firecrawl(api_key="fc-YOUR_API_KEY")
+
+res = firecrawl.map("https://docs.firecrawl.dev", limit=100)
+for link in res.links:
+    print(link.url)
+```
+
+```javascript
+const res = await firecrawl.map('https://docs.firecrawl.dev', { limit: 100 });
+for (const link of res.links) {
+  console.log(link.url);
+}
+```
+
+---
+
+## Key Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `url` **(required)** | `str` | Site to map |
+| `search` | `str` | Only return URLs whose path/text matches this keyword |
+| `limit` | `int` | Max number of URLs to return |
+
+The `search` filter is handy for narrowing a big site to a topic in one call:
+
+```python
+res = firecrawl.map("https://docs.firecrawl.dev", search="sdk")
+```
+
+---
+
+## Map-then-Scrape Pattern
+
+The recommended workflow for ingesting a focused slice of a site:
+
+```python
+# 1. Discover URLs
+res = firecrawl.map("https://docs.firecrawl.dev", search="features")
+urls = [link.url for link in res.links]
+
+# 2. Scrape only the pages you want
+docs = firecrawl.batch_scrape(urls[:20], formats=["markdown"])
+```
+
+This avoids a full crawl when you only need a handful of pages, and gives you
+explicit control over which URLs are fetched.
+
+---
+
+## Response Fields
+
+```json
+{
+  "links": [
+    { "url": "https://docs.firecrawl.dev/features/scrape" },
+    { "url": "https://docs.firecrawl.dev/sdks/python" }
+  ]
+}
+```
+
+In the SDK the URLs are available as `res.links`. Depending on options, each entry
+may also carry a title/description.
+
+For the canonical, always-current parameter list see the
+[Firecrawl map docs](https://docs.firecrawl.dev/features/map).

--- a/content/firecrawl/skills/firecrawl-best-practices/references/mcp.md
+++ b/content/firecrawl/skills/firecrawl-best-practices/references/mcp.md
@@ -1,0 +1,108 @@
+# Firecrawl MCP Server
+
+Firecrawl ships an official [Model Context Protocol](https://modelcontextprotocol.io)
+server, so an MCP-capable coding agent (Claude Code, Cursor, Windsurf, VS Code,
+Claude Desktop, n8n, …) can scrape, search, crawl, and extract without any SDK
+code. It is open source ([firecrawl/firecrawl-mcp-server](https://github.com/firecrawl/firecrawl-mcp-server),
+MIT) and runs either as a remote hosted URL or locally.
+
+## Two ways to connect
+
+### 1. Remote hosted URL (no install)
+
+```
+# With an API key — unlocks every tool plus higher limits
+https://mcp.firecrawl.dev/{FIRECRAWL_API_KEY}/v2/mcp
+
+# Keyless — scrape, search, and interact only, rate-limited per IP
+https://mcp.firecrawl.dev/v2/mcp
+```
+
+The keyless endpoint is the fastest way to try it: `firecrawl_scrape`,
+`firecrawl_search`, and `firecrawl_interact` work with no key (free, rate-limited
+per IP). Set an API key to unlock `crawl`, `extract`, `map`, and the rest.
+
+### 2. Local (stdio via npx)
+
+```bash
+env FIRECRAWL_API_KEY=fc-YOUR_API_KEY npx -y firecrawl-mcp
+# or install globally
+npm install -g firecrawl-mcp
+```
+
+Run it over streamable HTTP instead of stdio (e.g. for n8n):
+
+```bash
+env HTTP_STREAMABLE_SERVER=true FIRECRAWL_API_KEY=fc-YOUR_API_KEY npx -y firecrawl-mcp
+# serves http://localhost:3000/v2/mcp
+```
+
+## Client setup
+
+**Claude Code:**
+```bash
+# Remote hosted (recommended)
+claude mcp add --transport http firecrawl https://mcp.firecrawl.dev/your-api-key/v2/mcp
+
+# Or local via npx
+claude mcp add firecrawl -e FIRECRAWL_API_KEY=your-api-key -- npx -y firecrawl-mcp
+```
+
+**Cursor / Windsurf / VS Code / Claude Desktop** — add a standard `mcpServers`
+entry:
+```json
+{
+  "mcpServers": {
+    "firecrawl": {
+      "command": "npx",
+      "args": ["-y", "firecrawl-mcp"],
+      "env": { "FIRECRAWL_API_KEY": "fc-YOUR_API_KEY" }
+    }
+  }
+}
+```
+
+Claude Desktop also accepts the remote URL directly with a bearer header:
+```json
+{
+  "mcpServers": {
+    "firecrawl": {
+      "url": "https://mcp.firecrawl.dev/v2/mcp",
+      "headers": { "Authorization": "Bearer YOUR_API_KEY" }
+    }
+  }
+}
+```
+
+## Tools exposed
+
+| Tool | Purpose |
+|------|---------|
+| `firecrawl_scrape` | Scrape one URL → markdown/HTML/JSON/screenshot |
+| `firecrawl_search` | Web search, optionally scraping each result |
+| `firecrawl_map` | Discover all indexed URLs on a site |
+| `firecrawl_crawl` / `firecrawl_check_crawl_status` | Async crawl + status polling |
+| `firecrawl_extract` | LLM structured extraction from one or many URLs |
+| `firecrawl_agent` / `firecrawl_agent_status` | Autonomous research agent (async) |
+| `firecrawl_interact` / `firecrawl_interact_stop` | Drive a live page (click, fill, navigate) after a scrape |
+| `firecrawl_browser_create` / `_execute` / `_delete` / `_list` | Persistent CDP browser sessions for code execution |
+
+## Configuration
+
+- `FIRECRAWL_API_KEY` — required for the cloud API (optional with a self-hosted instance).
+- `FIRECRAWL_API_URL` — point at a self-hosted instance, e.g. `https://firecrawl.your-domain.com`.
+- Retry tuning: `FIRECRAWL_RETRY_MAX_ATTEMPTS` (default 3), `FIRECRAWL_RETRY_INITIAL_DELAY` (1000 ms), `FIRECRAWL_RETRY_MAX_DELAY` (10000 ms), `FIRECRAWL_RETRY_BACKOFF_FACTOR` (2).
+- Credit alerts: `FIRECRAWL_CREDIT_WARNING_THRESHOLD` (1000), `FIRECRAWL_CREDIT_CRITICAL_THRESHOLD` (100).
+
+The server handles rate limiting with exponential backoff and retries transient
+errors automatically.
+
+## When to prefer MCP over the SDK
+
+- Your agent host speaks MCP and you want web data with **zero integration code**.
+- You want to start instantly on the **keyless** tier (scrape/search/interact).
+- You need the **interact** / **browser session** tools (live click/fill/navigate),
+  which go beyond the plain SDK scrape surface.
+
+Reach for the [SDK](sdk.md) instead when you need tight programmatic control,
+custom retry/concurrency, or to embed Firecrawl inside a larger service.

--- a/content/firecrawl/skills/firecrawl-best-practices/references/scrape.md
+++ b/content/firecrawl/skills/firecrawl-best-practices/references/scrape.md
@@ -1,0 +1,179 @@
+# Scrape API Reference
+
+Scrape a single URL and get back clean, LLM-ready content. Firecrawl renders
+JavaScript, follows redirects, and strips boilerplate, so you get the page
+content instead of raw HTML noise.
+
+## Table of Contents
+
+- [Basic Usage](#basic-usage)
+- [Formats](#formats)
+- [Key Parameters](#key-parameters)
+- [Structured Extraction with JSON](#structured-extraction-with-json)
+- [Interactive Pages with Actions](#interactive-pages-with-actions)
+- [Caching with max_age](#caching-with-max_age)
+- [Response Fields](#response-fields)
+
+---
+
+## Basic Usage
+
+```python
+from firecrawl import Firecrawl
+
+firecrawl = Firecrawl(api_key="fc-YOUR_API_KEY")
+
+doc = firecrawl.scrape("https://firecrawl.dev", formats=["markdown"])
+print(doc.markdown)
+print(doc.metadata.title)
+```
+
+```javascript
+import { Firecrawl } from 'firecrawl';
+
+const firecrawl = new Firecrawl({ apiKey: 'fc-YOUR_API_KEY' });
+
+const doc = await firecrawl.scrape('https://firecrawl.dev', {
+  formats: ['markdown'],
+});
+console.log(doc.markdown);
+```
+
+---
+
+## Formats
+
+Request one or more output formats in a single call:
+
+| Format | Returns |
+|--------|---------|
+| `markdown` | Clean markdown (the default workhorse) |
+| `html` | Processed HTML |
+| `rawHtml` | Unmodified HTML |
+| `links` | All links found on the page |
+| `screenshot` | A screenshot of the page (full-page option available) |
+| `summary` | A short LLM-generated summary of the page |
+| `json` | Structured data extracted against a schema or prompt (see below) |
+
+```python
+doc = firecrawl.scrape("https://firecrawl.dev", formats=["markdown", "html", "links"])
+```
+
+---
+
+## Key Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `url` **(required)** | `str` | Page to scrape |
+| `formats` | `list` | Output formats (see table above) |
+| `only_main_content` | `bool` | Strip nav, footer, and chrome; keep the article body |
+| `include_tags` | `list[str]` | Only keep these HTML tags/selectors |
+| `exclude_tags` | `list[str]` | Drop these HTML tags/selectors |
+| `wait_for` | `int` | Milliseconds to wait for JS to render before scraping |
+| `actions` | `list` | Browser interactions to run before scraping (see below) |
+| `max_age` | `int` | Serve cached content up to this many ms old (see below) |
+| `timeout` | `int` | Request timeout in milliseconds |
+| `location` | `dict` | `{ "country": "US", "languages": ["en"] }` for geo-specific content |
+
+In the JS SDK these are camelCase: `onlyMainContent`, `includeTags`, `excludeTags`, `waitFor`, `maxAge`.
+
+PDFs are auto-detected — pass a PDF URL directly to `scrape` and Firecrawl parses it.
+
+---
+
+## Structured Extraction with JSON
+
+Use the `json` format to pull structured fields out of a single page. Provide a
+JSON schema, a Pydantic/Zod model, or a natural-language prompt.
+
+```python
+from pydantic import BaseModel
+
+class CompanyInfo(BaseModel):
+    mission: str
+    is_open_source: bool
+
+doc = firecrawl.scrape(
+    "https://firecrawl.dev",
+    formats=[{"type": "json", "schema": CompanyInfo.model_json_schema()}],
+)
+print(doc.json)
+```
+
+Prompt-only (no schema):
+
+```python
+doc = firecrawl.scrape(
+    "https://firecrawl.dev",
+    formats=[{"type": "json", "prompt": "Extract the company mission statement"}],
+)
+```
+
+For structured data across **many** pages or with wildcards, use
+[`extract`](extract.md) instead of per-page `scrape`.
+
+---
+
+## Interactive Pages with Actions
+
+`actions` let you drive the page before scraping — click, type, scroll, wait, or
+capture a screenshot. Useful for content behind a button, a search box, or
+infinite scroll.
+
+```python
+doc = firecrawl.scrape(
+    "https://example.com/search",
+    formats=["markdown"],
+    actions=[
+        {"type": "write", "text": "firecrawl"},
+        {"type": "press", "key": "Enter"},
+        {"type": "wait", "milliseconds": 2000},
+    ],
+)
+```
+
+Supported action types include `click`, `write`, `press`, `wait`, `scroll`, and `screenshot`.
+
+---
+
+## Caching with max_age
+
+Firecrawl caches scraped pages. Pass `max_age` (milliseconds) to accept a cached
+copy that is at most that old — much faster and cheaper than a fresh fetch. Set
+`max_age=0` to force a fresh scrape.
+
+```python
+# Accept a cached copy up to 1 hour old
+doc = firecrawl.scrape("https://firecrawl.dev", formats=["markdown"], max_age=3_600_000)
+
+# Always fetch fresh
+doc = firecrawl.scrape("https://firecrawl.dev", formats=["markdown"], max_age=0)
+```
+
+---
+
+## Response Fields
+
+The scrape response carries the requested formats plus page metadata:
+
+```json
+{
+  "markdown": "...",
+  "html": "...",
+  "links": ["..."],
+  "json": { "...": "..." },
+  "metadata": {
+    "title": "...",
+    "description": "...",
+    "sourceURL": "...",
+    "statusCode": 200
+  }
+}
+```
+
+In the SDKs these are surfaced as attributes/properties: `doc.markdown`,
+`doc.html`, `doc.json`, `doc.metadata.title`, `doc.metadata.source_url`.
+
+For the canonical, always-current parameter list see the
+[Firecrawl scrape docs](https://docs.firecrawl.dev/features/scrape).

--- a/content/firecrawl/skills/firecrawl-best-practices/references/scrape.md
+++ b/content/firecrawl/skills/firecrawl-best-practices/references/scrape.md
@@ -51,9 +51,12 @@ Request one or more output formats in a single call:
 | `html` | Processed HTML |
 | `rawHtml` | Unmodified HTML |
 | `links` | All links found on the page |
+| `images` | All image URLs found on the page |
 | `screenshot` | A screenshot of the page (full-page option available) |
 | `summary` | A short LLM-generated summary of the page |
 | `json` | Structured data extracted against a schema or prompt (see below) |
+| `changeTracking` | Diffs the page against prior scrapes (requires `markdown`; supports `git-diff` / `json` modes) |
+| `attributes` | Specific HTML attribute values pulled via CSS selectors |
 
 ```python
 doc = firecrawl.scrape("https://firecrawl.dev", formats=["markdown", "html", "links"])
@@ -133,7 +136,7 @@ doc = firecrawl.scrape(
 )
 ```
 
-Supported action types include `click`, `write`, `press`, `wait`, `scroll`, and `screenshot`.
+Supported action types: `wait`, `click`, `write`, `press`, `scroll`, `screenshot`, `scrape` (capture page HTML mid-sequence), `executeJavascript` (run custom JS; results in `actions.javascriptReturns`), and `pdf` (render the page to PDF).
 
 ---
 

--- a/content/firecrawl/skills/firecrawl-best-practices/references/sdk.md
+++ b/content/firecrawl/skills/firecrawl-best-practices/references/sdk.md
@@ -1,0 +1,214 @@
+---
+name: sdk
+description: "Firecrawl Python & JavaScript SDK reference: clients, scrape/crawl/map/search/extract, async, status polling"
+metadata:
+  languages: "python,javascript"
+  revision: 1
+  updated-on: "2026-06-21"
+  source: maintainer
+  tags: "firecrawl,sdk,python,javascript,scrape,crawl,map,search,extract,web-scraping"
+---
+# Firecrawl SDK Reference
+
+Single SDK for scrape, crawl, map, search, and extract, available for Python and
+JavaScript/TypeScript.
+
+## Table of Contents
+
+- [Python SDK](#python-sdk)
+- [JavaScript SDK](#javascript-sdk)
+- [Async and Concurrency](#async-and-concurrency)
+- [Batch Scrape](#batch-scrape)
+- [Status Polling](#status-polling)
+- [Error Handling](#error-handling)
+
+---
+
+## Python SDK
+
+**Package:** `firecrawl-py` on PyPI
+
+```bash
+pip install firecrawl-py
+```
+
+### Client
+
+The API key is read from `FIRECRAWL_API_KEY` if not passed explicitly.
+
+```python
+from firecrawl import Firecrawl
+
+firecrawl = Firecrawl(api_key="fc-YOUR_API_KEY")
+```
+
+### Methods
+
+```python
+# Scrape one page
+doc = firecrawl.scrape("https://firecrawl.dev", formats=["markdown", "html"])
+
+# Crawl a site (blocking)
+job = firecrawl.crawl("https://docs.firecrawl.dev", limit=100,
+                      scrape_options={"formats": ["markdown"]})
+
+# Crawl a site (async job + polling)
+started = firecrawl.start_crawl("https://docs.firecrawl.dev", limit=500)
+status = firecrawl.get_crawl_status(started.id)
+firecrawl.cancel_crawl(started.id)
+
+# Map URLs
+res = firecrawl.map("https://docs.firecrawl.dev", limit=100)
+
+# Search the web
+res = firecrawl.search("web scrapers", limit=5, sources=["web"])
+
+# Extract structured data
+res = firecrawl.extract(urls=["https://firecrawl.dev"],
+                        prompt="Extract the mission", schema={...})
+
+# Batch scrape many URLs
+docs = firecrawl.batch_scrape(["https://a.com", "https://b.com"],
+                              formats=["markdown"])
+started = firecrawl.start_batch_scrape(["https://a.com", "https://b.com"])
+status = firecrawl.get_batch_scrape_status(started.id)
+```
+
+---
+
+## JavaScript SDK
+
+**Package:** `firecrawl` on npm
+
+```bash
+npm install firecrawl
+```
+
+### Client
+
+```javascript
+import { Firecrawl } from 'firecrawl';
+
+const firecrawl = new Firecrawl({ apiKey: 'fc-YOUR_API_KEY' });
+```
+
+### Methods
+
+```javascript
+// Scrape one page
+const doc = await firecrawl.scrape('https://firecrawl.dev', { formats: ['markdown'] });
+
+// Crawl a site (blocking)
+const job = await firecrawl.crawl('https://docs.firecrawl.dev', {
+  limit: 100,
+  scrapeOptions: { formats: ['markdown'] },
+});
+
+// Crawl a site (async job + polling)
+const started = await firecrawl.startCrawl('https://docs.firecrawl.dev', { limit: 500 });
+const status = await firecrawl.getCrawlStatus(started.id);
+
+// Map URLs
+const map = await firecrawl.map('https://docs.firecrawl.dev', { limit: 100 });
+
+// Search the web
+const search = await firecrawl.search('web scrapers', { limit: 5 });
+
+// Extract structured data
+const extracted = await firecrawl.extract({
+  urls: ['https://firecrawl.dev'],
+  prompt: 'Extract the mission',
+  schema: { /* ... */ },
+});
+
+// Batch scrape
+const batch = await firecrawl.startBatchScrape(['https://a.com', 'https://b.com']);
+const batchStatus = await firecrawl.getBatchScrapeStatus(batch.id);
+```
+
+Method names are camelCase in JS (`startCrawl`, `getCrawlStatus`, `startBatchScrape`,
+`getBatchScrapeStatus`) and snake_case in Python (`start_crawl`, `get_crawl_status`,
+`start_batch_scrape`, `get_batch_scrape_status`).
+
+---
+
+## Async and Concurrency
+
+Python ships an async client with the same method names, all awaitable:
+
+```python
+import asyncio
+from firecrawl import AsyncFirecrawl
+
+firecrawl = AsyncFirecrawl(api_key="fc-YOUR_API_KEY")
+
+async def scrape_many(urls):
+    results = await asyncio.gather(
+        *(firecrawl.scrape(u, formats=["markdown"]) for u in urls),
+        return_exceptions=True,
+    )
+    return [r for r in results if not isinstance(r, Exception)]
+
+asyncio.run(scrape_many(["https://a.com", "https://b.com"]))
+```
+
+The JS client is async by default — run concurrent calls with `Promise.all` /
+`Promise.allSettled`.
+
+---
+
+## Batch Scrape
+
+When you already have a list of URLs, `batch_scrape` is more efficient than calling
+`scrape` in a loop. Use the blocking form for small lists, or
+`start_batch_scrape` + status polling for large ones.
+
+```python
+docs = firecrawl.batch_scrape(
+    ["https://docs.firecrawl.dev/features/scrape",
+     "https://docs.firecrawl.dev/features/crawl"],
+    formats=["markdown"],
+)
+for doc in docs.data:
+    print(doc.metadata.source_url)
+```
+
+---
+
+## Status Polling
+
+`crawl` and `batch_scrape` have non-blocking variants that return a job id. Poll
+the status endpoint until `status` is `completed` or `failed`:
+
+```python
+started = firecrawl.start_crawl("https://docs.firecrawl.dev", limit=500)
+status = firecrawl.get_crawl_status(started.id)
+while status.status not in ("completed", "failed"):
+    status = firecrawl.get_crawl_status(started.id)
+print(status.status, len(status.data))
+```
+
+---
+
+## Error Handling
+
+Wrap calls and handle network/timeouts and auth errors:
+
+```python
+try:
+    doc = firecrawl.scrape("https://example.com", formats=["markdown"])
+except Exception as e:
+    print(f"Scrape failed: {e}")
+```
+
+```javascript
+try {
+  const doc = await firecrawl.scrape('https://example.com', { formats: ['markdown'] });
+} catch (err) {
+  console.error('Scrape failed:', err.message);
+}
+```
+
+For the canonical, always-current SDK reference see the
+[Firecrawl Python SDK docs](https://docs.firecrawl.dev/sdks/python) and the
+[Firecrawl Node SDK docs](https://docs.firecrawl.dev/sdks/node).

--- a/content/firecrawl/skills/firecrawl-best-practices/references/search.md
+++ b/content/firecrawl/skills/firecrawl-best-practices/references/search.md
@@ -1,0 +1,124 @@
+# Search API Reference
+
+Search the web by query and optionally scrape the results in the same call. This
+turns "find pages about X" and "give me their content" into one request — ideal
+for RAG and agent workflows.
+
+## Table of Contents
+
+- [Basic Usage](#basic-usage)
+- [Key Parameters](#key-parameters)
+- [Sources](#sources)
+- [Search-then-Scrape in One Call](#search-then-scrape-in-one-call)
+- [Filtering](#filtering)
+- [Response Fields](#response-fields)
+
+---
+
+## Basic Usage
+
+```python
+from firecrawl import Firecrawl
+
+firecrawl = Firecrawl(api_key="fc-YOUR_API_KEY")
+
+res = firecrawl.search("best open source web scrapers", limit=5)
+for item in res.web or []:
+    print(item.title, item.url)
+```
+
+```javascript
+const res = await firecrawl.search('best open source web scrapers', { limit: 5 });
+for (const item of res.web ?? []) {
+  console.log(item.title, item.url);
+}
+```
+
+---
+
+## Key Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `query` **(required)** | `str` | Search query |
+| `limit` | `int` | Results per source |
+| `sources` | `list[str]` | `"web"` (default), `"news"`, `"images"` — request several at once |
+| `tbs` | `str` | Time filter: `"qdr:d"` (past day), `"qdr:w"` (week), `"qdr:m"` (month), `"qdr:y"` (year) |
+| `location` | `str` | Geographic context (e.g. `"Germany"`) |
+| `scrape_options` | `dict` | Scrape each result inline (`formats`, `only_main_content`, etc.) |
+
+In the JS SDK: `scrapeOptions` (camelCase). `limit` applies **per source**.
+
+---
+
+## Sources
+
+Request one or more result types in a single call. The response groups results by
+source, accessible as `res.web`, `res.news`, and `res.images`.
+
+```python
+res = firecrawl.search("AI agents", sources=["web", "news"], limit=5)
+print(len(res.web or []), "web,", len(res.news or []), "news")
+```
+
+---
+
+## Search-then-Scrape in One Call
+
+Add `scrape_options` to get full page content for every result without a second
+round-trip — the common pattern for feeding fresh web content to an LLM.
+
+```python
+res = firecrawl.search(
+    "firecrawl changelog 2026",
+    limit=5,
+    scrape_options={"formats": ["markdown"]},
+)
+for item in res.web or []:
+    print(item.url)
+    print(item.markdown[:500])
+```
+
+```javascript
+const res = await firecrawl.search('firecrawl changelog 2026', {
+  limit: 5,
+  scrapeOptions: { formats: ['markdown'] },
+});
+```
+
+---
+
+## Filtering
+
+```python
+# Recent results only
+res = firecrawl.search("openai release notes", tbs="qdr:w")
+
+# Localized results
+res = firecrawl.search("data privacy law", location="Germany")
+```
+
+---
+
+## Response Fields
+
+```json
+{
+  "web": [
+    {
+      "url": "https://...",
+      "title": "...",
+      "description": "...",
+      "markdown": "..."
+    }
+  ],
+  "news": [],
+  "images": []
+}
+```
+
+When `scrape_options` is set, each result also carries the requested scrape
+formats (e.g. `markdown`, `links`, `metadata`).
+
+For the canonical, always-current parameter list see the
+[Firecrawl search docs](https://docs.firecrawl.dev/features/search).


### PR DESCRIPTION
## What

Adds Firecrawl to the content registry under `content/firecrawl/`:

- **SDK docs** — `docs/sdk/python/DOC.md` and `docs/sdk/javascript/DOC.md` (verified against `firecrawl-py` 4.30.2 / `firecrawl` 4.28.2).
- **Best-practices skill** — `skills/firecrawl-best-practices/SKILL.md` plus eight reference files: `scrape`, `crawl`, `map`, `search`, `extract`, `sdk`, `mcp`, and `integrations`.

## Why

Firecrawl is a widely used web-data API (scrape / crawl / map / search / extract) that coding agents frequently call, yet there's no curated entry for it in the registry — and **no web-scraping/crawling provider exists here at all yet**. Agents currently guess Firecrawl's method names, parameters, and v4 conventions. This gives them accurate, versioned docs plus a skill that teaches method selection, the `json`-format vs `extract` tradeoff, MCP setup, and framework integrations.

## Testing

- [x] `npm test` passes (372 tests, 30 files)
- [x] `chub build content/ --validate-only` succeeds (1598 docs, 10 skills; only pre-existing `ade/*` warnings)
- [x] Manual testing done: built to a dist with `chub build content/ -o dist` and confirmed `registry.json` indexes `firecrawl/docs/sdk/{python,javascript}` and the `firecrawl-best-practices` skill with all 8 reference files.

## Notes

- All API details were verified against live sources, not memory: SDK versions/method names from the published `firecrawl-py` 4.30.2 wheel, and MCP/integrations details from `docs.firecrawl.dev/mcp-server` and `/integrations`.
- v4 accuracy callouts baked into the content: `crawl()` uses keyword args with `max_discovery_depth` (not `max_depth`); the standalone `extract` endpoint is in maintenance mode, so single-page structured extraction is steered toward `scrape` + `json`.
- `metadata.source` is set to `maintainer` (matching the existing `tavily` provider). Happy to switch to `community` if preferred.
- Entry points stay under the 500-line progressive-disclosure guideline; depth lives in `references/`.

