### PR TITLE
Add anthropic/claude-agent-sdk docs (Python + TypeScript)

### DIFF
--- a/content/anthropic/docs/claude-agent-sdk/python/DOC.md
+++ b/content/anthropic/docs/claude-agent-sdk/python/DOC.md
@@ -1,0 +1,158 @@
+---
+name: claude-agent-sdk
+description: "Claude Agent SDK (Python) — build production AI agents with Claude Code as a library: query(), tools, MCP, permissions, hooks, sessions"
+metadata:
+  languages: "python"
+  versions: "0.2.109"
+  revision: 1
+  updated-on: "2026-06-25"
+  source: community
+  tags: "anthropic,claude,agent-sdk,agents,python,mcp,claude-code"
+---
+
+# Claude Agent SDK — Python (`claude-agent-sdk`)
+
+Build AI agents that use Claude Code as a library: the agent runs the agentic loop,
+calls tools (file edits, bash, your custom functions, MCP), and you consume a stream
+of messages. Package: `claude-agent-sdk`. Requires Python 3.10+.
+
+## Install & auth
+
+```bash
+pip install claude-agent-sdk          # or: uv add claude-agent-sdk
+```
+
+```bash
+ANTHROPIC_API_KEY=sk-...              # in .env or shell. Cloud providers:
+# Bedrock: CLAUDE_CODE_USE_BEDROCK=1  •  Vertex: CLAUDE_CODE_USE_VERTEX=1  •  Foundry: CLAUDE_CODE_USE_FOUNDRY=1
+```
+
+## Minimal agent — `query()`
+
+`query()` is the entry point. It's an async iterator yielding messages.
+
+```python
+import asyncio
+from claude_agent_sdk import query, ClaudeAgentOptions, AssistantMessage, ResultMessage
+
+async def main():
+    async for message in query(
+        prompt="Review utils.py for crash bugs and fix them.",
+        options=ClaudeAgentOptions(
+            allowed_tools=["Read", "Edit", "Glob"],
+            permission_mode="acceptEdits",
+        ),
+    ):
+        if isinstance(message, AssistantMessage):
+            for block in message.content:
+                if hasattr(block, "text"):    print(block.text)
+                elif hasattr(block, "name"):  print(f"Tool: {block.name}")
+        elif isinstance(message, ResultMessage):
+            print(f"Done: {message.subtype}")   # 'result' / 'error'
+
+asyncio.run(main())
+```
+
+## Key `ClaudeAgentOptions` fields
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `allowed_tools` | `list[str]` | tools auto-approved without prompting (does NOT restrict to only these) |
+| `disallowed_tools` | `list[str]` | tools to deny, e.g. `"Bash(rm *)"` |
+| `permission_mode` | `str` | `default`/`acceptEdits`/`plan`/`dontAsk`/`bypassPermissions` |
+| `system_prompt` | `str \| {'type':'preset','preset':'claude_code'}` | custom or the Claude Code preset |
+| `append_system_prompt` | `str` | add to the default prompt |
+| `mcp_servers` | `dict[str, McpServerConfig] \| path` | in-process or external MCP servers |
+| `model` | `str` | e.g. `"claude-sonnet-4-6"` |
+| `max_turns` | `int` | cap agentic turns |
+| `cwd` | `str \| Path` | working directory |
+| `setting_sources` | `list` | which settings to load: `[]` skips all (user/project/local) |
+| `can_use_tool` | `callable` | custom permission callback |
+| `hooks` | `dict` | lifecycle hooks |
+| `resume` / `continue_conversation` | `str` / `bool` | session resume / multi-turn continue |
+| `output_format` | `dict` | JSON schema for structured output |
+
+## Custom tools (in-process MCP)
+
+Define a tool with `@tool(name, description, schema)`, wrap it in an in-process MCP
+server, pass to `mcp_servers`. Tool name becomes `mcp__<server>__<tool>`. The handler
+returns a **content array** (what Claude sees as the result).
+
+```python
+from claude_agent_sdk import tool, create_sdk_mcp_server, query, ClaudeAgentOptions
+
+@tool(
+    "add",
+    "Add two numbers",
+    {"a": float, "b": float},          # schema: {field: python type}
+)
+async def add(args: dict) -> dict:
+    return {"content": [{"type": "text", "text": str(args["a"] + args["b"])}]}
+
+calc = create_sdk_mcp_server(name="calc", version="1.0.0", tools=[add])
+
+async for m in query(
+    prompt="What is 2 + 2?",
+    options=ClaudeAgentOptions(
+        mcp_servers={"calc": calc},
+        allowed_tools=["mcp__calc__add"],
+        permission_mode="acceptEdits",
+    ),
+):
+    ...
+```
+
+The schema dict maps field names to Python types (`int`, `float`, `str`, `bool`); each key is required.
+
+## External MCP servers
+
+Pass a config dict (same shape as `.mcp.json`):
+
+```python
+options = ClaudeAgentOptions(
+    mcp_servers={"db": {"command": "npx", "args": ["-y", "db-mcp"], "env": {"URL": "..."}}},
+    allowed_tools=["mcp__db__query"],
+)
+```
+
+## Structured output
+
+Pass a JSON schema to `output_format`; the SDK validates and re-prompts on mismatch:
+
+```python
+options = ClaudeAgentOptions(
+    allowed_tools=["WebSearch"],
+    permission_mode="acceptEdits",
+    output_format={
+        "type": "object",
+        "properties": {"name": {"type": "string"}, "employee_count": {"type": "integer"}},
+        "required": ["name"],
+    },
+)
+```
+
+## Sessions (multi-turn)
+
+```python
+# First turn
+options = ClaudeAgentOptions(...)
+# ... run query(), capture result.session_id
+
+# Continue the SAME session (shared history)
+options2 = ClaudeAgentOptions(resume="<session_id>")          # resume by id
+# or for same-process chaining: continue_conversation=True
+```
+
+## Gotchas
+
+- **`allowed_tools` auto-approves but doesn't restrict.** To actually restrict tools,
+  use `disallowed_tools`, or rely on `permission_mode`. Unlisted tools fall through to
+  the permission mode / `can_use_tool`.
+- **`bypassPermissions` is the only fully non-interactive mode besides `dontAsk`.** For
+  autonomous agents in a sandbox, use `permission_mode="bypassPermissions"`.
+- **`system_prompt` default is minimal.** Pass `{"type":"preset","preset":"claude_code"}`
+  to get Claude Code's full system prompt (with tool guidance) instead of a bare one.
+- **Opus 4.7 needs SDK ≥ 0.2.111** (`thinking.type.adaptive`). If you hit
+  `thinking.type.enabled is not supported`, upgrade.
+- **Use `setting_sources=[]`** in production/embedded use to avoid picking up the user's
+  ambient `~/.claude` settings and MCP servers.

--- a/content/anthropic/docs/claude-agent-sdk/typescript/DOC.md
+++ b/content/anthropic/docs/claude-agent-sdk/typescript/DOC.md
@@ -1,0 +1,141 @@
+---
+name: claude-agent-sdk
+description: "Claude Agent SDK (TypeScript) — build production AI agents with Claude Code as a library: query(), tools, MCP, permissions, hooks, sessions"
+metadata:
+  languages: "typescript"
+  versions: "0.3.190"
+  revision: 1
+  updated-on: "2026-06-25"
+  source: community
+  tags: "anthropic,claude,agent-sdk,agents,typescript,mcp,claude-code"
+---
+
+# Claude Agent SDK — TypeScript (`@anthropic-ai/claude-agent-sdk`)
+
+Build AI agents that use Claude Code as a library: the agent runs the agentic loop,
+calls tools (file edits, bash, your custom functions, MCP), and you consume a stream
+of messages. Package: `@anthropic-ai/claude-agent-sdk`. Requires Node.js 18+.
+(A native Claude Code binary is bundled as an optional dependency — no separate install.)
+
+## Install & auth
+
+```bash
+npm install @anthropic-ai/claude-agent-sdk
+```
+
+```bash
+ANTHROPIC_API_KEY=sk-...              # .env or shell. Cloud providers:
+# Bedrock: CLAUDE_CODE_USE_BEDROCK=1  •  Vertex: CLAUDE_CODE_USE_VERTEX=1  •  Foundry: CLAUDE_CODE_USE_FOUNDRY=1
+```
+
+## Minimal agent — `query()`
+
+`query()` is the entry point. It's an async iterator yielding messages.
+
+```typescript
+import { query } from "@anthropic-ai/claude-agent-sdk";
+
+for await (const message of query({
+  prompt: "Review utils.py for crash bugs and fix them.",
+  options: {
+    allowedTools: ["Read", "Edit", "Glob"],
+    permissionMode: "acceptEdits",
+  },
+})) {
+  if (message.type === "assistant" && message.message?.content) {
+    for (const block of message.message.content) {
+      if ("text" in block) console.log(block.text);
+      else if ("name" in block) console.log(`Tool: ${block.name}`);
+    }
+  } else if (message.type === "result") {
+    console.log(`Done: ${message.subtype}`);   // 'result' / 'error'
+  }
+}
+```
+
+Run with `npx tsx agent.ts`.
+
+## Key options fields
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `allowedTools` | `string[]` | tools auto-approved without prompting (does NOT restrict to only these) |
+| `disallowedTools` | `string[]` | tools to deny, e.g. `"Bash(rm *)"`, `"mcp__*"` |
+| `permissionMode` | `PermissionMode` | `default`/`acceptEdits`/`plan`/`auto`/`dontAsk`/`bypassPermissions` |
+| `systemPrompt` | `string \| { type:'preset', preset:'claude_code', append?: string }` | custom or the Claude Code preset |
+| `mcpServers` | `Record<string, McpServerConfig>` | in-process or external MCP servers |
+| `model` | `string` | e.g. `"claude-sonnet-4-6"` |
+| `maxTurns` | `number` | cap agentic turns |
+| `cwd` | `string` | working directory |
+| `settingSources` | `('user'\|'project'\|'local')[]` | `[]` skips all ambient settings |
+| `canUseTool` | `CanUseTool` | custom permission callback |
+| `hooks` | object | lifecycle hooks |
+| `resume` / `continue` | `string` / `boolean` | session resume / multi-turn continue |
+| `skills` | `string[] \| 'all'` | enable specific or all discovered skills |
+| `outputSchema` / structured output | — | see structured-outputs guide |
+
+## Custom tools (in-process MCP)
+
+Define a tool with `tool(name, description, zodSchema, handler)` (positional args), wrap
+it in an in-process MCP server, pass to `mcpServers`. Tool name becomes `mcp__<server>__<tool>`.
+
+```typescript
+import { tool, createSdkMcpServer, query } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+
+const add = tool(
+  "add",                       // name
+  "Add two numbers",           // description (Claude sees this)
+  { a: z.number(), b: z.number() },                 // Zod raw shape = input schema
+  async (args) => ({ content: [{ type: "text", text: String(args.a + args.b) }] }),  // handler
+);
+
+const calc = createSdkMcpServer({ name: "calc", version: "1.0.0", tools: [add] });
+
+for await (const m of query({
+  prompt: "What is 2 + 2?",
+  options: {
+    mcpServers: { calc },
+    allowedTools: ["mcp__calc__add"],
+    permissionMode: "acceptEdits",
+  },
+})) {
+  /* ... */
+}
+```
+
+## External MCP servers
+
+Pass a config record (same shape as `.mcp.json`):
+
+```typescript
+options: {
+  mcpServers: {
+    db: { command: "npx", args: ["-y", "db-mcp"], env: { URL: "..." } },
+  },
+  allowedTools: ["mcp__db__query"],
+}
+```
+
+## Sessions (multi-turn)
+
+```typescript
+// First turn — capture result.session_id from the final 'result' message.
+// Continue the SAME session (shared history):
+query({ prompt: "...", options: { resume: "<session-id>" } });
+// same-process chaining: options: { continue: true }
+```
+
+## Gotchas
+
+- **`allowedTools` auto-approves but doesn't restrict.** To restrict tools, use
+  `disallowedTools` (or `tools` to list exactly the built-ins you want). Unlisted tools
+  fall through to the permission mode / `canUseTool`.
+- **`bypassPermissions` is the only fully non-interactive mode besides `dontAsk`/`auto`.**
+  For autonomous agents in a sandbox, use `permissionMode: "bypassPermissions"`.
+- **`systemPrompt` default is minimal.** Pass `{ type: "preset", preset: "claude_code" }`
+  to get Claude Code's full system prompt (with tool guidance).
+- **Use `settingSources: []`** in production/embedded use to avoid picking up the user's
+  ambient `~/.claude` settings and MCP servers; add `strictMcpConfig: true` to use only
+  the servers you pass in `mcpServers`.
+- **`auto` mode is TypeScript-only** in the SDK (a classifier approves/denies each call).


### PR DESCRIPTION
## What

Adds a curated `anthropic/claude-agent-sdk` doc entry with **Python (0.2.109)** and **TypeScript (0.3.190)** variants. Complements `anthropic/claude-api` (calling models) and `anthropic/claude-code` (the CLI) — this one is for **building agents programmatically** with the SDK.

## Why

The Claude Agent SDK (formerly Claude Code SDK) lets you run Claude Code as a library. This is a code-first reference for the ~90% case:

- `query()` agentic loop + message types
- Key options: `allowedTools`, `permissionMode`, `systemPrompt`, `mcpServers`, `maxTurns`, `settingSources`, `canUseTool`, `hooks`
- **Custom in-process tools** — `tool()` + `createSdkMcpServer()` (TS) / `@tool` + `create_sdk_mcp_server()` (py)
- External MCP servers, structured output, sessions (resume/continue)
- Gotchas (e.g. `allowedTools` auto-approves but doesn't restrict; `systemPrompt` defaults to minimal)

## Source

Authored from https://code.claude.com/docs/llms.txt — agent-sdk overview, quickstart, the Python + TypeScript references, custom-tools, and structured-outputs. The exact `tool()`/`@tool` call shapes were checked against the references before submission. `source: community`.

## Validation

```
node cli/bin/chub build content/ --validate-only   →  Valid (+1 doc, no new warnings)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)