### PR TITLE
fix(cli): write multi-file `get -o` output instead of an empty file

### DIFF
--- a/cli/src/commands/get.js
+++ b/cli/src/commands/get.js
@@ -144,7 +144,11 @@ async function fetchEntries(ids, opts, globalOpts) {
       } else {
         const outPath = isDir ? join(opts.output, `${results[0].id}.md`) : opts.output;
         mkdirSync(dirname(outPath), { recursive: true });
-        const combined = results.map((r) => r.content).join('\n\n---\n\n');
+        // Multi-file results carry `files`, not `content`; expand them the same
+        // way the stdout path does so `-o` doesn't write an empty file.
+        const combined = results
+          .flatMap((r) => (r.files ? r.files.map((f) => `# FILE: ${f.name}\n\n${f.content}`) : [r.content]))
+          .join('\n\n---\n\n');
         writeFileSync(outPath, combined);
         info(`Written to ${outPath}`);
       }


### PR DESCRIPTION
## Summary
Supersedes #308. When `chub get <id> --file a,b -o <path>` fetches multiple files, the result now carries `files` instead of `content`. The previous `-o` branch wrote `r.content`, which was undefined, producing a 0-byte file. This fix expands `files` the same way the stdout path does (`# FILE: <name>` sections joined with `---`) before writing to the output file.

## Change
- `cli/src/commands/get.js`: join multi-file `files` content for `-o` output.

## Verification
- Local smoke: `npx vitest run test/e2e.test.js -t 'writes to file with -o'` passes in `cli/`