### PR TITLE
fix: --force flag in chub update was always true

### DIFF
--- a/cli/src/commands/cache.js
+++ b/cli/src/commands/cache.js
@@ -39,7 +39,7 @@ export function registerCacheCommand(program) {
   cache
     .command('clear')
     .description('Clear cached data')
-    .action((opts) => {
+    .action(() => {
       const globalOpts = program.optsWithGlobals();
       clearCache();
       output(

--- a/cli/src/commands/update.js
+++ b/cli/src/commands/update.js
@@ -31,7 +31,7 @@ export function registerUpdateCommand(program) {
           );
         } else {
           info('Updating registries...');
-          const errors = await fetchAllRegistries(opts.force || true);
+          const errors = await fetchAllRegistries(opts.force);
           if (errors.length > 0) {
             for (const e of errors) {
               process.stderr.write(chalk.yellow(`Warning: ${e.source}: ${e.error}\n`));


### PR DESCRIPTION
The update command had \`opts.force || true\` which always evaluates to true — so every \`chub update\` was forcing a full re-download even without \`--force\`. Changed to just \`opts.force\` so the cache freshness check actually kicks in when you don't explicitly ask for a force update.

Also removed an unused \`opts\` parameter from the cache clear action callback.