### PR TITLE
docs: add beehiiv API v2 (community)

### DIFF
--- a/content/beehiiv/docs/api/DOC.md
+++ b/content/beehiiv/docs/api/DOC.md
@@ -1,0 +1,128 @@
+---
+name: api
+description: "beehiiv newsletter platform REST API v2 — subscriptions, tags, custom fields, automations, posts, publications"
+metadata:
+  languages: "javascript"
+  versions: "2.0.0"
+  revision: 1
+  updated-on: "2026-07-19"
+  source: community
+  tags: "beehiiv,newsletter,email,subscriptions,api,rest"
+---
+# beehiiv API v2
+
+REST API for the beehiiv newsletter platform. Manage subscriptions, tags, custom fields, automations, and posts programmatically. There is no official SDK — call the REST API directly.
+
+Base URL: `https://api.beehiiv.com/v2`
+
+## Authentication
+
+Bearer token in the `Authorization` header. Create API keys in the beehiiv dashboard under Settings → API. Nearly every endpoint is scoped to a publication via a path parameter — the publication ID is prefixed `pub_` (find it in the dashboard or via `GET /publications`).
+
+```javascript
+const BEEHIIV_API = "https://api.beehiiv.com/v2";
+const headers = {
+  Authorization: `Bearer ${process.env.BEEHIIV_API_KEY}`,
+  "Content-Type": "application/json",
+};
+```
+
+OAuth2 (authorization-code flow) is also available for multi-account integrations; endpoints then enforce per-scope permissions like `subscriptions:write` and `posts:read`. For single-publication automation, a plain API key is the common path.
+
+## Create a subscription (the most common call)
+
+`POST /publications/{publicationId}/subscriptions`
+
+```javascript
+const res = await fetch(`${BEEHIIV_API}/publications/pub_00000000-0000-0000-0000-000000000000/subscriptions`, {
+  method: "POST",
+  headers,
+  body: JSON.stringify({
+    email: "reader@example.com",
+    reactivate_existing: true,      // re-subscribe a previously unsubscribed email (only if knowingly resubscribing)
+    send_welcome_email: false,      // default false — set true to trigger the welcome email
+    utm_source: "website",
+    utm_medium: "signup-form",
+    utm_campaign: "spring-launch",
+    referring_site: "https://example.com",
+    custom_fields: [{ name: "Plan", value: "free" }],
+  }),
+});
+const { data } = await res.json();  // data.id is the subscription ID (sub_...)
+```
+
+Key behaviors:
+
+- **Creating a subscription for an email that already exists is not an error** — the existing subscription is returned. Safe to call idempotently from signup forms.
+- **`custom_fields` must already exist on the publication.** Unknown field names are silently discarded, not created. Create them first via `POST /publications/{publicationId}/custom_fields` or in the dashboard.
+- **`double_opt_override`** (`"on"` | `"off"` | `"not_set"`) overrides the publication's double-opt-in default for this one subscription.
+- **`automation_ids`** enrolls the subscriber into automations on creation — but only automations that have an active *Add by API* trigger. Without that trigger, enrollment silently does nothing.
+- Premium/paid assignment: `tier`, `premium_tiers` (names), `premium_tier_ids`, and `stripe_customer_id` link the subscription to paid tiers.
+
+Response is `{ "data": { ...subscription } }` — the object is wrapped in `data`, as with all v2 endpoints.
+
+## Tag a subscription
+
+`POST /publications/{publicationId}/subscriptions/{subscriptionId}/tags`
+
+```javascript
+await fetch(`${BEEHIIV_API}/publications/${pubId}/subscriptions/${subId}/tags`, {
+  method: "POST",
+  headers,
+  body: JSON.stringify({ tags: ["customer", "beta"] }),
+});
+```
+
+Tags that don't exist on the publication are **created automatically** (opposite behavior from custom fields). Tags accumulate on the subscriber profile; re-applying the same tag set is harmless, so tag application is safe to retry.
+
+## Look up subscriptions
+
+- `GET /publications/{publicationId}/subscriptions/by_email/{email}` — fetch by email.
+- `GET /publications/{publicationId}/subscriptions/{subscriptionId}` — fetch by `sub_` ID.
+- `GET /publications/{publicationId}/subscriptions` — list, with filters and pagination.
+
+Add `expand[]=custom_fields` (and other expand values) to include nested data that is omitted by default.
+
+## Pagination
+
+Two schemes exist; **cursor-based is current, offset-based (`page`/`per_page`) is deprecated** — don't write new code against offsets.
+
+```
+GET /publications/{pubId}/subscriptions?limit=100
+GET /publications/{pubId}/subscriptions?limit=100&cursor={next_cursor}
+```
+
+- `limit`: 1–100, default 10.
+- Response envelope: `{ "data": [...], "pagination": { "limit", "has_more", "next_cursor" } }`.
+- Loop while `has_more` is true, passing `next_cursor` back as `cursor`.
+
+## Rate limiting
+
+**180 requests per minute per organization.** Exceeding it returns `429`. Every response carries `RateLimit-Limit`, `RateLimit-Remaining`, and `RateLimit-Reset` (epoch seconds) headers — throttle proactively (~3 req/s sustained) and use exponential backoff on 429s. Bulk endpoints (`POST /publications/{pubId}/subscriptions/bulk`, bulk status updates) exist for large imports; prefer them over looping single creates.
+
+## Posts
+
+- `GET /publications/{publicationId}/posts` — list posts (filter by `status`, `audience`, etc.).
+- `GET /publications/{publicationId}/posts/{postId}` — single post; `expand[]=stats` for performance data, `expand[]=free_web_content` / `premium_web_content` for rendered HTML.
+- `GET /publications/{publicationId}/posts/aggregate_stats` — aggregate stats across posts.
+- **`POST /publications/{publicationId}/posts` (Create post) exists but is beta and Enterprise-plan only.** On standard plans, posts cannot be created or published via the REST API — draft creation is available through beehiiv's hosted MCP server (paid plans), and publishing/scheduling always happens in the beehiiv app.
+
+See [references/posts.md](references/posts.md) for the Create Post endpoint's content model (blocks vs raw HTML) and its HTML sanitization rules.
+
+## Webhooks
+
+Configure per-publication webhooks in the dashboard or via `POST /publications/{publicationId}/webhooks`. Event types cover subscription lifecycle (`subscription.created`, `.confirmed`, `.deleted`, `.upgraded`, `.downgraded`, `.paused`, `.resumed`, tier events), post lifecycle (`post.sent`, `post.updated`, `post.scheduled`), newsletter-list subscription events, and `survey.response_submitted`.
+
+## Error handling
+
+Standard HTTP status codes: `400` (validation), `401` (bad/missing key), `404` (wrong publication/resource ID — also returned when the API key doesn't own the publication), `429` (rate limit), `500`. Error bodies are JSON. Treat newsletter side-effects as best-effort in critical flows (e.g., a checkout webhook that also subscribes the buyer): log and continue on beehiiv errors rather than failing the parent operation.
+
+## Gotchas summary
+
+1. `custom_fields` on subscription-create must pre-exist; unknown names are silently dropped. Tags, by contrast, auto-create.
+2. All responses wrap payloads in `data`; lists add a `pagination` object.
+3. Offset pagination is deprecated — use `cursor`/`limit`/`has_more`.
+4. `automation_ids` enrollment requires the automation to have an active *Add by API* trigger.
+5. Post creation via REST is Enterprise-beta only; standard plans read posts but cannot create or publish them via API.
+6. `send_welcome_email` defaults to false — forgetting it means silent no-welcome, setting it in transactional contexts means double-messaging if you have another onboarding automation.
+7. Rate limit is per-organization (180/min), not per-key — parallel jobs share the same budget.

--- a/content/beehiiv/docs/api/references/posts.md
+++ b/content/beehiiv/docs/api/references/posts.md
@@ -1,0 +1,34 @@
+# beehiiv Create Post endpoint (beta, Enterprise-only)
+
+`POST https://api.beehiiv.com/v2/publications/{publicationId}/posts`
+
+Beta: the API is subject to change and is available only to Enterprise-plan organizations. On other plans this endpoint is unavailable — post drafts can be created through beehiiv's hosted MCP server (paid plans), and publishing/scheduling is always a manual action in the beehiiv app.
+
+## Content methods
+
+Provide exactly one of `blocks` or `body_content` (not both):
+
+1. **`blocks`** — structured content blocks (paragraph, heading, image, button, table, html, …). Each block has a `type` plus type-specific properties. Supports visual settings, visibility settings, and dynamic content targeting.
+2. **`body_content`** — one raw HTML string; internally wrapped in an `htmlSnippet` block. Useful for pre-built HTML or platform migrations.
+3. **Hybrid** — `type: "html"` blocks inside the `blocks` array mix raw HTML snippets with structured blocks.
+
+## HTML sanitization rules
+
+All HTML passes through a sanitization pipeline before rendering:
+
+- `<style>` tags are **removed** — embedded stylesheets never survive.
+- `<link>` tags are **removed** — no external stylesheets.
+- **Inline `style` attributes are preserved** — the only reliable styling mechanism.
+- CSS classes are kept in markup but have no effect (no stylesheet is loaded for them).
+- Content renders inside beehiiv's email table wrapper, which imposes its own layout and spacing.
+
+Practical rule: style every element inline; assume your HTML is a fragment inside beehiiv's template, not a full document.
+
+## Related endpoints
+
+- `POST /publications/{publicationId}/posts/{postId}/test_send` — send a test email of a post.
+- `GET /publications/{publicationId}/posts/{postId}/preview` — generate a shareable preview URL.
+- `GET /publications/{publicationId}/post_templates` — list post templates.
+- `PATCH`/`DELETE` on `/posts/{postId}` — update or delete (same Enterprise-beta gate as create).
+
+Full walkthrough: beehiiv's "Using the Send API and Create Post Endpoint" support article.


### PR DESCRIPTION
Adds a community doc for the beehiiv newsletter platform REST API v2 (`beehiiv/api`).

**Coverage:** Bearer auth + publication scoping, create subscription (idempotency, custom-field pre-existence requirement, double-opt override, automation enrollment caveat), subscription tagging (auto-create behavior), lookups by email/ID, cursor pagination (offset deprecated), per-org rate limits (180/min + RateLimit-* headers), webhook event types, and error conventions. A companion reference covers the Enterprise-beta Create Post endpoint: blocks vs body_content, and the HTML sanitization rules (style/link stripped, inline styles only).

**Why:** beehiiv has no official SDK and wasn't in the registry; examples are plain `fetch`. Content is distilled from developers.beehiiv.com (verified 2026-07-19) plus gotchas hit in production integration work.

Validated with `node cli/bin/chub build content/ --validate-only` (passes; the two warnings are pre-existing skills missing `metadata.source`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)