### PR TITLE
docs(threadplane): add Angular agent-UI docs and a scaffold skill

### DIFF
--- a/content/threadplane/docs/ag-ui/typescript/DOC.md
+++ b/content/threadplane/docs/ag-ui/typescript/DOC.md
@@ -1,0 +1,85 @@
+---
+name: ag-ui
+description: "AG-UI backend adapter for Angular AI chat — provideAgent({url}) + injectAgent() bind @threadplane/chat to any AG-UI-compatible agent (CrewAI, Mastra, Pydantic AI, LangGraph, custom). Use when wiring an Angular chat UI to an AG-UI backend."
+metadata:
+  languages: "typescript"
+  versions: "0.0.53"
+  revision: 1
+  updated-on: "2026-06-24"
+  source: official
+  tags: "angular,typescript,ag-ui,agent,streaming,chat,adapter,threadplane"
+---
+
+# @threadplane/ag-ui for Angular
+
+`@threadplane/ag-ui` connects an Angular app to any AG-UI-compatible backend and exposes it as the runtime-neutral `Agent` contract that `<chat [agent]>` consumes. AG-UI is the recommended default adapter — it works with anything that speaks the AG-UI protocol (CrewAI, Mastra, Pydantic AI, LangGraph, or a custom service).
+
+Requires Angular 20+ and Node 22+.
+
+## Install
+
+```bash
+npm install @threadplane/chat @threadplane/ag-ui @ag-ui/client @ag-ui/core
+```
+
+`@ag-ui/client` and `@ag-ui/core` are both required peers of the adapter.
+
+## Configure the provider
+
+```typescript
+// app.config.ts
+import { ApplicationConfig } from '@angular/core';
+import { provideAgent } from '@threadplane/ag-ui';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideAgent({
+      url: 'http://localhost:3000/agent',
+      // headers: { Authorization: `Bearer ${token}` }, // optional — sent with every request
+    }),
+  ],
+};
+```
+
+`provideAgent` also accepts `agentId`, `threadId`, and `headers` — `headers` is the documented way to send auth tokens to your backend.
+
+No backend yet? Use `provideFakeAgent({ tokens: ['Hello', ' from', ' a fake agent.'] })` — it streams the canned tokens so you can build and test UI offline. (`provideFakeAgent({})` wires the transport but emits no reply.)
+
+## Render the chat
+
+```typescript
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { ChatComponent } from '@threadplane/chat';
+import { injectAgent } from '@threadplane/ag-ui';
+
+@Component({
+  selector: 'app-streaming',
+  standalone: true,
+  imports: [ChatComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<chat [agent]="agent" />`,
+})
+export class StreamingComponent {
+  protected readonly agent = injectAgent();
+}
+```
+
+`<chat>` handles streaming messages, tool calls, errors, and submit — all bound to the AG-UI backend through the `Agent` contract.
+
+## Switching backends without changing UI
+
+The `Agent` contract is the payoff: your component never learns the protocol. Swapping AG-UI ↔ LangGraph is a one-line change in `app.config.ts`; component code is identical.
+
+```diff
+- import { provideAgent } from '@threadplane/langgraph';
+- providers: [provideAgent({ apiUrl: '...', assistantId: 'chat' })],
++ import { provideAgent } from '@threadplane/ag-ui';
++ providers: [provideAgent({ url: '...' })],
+```
+
+## Common pitfalls
+
+- **Config key is `url`, not `apiUrl`.** `@threadplane/ag-ui`'s `provideAgent` takes `{ url }`. `apiUrl` is the LangGraph adapter's key — a different function in a different package.
+- **Install `@ag-ui/client` and `@ag-ui/core`.** Both are required peers for the AG-UI transport.
+- **Import `injectAgent`/`provideAgent` from `@threadplane/ag-ui`**, not from `@threadplane/chat`. Mixing adapter symbols across packages won't resolve.
+- **Use `provideFakeAgent({ tokens: [...] })` for offline** — `provideFakeAgent({})` wires the transport but streams no reply. Don't point `url` at a server that isn't running while building UI.

--- a/content/threadplane/docs/ag-ui/typescript/DOC.md
+++ b/content/threadplane/docs/ag-ui/typescript/DOC.md
@@ -3,9 +3,9 @@ name: ag-ui
 description: "AG-UI backend adapter for Angular AI chat — provideAgent({url}) + injectAgent() bind @threadplane/chat to any AG-UI-compatible agent (CrewAI, Mastra, Pydantic AI, LangGraph, custom). Use when wiring an Angular chat UI to an AG-UI backend."
 metadata:
   languages: "typescript"
-  versions: "0.0.53"
-  revision: 1
-  updated-on: "2026-06-24"
+  versions: "0.0.55"
+  revision: 2
+  updated-on: "2026-07-06"
   source: official
   tags: "angular,typescript,ag-ui,agent,streaming,chat,adapter,threadplane"
 ---

--- a/content/threadplane/docs/chat/typescript/DOC.md
+++ b/content/threadplane/docs/chat/typescript/DOC.md
@@ -3,9 +3,9 @@ name: chat
 description: "Drop-in streaming chat UI for Angular AI agents — render <chat [agent]> from @threadplane/chat against an AG-UI or LangGraph backend, or any Agent contract. Use when adding an agent chat interface to an Angular app."
 metadata:
   languages: "typescript"
-  versions: "0.0.53"
-  revision: 1
-  updated-on: "2026-06-24"
+  versions: "0.0.55"
+  revision: 2
+  updated-on: "2026-07-06"
   source: official
   tags: "angular,typescript,chat,streaming,agent,ui,generative-ui,langgraph,ag-ui,threadplane"
 ---

--- a/content/threadplane/docs/chat/typescript/DOC.md
+++ b/content/threadplane/docs/chat/typescript/DOC.md
@@ -1,0 +1,111 @@
+---
+name: chat
+description: "Drop-in streaming chat UI for Angular AI agents — render <chat [agent]> from @threadplane/chat against an AG-UI or LangGraph backend, or any Agent contract. Use when adding an agent chat interface to an Angular app."
+metadata:
+  languages: "typescript"
+  versions: "0.0.53"
+  revision: 1
+  updated-on: "2026-06-24"
+  source: official
+  tags: "angular,typescript,chat,streaming,agent,ui,generative-ui,langgraph,ag-ui,threadplane"
+---
+
+# @threadplane/chat for Angular
+
+`@threadplane/chat` is a production chat UI for Angular AI agents: streaming messages, tool calls, errors, interrupts, threads, and generative UI. You bind one component, `<chat [agent]>`, to an `Agent` — a runtime-neutral contract implemented by the AG-UI and LangGraph adapters (or `mockAgent()` for offline work). The UI never learns which backend it talks to.
+
+Requires Angular 20+.
+
+## Install
+
+```bash
+npm install @threadplane/chat marked
+```
+
+`marked` renders markdown in assistant messages. To talk to a real backend, also install an adapter — `@threadplane/ag-ui` (recommended default) or `@threadplane/langgraph`. Fetch their docs with `chub get threadplane/ag-ui` or `chub get threadplane/langgraph`.
+
+## Render a chat (no backend)
+
+`mockAgent()` implements the same `Agent` contract with canned messages, so the UI renders exactly as it will against a real agent. Use it to build UI before a backend exists.
+
+```typescript
+// chat-page.component.ts
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChatComponent, mockAgent } from '@threadplane/chat';
+
+@Component({
+  selector: 'app-chat-page',
+  standalone: true,
+  imports: [ChatComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<div style="height: 100vh"><chat [agent]="agent" /></div>`,
+})
+export class ChatPageComponent {
+  protected readonly agent = mockAgent({
+    messages: [
+      { id: 'm1', role: 'user', content: 'Hello' },
+      { id: 'm2', role: 'assistant', content: 'Hi — I am a mock agent.' },
+    ],
+  });
+}
+```
+
+The chat ships its own design tokens and component-scoped styles — no Tailwind, PostCSS, or global stylesheet import needed.
+
+## Configure providers (real backend)
+
+`provideChat()` sets chat-wide options such as the assistant's display name. The adapter provides the agent. This example uses AG-UI (the default adapter):
+
+```typescript
+// app.config.ts
+import { ApplicationConfig } from '@angular/core';
+import { provideChat } from '@threadplane/chat';
+import { provideAgent } from '@threadplane/ag-ui'; // or @threadplane/langgraph
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideChat({ assistantName: 'Assistant' }),
+    provideAgent({ url: 'http://localhost:3000/agent' }), // AG-UI
+  ],
+};
+```
+
+Then inject the agent in the component with the **adapter's** `injectAgent()` and bind it:
+
+```typescript
+import { injectAgent } from '@threadplane/ag-ui'; // import from the package you provided
+// ...
+protected readonly agent = injectAgent();
+// template: <chat [agent]="agent" />
+```
+
+Wire a real backend with one of the adapters:
+- AG-UI (recommended default): `chub get threadplane/ag-ui`
+- LangGraph: `chub get threadplane/langgraph`
+
+## Generative UI
+
+`<chat>` can render agent-produced UI, not just text. Pass a `views` catalog (and optional `handlers`); chat detects json-render specs and A2UI surfaces in the stream and renders them through your registered components.
+
+```html
+<chat [agent]="agent" [views]="catalog" [handlers]="handlers" />
+```
+
+See `chub get threadplane/generative-ui` for the json-render and A2UI paths.
+
+## Do I need a license?
+
+Evaluating costs nothing — the chat runs without a license token, emitting a single advisory `console.warn` (it never blocks rendering). For commercial use, pass your license token to `provideChat()`:
+
+```typescript
+provideChat({ assistantName: 'Assistant', license: 'YOUR_LICENSE_TOKEN' });
+```
+
+The token is verified at runtime against a public key compiled into the build. `@threadplane/chat` is the one commercially-licensed package; the rest of the framework is MIT.
+
+## Common pitfalls
+
+- **`injectAgent()` and `provideAgent()` come from the ADAPTER, not from `@threadplane/chat`.** Import them from `@threadplane/ag-ui` or `@threadplane/langgraph` — whichever you provided. `@threadplane/chat` itself exports `provideChat()` and `mockAgent()`.
+- **Forgetting `marked`.** Assistant markdown won't render without it.
+- **Wrong adapter config key.** AG-UI uses `provideAgent({ url })`; LangGraph uses `provideAgent({ apiUrl, assistantId })`. They are different functions from different packages — see the adapter docs.
+- **The component selector is `<chat>`; the class is `ChatComponent`.** Add `ChatComponent` to `imports`.

--- a/content/threadplane/docs/generative-ui/typescript/DOC.md
+++ b/content/threadplane/docs/generative-ui/typescript/DOC.md
@@ -1,0 +1,111 @@
+---
+name: generative-ui
+description: "Agent-generated UI in Angular — render structured json-render specs with <render-spec> from @threadplane/render, or stream agent-built A2UI surfaces through <chat [views]>. Use when an AI agent should produce real Angular UI (cards, forms, dashboards) instead of plain text."
+metadata:
+  languages: "typescript"
+  versions: "0.0.53"
+  revision: 1
+  updated-on: "2026-06-24"
+  source: official
+  tags: "angular,typescript,generative-ui,json-render,a2ui,render,agent,threadplane"
+---
+
+# Generative UI in Angular (@threadplane/render + A2UI)
+
+Threadplane renders agent-produced UI two ways. Pick by contract shape:
+
+- **json-render** (`@threadplane/render`) — a fixed JSON spec becomes an Angular component tree. Best when the app owns the schema and you can validate the whole UI before showing it (cards, forms, dashboards, structured results).
+- **A2UI** (`@threadplane/a2ui`, rendered through `@threadplane/chat`) — an agent-owned protocol for surfaces that update over time and send structured actions back. Best for live conversational UI with partial or streaming data.
+
+Both resolve element/component **type names through a registry that acts as an allowlist** — an unregistered name falls back instead of executing. Requires Angular 20+.
+
+## json-render: render a spec
+
+```bash
+npm install @threadplane/render
+```
+
+A registered component receives its resolved props plus a standard input contract — `spec`, `childKeys`, and (optionally) an `emit` function to dispatch actions to `[handlers]`:
+
+```typescript
+// text.component.ts
+import { Component, ChangeDetectionStrategy, input } from '@angular/core';
+import type { Spec } from '@json-render/core';
+
+@Component({
+  selector: 'app-text',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<p>{{ label() }}</p>`,
+})
+export class TextComponent {
+  readonly label = input<string>('');       // a resolved prop from the spec
+  readonly childKeys = input<string[]>([]);  // standard: keys of child elements
+  readonly spec = input.required<Spec>();    // standard: this element's spec node
+}
+```
+
+Map type names to components with `defineAngularRegistry()`, then render a spec with `<render-spec>`:
+
+```typescript
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { RenderSpecComponent, defineAngularRegistry, signalStateStore } from '@threadplane/render';
+import type { Spec } from '@json-render/core';
+import { TextComponent } from './text.component';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [RenderSpecComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<render-spec [spec]="spec" [registry]="registry" [store]="store" />`,
+})
+export class AppComponent {
+  registry = defineAngularRegistry({ Text: TextComponent });
+  store = signalStateStore({ name: 'World' });
+
+  spec: Spec = {
+    root: 'greeting',
+    elements: {
+      greeting: { type: 'Text', props: { label: { $state: '/name' } } },
+    },
+  };
+}
+```
+
+A spec is a flat `elements` map plus a `root` key. A prop with a `{ $state: '/path' }` expression reads reactively from the store; `store.set('/name', 'Angular')` updates the rendered tree. You can also embed initial state in `spec.state` and omit `[store]` — `<render-spec>` creates an internal store for you.
+
+## A2UI: agent-built surfaces in chat
+
+A2UI surfaces arrive in the chat stream. Provide a catalog via `<chat [views]>`. `a2uiBasicCatalog()` ships 18 built-in components — `Text`, `Button`, `Card`, `Column`, `Row`, `Divider`, `Icon`, `Image`, `List`, `Modal`, `Tabs`, `TextField`, `CheckBox`, `MultipleChoice`, `Slider`, `DateTimeInput`, `AudioPlayer`, and `Video`:
+
+```typescript
+import { a2uiBasicCatalog } from '@threadplane/chat';
+// ...
+catalog = a2uiBasicCatalog();
+```
+
+```html
+<chat [agent]="agent" [views]="catalog" [handlers]="handlers" />
+```
+
+`<chat>` classifies each assistant message as it streams: plain text → markdown; content whose first non-whitespace char is `{` → json-render; content starting with `---a2ui_JSON---` → A2UI. Both paths use the same `views` catalog.
+
+## Registry builders: `views()` vs `defineAngularRegistry()`
+
+There are two builders, and they are not interchangeable:
+
+- **`defineAngularRegistry({...})`** → an `AngularRegistry` consumed directly by `<render-spec>`.
+- **`views({...})`** (from `@threadplane/render`) → a `ViewRegistry`, the shape `<chat [views]>` consumes. `toRenderRegistry()` converts a `ViewRegistry` into an `AngularRegistry` so one component map serves both. Compose registries with `withViews()`.
+
+Use `defineAngularRegistry()` when you drive `<render-spec>` yourself; use `views()` when wiring components into chat.
+
+A registry value can be a bare component class or an object — `{ component, fallback?, schema? }`. `fallback` renders while bound data is still streaming in, and `schema` gates when a component is considered ready. These make streaming, agent-built UI safe to mount incrementally.
+
+## Common pitfalls
+
+- **The registry is the allowlist.** If the agent emits a type the registry doesn't contain, the renderer falls back — it never executes unknown UI. Don't register components you don't want the model able to mount.
+- **Two registry builders.** `<render-spec>` needs `defineAngularRegistry()` (`AngularRegistry`); `<chat [views]>` needs `views()` (`ViewRegistry`). Convert with `toRenderRegistry()`; don't pass one where the other is expected.
+- **`Spec` is imported from `@json-render/core`**, not `@threadplane/render`.
+- **Path selection is by content prefix** (`{` vs `---a2ui_JSON---`); your agent must emit the shape that matches the path you want.
+- **A2UI is for streaming, updating surfaces; json-render is one-spec-one-tree.** Don't reach for A2UI when a fixed, validated spec is enough.

--- a/content/threadplane/docs/generative-ui/typescript/DOC.md
+++ b/content/threadplane/docs/generative-ui/typescript/DOC.md
@@ -3,9 +3,9 @@ name: generative-ui
 description: "Agent-generated UI in Angular — render structured json-render specs with <render-spec> from @threadplane/render, or stream agent-built A2UI surfaces through <chat [views]>. Use when an AI agent should produce real Angular UI (cards, forms, dashboards) instead of plain text."
 metadata:
   languages: "typescript"
-  versions: "0.0.53"
-  revision: 1
-  updated-on: "2026-06-24"
+  versions: "0.0.55"
+  revision: 2
+  updated-on: "2026-07-06"
   source: official
   tags: "angular,typescript,generative-ui,json-render,a2ui,render,agent,threadplane"
 ---

--- a/content/threadplane/docs/langgraph/typescript/DOC.md
+++ b/content/threadplane/docs/langgraph/typescript/DOC.md
@@ -1,0 +1,101 @@
+---
+name: langgraph
+description: "LangGraph backend adapter for Angular AI chat — provideAgent({apiUrl,assistantId}) + injectAgent() expose signal-based messages/isLoading/error/submit for @threadplane/chat. Use when wiring an Angular chat UI to a LangGraph server."
+metadata:
+  languages: "typescript"
+  versions: "0.0.53"
+  revision: 1
+  updated-on: "2026-06-24"
+  source: official
+  tags: "angular,typescript,langgraph,agent,streaming,chat,adapter,signals,threadplane"
+---
+
+# @threadplane/langgraph for Angular
+
+`@threadplane/langgraph` connects an Angular app to a LangGraph server (LangGraph Platform or a local `langgraph dev`) and exposes it as the runtime-neutral `Agent` contract. `injectAgent()` returns a ref whose every property is an Angular Signal, so you can render with `<chat [agent]>` or hand-roll your own template.
+
+Requires Angular 20+ and Node 18+.
+
+## Install
+
+```bash
+npm install @threadplane/langgraph
+```
+
+Add `@threadplane/chat` too if you want the drop-in `<chat>` UI.
+
+## Configure the provider
+
+```typescript
+// app.config.ts
+import { ApplicationConfig, signal } from '@angular/core';
+import { provideAgent } from '@threadplane/langgraph';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideAgent({
+      apiUrl: 'http://localhost:2024',
+      assistantId: 'chat',        // maps to a key in your langgraph.json "graphs"
+      threadId: signal(null),     // optional — set to persist a thread across reloads
+    }),
+  ],
+};
+```
+
+`apiUrl` is optional (the SDK falls back to a default base URL) but you will usually set it. `assistantId` is required at runtime and must match a key in your `langgraph.json` `"graphs"`. `threadId` accepts a Signal, a plain string, or `null`.
+
+## Use the agent
+
+`injectAgent()` returns the singleton wired above. Every property is a Signal — call it.
+
+```typescript
+import { Component, ChangeDetectionStrategy, signal, computed } from '@angular/core';
+import { injectAgent } from '@threadplane/langgraph';
+
+@Component({
+  selector: 'app-chat',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './chat.component.html',
+})
+export class ChatComponent {
+  protected readonly chat = injectAgent();
+  input = signal('');
+  isStreaming = computed(() => this.chat.isLoading());
+
+  send() {
+    const msg = this.input();
+    if (!msg.trim()) return;
+    this.chat.submit({ message: msg });
+    this.input.set('');
+  }
+}
+```
+
+```html
+<!-- chat.component.html -->
+@for (msg of chat.messages(); track $index) {
+  <div [class]="msg.role">{{ msg.content }}</div>
+}
+@if (chat.error(); as err) { <div class="error">{{ err.message }}</div> }
+<form (submit)="send(); $event.preventDefault()">
+  <input [ngModel]="input()" (ngModelChange)="input.set($event)" />
+  <button type="submit" [disabled]="isStreaming()">Send</button>
+</form>
+```
+
+Prefer the drop-in UI? Skip the hand-rolled template and bind the same agent to `<chat [agent]="injectAgent()" />` from `@threadplane/chat`.
+
+The agent ref exposes more than the basics above: `stop()`, `retry()`, `regenerate(index)`, an `interrupt` signal (resume with `submit({ resume })` or `submit(null)`), `switchThread(id)`, and a structured `error()` of type `AgentError` with `.kind` and `.retryable`. `submit()` accepts a message as `string | ContentBlock[]` plus optional `resume`/`state` and a second options argument. Because a message's `content` can be a `ContentBlock[]`, the plain-text template above is illustrative — `<chat [agent]>` renders every content shape for you.
+
+## Start the backend
+
+```bash
+langgraph dev   # serves on http://localhost:2024
+```
+
+## Common pitfalls
+
+- **Config keys are `apiUrl` + `assistantId`** — not `url`. (`url` is the AG-UI adapter's key, a different package.)
+- **`assistantId` must match a key in `langgraph.json` "graphs".** A mismatch yields an empty or erroring stream.
+- **Agent ref properties are Signals — call them.** Use `chat.messages()`, `chat.isLoading()`, `chat.error()`, not `chat.messages`.
+- **`threadId` accepts a Signal, string, or `null`.** Omit it for the minimal path; pass `signal(...)` to persist a thread across reloads.

--- a/content/threadplane/docs/langgraph/typescript/DOC.md
+++ b/content/threadplane/docs/langgraph/typescript/DOC.md
@@ -3,9 +3,9 @@ name: langgraph
 description: "LangGraph backend adapter for Angular AI chat — provideAgent({apiUrl,assistantId}) + injectAgent() expose signal-based messages/isLoading/error/submit for @threadplane/chat. Use when wiring an Angular chat UI to a LangGraph server."
 metadata:
   languages: "typescript"
-  versions: "0.0.53"
-  revision: 1
-  updated-on: "2026-06-24"
+  versions: "0.0.55"
+  revision: 2
+  updated-on: "2026-07-06"
   source: official
   tags: "angular,typescript,langgraph,agent,streaming,chat,adapter,signals,threadplane"
 ---

--- a/content/threadplane/skills/scaffold-angular-agent-chat/SKILL.md
+++ b/content/threadplane/skills/scaffold-angular-agent-chat/SKILL.md
@@ -2,8 +2,8 @@
 name: scaffold-angular-agent-chat
 description: "Scaffolds a streaming AI chat UI in an Angular app using @threadplane/chat, rendering <chat [agent]> bound to a backend adapter — @threadplane/ag-ui (default) or @threadplane/langgraph. Use when a user wants to add an agent chat interface, streaming chat, or generative UI to an Angular project, or mentions Threadplane, @threadplane/*, AG-UI with Angular, or LangGraph with Angular. Confirm which adapter the user is on before scaffolding; default to AG-UI if unspecified."
 metadata:
-  revision: 1
-  updated-on: "2026-06-24"
+  revision: 2
+  updated-on: "2026-07-06"
   source: official
   tags: "angular,typescript,chat,agent,streaming,generative-ui,ag-ui,langgraph,threadplane"
 ---

--- a/content/threadplane/skills/scaffold-angular-agent-chat/SKILL.md
+++ b/content/threadplane/skills/scaffold-angular-agent-chat/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: scaffold-angular-agent-chat
+description: "Scaffolds a streaming AI chat UI in an Angular app using @threadplane/chat, rendering <chat [agent]> bound to a backend adapter — @threadplane/ag-ui (default) or @threadplane/langgraph. Use when a user wants to add an agent chat interface, streaming chat, or generative UI to an Angular project, or mentions Threadplane, @threadplane/*, AG-UI with Angular, or LangGraph with Angular. Confirm which adapter the user is on before scaffolding; default to AG-UI if unspecified."
+metadata:
+  revision: 1
+  updated-on: "2026-06-24"
+  source: official
+  tags: "angular,typescript,chat,agent,streaming,generative-ui,ag-ui,langgraph,threadplane"
+---
+
+# Scaffold an Angular agent chat UI with Threadplane
+
+Threadplane provides a production chat UI for Angular AI agents (`@threadplane/chat`) bound to a runtime-neutral `Agent` contract. The same `<chat [agent]>` UI works against any backend through an adapter. Requires Angular 20+.
+
+## Step 0 — Confirm the backend adapter (do this first)
+
+Threadplane has two backend adapters. Pick the right one before writing any code:
+
+- **`@threadplane/ag-ui`** — for any AG-UI-compatible backend (CrewAI, Mastra, Pydantic AI, LangGraph, custom). **This is the default** — use it unless the user says otherwise.
+- **`@threadplane/langgraph`** — for a LangGraph server specifically (config keys `apiUrl` + `assistantId`).
+
+Determine the adapter, in order:
+1. Ask the user which backend they are using, or
+2. Check `package.json` for an existing `@threadplane/ag-ui` or `@threadplane/langgraph` dependency, then
+3. If still unknown, default to **AG-UI** and tell the user that is what you chose.
+
+Do not assume the LangGraph adapter just because the backend happens to use LangGraph — an AG-UI-wrapped LangGraph backend uses the AG-UI adapter.
+
+## Step 1 — Fetch the current docs
+
+Before writing code, fetch the exact, version-pinned API with chub (it changes between releases):
+
+```bash
+chub get threadplane/chat --lang typescript
+chub get threadplane/ag-ui --lang typescript          # or threadplane/langgraph
+chub get threadplane/generative-ui --lang typescript  # only if generating UI
+```
+
+## Step 2 — Install
+
+```bash
+npm install @threadplane/chat marked
+# then the chosen adapter:
+npm install @threadplane/ag-ui @ag-ui/client @ag-ui/core   # AG-UI (default)
+# or
+npm install @threadplane/langgraph                    # LangGraph
+```
+
+## Step 3 — Provide the chat + agent (app.config.ts)
+
+AG-UI (default):
+
+```typescript
+import { ApplicationConfig } from '@angular/core';
+import { provideChat } from '@threadplane/chat';
+import { provideAgent } from '@threadplane/ag-ui';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideChat({ assistantName: 'Assistant' }),
+    provideAgent({ url: 'http://localhost:3000/agent' }),
+  ],
+};
+```
+
+LangGraph (if chosen): use `provideAgent({ apiUrl: 'http://localhost:2024', assistantId: 'chat' })` from `@threadplane/langgraph` instead.
+
+## Step 4 — Render the chat
+
+```typescript
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { ChatComponent } from '@threadplane/chat';
+import { injectAgent } from '@threadplane/ag-ui'; // import from the SAME package you provided
+
+@Component({
+  selector: 'app-chat',
+  standalone: true,
+  imports: [ChatComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<div style="height: 100vh"><chat [agent]="agent" /></div>`,
+})
+export class ChatPageComponent {
+  protected readonly agent = injectAgent();
+}
+```
+
+## Escape hatch — no backend yet
+
+Build UI offline without a server:
+- AG-UI: use `provideFakeAgent({})` instead of `provideAgent({...})`.
+- Or skip providers entirely: `mockAgent({ messages: [...] })` from `@threadplane/chat`, constructed directly in the component.
+
+## Critical rules (where agents go wrong)
+
+- `injectAgent()` and `provideAgent()` come from the ADAPTER package (`@threadplane/ag-ui` or `@threadplane/langgraph`), NOT from `@threadplane/chat`. `@threadplane/chat` exports `provideChat()` and `mockAgent()`.
+- AG-UI's config key is `url`; LangGraph's are `apiUrl` + `assistantId`. They are different `provideAgent` functions from different packages — never mix them.
+- Install `marked` for chat markdown; install `@ag-ui/client` + `@ag-ui/core` for the AG-UI adapter.
+- The component selector is `<chat>`; the imported class is `ChatComponent`.
+- For generative UI (agent-produced cards/forms), pass `<chat [views]="catalog">` and fetch `chub get threadplane/generative-ui`.


### PR DESCRIPTION
## What

Adds a new `threadplane` author — four TypeScript docs (chat, ag-ui, langgraph, generative-ui) and one scaffold skill — for the MIT Angular agent-UI framework that runs on LangGraph, AG-UI, and A2UI. I maintain Threadplane, so entries are `source: official`.

## Why

When a coding agent builds an Angular agent UI with Threadplane today, it guesses the API and gets the predictable things wrong: the two `provideAgent` functions (`{ url }` for AG-UI vs `{ apiUrl, assistantId }` for LangGraph), and the two generative-UI registry builders. These docs pin those down so the agent writes correct code.

## Testing

- [x] `chub build content --validate-only` succeeds — `Valid: 1601 docs, 10 skills` (the 2 warnings are pre-existing `ade/*` skills)
- [x] Files exist at the documented paths under `content/threadplane/`
- [x] Frontmatter complete (name, description, languages/versions/revision/updated-on/source/tags)
- [x] Entry files (DOC.md, SKILL.md) under 500 lines
- [x] Built locally as a source and verified retrieval:
      `chub search threadplane` → 5 results (4 docs ts/official, 1 skill)
      `chub get threadplane/chat --lang typescript` → prints the full doc

## Notes

```
content/threadplane/docs/{chat,ag-ui,langgraph,generative-ui}/typescript/DOC.md
content/threadplane/skills/scaffold-angular-agent-chat/SKILL.md
```

All entries pinned to npm 0.0.53, revision 1.
