### PR TITLE
content: add SERPdive SDK docs and best-practices skill

### DIFF
--- a/content/serpdive/docs/sdk/javascript/DOC.md
+++ b/content/serpdive/docs/sdk/javascript/DOC.md
@@ -57,7 +57,7 @@ for (const result of response.results) {
 
 | Option | Type | Description |
 |---|---|---|
-| `model` | `"mako"` \| `"moby"` | Retrieval depth. `mako` (default) returns the fact-carrying sentences of each source. `moby` returns the full readable content of every page. Unknown values fall back to `mako`. |
+| `model` | `"krill"` \| `"mako"` \| `"moby"` | Retrieval depth. `mako` (default) returns the fact-carrying sentences of each source. `moby` returns the full readable content of every page. `krill` is the free tier: unlimited under fair use, the smallest useful payload, one request at a time, at low priority, with no written answer. Unknown values fall back to `mako`. |
 | `answer` | `boolean` | Opt-in written answer built from the sources: concise on Mako, detailed with `[n]` citations on Moby. Included in the price, never extra credits; adds a few hundred milliseconds. |
 | `maxResults` | `number`, 1-10 | Hard cap on delivered results, keeping the best-ranked ones. Trims the response and the downstream token bill, but does not speed up the search: the engine always does its full read. Omit it to get everything considered relevant. Sent as `max_results`. |
 
@@ -72,7 +72,7 @@ Japanese web, wherever the caller is. There is no country option.
 
 ```ts
 response.query            // your query, echoed untouched
-response.model            // "mako" or "moby"
+response.model            // "krill", "mako" or "moby"
 response.response_time_ms // wall-clock time in milliseconds
 response.answer           // only when answer: true, may be null
 response.results          // SearchResult[], best first
@@ -142,7 +142,7 @@ export const webSearch = tool({
 
 ## Credits
 
-One Mako search costs 1 credit, one Moby search 1.5. Pay as you go is $5 per
+One Mako search costs 1 credit, one Moby search 1.5, and a Krill search costs nothing — it is free and unlimited under fair use. Pay as you go is $5 per
 1,000 credits at the launch rate. The 1,000 monthly free credits require no
 card.
 

--- a/content/serpdive/docs/sdk/javascript/DOC.md
+++ b/content/serpdive/docs/sdk/javascript/DOC.md
@@ -1,0 +1,154 @@
+---
+name: sdk
+description: "Web search API for AI agents that returns extracted, answer-ready page content instead of links"
+metadata:
+  languages: "javascript,typescript"
+  versions: "0.1.0"
+  revision: 1
+  updated-on: "2026-07-21"
+  source: maintainer
+  tags: "serpdive,search,web-search,ai,agents,rag,llm,mcp,tavily-alternative"
+---
+# SERPdive TypeScript SDK
+
+Web search built for AI agents. You send a question, the API returns the
+sentences that answer it, already extracted from the live pages, sized for a
+context window. There is no list of links to fetch and no scraping loop to
+maintain.
+
+On a public 1,000-question benchmark judged blind by an independent model,
+SERPdive wins 60.7% of decided duels against Tavily's default search while
+returning 20.2% fewer tokens (1,001 vs 1,255 on average), at comparable
+latency. The harness, prompts and per-question results are public and the run
+can be replayed: https://github.com/edendalexis/serpdive-benchmark
+
+## Install
+
+```bash
+npm install serpdive
+```
+
+Zero runtime dependencies, ESM and CJS, types included.
+
+## Authentication
+
+Create a key at https://serpdive.com/dashboard/keys. Every account gets 1,000
+free credits per month, no card required. The SDK reads `SERPDIVE_API_KEY`
+from the environment when no key is passed.
+
+## Quickstart
+
+```ts
+import { SerpDive } from "serpdive";
+
+const client = new SerpDive(); // or new SerpDive({ apiKey: "sd_live_..." })
+
+const response = await client.search("what changed in the EU AI Act this month");
+
+for (const result of response.results) {
+  console.log(result.title, result.url);
+  console.log(result.content); // extracted page content, not a snippet
+}
+```
+
+## Parameters
+
+`search(query, options?)`
+
+| Option | Type | Description |
+|---|---|---|
+| `model` | `"mako"` \| `"moby"` | Retrieval depth. `mako` (default) returns the fact-carrying sentences of each source. `moby` returns the full readable content of every page. Unknown values fall back to `mako`. |
+| `answer` | `boolean` | Opt-in written answer built from the sources: concise on Mako, detailed with `[n]` citations on Moby. Included in the price, never extra credits; adds a few hundred milliseconds. |
+| `maxResults` | `number`, 1-10 | Hard cap on delivered results, keeping the best-ranked ones. Trims the response and the downstream token bill, but does not speed up the search: the engine always does its full read. Omit it to get everything considered relevant. Sent as `max_results`. |
+
+The query is capped at 300 characters; longer queries are truncated, not
+rejected.
+
+**Localization is automatic.** The query's language decides where the search
+runs: a German query searches the German-language web, a Japanese one the
+Japanese web, wherever the caller is. There is no country option.
+
+## Response
+
+```ts
+response.query            // your query, echoed untouched
+response.model            // "mako" or "moby"
+response.response_time_ms // wall-clock time in milliseconds
+response.answer           // only when answer: true, may be null
+response.results          // SearchResult[], best first
+```
+
+Response fields keep the API's own names verbatim (snake_case). Each
+`SearchResult` has `url`, `title`, `content` (the extraction) and `date` when a
+publication date is known, always ISO `YYYY-MM-DD`.
+
+Results are real page extractions only: a source that could not be read is
+simply absent, with no snippet padding and no placeholders. Tracking
+parameters are stripped from URLs, so what you cite is clean.
+
+## Timeouts
+
+Mako answers in a few seconds. Moby reads whole pages and can take
+substantially longer on heavy sources. Use a generous client timeout; 80
+seconds is what the official playground uses.
+
+```ts
+const client = new SerpDive({ timeoutMs: 80_000 });
+```
+
+## Errors
+
+Every failure throws a typed error carrying a stable machine-readable code.
+
+```ts
+import {
+  SerpDive,
+  AuthenticationError,
+  InvalidRequestError,
+  RateLimitError,
+  QuotaExceededError,
+  ServerError,
+} from "serpdive";
+
+try {
+  const response = await client.search("...");
+} catch (err) {
+  if (err instanceof RateLimitError) {
+    // back off and retry
+  }
+}
+```
+
+A failed search is never billed.
+
+## Vercel AI SDK
+
+```ts
+import { tool } from "ai";
+import { z } from "zod";
+import { SerpDive } from "serpdive";
+
+const client = new SerpDive();
+
+export const webSearch = tool({
+  description: "Search the live web and return extracted, answer-ready content.",
+  inputSchema: z.object({ query: z.string() }),
+  execute: async ({ query }) => {
+    const { results } = await client.search(query, { maxResults: 5 });
+    return results.map((r) => ({ url: r.url, title: r.title, content: r.content }));
+  },
+});
+```
+
+## Credits
+
+One Mako search costs 1 credit, one Moby search 1.5. Pay as you go is $5 per
+1,000 credits at the launch rate. The 1,000 monthly free credits require no
+card.
+
+## Related
+
+- API reference: https://serpdive.com/docs
+- Agent-readable docs: https://serpdive.com/llms.txt
+- Hosted MCP server: https://mcp.serpdive.com
+- Benchmark: https://github.com/edendalexis/serpdive-benchmark

--- a/content/serpdive/docs/sdk/python/DOC.md
+++ b/content/serpdive/docs/sdk/python/DOC.md
@@ -1,0 +1,149 @@
+---
+name: sdk
+description: "Web search API for AI agents that returns extracted, answer-ready page content instead of links"
+metadata:
+  languages: "python"
+  versions: "0.1.1"
+  revision: 1
+  updated-on: "2026-07-21"
+  source: maintainer
+  tags: "serpdive,search,web-search,ai,agents,rag,llm,mcp,tavily-alternative"
+---
+# SERPdive Python SDK
+
+Web search built for AI agents. You send a question, the API returns the
+sentences that answer it, already extracted from the live pages, sized for a
+context window. There is no list of links to fetch and no scraping loop to
+maintain.
+
+On a public 1,000-question benchmark judged blind by an independent model,
+SERPdive wins 60.7% of decided duels against Tavily's default search while
+returning 20.2% fewer tokens (1,001 vs 1,255 on average), at comparable
+latency. The harness, prompts and per-question results are public and the run
+can be replayed: https://github.com/edendalexis/serpdive-benchmark
+
+## Install
+
+```bash
+pip install serpdive
+```
+
+## Authentication
+
+Create a key at https://serpdive.com/dashboard/keys. Every account gets 1,000
+free credits per month, no card required. The SDK reads `SERPDIVE_API_KEY`
+from the environment when no key is passed.
+
+```bash
+export SERPDIVE_API_KEY="sd_live_..."
+```
+
+## Quickstart
+
+```python
+from serpdive import SerpDive
+
+client = SerpDive()  # or SerpDive(api_key="sd_live_...")
+
+response = client.search("what changed in the EU AI Act this month")
+
+for result in response.results:
+    print(result.title, result.url)
+    print(result.content)  # extracted page content, not a snippet
+```
+
+## Async
+
+```python
+import asyncio
+from serpdive import AsyncSerpDive
+
+async def main():
+    async with AsyncSerpDive() as client:
+        response = await client.search("who won the 2026 Champions League final")
+        print(response.results[0].content)
+
+asyncio.run(main())
+```
+
+## Parameters
+
+`search(query, *, model=None, answer=None, max_results=None, **extra)`
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `str`, required | The question, phrased as you would ask it. Up to 300 characters; longer queries are truncated, not rejected. |
+| `model` | `"mako"` \| `"moby"` | Retrieval depth. `mako` (default) returns the fact-carrying sentences of each source. `moby` returns the full readable content of every page. Unknown values fall back to `mako`. |
+| `answer` | `bool` | Opt-in written answer built from the sources: concise on Mako, detailed with `[n]` citations on Moby. Included in the price, never extra credits; adds a few hundred milliseconds. |
+| `max_results` | `int`, 1-10 | Hard cap on delivered results, keeping the best-ranked ones. Trims the response and the downstream token bill, but does not speed up the search: the engine always does its full read. Omit it to get everything considered relevant. |
+
+**Localization is automatic.** The query's language decides where the search
+runs: a German query searches the German-language web, a Japanese one the
+Japanese web, wherever the caller is. There is no country parameter.
+
+## Response
+
+```python
+response.query             # your query, echoed untouched
+response.model             # "mako" or "moby"
+response.response_time_ms  # wall-clock time in milliseconds
+response.answer            # only when answer=True, may be None
+response.results           # list[SearchResult], best first
+```
+
+Each `SearchResult` has `url`, `title`, `content` (the extraction) and `date`
+when a publication date is known, always ISO `YYYY-MM-DD`.
+
+Results are real page extractions only: a source that could not be read is
+simply absent, with no snippet padding and no placeholders. Tracking
+parameters are stripped from URLs, so what you cite is clean.
+
+## Timeouts
+
+Mako answers in a few seconds. Moby reads whole pages and can take
+substantially longer on heavy sources. Use a generous client timeout; 80
+seconds is what the official playground uses.
+
+```python
+client = SerpDive(timeout=80.0)
+```
+
+## Errors
+
+Every failure raises a typed exception carrying a stable machine-readable
+code.
+
+```python
+from serpdive import (
+    SerpDive,
+    AuthenticationError,
+    InvalidRequestError,
+    RateLimitError,
+    QuotaExceededError,
+    ServerError,
+)
+
+try:
+    response = client.search("...")
+except RateLimitError:
+    ...   # back off and retry
+except QuotaExceededError:
+    ...   # monthly credits exhausted
+except AuthenticationError:
+    ...   # missing, expired or revoked key
+```
+
+A failed search is never billed.
+
+## Credits
+
+One Mako search costs 1 credit, one Moby search 1.5. Pay as you go is $5 per
+1,000 credits at the launch rate. The 1,000 monthly free credits require no
+card.
+
+## Related
+
+- API reference: https://serpdive.com/docs
+- Agent-readable docs: https://serpdive.com/llms.txt
+- Hosted MCP server: https://mcp.serpdive.com
+- Benchmark: https://github.com/edendalexis/serpdive-benchmark

--- a/content/serpdive/docs/sdk/python/DOC.md
+++ b/content/serpdive/docs/sdk/python/DOC.md
@@ -73,7 +73,7 @@ asyncio.run(main())
 | Parameter | Type | Description |
 |---|---|---|
 | `query` | `str`, required | The question, phrased as you would ask it. Up to 300 characters; longer queries are truncated, not rejected. |
-| `model` | `"mako"` \| `"moby"` | Retrieval depth. `mako` (default) returns the fact-carrying sentences of each source. `moby` returns the full readable content of every page. Unknown values fall back to `mako`. |
+| `model` | `"krill"` \| `"mako"` \| `"moby"` | Retrieval depth. `mako` (default) returns the fact-carrying sentences of each source. `moby` returns the full readable content of every page. `krill` is the free tier: unlimited under fair use, the smallest useful payload, one request at a time, at low priority, with no written answer. Unknown values fall back to `mako`. |
 | `answer` | `bool` | Opt-in written answer built from the sources: concise on Mako, detailed with `[n]` citations on Moby. Included in the price, never extra credits; adds a few hundred milliseconds. |
 | `max_results` | `int`, 1-10 | Hard cap on delivered results, keeping the best-ranked ones. Trims the response and the downstream token bill, but does not speed up the search: the engine always does its full read. Omit it to get everything considered relevant. |
 
@@ -85,7 +85,7 @@ Japanese web, wherever the caller is. There is no country parameter.
 
 ```python
 response.query             # your query, echoed untouched
-response.model             # "mako" or "moby"
+response.model             # "krill", "mako" or "moby"
 response.response_time_ms  # wall-clock time in milliseconds
 response.answer            # only when answer=True, may be None
 response.results           # list[SearchResult], best first
@@ -137,7 +137,7 @@ A failed search is never billed.
 
 ## Credits
 
-One Mako search costs 1 credit, one Moby search 1.5. Pay as you go is $5 per
+One Mako search costs 1 credit, one Moby search 1.5, and a Krill search costs nothing — it is free and unlimited under fair use. Pay as you go is $5 per
 1,000 credits at the launch rate. The 1,000 monthly free credits require no
 card.
 

--- a/content/serpdive/skills/serpdive-best-practices/SKILL.md
+++ b/content/serpdive/skills/serpdive-best-practices/SKILL.md
@@ -53,7 +53,8 @@ and 5. Omit `max_results` when recall matters more than context size.
 ## The written answer
 
 `answer: true` adds a prose answer built from the sources: concise on mako,
-detailed with `[n]` citations on moby. It is included in the price, never
+detailed with `[n]` citations on moby, and unavailable on krill, which returns
+sources only. It is included in the price, never
 extra credits, and adds a few hundred milliseconds.
 
 Use it when the agent will surface an answer to a human. Skip it when the

--- a/content/serpdive/skills/serpdive-best-practices/SKILL.md
+++ b/content/serpdive/skills/serpdive-best-practices/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: serpdive-best-practices
+description: "Give an agent live web knowledge with SERPdive: pick between the mako and moby models, keep context small, wire it through REST, the SDKs or the hosted MCP server, and handle errors and credits correctly"
+metadata:
+  revision: 1
+  updated-on: "2026-07-21"
+  source: maintainer
+  tags: "serpdive,search,web-search,ai,agents,rag,llm,mcp,context,tokens"
+---
+
+# SERPdive
+
+SERPdive is a web search API for AI agents. It takes a question and returns
+the sentences that answer it, already extracted from the live pages it read,
+sized for a context window. It does not return a ranked list of links for the
+agent to go fetch.
+
+That difference is the whole design: the expensive part of "search the web" in
+an agent loop is not the search, it is choosing URLs, fetching them, stripping
+boilerplate and truncating to fit. SERPdive does that server side and bills it
+as one call.
+
+## When to reach for it
+
+Use SERPdive when the agent needs facts from the current web: prices,
+releases, filings, documentation, news, anything that postdates the model.
+
+Do not use it to fetch one URL the agent already knows; that is a scraper's
+job. It is also not a SERP API: it returns no rank positions, no ads and no
+shopping boxes, so SEO tooling needs a different product.
+
+## Two models, and how to choose
+
+| Model | What it returns | Credits | Use it when |
+|---|---|---|---|
+| `mako` (default) | The fact-carrying sentences of each source | 1 | Almost always. Fast, and the smallest context footprint. |
+| `moby` | The full readable content of every page | 1.5 | The answer depends on document structure: long analyses, deep research, reading a spec end to end. |
+
+Start with `mako`. Move a query to `moby` only when you can name what mako's
+sentences are missing. Moby is slower and multiplies the tokens the model then
+has to read, which is usually the real cost.
+
+## Keeping context small
+
+`max_results` (1-10) caps how many sources come back, keeping the best-ranked
+ones. It trims the response and the downstream token bill, but it does not
+speed up the search: the engine always does its full read either way.
+
+A practical default for an agent loop is `mako` with `max_results` between 3
+and 5. Omit `max_results` when recall matters more than context size.
+
+## The written answer
+
+`answer: true` adds a prose answer built from the sources: concise on mako,
+detailed with `[n]` citations on moby. It is included in the price, never
+extra credits, and adds a few hundred milliseconds.
+
+Use it when the agent will surface an answer to a human. Skip it when the
+agent does its own reasoning over the sources, since paying for prose the
+model then rewrites is waste.
+
+## Localization is automatic
+
+The query's language decides where the search runs. A German query searches
+the German-language web, a Japanese one the Japanese web, wherever the caller
+is. There is no country parameter to set, so do not translate the user's query
+into English before searching: doing so changes which web gets searched.
+
+## Wiring it up
+
+Four surfaces, same engine. Pick by where the agent lives.
+
+- **REST**: `POST https://api.serpdive.com/v1/search`, `Authorization: Bearer sd_live_...`
+- **SDKs**: `pip install serpdive`, `npm install serpdive`
+- **Frameworks**: `langchain-serpdive`, `llama-index-tools-serpdive`
+- **MCP**: hosted at `https://mcp.serpdive.com`, or `npx serpdive-mcp` for stdio-only clients
+
+Full snippets are in [references/integrations.md](references/integrations.md).
+
+## Errors and credits
+
+Every failure returns a stable machine-readable code, and a failed search is
+never billed. Retry on `rate_limit` with backoff; stop and surface the problem
+on `invalid_api_key` and `quota_exceeded`, because retrying those never helps.
+
+One mako search costs 1 credit, one moby search 1.5. Every account gets 1,000
+free credits per month with no card, so an agent doing about 30 searches a day
+stays inside the free tier indefinitely.
+
+See [references/errors.md](references/errors.md) for the full list.
+
+## Why it is worth measuring
+
+Search API output is LLM input: every token it returns is billed again by the
+model on every turn that reads it. On a public 1,000-question benchmark judged
+blind by an independent model, SERPdive won 60.7% of decided duels against
+Tavily's default search while returning 20.2% fewer tokens (1,001 vs 1,255 on
+average), at comparable latency.
+
+The harness, prompts, raw payloads and per-question verdicts are public, so
+the run can be replayed with your own keys and your own judge:
+https://github.com/edendalexis/serpdive-benchmark
+
+Scope note, because an honest benchmark states its limits: the comparison is
+against Tavily's default (basic) search, the tier in the same price class.
+Tavily's advanced mode was not tested and no claim is made about it.

--- a/content/serpdive/skills/serpdive-best-practices/SKILL.md
+++ b/content/serpdive/skills/serpdive-best-practices/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: serpdive-best-practices
-description: "Give an agent live web knowledge with SERPdive: pick between the mako and moby models, keep context small, wire it through REST, the SDKs or the hosted MCP server, and handle errors and credits correctly"
+description: "Give an agent live web knowledge with SERPdive: pick between the krill, mako and moby models, keep context small, wire it through REST, the SDKs or the hosted MCP server, and handle errors and credits correctly"
 metadata:
   revision: 1
   updated-on: "2026-07-21"
@@ -34,6 +34,7 @@ shopping boxes, so SEO tooling needs a different product.
 | Model | What it returns | Credits | Use it when |
 |---|---|---|---|
 | `mako` (default) | The fact-carrying sentences of each source | 1 | Almost always. Fast, and the smallest context footprint. |
+| `krill` | The same, on a tighter budget — fewer sources, no written answer | **free** | Token budget matters more than depth, or you are building and do not want to spend. Unlimited under fair use, one request at a time, low priority. |
 | `moby` | The full readable content of every page | 1.5 | The answer depends on document structure: long analyses, deep research, reading a spec end to end. |
 
 Start with `mako`. Move a query to `moby` only when you can name what mako's
@@ -83,7 +84,7 @@ Every failure returns a stable machine-readable code, and a failed search is
 never billed. Retry on `rate_limit` with backoff; stop and surface the problem
 on `invalid_api_key` and `quota_exceeded`, because retrying those never helps.
 
-One mako search costs 1 credit, one moby search 1.5. Every account gets 1,000
+One mako search costs 1 credit, one moby search 1.5, and a krill search costs nothing — it is free and unlimited under fair use. Every account gets 1,000
 free credits per month with no card, so an agent doing about 30 searches a day
 stays inside the free tier indefinitely.
 

--- a/content/serpdive/skills/serpdive-best-practices/references/errors.md
+++ b/content/serpdive/skills/serpdive-best-practices/references/errors.md
@@ -41,6 +41,7 @@ usually better than hand-rolling it.
 
 | Model | Credits per search |
 |---|---|
+| `krill` | 0 — free, unlimited under fair use |
 | `mako` | 1 |
 | `moby` | 1.5 |
 

--- a/content/serpdive/skills/serpdive-best-practices/references/errors.md
+++ b/content/serpdive/skills/serpdive-best-practices/references/errors.md
@@ -1,0 +1,60 @@
+# SERPdive errors and credits
+
+Every failure returns JSON with two fields: `error`, a stable machine-readable
+code, and `message`, a human sentence that says what to do about it. A failed
+search is never billed.
+
+```json
+{
+  "error": "invalid_api_key",
+  "message": "..."
+}
+```
+
+## Codes
+
+| Status | Code | Meaning | Agent should |
+|---|---|---|---|
+| 400 | `invalid_json` | The body is not valid JSON | Fix the request, do not retry |
+| 400 | `missing_query` | No `query` in the body | Fix the request, do not retry |
+| 401 | `missing_api_key` / `invalid_api_key` | No usable key in the `Authorization` header | Stop and surface it; retrying never helps |
+| 429 | `rate_limit_exceeded` | Over 5 requests per second or 200 per minute | Honor `retry-after`, back off, retry |
+| 429 | `monthly_quota_exceeded` | Monthly credits used up, or the pay-as-you-go spend limit set in Billing was reached. Resets when the monthly cycle renews | Stop; surface to the human |
+| 429 | `key_limit_exceeded` | This key hit the monthly credit limit it was created with. Other keys keep working | Stop, or fall back to another key |
+| 502 | `search_failed` | The search could not complete | Safe to retry |
+| 503 | `server_busy` | Momentarily at full capacity, carries `retry-after` | Wait the advertised delay, retry |
+
+## Retry policy that works
+
+Retry only `rate_limit_exceeded`, `search_failed` and `server_busy`. Honor the
+`retry-after` header when present, otherwise use exponential backoff with
+jitter and a small cap, for example three attempts.
+
+Never retry `invalid_api_key`, `missing_query`, `invalid_json`,
+`monthly_quota_exceeded` or `key_limit_exceeded`: the outcome cannot change,
+and retrying only burns wall-clock time in the agent loop.
+
+Both official SDKs already implement this policy, so calling them directly is
+usually better than hand-rolling it.
+
+## Credits
+
+| Model | Credits per search |
+|---|---|
+| `mako` | 1 |
+| `moby` | 1.5 |
+
+The written answer (`answer: true`) is included in the price and never costs
+extra credits.
+
+Every account gets 1,000 free credits per month with no card. Pay as you go is
+$5 per 1,000 credits at the launch rate. An agent doing roughly 30 searches a
+day stays inside the free tier indefinitely.
+
+## Timeouts
+
+Mako answers in a few seconds. Moby reads whole pages and can take
+substantially longer on heavy sources. Set a generous client timeout; 80
+seconds is what the official playground uses. A timeout set too low is the
+most common cause of a "failed" moby search that actually succeeded server
+side.

--- a/content/serpdive/skills/serpdive-best-practices/references/integrations.md
+++ b/content/serpdive/skills/serpdive-best-practices/references/integrations.md
@@ -74,7 +74,7 @@ pip install llama-index-tools-serpdive
 ```
 
 ```python
-from llama_index.tools.serpdive import SerpdiveToolSpec
+from llama_index_tools_serpdive import SerpdiveToolSpec
 
 tools = SerpdiveToolSpec().to_tool_list()
 ```

--- a/content/serpdive/skills/serpdive-best-practices/references/integrations.md
+++ b/content/serpdive/skills/serpdive-best-practices/references/integrations.md
@@ -1,0 +1,150 @@
+# Wiring SERPdive into an agent
+
+Same engine behind every surface. Pick by where the agent already lives.
+
+## REST
+
+```bash
+curl -X POST https://api.serpdive.com/v1/search \
+  -H "Authorization: Bearer sd_live_YOUR_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "what changed in the EU AI Act this month", "max_results": 5}'
+```
+
+## Python
+
+```bash
+pip install serpdive
+```
+
+```python
+from serpdive import SerpDive
+
+client = SerpDive()  # reads SERPDIVE_API_KEY
+
+response = client.search("q3 2026 nvidia datacenter revenue", max_results=5)
+for r in response.results:
+    print(r.title, r.url)
+    print(r.content)
+```
+
+Async, for agent loops that fan out:
+
+```python
+import asyncio
+from serpdive import AsyncSerpDive
+
+async def research(questions: list[str]):
+    async with AsyncSerpDive() as client:
+        return await asyncio.gather(*(client.search(q, max_results=3) for q in questions))
+```
+
+## TypeScript
+
+```bash
+npm install serpdive
+```
+
+```ts
+import { SerpDive } from "serpdive";
+
+const client = new SerpDive();
+const { results } = await client.search("latest postgres 18 release notes", {
+  maxResults: 5,
+});
+```
+
+## LangChain
+
+```bash
+pip install langchain-serpdive
+```
+
+```python
+from langchain_serpdive import SerpdiveSearch
+
+tool = SerpdiveSearch(max_results=5)
+agent = create_react_agent(model, [tool])
+```
+
+## LlamaIndex
+
+```bash
+pip install llama-index-tools-serpdive
+```
+
+```python
+from llama_index.tools.serpdive import SerpdiveToolSpec
+
+tools = SerpdiveToolSpec().to_tool_list()
+```
+
+The tool spec returns `Document` objects, so results drop straight into an
+index or a query engine.
+
+## Vercel AI SDK
+
+```ts
+import { tool } from "ai";
+import { z } from "zod";
+import { SerpDive } from "serpdive";
+
+const client = new SerpDive();
+
+export const webSearch = tool({
+  description: "Search the live web and return extracted, answer-ready content.",
+  inputSchema: z.object({ query: z.string() }),
+  execute: async ({ query }) => {
+    const { results } = await client.search(query, { maxResults: 5 });
+    return results.map((r) => ({ url: r.url, title: r.title, content: r.content }));
+  },
+});
+```
+
+## MCP
+
+Hosted, nothing to install. Works with Claude Code, Claude Desktop, Cursor and
+any MCP client.
+
+```bash
+claude mcp add --transport http serpdive https://mcp.serpdive.com \
+  --header "Authorization: Bearer sd_live_YOUR_KEY"
+```
+
+For clients that only accept a URL:
+
+```json
+{
+  "mcpServers": {
+    "serpdive": {
+      "url": "https://mcp.serpdive.com/?key=sd_live_YOUR_KEY"
+    }
+  }
+}
+```
+
+For stdio-only clients, the same tool runs locally:
+
+```json
+{
+  "mcpServers": {
+    "serpdive": {
+      "command": "npx",
+      "args": ["-y", "serpdive-mcp"],
+      "env": { "SERPDIVE_API_KEY": "sd_live_YOUR_KEY" }
+    }
+  }
+}
+```
+
+The server exposes one tool, `serpdive_search`, with the same parameters as
+the API. Searches through MCP are billed exactly like API calls: same credits,
+same rate limits.
+
+## Agent-readable docs
+
+For agents that prefer to read the contract themselves:
+
+- https://serpdive.com/llms.txt
+- https://serpdive.com/docs.md
+- https://serpdive.com/openapi.json


### PR DESCRIPTION
## What

A `content/serpdive/` entry, laid out like the existing `content/tavily/` one:

- `docs/sdk/python` and `docs/sdk/javascript` — install, auth, parameters,
  response shape, timeouts and typed errors for both official SDKs
- `skills/serpdive-best-practices` — when to reach for it **and when not to**,
  how to choose between the two retrieval models, how to keep the context
  small, and how to wire it through REST, the SDKs, LangChain, LlamaIndex, the
  Vercel AI SDK or the hosted MCP server
- two `references/` files so the entry points stay short, per the progressive
  disclosure guideline

## Why

A web search API for AI agents. It takes a question and returns the sentences
that answer it, already extracted from the live pages it read and sized for a
context window, instead of a ranked list of links. The point is to remove the
fetch, strip and truncate loop that otherwise sits between a search call and
the model.

Relevant to a context hub specifically: search output *is* model input, so
what a search tool returns per call is a recurring context cost on every turn
that re-reads it. On a public 1,000-question benchmark judged blind by an
independent model, SERPdive won **60.7% of decided duels against Tavily's
default search** while returning **20.2% fewer tokens** (1,001 vs 1,255 on
average), at comparable latency. Harness, prompts, raw payloads and
per-question verdicts are public and the run is replayable:
https://github.com/edendalexis/serpdive-benchmark

Scope note, since an honest benchmark states its limits: that comparison is
against Tavily's default (basic) search, the tier in the same price class.
Tavily's advanced mode was not tested and no claim is made about it.

The skill also says plainly what SERPdive is *not*: it is not a scraper for a
known URL, and it is not a SERP API, so it returns no rank positions or ads.
Agents pick better tools when the docs mark the boundaries.

## Testing

- [ ] `npm test` passes — not run: this PR adds content only, no code paths touched. Happy to run it if you want it on the record.
- [x] `chub build sample-content/ --validate-only` succeeds — run against the new entry and the full tree, output below
- [x] Manual testing done (described below)

```
$ node cli/bin/chub build content/serpdive --validate-only
Valid: 1 docs, 1 skills, 0 warnings
```

Full tree still validates: `Valid: 1598 docs, 10 skills, 2 warnings`, the two
warnings being pre-existing ones under `skills/ade/`.

`metadata.source` is set to `maintainer`: I maintain SERPdive. Happy to change
anything about the structure, tone or depth.

Every snippet was checked against the published SDKs rather than written from memory — including one real fix: the LlamaIndex integration is a flat import (`llama_index_tools_serpdive`), not the `llama_index.tools.*` namespace, verified against a clean `pip install`.

A key is created at https://serpdive.com/dashboard/keys and the free tier needs no card.

---

Disclosure: I built SERPdive. If a vendor-authored entry is not something you want to carry, feel free to close — no hard feelings.

