### PR TITLE
Add neuro-san Python package docs

### DIFF
--- a/content/neuro-san/docs/package/python/DOC.md
+++ b/content/neuro-san/docs/package/python/DOC.md
@@ -1,0 +1,498 @@
+---
+name: package
+description: "Neuro-SAN Python package guide for building data-driven multi-agent networks with HOCON configuration, coded tools, and multi-provider LLM support"
+metadata:
+  languages: "python"
+  versions: "0.6.92"
+  revision: 3
+  updated-on: "2026-08-12"
+  source: maintainer
+  tags: "neuro-san,agents,multi-agent,llm,langchain,langgraph,hocon,orchestration,python,mcp,langfuse,openrouter"
+---
+
+# Neuro-SAN Python Package Guide
+
+## What It Is
+
+`neuro-san` (Neuro AI System of Agent Networks) is a data-driven multi-agent orchestration framework. Agent networks are defined entirely in HOCON configuration files — no Python code required for pure LLM agent networks. Custom logic is added through CodedTool Python classes when deterministic behavior is needed.
+
+Use it when you need:
+
+- Multiple LLM-backed agents collaborating on complex problems
+- Data-driven agent configuration that non-programmers can author
+- Mixed agent types (LLM agents, coded tools, external services, MCP servers)
+- Multi-provider LLM support (OpenAI, Anthropic, Google, AWS Bedrock, NVIDIA, Azure, Ollama, OpenRouter)
+- A server that exposes agent networks via HTTP REST API and/or MCP protocol
+- Observability/tracing feeds (LangSmith, Arize Phoenix, HoneyHive, Langfuse)
+- Per-user authorization for agent networks (OpenFGA)
+
+## Installation
+
+```bash
+pip install neuro-san==0.6.92
+```
+
+Python 3.10+ is required (the quick-start scripts assume 3.12+). To work from source instead, clone https://github.com/cognizant-ai-lab/neuro-san, `pip install -r requirements.txt`, and set `PYTHONPATH` to the repo root.
+
+## LLM Setup and Authentication
+
+Set the API key for your chosen LLM provider:
+
+```bash
+# OpenAI (default provider)
+export OPENAI_API_KEY="your-key"
+
+# Anthropic
+export ANTHROPIC_API_KEY="your-key"
+
+# Google Gemini
+export GOOGLE_API_KEY="your-key"
+
+# AWS Bedrock (or use an AWS_PROFILE)
+export AWS_ACCESS_KEY_ID="your-key"
+export AWS_SECRET_ACCESS_KEY="your-secret"
+
+# OpenRouter
+export OPENROUTER_API_KEY="your-key"
+
+# Azure OpenAI
+export AZURE_OPENAI_API_KEY="your-key"
+export AZURE_OPENAI_ENDPOINT="your-endpoint"
+
+# NVIDIA
+export NVIDIA_API_KEY="your-key"
+
+# Ollama — no key required
+```
+
+The default model is `gpt-5.2`. Override per-network or per-agent via `llm_config` in HOCON files.
+
+End-users can also supply their own API keys at request time as `sly_data` (see [Client-Provided API Keys](#client-provided-api-keys)).
+
+## Quick Start
+
+Terminal 1 — start server:
+
+```bash
+python -m neuro_san.service.main_loop.server_main_loop
+```
+
+Terminal 2 — CLI client:
+
+```bash
+python -m neuro_san.client.agent_cli --http --agent hello_world
+```
+
+### Library Mode (No Server)
+
+```bash
+python -m neuro_san.client.agent_cli --agent hello_world
+```
+
+(When working from a source checkout, `./quick-start/start-server.sh` and `./quick-start/start-client.sh hello_world` wrap the same commands.)
+
+## Core Concept: Agent Networks in HOCON
+
+Agent networks are defined in `.hocon` files. HOCON is JSON with comments and syntactic sugar. Each file defines a network of agents that can call each other.
+
+Minimal two-agent network:
+
+```hocon
+{
+    "llm_config": {
+        "model_name": "gpt-5.2"
+    },
+    "tools": [
+        {
+            "name": "announcer",
+            "function": {
+                "description": "I can help make terse announcements."
+            },
+            "instructions": "You write the shortest possible announcements.",
+            "tools": ["synonymizer"]
+        },
+        {
+            "name": "synonymizer",
+            "function": {
+                "description": "Returns sequences of synonyms.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "input_string": {
+                            "type": "string",
+                            "description": "Words to find synonyms for"
+                        }
+                    },
+                    "required": ["input_string"]
+                }
+            },
+            "instructions": "You are a thesaurus. Find synonyms for each word."
+        }
+    ]
+}
+```
+
+Key rules:
+
+- The **first** agent in `tools` is the **Front Man** — the entry point that talks to clients.
+- The Front Man has no `parameters` in its `function` definition.
+- Other agents (Branch Agents) are called by name via the `tools` list.
+- Agents form a graph (trees, DAGs, or cycles are all valid).
+
+## Agent Types
+
+| Type | Defined By | Purpose |
+|------|-----------|---------|
+| **Front Man** | First in `tools`, no `parameters` | Entry point, talks to client |
+| **Branch Agent** | Has `parameters` in `function` | LLM-powered sub-agent |
+| **Coded Tool** | Has `class` key | Python implementation for deterministic logic |
+| **Toolbox Tool** | Has `toolbox` key | Pre-built LangChain or coded tool (cannot have a `tools` field) |
+| **External Agent** | Tool name starts with `/` or URL | Agent on same or remote server |
+| **MCP Server** | http(s) URL with `mcp` as a hostname label or path segment (e.g. `https://mcp.example.com`, `https://example.com/mcp/free`) | MCP protocol tools |
+
+## Using the Python API
+
+### Library Mode (in-process, no server)
+
+Create sessions through `AgentSessionFactory`. Pass `use_direct=True` so external agents are also resolved in-process (without it, external-agent references try to reach a server over HTTP and hang if none is running):
+
+```python
+from neuro_san.client.agent_session_factory import AgentSessionFactory
+
+session = AgentSessionFactory().create_session("direct", "hello_world", use_direct=True)
+
+# Get agent capabilities
+func = session.function({})
+print(func["function"]["description"])
+
+# Chat with streaming responses
+responses = session.streaming_chat({
+    "user_message": {"text": "Greet a new planet"},
+    "chat_context": {},
+    "sly_data": {}
+})
+
+for response in responses:
+    msg = response.get("response", {})
+    text = msg.get("text", "")
+    if text:
+        print(text)
+```
+
+### HTTP Client Mode
+
+Same session API against a running server — either via the factory or the session class directly:
+
+```python
+from neuro_san.session.http_service_agent_session import HttpServiceAgentSession
+
+session = HttpServiceAgentSession(agent_name="hello_world", host="localhost", port=8080)
+# ...same function() / streaming_chat() calls as above
+```
+
+### Async Version
+
+`neuro_san.session.async_http_service_agent_session.AsyncHttpServiceAgentSession` takes the same constructor arguments and exposes the same API with async/await (`async for response in session.streaming_chat(...)`).
+
+## REST API
+
+When running the server, these endpoints are available:
+
+```
+GET  /api/v1/{agent_name}/function         # Get agent description and capabilities
+POST /api/v1/{agent_name}/streaming_chat    # Chat with an agent
+GET  /api/v1/list                           # List all available agents
+GET  /healthz                               # Health check (also /livez, /readyz)
+GET  /api/v1/docs                           # OpenAPI specification
+```
+
+Chat request body:
+
+```json
+{
+    "user_message": {"text": "Your question here"},
+    "chat_context": {},
+    "sly_data": {"private_key": "private_value"}
+}
+```
+
+cURL example:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/hello_world/streaming_chat \
+  -H "Content-Type: application/json" \
+  -d '{"user_message": {"text": "Greet a new planet"}}'
+```
+
+## Writing a Coded Tool
+
+When you need deterministic logic (API calls, database operations, calculations), implement a `CodedTool`:
+
+```python
+from typing import Any, Dict
+from neuro_san.interfaces.coded_tool import CodedTool
+
+class Calculator(CodedTool):
+
+    async def async_invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> Any:
+        operation = args.get("operation", "add")
+        a = args.get("a", 0)
+        b = args.get("b", 0)
+
+        if operation == "add":
+            return str(a + b)
+        elif operation == "multiply":
+            return str(a * b)
+        else:
+            return f"Unknown operation: {operation}"
+```
+
+Reference it in your HOCON file:
+
+```hocon
+{
+    "name": "calculator",
+    "function": {
+        "description": "Performs arithmetic operations.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "operation": {"type": "string", "description": "add or multiply"},
+                "a": {"type": "float", "description": "First number"},
+                "b": {"type": "float", "description": "Second number"}
+            },
+            "required": ["operation", "a", "b"]
+        }
+    },
+    "class": "calculator.Calculator"
+}
+```
+
+Place the Python file under `AGENT_TOOL_PATH` (default: `coded_tools/<agent_name>/`).
+
+## Sly Data (Private Data Channel)
+
+Sly data is a dictionary of private information kept out of LLM chat streams. Use it for credentials, API keys, personal data, or inter-agent communication that should not be visible to LLMs.
+
+```python
+# Client passes sly_data
+responses = session.streaming_chat({
+    "user_message": {"text": "Look up my account"},
+    "sly_data": {"user_token": "abc123", "api_key": "secret"}
+})
+```
+
+Inside a CodedTool, sly_data is accessible:
+
+```python
+async def async_invoke(self, args, sly_data):
+    token = sly_data.get("user_token")
+    # Use token for authenticated API call
+    # Can also add new keys for downstream agents:
+    sly_data["lookup_result_id"] = "xyz789"
+    return "Account found"
+```
+
+Control sly_data flow to/from external agents via `allow` policies in HOCON. By default, **no sly_data crosses network boundaries** — you must explicitly enable each key.
+
+```hocon
+"allow": {
+    "connectivity": true,
+    "to_downstream": {
+        "sly_data": {"user_token": true, "api_key": false}
+    },
+    "from_downstream": {
+        "sly_data": {"result_id": true},
+        "messages": true
+    },
+    "to_upstream": {
+        "sly_data": ["result_id"]
+    }
+}
+```
+
+A Front Man can advertise the schema of sly_data it expects (input) and produces (output) via `function.sly_data_schema` and `function.sly_data_output_schema`. Generic clients use these to prompt users for required private inputs.
+
+### Client-Provided API Keys
+
+End-users can supply their own LLM API keys at request time by putting an `llm_config` dictionary inside `sly_data`:
+
+```python
+responses = session.streaming_chat({
+    "user_message": {"text": "Hello"},
+    "sly_data": {
+        "llm_config": {
+            "openai_api_key": "sk-...",
+            "anthropic_api_key": "..."
+        }
+    }
+})
+```
+
+Key names are the lowercase form of the environment variable names (e.g. `OPENAI_API_KEY` → `openai_api_key`). The network's HOCON should advertise this requirement in its `sly_data_schema`. See the [`music_nerd_pro_sly_api_key.hocon`](https://github.com/cognizant-ai-lab/neuro-san/blob/main/neuro_san/registries/music_nerd_pro_sly_api_key.hocon) example.
+
+### MCP Authentication via Sly Data
+
+Per-server MCP authentication headers can also be passed in `sly_data`:
+
+```python
+"sly_data": {
+    "http_headers": {
+        "https://example.com/mcp": {"Authorization": "Bearer <token>"},
+        "https://other.com/mcp":   {"client_id": "...", "client_secret": "..."}
+    }
+}
+```
+
+Or define them server-side via the `MCP_SERVERS_INFO_FILE` environment variable pointing at a HOCON file of per-URL `http_headers` and tool filters.
+
+## LLM Configuration
+
+### Default LLM for All Agents
+
+```hocon
+{
+    "llm_config": {
+        "model_name": "gpt-5.2"
+    },
+    "tools": [...]
+}
+```
+
+### Per-Agent LLM Override
+
+```hocon
+{
+    "name": "budget_agent",
+    "llm_config": {
+        "model_name": "gpt-5.4-mini"
+    },
+    "function": {...},
+    "instructions": "..."
+}
+```
+
+### Using Anthropic Models
+
+```hocon
+"llm_config": {
+    "model_name": "claude-sonnet"
+}
+```
+
+Aliases `claude-haiku`, `claude-sonnet`, `claude-opus`, `claude-fable` auto-resolve to latest versions. For Claude on AWS Bedrock, use `"class": "anthropic-bedrock"` with a cross-region inference profile ID, or the `bedrock-claude-opus`/`-sonnet`/`-haiku` aliases.
+
+### Fallback LLMs
+
+```hocon
+"llm_config": {
+    "model_name": "gpt-5.2",
+    "fallbacks": [
+        {"model_name": "claude-sonnet"},
+        {"model_name": "gpt-5.4-mini"}
+    ]
+}
+```
+
+### OpenRouter (many providers via one key)
+
+```hocon
+"llm_config": {
+    "class": "openrouter",
+    "model_name": "anthropic/claude-sonnet-4-5"
+}
+```
+
+Model names follow OpenRouter's `provider/model` convention; meta-routers `openrouter/free` and `openrouter/auto` pick a model per request.
+
+### Custom LLM Provider
+
+```hocon
+"llm_config": {
+    "class": "langchain_nvidia_ai_endpoints.chat_models.ChatNVIDIA",
+    "model_name": "meta/llama-3.1-405b-instruct"
+}
+```
+
+## External Agents and Composability
+
+Agent networks can call agents in other networks, enabling composition:
+
+```hocon
+"tools": [
+    "local_agent",                        // Agent in same network
+    "/date_time",                         // External agent on same server
+    "http://other-server:8080/math_guy",  // Agent on remote server
+    "https://example.com/mcp"             // MCP server tools
+]
+```
+
+Expose agents as MCP tools with `AGENT_MCP_ENABLE=true` and `"mcp": true` in manifest.
+
+## Environment Variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `OPENAI_API_KEY` | — | OpenAI API key |
+| `ANTHROPIC_API_KEY` | — | Anthropic API key |
+| `GOOGLE_API_KEY` | — | Google Gemini API key |
+| `NVIDIA_API_KEY` | — | NVIDIA API key |
+| `OPENROUTER_API_KEY` | — | OpenRouter API key |
+| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (or `AWS_PROFILE`) | — | Amazon Bedrock credentials |
+| `AZURE_OPENAI_API_KEY` / `AZURE_OPENAI_ENDPOINT` | — | Azure OpenAI credentials |
+| `AGENT_MANIFEST_FILE` | `neuro_san/registries/manifest.hocon` | Manifest path(s), separated by `os.pathsep` |
+| `AGENT_TOOL_PATH` | `<repo>/coded_tools` | Path to coded tool implementations |
+| `AGENT_LLM_INFO_FILE` | — | Custom LLM definitions file |
+| `AGENT_TOOLBOX_INFO_FILE` | — | Custom toolbox definitions file |
+| `AGENT_HTTP_PORT` | `8080` | HTTP server port |
+| `AGENT_MCP_ENABLE` | `true` | Expose MCP protocol alongside REST |
+| `AGENT_MCP_ONLY` | `false` | Disable REST and serve only MCP |
+| `AGENT_MANIFEST_UPDATE_PERIOD_SECONDS` | `0` | Manifest/network hot-reload interval (0 = disabled) |
+| `AGENT_AUTHORIZER` | — | Per-user authorization plugin (e.g. OpenFGA) |
+| `MCP_SERVERS_INFO_FILE` | — | HOCON file with per-MCP-URL auth headers and tool filters |
+| `LANGFUSE_ENABLED` | `false` | Enable Langfuse tracing |
+
+## Common Pitfalls
+
+- Do not assume the default model works for tool-calling. Some models lack tool-use capability. Check `default_llm_info.hocon` for the `capabilities` section.
+- Do not put secrets in HOCON files. Use environment variables for API keys and credentials.
+- Do not forget that the first agent in `tools` is always the Front Man. It cannot be a CodedTool or Toolbox tool.
+- Do not confuse agent-level `tools` (list of callable agents) with the top-level `tools` (list of agent definitions).
+- Do not use synchronous `invoke()` in production CodedTools. Use `async_invoke()` to avoid blocking the event loop.
+- Do not forget `parameters` on branch agents. Without them, the calling LLM cannot pass arguments.
+- Do not pass sly_data keys to external agents without explicit `allow` configuration. By default, no sly_data crosses network boundaries.
+- Do not use `max_iterations` in new configurations. It is deprecated — use `max_steps` (LangGraph recursion limit, default `10000`).
+- Do not put a `tools` field on an agent that uses `toolbox`. Toolbox agents execute code directly and cannot call sub-agents.
+- Do not build new networks on the default `langchain_community`-based toolbox tools (web search / requests toolkit). They are deprecated and slated for removal; use dedicated integration packages or your own toolbox file instead.
+
+## Version-Sensitive Notes for 0.6.92
+
+- `0.6.92` is the current release, tagged on 2026-08-11.
+- Requires Python >=3.10. Quick-start scripts assume Python 3.12+.
+- Built on LangChain + LangGraph for LLM orchestration, but abstracts both away from agent authors.
+- The default LLM model is `gpt-5.2` when no `llm_config` is specified.
+- Anthropic model aliases (`claude-haiku`, `claude-sonnet`, `claude-opus`, `claude-fable`) auto-resolve to latest versions to avoid deprecation issues.
+- **`max_iterations` is deprecated**; use `max_steps` instead. `max_steps` corresponds to the LangGraph recursion-limit (super-step budget) and defaults to **10,000** — much higher than the old `max_iterations` default of 20.
+- `max_execution_seconds` (per-agent wall-clock timeout) defaults to **5 minutes** (was 2 minutes in releases before mid-2026).
+- `max_attempts` (top-level or per-agent, default `3`) retries retryable LLM errors such as rate limits and timeouts.
+- Toolbox agents (those with a `toolbox` key) **cannot** declare a `tools` field — they execute directly rather than calling an LLM.
+- Front Man agents can declare both `sly_data_schema` (expected inputs) and `sly_data_output_schema` (produced outputs).
+- MCP protocol is enabled by default (`AGENT_MCP_ENABLE=true`). Authentication headers may come from `sly_data["http_headers"]` or the `MCP_SERVERS_INFO_FILE` HOCON file.
+- Langfuse tracing is available when `LANGFUSE_ENABLED=true`; `user_id` and `session_id` are propagated as Langfuse attributes. sly_data values are redacted from tracing unless allowed per-key via the `allow.to_tracing.sly_data` policy.
+- A Front Man can declare `"invocation": "event"` to acknowledge immediately and keep processing after the caller disconnects; the manifest's `periodic` key can trigger such networks on a cron schedule without a client request.
+- Per-model `price_per_1k_input_tokens` / `price_per_1k_output_tokens` in the LLM info file drive token-cost accounting; models without prices report cost 0.
+- LangChain-style **AgentMiddleware** classes can be attached to any LLM agent via the `middleware` HOCON key for cross-cutting concerns (logging, PII redaction, summarization, etc.).
+
+## Official Source URLs
+
+- GitHub: https://github.com/cognizant-ai-lab/neuro-san
+- PyPI: https://pypi.org/project/neuro-san/
+- Agent HOCON Reference: https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md
+- LLM Info Reference: https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/llm_info_hocon_reference.md
+- Manifest Reference: https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/manifest_hocon_reference.md
+- Toolbox Reference: https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/toolbox_info_hocon_reference.md
+- Test Case Reference: https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/test_case_hocon_reference.md
+- MCP Service Docs: https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/mcp_service.md
+- Client Docs: https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/clients.md
+- HOCON Validator CLI: https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/hocon_validator_cli.md
+- neuro-san-studio (examples & tutorials): https://github.com/cognizant-ai-lab/neuro-san-studio

--- a/content/neuro-san/docs/package/python/references/agent-networks.md
+++ b/content/neuro-san/docs/package/python/references/agent-networks.md
@@ -1,0 +1,430 @@
+# Agent Network HOCON Configuration Reference
+
+## File Structure
+
+Each agent network is a single `.hocon` file placed in the registries directory. HOCON is JSON with comments, multi-line strings, and syntactic sugar.
+
+## Complete Agent Network Example
+
+```hocon
+{
+    # Reusable values defined at the top of the file, referenced below
+    # via standard HOCON substitutions (${var}).
+    "default_llm_config": {
+        "model_name": "gpt-5.2"
+    },
+    "support_instructions": """
+You are the primary support agent for Acme Corp.
+Route order issues to order_lookup and policy questions to policy_expert.
+""",
+
+    "metadata": {
+        "description": "Customer support agent network",
+        "tags": ["support", "customer"],
+        "sample_queries": [
+            "I need help with my order",
+            "What is your return policy?"
+        ]
+    },
+
+    "llm_config": ${default_llm_config},
+
+    "tools": [
+        # Front Man — entry point
+        {
+            "name": "support_agent",
+            "function": {
+                "description": "I help with customer support for Acme Corp."
+            },
+            "instructions": ${support_instructions},
+            "tools": ["order_lookup", "policy_expert"]
+        },
+
+        # Branch agent — LLM-powered
+        {
+            "name": "policy_expert",
+            "function": {
+                "description": "Answers policy and FAQ questions.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "question": {
+                            "type": "string",
+                            "description": "The policy question to answer"
+                        }
+                    },
+                    "required": ["question"]
+                }
+            },
+            "instructions": "You are a policy expert for Acme Corp. Answer questions accurately.",
+            "llm_config": {
+                "model_name": "gpt-5.4-mini"
+            }
+        },
+
+        # Coded Tool — Python implementation
+        {
+            "name": "order_lookup",
+            "function": {
+                "description": "Looks up order status by order ID.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "order_id": {
+                            "type": "string",
+                            "description": "The order ID to look up"
+                        }
+                    },
+                    "required": ["order_id"]
+                }
+            },
+            "class": "order_lookup.OrderLookup"
+        }
+    ]
+}
+```
+
+## Top-Level Keys
+
+### llm_config
+
+Default LLM settings for all agents in the network.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `model_name` | string | `"gpt-5.2"` | Model identifier |
+| `temperature` | float | provider default | Randomness (0.0–1.0); many newer models ignore or reject it |
+| `class` | string | — | Provider class or LangChain class path |
+| `fallbacks` | list | — | Ordered list of fallback `llm_config` dicts |
+
+Supported provider class values: `openai`, `anthropic`, `azure-openai`, `gemini`, `nvidia`, `ollama`, `openrouter`, `bedrock`, `anthropic-bedrock`. For Claude on AWS Bedrock prefer `anthropic-bedrock` (async, Anthropic SDK) over the legacy boto3-based `bedrock` class.
+
+For custom providers, use the full LangChain class path:
+
+```hocon
+"class": "langchain_nvidia_ai_endpoints.chat_models.ChatNVIDIA"
+```
+
+### tools
+
+Array of agent definitions. The first is always the Front Man.
+
+### metadata
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `description` | string | Human-readable network description |
+| `tags` | list | Grouping tags |
+| `sample_queries` | list | Example queries for the network |
+
+### Reusing Values (HOCON Substitutions)
+
+To avoid repetition, prefer standard HOCON substitutions (`${var}`) — they are a built-in feature of the HOCON format (implemented in neuro-san by [pyhocon](https://github.com/chimpler/pyhocon)) and work for any value: scalars, dicts, lists.
+
+Define reusable values at the top of the file and reference them as whole values elsewhere:
+
+```hocon
+{
+    "default_llm_config": {
+        "model_name": "gpt-5.2"
+    },
+    "query_params": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Input query"}
+        },
+        "required": ["query"]
+    },
+
+    "llm_config": ${default_llm_config},
+
+    "tools": [
+        {
+            "name": "searcher",
+            "function": {
+                "description": "Search the web.",
+                "parameters": ${query_params}
+            },
+            ...
+        }
+    ]
+}
+```
+
+Other useful HOCON features for the same goal:
+
+- **Environment variables** — `"api_endpoint": ${API_ENDPOINT}` reads from the process environment.
+- **Optional substitution** — `"feature_flag": ${?ENABLE_FEATURE}` is silently dropped when the variable is missing instead of erroring.
+- **`include`** — pull in shared HOCON files (e.g. `include "registries/shared_prompts.hocon"`) and reference their keys from any file that includes them. See the [neuro-san-studio user guide](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/user_guide.md) for the include + substitution pattern.
+
+**Caveat:** HOCON substitutions are **not parsed inside quoted strings**. To interpolate within a string, concatenate with adjacent string literals: `"instructions": ${prefix} " main text " ${suffix}`. For most agent-network use cases, substituting the whole value (as in the example above) is cleaner.
+
+A legacy `commondefs` block with `replacement_strings` / `replacement_values` keys is still recognized for backwards compatibility, but new networks should use HOCON substitutions.
+
+### Other Top-Level Keys
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `max_steps` | int | `10000` | LangGraph recursion-limit (super-step budget for the entire graph) |
+| `max_iterations` | int | — | **Deprecated**. Use `max_steps`. |
+| `max_execution_seconds` | int | `300` | Wall-clock timeout per agent (5 minutes) |
+| `max_attempts` | int | `3` | Attempts for retryable LLM errors (rate limits, timeouts); non-retryable errors are not retried |
+| `request_timeout_seconds` | int | `0` | Client request timeout (0 = none) |
+| `verbose` | bool/string | `false` | Server logging (`true`, `false`, `"extra"`) |
+| `error_formatter` | string | `"string"` | Error format: `"string"` or `"json"` |
+| `error_fragments` | list | — | Strings that trigger error detection |
+| `llm_info_file` | string | — | Path to custom LLM definitions |
+| `toolbox_info_file` | string | — | Path to custom toolbox definitions |
+
+## Single Agent Keys
+
+### Required Keys
+
+| Key | Description |
+|-----|-------------|
+| `name` | Unique identifier (alphanumeric, `-`, `_`) |
+| `function.description` | What this agent does (used as prompt for Front Man) |
+
+### instructions
+
+System prompt for LLM-powered agents. Multi-line strings supported via `"""triple quotes"""`.
+
+```hocon
+"instructions": """
+You are a research assistant.
+Always cite your sources.
+Never make up information.
+"""
+```
+
+### function.parameters
+
+JSON Schema describing input arguments. Required for branch agents; omitted for Front Man.
+
+```hocon
+"parameters": {
+    "type": "object",
+    "properties": {
+        "query": {"type": "string", "description": "Search query"},
+        "max_results": {"type": "int", "description": "Max results", "default": 5}
+    },
+    "required": ["query"]
+}
+```
+
+### function.sly_data_schema
+
+JSON Schema for private data the agent expects as **input**. Front Man only. Same format as `parameters`. Generic clients use this to prompt for required private inputs (e.g., user tokens, per-user API keys).
+
+A reserved key `llm_config` inside `sly_data_schema` indicates the network accepts client-provided LLM API keys (e.g., `openai_api_key`, `anthropic_api_key`):
+
+```hocon
+"sly_data_schema": {
+    "type": "object",
+    "properties": {
+        "llm_config": {"type": "object", "description": "Per-user LLM API keys"}
+    }
+}
+```
+
+### function.sly_data_output_schema
+
+JSON Schema for private data the agent **produces** as output. Front Man only. Same format as `parameters`. Lets clients know which sly_data keys will come back in the final response.
+
+### function.invocation
+
+Front Man only. How the network is called: `"chatbot"` (default) makes the caller wait for the full response and abandons work if the caller disconnects; `"event"` returns a quick acknowledgment and keeps processing after the caller disconnects. `"event"` networks can also be triggered on a schedule via the manifest's `periodic` key (see below).
+
+### tools (agent-level)
+
+List of agents/tools this agent can call:
+
+```hocon
+"tools": [
+    "local_agent_name",       // Agent in same network
+    "/date_time",             // External agent on same server
+    "http://host:8080/agent", // External agent on remote server
+    "https://example.com/mcp" // MCP server tools
+]
+```
+
+MCP with tool filtering:
+
+```hocon
+"tools": [
+    {
+        "url": "https://example.com/mcp",
+        "tools": ["tool_1", "tool_2"]
+    }
+]
+```
+
+#### MCP Authentication
+
+MCP servers may require authentication. Two options:
+
+1. Per-request via `sly_data["http_headers"]`, a dict keyed by MCP URL:
+
+   ```json
+   "sly_data": {
+       "http_headers": {
+           "https://example.com/mcp": {"Authorization": "Bearer <token>"}
+       }
+   }
+   ```
+
+2. Server-side via the `MCP_SERVERS_INFO_FILE` environment variable pointing at a HOCON file:
+
+   ```hocon
+   {
+       "https://example.com/mcp": {
+           "http_headers": {"Authorization": "Bearer <token>"},
+           "tools": ["tool_1", "tool_2"]
+       }
+   }
+   ```
+
+   `sly_data` overrides the configuration file for the same URL. Tool filtering from the file is used only when the agent's HOCON does not specify its own.
+
+A Front Man can advertise which MCP URLs need headers by listing them in `function.sly_data_schema` under an `http_headers` property (with a `required` list). OAuth-capable clients (e.g. nsflow) use this to run the sign-in flow and inject bearer tokens into sly_data on the user's behalf.
+
+### class
+
+Python class implementing `CodedTool` interface. Mutually exclusive with LLM agent behavior.
+
+```hocon
+"class": "calculator.Calculator"
+// Resolves to: AGENT_TOOL_PATH/<agent_name>/calculator.py -> Calculator class
+```
+
+Or fully qualified:
+
+```hocon
+"class": "my_package.tools.calculator.Calculator"
+```
+
+### toolbox
+
+Reference to a pre-built tool from toolbox configuration:
+
+```hocon
+"toolbox": "tavily_search"
+```
+
+A toolbox agent executes code directly (LangChain `BaseTool` or `CodedTool`) and therefore **cannot have a `tools` field** — it cannot invoke other agents downstream.
+
+### args
+
+Extra key/value pairs passed to CodedTools or toolbox tools at invocation time:
+
+```hocon
+"args": {
+    "api_endpoint": "https://api.example.com",
+    "timeout": 30
+}
+```
+
+### allow
+
+Security policy for information flow to/from external agents.
+
+```hocon
+"allow": {
+    "connectivity": true,
+    "to_downstream": {
+        "sly_data": {"user_token": true, "secret": false}
+    },
+    "from_downstream": {
+        "sly_data": {"result_id": true},
+        "messages": true
+    },
+    "to_upstream": {
+        "sly_data": ["output_key_1", "output_key_2"]
+    }
+}
+```
+
+`sly_data` can be a dict (key → bool/string), a list of allowed keys, or omitted (blocks all).
+
+String values in sly_data dicts translate keys: `{"my_session": "session_id"}` maps `my_session` to `session_id`.
+
+`messages` controls whether downstream external agent messages are forwarded to client. Values: `true`/`false`, a single agent string, a list of agent strings, or a dict mapping agents to booleans.
+
+`to_tracing` (Front Man only) controls what reaches tracing applications (Langfuse etc.). By default sly_data keys appear in traced messages with values `<redacted>`; enable specific values with the same dict/list spec as `to_downstream`:
+
+```hocon
+"allow": {
+    "to_tracing": {
+        "sly_data": {"user_id": true}
+    }
+}
+```
+
+### Other Agent Keys
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `command` | string | — | Optional command to set agent in motion |
+| `display_as` | string | auto | How agent appears in connectivity visualization (`external_agent`, `coded_tool`, `langchain_tool`, `llm_agent`) |
+| `max_message_history` | int | None | Front Man only: limit chat history messages |
+| `structure_formats` | list | — | Front Man only: parse formats from responses (`"json"`) |
+| `verbose` | bool/string | inherited | Per-agent logging override |
+| `max_steps` | int | inherited | Per-agent LangGraph recursion limit |
+| `max_iterations` | int | — | **Deprecated**. Use `max_steps`. |
+| `max_execution_seconds` | int | inherited | Per-agent timeout |
+| `max_attempts` | int | inherited | Per-agent retry attempts for retryable LLM errors |
+| `error_formatter` | string | inherited | Per-agent error format |
+| `error_fragments` | list | inherited | Per-agent error detection strings |
+
+### middleware
+
+List of LangChain `AgentMiddleware` instances applied to the agent. Order matters.
+
+```hocon
+"middleware": [
+    {
+        "class": "my_package.middleware.LoggingMiddleware",
+        "args": {
+            "log_level": "DEBUG"
+        }
+    }
+]
+```
+
+Middleware classes can implement any of the async hooks: `abefore_agent()`, `aafter_agent()`, `abefore_model()`, `aafter_model()`, `awrap_model_call()`, `awrap_tool_call()`. Only class-based middleware is supported (not annotation-based).
+
+Special args automatically populated by the framework when present in both the dict and the constructor signature: `chat_history`, `origin`, `origin_str`, `progress_reporter`, `sly_data`.
+
+## Agent Manifest (manifest.hocon)
+
+Controls which networks the server loads and exposes:
+
+```hocon
+{
+    // Simple: boolean — true serves and lists the agent, false hides it entirely
+    "hello_world.hocon": true,
+
+    // Detailed: dict with options
+    "math_guy.hocon": {
+        "serve": true,     // Whether to load and serve the network at all
+        "public": true,    // Whether to list in the Concierge /list endpoint
+        "mcp": true        // Expose as MCP tool (implicitly sets public=true)
+    },
+
+    // Subdirectory path — internal-only network callable as an external agent
+    "deep/special_agent.hocon": {
+        "serve": true,
+        "public": false
+    },
+
+    // Cron-triggered network — front man must have "invocation": "event"
+    "monitor.hocon": {
+        "serve": true,
+        "periodic": "*/5 * * * *"   // every 5 minutes; true = every minute
+    }
+}
+```
+
+The `periodic` value can be a boolean (`true` = every minute with the default text "Do your thing"), a cron string, or a dict with an `interactions` list for fine-grained control (`cron_schedule`, `text`, `sly_data`, `metadata` per interaction).
+
+When `AGENT_MANIFEST_UPDATE_PERIOD_SECONDS > 0`, the server polls the manifest and referenced network files at that interval and hot-reloads added/removed/changed networks without a restart. Useful for dev and for shared read-only volume mounts in cluster deployments.

--- a/content/neuro-san/docs/package/python/references/coded-tools.md
+++ b/content/neuro-san/docs/package/python/references/coded-tools.md
@@ -1,0 +1,265 @@
+# Coded Tools Development Guide
+
+## What Are Coded Tools?
+
+Coded Tools are Python classes that execute deterministic logic within a neuro-san agent network. Use them when an agent needs to call APIs, query databases, perform calculations, or handle any task that should not be left to LLM interpretation.
+
+## Interface
+
+Implement the `CodedTool` class from `neuro_san.interfaces.coded_tool`:
+
+```python
+from typing import Any, Dict
+from neuro_san.interfaces.coded_tool import CodedTool
+
+class MyTool(CodedTool):
+
+    async def async_invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> Any:
+        """
+        :param args: Read-only dict of arguments populated by the calling LLM
+                     based on the function.parameters schema in HOCON.
+        :param sly_data: Private data dict kept out of LLM chat streams.
+                         Largely read-only. Can add new keys as a bulletin board.
+        :return: Value that goes into the chat stream as the tool's response.
+        """
+        result = args.get("query", "")
+        return f"Processed: {result}"
+```
+
+Requirements:
+
+- No-args constructor (the framework instantiates your class).
+- Override `async_invoke()` (preferred) or `invoke()` (synchronous fallback).
+- Return a value (string, dict, list) that goes back into the chat stream.
+
+## Synchronous vs Asynchronous
+
+**Always prefer `async_invoke()`** in production. The synchronous `invoke()` blocks the event loop and prevents concurrent request handling.
+
+If your code must call blocking I/O, wrap it with `asyncio.to_thread()`:
+
+```python
+import asyncio
+from neuro_san.interfaces.coded_tool import CodedTool
+
+class BlockingApiTool(CodedTool):
+
+    def _call_api(self, url):
+        import requests
+        return requests.get(url).json()
+
+    async def async_invoke(self, args, sly_data):
+        url = args.get("url")
+        result = await asyncio.to_thread(self._call_api, url)
+        return str(result)
+```
+
+## File Placement
+
+Place coded tool files under the `AGENT_TOOL_PATH` directory (default: `coded_tools/`).
+
+Directory structure:
+
+```
+coded_tools/
+├── my_network/
+│   ├── my_tool.py          # Contains MyTool class
+│   └── another_tool.py     # Contains AnotherTool class
+├── shared_tool.py           # Shared across networks (fallback lookup)
+```
+
+Resolution order for `"class": "my_tool.MyTool"` on agent named `my_network`:
+
+1. `AGENT_TOOL_PATH/my_network/my_tool.py` → `MyTool`
+2. `AGENT_TOOL_PATH/my_tool.py` → `MyTool` (shared fallback)
+
+Or use a fully-qualified class name to bypass resolution:
+
+```hocon
+"class": "my_package.tools.my_tool.MyTool"
+```
+
+## HOCON Configuration
+
+```hocon
+{
+    "name": "order_lookup",
+    "function": {
+        "description": "Looks up order status in the database.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "order_id": {
+                    "type": "string",
+                    "description": "The order ID to look up"
+                }
+            },
+            "required": ["order_id"]
+        }
+    },
+    "class": "order_lookup.OrderLookup"
+}
+```
+
+## Working with sly_data
+
+Sly data is a private channel for sensitive information (credentials, tokens, intermediate results). It is never sent to LLMs.
+
+Reading sly_data:
+
+```python
+async def async_invoke(self, args, sly_data):
+    api_key = sly_data.get("api_key")
+    user_id = sly_data.get("user_id")
+    # Use for authenticated API calls
+```
+
+Writing to sly_data (adding new keys only):
+
+```python
+async def async_invoke(self, args, sly_data):
+    result = await self._fetch_data(args)
+    # Add new key for downstream agents
+    sly_data["fetched_data_id"] = result["id"]
+    return f"Found data: {result['summary']}"
+```
+
+Rules:
+
+- Treat existing keys as read-only.
+- Only add new keys that do not already exist.
+- Ensure only one CodedTool writes a given key to avoid race conditions.
+
+## Using args from HOCON
+
+The `args` key in HOCON passes static configuration to your tool. The framework **merges these HOCON args into the same `args` dict passed to `async_invoke()`**, alongside the LLM-provided arguments:
+
+```hocon
+{
+    "name": "weather_tool",
+    "function": {
+        "description": "Gets weather for a city.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "city": {"type": "string", "description": "City name"}
+            },
+            "required": ["city"]
+        }
+    },
+    "class": "weather.WeatherTool",
+    "args": {
+        "api_endpoint": "https://api.weather.example.com",
+        "units": "metric"
+    }
+}
+```
+
+Inside `WeatherTool.async_invoke(args, sly_data)`, `args["city"]` is LLM-provided while `args["api_endpoint"]` and `args["units"]` come from HOCON. This lets a single CodedTool implementation be reused by multiple agents with different static config.
+
+The same mechanism can also override arguments of LangChain tools referenced via `toolbox`.
+
+## Example: Complete Coded Tool
+
+HOCON (`registries/math_guy.hocon` excerpt):
+
+```hocon
+{
+    "name": "calculator",
+    "function": {
+        "description": "Does arithmetic. Supports add, subtract, multiply, divide.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "description": "One of: add, subtract, multiply, divide"
+                },
+                "operand_a": {
+                    "type": "float",
+                    "description": "First operand"
+                },
+                "operand_b": {
+                    "type": "float",
+                    "description": "Second operand"
+                }
+            },
+            "required": ["operation", "operand_a", "operand_b"]
+        }
+    },
+    "class": "calculator.Calculator"
+}
+```
+
+Python (`coded_tools/math_guy/calculator.py`):
+
+```python
+from typing import Any, Dict
+from neuro_san.interfaces.coded_tool import CodedTool
+
+class Calculator(CodedTool):
+
+    async def async_invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> Any:
+        operation = args.get("operation", "")
+        a = float(args.get("operand_a", 0))
+        b = float(args.get("operand_b", 0))
+
+        ops = {
+            "add": a + b,
+            "subtract": a - b,
+            "multiply": a * b,
+            "divide": a / b if b != 0 else "Error: division by zero",
+        }
+
+        result = ops.get(operation, f"Unknown operation: {operation}")
+        return str(result)
+```
+
+## Calling Other Agents from a Coded Tool (BranchActivation)
+
+A CodedTool that also subclasses `BranchActivation` can programmatically invoke other agents via its inherited `use_tool()` method. To keep these calls visible to validation and to the `Connectivity()` API, declare the callable agents under `args.tools` in HOCON. The keys are arbitrary role names your code uses to pick which agent to call; the values are agent name references.
+
+HOCON (from the neuro-san-studio [`mdap_decomposer`](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/registries/experimental/mdap_decomposer.hocon) example):
+
+```hocon
+{
+    "name": "decomposition_solver",
+    "class": "decomposition_solver.DecompositionSolver",
+    "args": {
+        "tools": {
+            "decomposer": "decomposer",
+            "solution_discriminator": "solution_discriminator",
+            "problem_solver": "problem_solver",
+            "composition_discriminator": "composition_discriminator"
+        }
+    }
+}
+```
+
+Python:
+
+```python
+from neuro_san.interfaces.coded_tool import CodedTool
+from neuro_san.internals.graph.activations.branch_activation import BranchActivation
+
+class DecompositionSolver(BranchActivation, CodedTool):
+
+    async def async_invoke(self, args, sly_data):
+        tools = args.get("tools", {})
+        # tools["decomposer"] resolves to the agent name "decomposer"
+        # Call it via BranchActivation.use_tool(), or wrap it in a caller
+        # (see neuro-san-studio's CodedToolAgentCaller for one pattern).
+        ...
+```
+
+For the full implementation pattern, see neuro-san-studio's [`decomposition_solver.py`](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/coded_tools/experimental/mdap_decomposer/decomposition_solver.py).
+
+## Common Pitfalls
+
+- Do not use `invoke()` for production. It blocks the async event loop. Use `async_invoke()`.
+- Do not modify existing sly_data keys. Only add new ones.
+- Do not forget the no-args constructor. The framework instantiates your class with no arguments (unless it subclasses `BranchActivation`).
+- Do not assume args will always have all keys. Use `.get()` with defaults.
+- Do not put a `class` key on the Front Man agent. Front Man cannot be a CodedTool.
+- Do not perform heavy computation synchronously. Use `asyncio.to_thread()` for blocking operations.
+- Do not use global state or singletons to work around the no-args constructor. CodedTools run in a multi-threaded async environment; share request-scoped state via `sly_data` instead.


### PR DESCRIPTION
## What

Adds documentation for the [neuro-san](https://github.com/cognizant-ai-lab/neuro-san) Python package ([PyPI](https://pypi.org/project/neuro-san/)) — a data-driven multi-agent orchestration framework where agent networks are defined in HOCON configuration files.

New entry `neuro-san/package` at `content/neuro-san/docs/package/python/`:

- `DOC.md` — install, LLM provider setup, quick start, HOCON agent networks, Python client API, REST API, coded tools, sly_data (private data channel), LLM configuration, environment variables, common pitfalls (498 lines)
- `references/agent-networks.md` — full HOCON configuration reference for agent networks and the manifest
- `references/coded-tools.md` — CodedTool development guide

Content is written against the current release (0.6.92) and verified against the source.

## Why

neuro-san is not yet in Context Hub. Its agent networks are authored in a HOCON dialect with framework-specific conventions (front-man agents, sly_data, coded tools, allow policies) that coding agents reliably hallucinate without curated context.

## Testing

- [x] `npm test` passes (372 tests, 30 files)
- [x] `chub build content/ --validate-only` succeeds (`Valid: 1598 docs, 9 skills`)
- [x] Manual testing done (describe below)

Ran a full `chub build` and verified the registry output: entry `neuro-san/package` registers with language `python`, version `0.6.92`, and both reference files discoverable.

## Notes

`source: maintainer` — I work on the neuro-san team at Cognizant AI Lab (the library authors), and we intend to keep this entry current as the package evolves.