### PR TITLE
fix(cli): write multi-file `get -o` output instead of an empty file

### DIFF
--- a/cli/src/commands/get.js
+++ b/cli/src/commands/get.js
@@ -144,7 +144,11 @@ async function fetchEntries(ids, opts, globalOpts) {
       } else {
         const outPath = isDir ? join(opts.output, `${results[0].id}.md`) : opts.output;
         mkdirSync(dirname(outPath), { recursive: true });
-        const combined = results.map((r) => r.content).join('\n\n---\n\n');
+        // Multi-file results carry `files`, not `content`; expand them the same
+        // way the stdout path does so `-o` doesn't write an empty file.
+        const combined = results
+          .flatMap((r) => (r.files ? r.files.map((f) => `# FILE: ${f.name}\n\n${f.content}`) : [r.content]))
+          .join('\n\n---\n\n');
         writeFileSync(outPath, combined);
         info(`Written to ${outPath}`);
       }


### PR DESCRIPTION
## What

`chub get <id> --file a,b -o <path>` (multiple comma-separated files written to a file) writes a **0-byte file**, silently discarding all fetched content. Single-file `--file -o` works, and multi-file to **stdout** works — only multi-file + `-o` is broken.

## Why

For multiple `--file` paths, `fetchEntries` pushes a result shaped `{ files: [...] }` (no `content`). Without `--full`, output falls to the combined-file branch in `cli/src/commands/get.js`:

```js
const combined = results.map((r) => r.content).join('\n\n---\n\n');
writeFileSync(outPath, combined);
```

`r.content` is `undefined` for a files-shaped result, so `[undefined].join(...)` is `""` and a 0-byte file is written. The stdout path already handles this correctly by expanding `r.files` into `# FILE: <name>` sections.

## Fix

Expand `files` in the `-o` combined branch exactly as the stdout path does, so `-o` writes the same content it prints to stdout:

```js
const combined = results
  .flatMap((r) => (r.files ? r.files.map((f) => `# FILE: ${f.name}\n\n${f.content}`) : [r.content]))
  .join('\n\n---\n\n');
```

`-o` keeps writing to a single file (unchanged shape); single-file / single-doc output is byte-identical.

## Testing

Manual: with a doc that has multiple reference files, `chub get <id> --file a,b -o out.md` now writes a non-empty `out.md` containing both files (matching `chub get <id> --file a,b` to stdout), instead of a 0-byte file.
