### PR TITLE
Add Keenable documentation and best-practices skill

### DIFF
--- a/content/keenable/docs/api/DOC.md
+++ b/content/keenable/docs/api/DOC.md
@@ -1,0 +1,106 @@
+---
+name: api
+description: "Keenable web search API for AI agents: keyless-by-default search and clean-markdown page fetch over HTTP"
+metadata:
+  languages: "http,python,javascript"
+  versions: "v1"
+  revision: 1
+  updated-on: "2026-07-07"
+  source: maintainer
+  tags: "keenable,search,fetch,web-search,ai,agents,rag,http,api,keyless"
+---
+# Keenable API
+
+Keenable is a web search API built for AI agents. Two endpoints: **search** (live web search with site and date filters) and **fetch** (turn a URL into clean markdown).
+
+**Base URL:** `https://api.keenable.ai`
+
+**Keyless by default.** Every endpoint has a public variant that works with no account or API key (rate-limited). An optional `KEENABLE_API_KEY` (`keen_...`, from <https://keenable.ai/console>) switches to the authenticated endpoint and lifts the hourly cap. A key is never required to start.
+
+| Operation | Keyless (no key) | Authenticated (with key) |
+|---|---|---|
+| Search | `POST /v1/search/public` | `POST /v1/search` |
+| Fetch  | `GET /v1/fetch/public`   | `GET /v1/fetch` |
+
+Auth: send the key in the `X-API-Key` header on the authenticated endpoints. No header for the public ones.
+
+## Search
+
+`POST /v1/search/public` (keyless) or `POST /v1/search` (keyed).
+
+Request body (JSON):
+
+| Field | Type | Notes |
+|---|---|---|
+| `query` | string (required) | The search query. |
+| `mode` | string | Search mode, defaults to `"pro"`. |
+| `site` | string | Restrict to a single domain, e.g. `"techcrunch.com"`. |
+| `published_after` / `published_before` | string | Filter by publication date, `YYYY-MM-DD`. |
+| `acquired_after` / `acquired_before` | string | Filter by index date, `YYYY-MM-DD`. |
+
+Response: `{ "results": [ { "title", "url", "description", "published_at", "acquired_at" } ] }`.
+
+```bash
+curl -s https://api.keenable.ai/v1/search/public \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "typescript best practices", "mode": "pro"}'
+```
+
+```javascript
+const res = await fetch("https://api.keenable.ai/v1/search/public", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ query: "typescript best practices", mode: "pro" }),
+});
+const { results } = await res.json();
+
+// With a key, to lift the rate limit:
+await fetch("https://api.keenable.ai/v1/search", {
+  method: "POST",
+  headers: { "Content-Type": "application/json", "X-API-Key": process.env.KEENABLE_API_KEY },
+  body: JSON.stringify({ query: "latest AI agents", site: "arxiv.org" }),
+});
+```
+
+```python
+import os, requests
+
+# Keyless
+r = requests.post("https://api.keenable.ai/v1/search/public",
+                  json={"query": "typescript best practices", "mode": "pro"})
+results = r.json()["results"]
+
+# Keyed
+r = requests.post("https://api.keenable.ai/v1/search",
+                  headers={"X-API-Key": os.environ["KEENABLE_API_KEY"]},
+                  json={"query": "latest AI agents", "published_after": "2026-01-01"})
+```
+
+## Fetch
+
+`GET /v1/fetch/public?url=...` (keyless) or `GET /v1/fetch?url=...` (keyed). Returns the main page content as markdown.
+
+Response: `{ "url", "title", "content", "description", "author", "published_at" }` (extra fields appear when the page exposes them).
+
+```bash
+curl -s "https://api.keenable.ai/v1/fetch/public?url=https://example.com/article"
+```
+
+```python
+import requests
+page = requests.get("https://api.keenable.ai/v1/fetch/public",
+                    params={"url": "https://example.com/article"}).json()
+print(page["title"], page["content"][:200])
+```
+
+The typical agent loop is search then fetch: discover URLs with search, then read the full page content of the most relevant ones with fetch.
+
+## Errors and rate limits
+
+- Non-2xx responses carry a JSON body with a `message` (or `error` / `detail`) field; surface it to the caller.
+- `429` means the keyless rate limit was hit. Set `KEENABLE_API_KEY` and use the authenticated endpoints to lift the cap.
+- `401` on an authenticated endpoint means the key was rejected.
+
+## Official integrations
+
+Keenable ships first-party packages so you rarely call the HTTP API by hand. See **[../../skills/keenable-best-practices/references/integrations.md](../../skills/keenable-best-practices/references/integrations.md)** for LangChain, LlamaIndex, Haystack, Langflow, Pi, OpenClaw, Mastra, and the hosted MCP server.

--- a/content/keenable/skills/keenable-best-practices/SKILL.md
+++ b/content/keenable/skills/keenable-best-practices/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: keenable-best-practices
+description: "Use Keenable web search and page fetch effectively in agents and RAG pipelines: keyless-first, search-then-fetch, site and date filters, error handling"
+metadata:
+  revision: 1
+  updated-on: "2026-07-07"
+  source: maintainer
+  tags: "keenable,search,fetch,web-search,ai,agents,rag,web-scraping,best-practices,keyless"
+---
+
+# Keenable
+
+Keenable is a web search API built for AI agents. It exposes two operations over HTTP: **search** (live web results) and **fetch** (a URL turned into clean markdown).
+
+**Base URL:** `https://api.keenable.ai`
+
+## Keyless first
+
+Keenable works with no account or API key against the public endpoints (`/v1/search/public`, `/v1/fetch/public`), which are rate-limited. Start keyless. Only add a key when you hit the rate limit: set `KEENABLE_API_KEY` (`keen_...` from <https://keenable.ai/console>), send it as the `X-API-Key` header, and call the authenticated endpoints (`/v1/search`, `/v1/fetch`). The key lifts the cap; it does not unlock features.
+
+Do not hardcode a key. Read it from the environment and fall back to the keyless endpoint when it is absent.
+
+## The search-then-fetch loop
+
+The standard pattern: search to discover URLs, then fetch the most relevant ones for full content.
+
+1. `search(query)` returns a ranked list of `{ title, url, description }`.
+2. Pick the URLs worth reading (usually the top few).
+3. `fetch(url)` returns the page as markdown for grounding the answer.
+
+Do not fetch every result. Fetch is more expensive than search, so read only what the task needs.
+
+## Writing good queries
+
+- Keep queries specific and keyword-dense; this is a search engine, not a chat prompt.
+- Narrow with `site` when you know the source (e.g. `site: "arxiv.org"`).
+- Narrow by recency with `published_after` / `published_before` (`YYYY-MM-DD`) for time-sensitive questions.
+- Use `acquired_after` / `acquired_before` to filter by when Keenable indexed the page.
+
+See **[references/search.md](references/search.md)** for the full search parameter and response reference.
+
+## Reading pages
+
+`fetch` returns `{ url, title, content, description?, author?, publishedAt? }` with `content` as markdown. Prefer it over raw HTTP fetching: it strips boilerplate and returns clean text an LLM can use directly.
+
+See **[references/fetch.md](references/fetch.md)** for the fetch reference.
+
+## Error handling
+
+- Check for non-2xx responses and surface the JSON `message`/`error`/`detail` field.
+- Treat `429` as "rate limited": set a key and use the authenticated endpoints, or back off.
+- Treat `401` (authenticated endpoint) as a bad key.
+
+## Prefer a first-party integration
+
+If you are in LangChain, LlamaIndex, Haystack, Langflow, Pi, OpenClaw, Mastra, or any MCP client, use the official Keenable package instead of calling HTTP directly. They handle keyless/keyed selection and attribution for you.
+
+See **[references/integrations.md](references/integrations.md)**.

--- a/content/keenable/skills/keenable-best-practices/references/fetch.md
+++ b/content/keenable/skills/keenable-best-practices/references/fetch.md
@@ -1,0 +1,59 @@
+# Keenable fetch reference
+
+`GET /v1/fetch/public?url=...` (keyless) or `GET /v1/fetch?url=...` (with `X-API-Key`). Fetches a single URL and returns its main content as markdown.
+
+## Request
+
+| Param | Type | Required | Notes |
+|---|---|---|---|
+| `url` | string | yes | The absolute `http(s)` URL to fetch, URL-encoded in the query string. |
+
+## Response
+
+```json
+{
+  "url": "https://example.com/article",
+  "title": "Article title",
+  "content": "# Article title\n\nClean markdown body ...",
+  "description": "Optional meta description",
+  "author": "Optional author",
+  "published_at": "2026-02-03T00:00:00Z"
+}
+```
+
+`content` is the main article text as markdown, boilerplate stripped. `description`, `author`, and `published_at` appear when the page exposes them.
+
+## Examples
+
+```python
+import os, requests
+from urllib.parse import quote
+
+def keenable_fetch(url):
+    key = os.environ.get("KEENABLE_API_KEY")
+    base = "https://api.keenable.ai/v1/fetch" if key else "https://api.keenable.ai/v1/fetch/public"
+    headers = {"X-API-Key": key} if key else {}
+    r = requests.get(base, params={"url": url}, headers=headers)
+    r.raise_for_status()
+    return r.json()
+
+page = keenable_fetch("https://example.com/article")
+print(page["title"], "\n", page["content"][:500])
+```
+
+```javascript
+async function keenableFetch(url) {
+  const key = process.env.KEENABLE_API_KEY;
+  const base = key ? "/v1/fetch" : "/v1/fetch/public";
+  const headers = key ? { "X-API-Key": key } : {};
+  const res = await fetch(`https://api.keenable.ai${base}?url=${encodeURIComponent(url)}`, { headers });
+  if (!res.ok) throw new Error(`Keenable fetch failed (${res.status})`);
+  return res.json();
+}
+```
+
+## Notes
+
+- Pair fetch with search: search returns URLs, fetch reads the ones worth grounding on.
+- Prefer fetch over a raw HTTP GET plus your own HTML-to-text step; it returns clean markdown directly.
+- Only fetch pages you actually need; it is heavier than search.

--- a/content/keenable/skills/keenable-best-practices/references/integrations.md
+++ b/content/keenable/skills/keenable-best-practices/references/integrations.md
@@ -1,0 +1,58 @@
+# Keenable framework integrations
+
+Keenable ships first-party packages for common agent frameworks. Prefer these over calling the HTTP API by hand: they select the keyless vs keyed endpoint automatically and tag traffic for attribution. All are keyless by default; set `KEENABLE_API_KEY` to lift the rate limit.
+
+## Python
+
+**LangChain** (`langchain-keenable`, PyPI):
+
+```python
+from langchain_keenable import KeenableSearch, KeenableFetch
+
+results = KeenableSearch().invoke({"query": "typescript best practices"})
+page = KeenableFetch().invoke({"url": results[0]["url"]})
+```
+
+**LlamaIndex** (`llama-index-tools-keenable`, PyPI):
+
+```python
+from llama_index.tools.keenable import KeenableToolSpec
+
+spec = KeenableToolSpec()               # or KeenableToolSpec(api_key="keen_...")
+docs = spec.search("typescript best practices")
+page = spec.fetch(docs[0].metadata["url"])
+```
+
+**Haystack** (`keenable-haystack`, PyPI):
+
+```python
+from haystack_integrations.components.websearch.keenable import KeenableWebSearch
+from haystack_integrations.components.fetchers.keenable import KeenableFetcher
+
+hits = KeenableWebSearch(top_k=5).run(query="latest AI agents")
+pages = KeenableFetcher().run(urls=hits["links"][:2])
+```
+
+**Langflow** (`lfx-keenable`, PyPI): install and restart Langflow; the Keenable components appear in the palette under the **keenable** group.
+
+## JavaScript / TypeScript
+
+**Mastra** (`@keenable/mastra`, npm):
+
+```typescript
+import { createKeenableTools } from "@keenable/mastra";
+
+const tools = createKeenableTools(); // keyless; or { apiKey: "keen_..." }
+```
+
+**Pi (pi.dev)** (`@keenable/pi-search`, npm): `pi install npm:@keenable/pi-search`. Tools auto-register.
+
+**OpenClaw** (`@keenable/openclaw-search`, npm + ClawHub): `openclaw plugins install @keenable/openclaw-search`, then pick Keenable as the web-search provider.
+
+## MCP (any client)
+
+Hosted MCP server over Streamable HTTP: `https://api.keenable.ai/mcp`. Tools: `search_web_pages` and `fetch_page_content`. Local stdio bridge: `npx -y @keenable/mcp`. Works in Claude Desktop, VS Code / GitHub MCP Registry, Cursor, Cline, and other MCP clients.
+
+## Also built in
+
+Keenable is a built-in web-search option in several platforms, including Dify (Marketplace plugin) and RAGFlow (built-in agent tool). Select "Keenable" in the platform's web-search settings; leave the key empty for keyless.

--- a/content/keenable/skills/keenable-best-practices/references/search.md
+++ b/content/keenable/skills/keenable-best-practices/references/search.md
@@ -1,0 +1,71 @@
+# Keenable search reference
+
+`POST /v1/search/public` (keyless) or `POST /v1/search` (with `X-API-Key`).
+
+## Request
+
+JSON body:
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `query` | string | yes | The search query. |
+| `mode` | string | no | Search mode. Defaults to `"pro"` (deeper retrieval, higher quality). |
+| `site` | string | no | Restrict results to one domain, e.g. `"techcrunch.com"`. |
+| `published_after` | string | no | Only pages published on or after this date (`YYYY-MM-DD`). |
+| `published_before` | string | no | Only pages published on or before this date (`YYYY-MM-DD`). |
+| `acquired_after` | string | no | Only pages indexed by Keenable on or after this date (`YYYY-MM-DD`). |
+| `acquired_before` | string | no | Only pages indexed on or before this date (`YYYY-MM-DD`). |
+
+## Response
+
+```json
+{
+  "results": [
+    {
+      "title": "TypeScript Best Practices 2026",
+      "url": "https://example.com/ts-best-practices",
+      "description": "A comprehensive guide ...",
+      "published_at": "2026-01-15T10:30:00Z",
+      "acquired_at": "2026-01-16T08:12:34Z"
+    }
+  ]
+}
+```
+
+`published_at` and `acquired_at` appear when known. The API returns a fixed-size result set; cap it client-side if you need fewer.
+
+## Examples
+
+```python
+import os, requests
+
+def keenable_search(query, **filters):
+    key = os.environ.get("KEENABLE_API_KEY")
+    payload = {"query": query, "mode": "pro", **filters}
+    if key:
+        r = requests.post("https://api.keenable.ai/v1/search",
+                          headers={"X-API-Key": key}, json=payload)
+    else:
+        r = requests.post("https://api.keenable.ai/v1/search/public", json=payload)
+    r.raise_for_status()
+    return r.json()["results"]
+
+# Recent results from a single domain
+results = keenable_search("agent frameworks", site="github.com", published_after="2026-01-01")
+```
+
+```javascript
+async function keenableSearch(query, filters = {}) {
+  const key = process.env.KEENABLE_API_KEY;
+  const path = key ? "/v1/search" : "/v1/search/public";
+  const headers = { "Content-Type": "application/json" };
+  if (key) headers["X-API-Key"] = key;
+  const res = await fetch(`https://api.keenable.ai${path}`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ query, mode: "pro", ...filters }),
+  });
+  if (!res.ok) throw new Error(`Keenable search failed (${res.status})`);
+  return (await res.json()).results;
+}
+```


### PR DESCRIPTION
## What

Add `content/keenable/`: documentation and a best-practices skill for [Keenable](https://keenable.ai), a web search API built for AI agents.

- `docs/api/DOC.md`: the Keenable HTTP API reference (search + clean-markdown fetch), with curl / JavaScript / Python examples.
- `skills/keenable-best-practices/`: a `SKILL.md` (keyless-first, search-then-fetch loop, query filters, error handling) plus reference files for `search`, `fetch`, and the first-party framework integrations (LangChain, LlamaIndex, Haystack, Langflow, Pi, OpenClaw, Mastra, MCP).

## Why

Keenable is a search API for LLM applications with no representation in the hub. Unlike most search APIs it is keyless by default (agents can search and fetch with no key, rate-limited), which the docs make explicit so agents pick the right endpoint.

## Testing

- `node cli/bin/chub build content/keenable --validate-only` → Valid: 1 docs, 1 skills, 0 warnings
- `node cli/bin/chub build content/ --validate-only` → passes (the only warnings are pre-existing, in `ade/`)
- Entry files stay under the 500-line progressive-disclosure guideline; detail lives in `references/`.